### PR TITLE
20151225 missing docstring attr

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@ ChangeLog for Pylint
 
 --
     
+    * Treat properties as attributes for the purposes of missing-docstring
+
     * Suppress reporting 'unneeded-not' inside `__ne__` methods
 
       Closes issue #749.

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1369,10 +1369,13 @@ class DocStringChecker(_BasicChecker):
     @check_messages('missing-docstring', 'empty-docstring')
     def visit_functiondef(self, node):
         if self.config.no_docstring_rgx.match(node.name) is None:
-            ftype = node.is_method() and 'method' or 'function'
+            if _determine_function_name_type(node) == "attr":
+                return
+
             if node.decorators and self._is_setter_or_deleter(node):
                 return
 
+            ftype = node.is_method() and 'method' or 'function'
             if isinstance(node.parent.frame(), astroid.ClassDef):
                 overridden = False
                 confidence = (INFERENCE if has_known_bases(node.parent.frame())

--- a/pylint/test/functional/missing_docstring.py
+++ b/pylint/test/functional/missing_docstring.py
@@ -36,14 +36,14 @@ def __mangled():
 
 
 class Property(object):
-    """Don't warn about setters and deleters."""
+    """Treat properties as attributes."""
 
     def __init__(self):
         self._value = None
 
     @property
     def test(self):
-        """Default docstring for setters and deleters."""
+        return self._value
 
     @test.setter
     def test(self, value):


### PR DESCRIPTION
Don't report "Missing method docstring" on properties, which should be treated as attributes.

Thanks to @malinoff for pointing this out on IRC as an inconsistency