### PR TITLE
Fix python3 checker to handle raising an empty tuple.

### DIFF
--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -535,7 +535,7 @@ class Python3Checker(checkers.BaseChecker):
         else:
             try:
                 value = next(astroid.unpack_infer(expr))
-            except astroid.InferenceError:
+            except (astroid.InferenceError, StopIteration):
                 return
             self._check_raise_value(node, value)
 

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -407,6 +407,13 @@ class Python3CheckerTest(testutils.CheckerTestCase):
             with self.assertAddsMessages(message):
                 self.checker.visit_call(node)
 
+    def test_raise_empty_tuple(self):
+        node = test_utils.extract_node("""
+        raise()  #@
+        """)
+        with self.assertNoMessages():
+          self.checker.visit_raise(node)
+
 
 @python2_only
 class Python3TokenCheckerTest(testutils.CheckerTestCase):


### PR DESCRIPTION
I'm new to working with pylint - please let me know if there's a better way to make this change.