### PR TITLE
remove @check_message decorator from [visit|leave]_classdef methods of the ClassChecker

### DIFF
--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -347,11 +347,6 @@ a metaclass class method.'}
         self._first_attrs = []
         self._meth_could_be_func = None
 
-    @check_messages('no-init', 'invalid-slots', 'inherit-non-class',
-                    'inconsistent-mro', 'duplicate-bases',
-                    'invalid-slots', 'invalid-slots-object', 'abstract-method',
-                    'access-member-before-definition',
-                    'attribute-defined-outside-init')
     def visit_classdef(self, node):
         """init visit variable _accessed
         """
@@ -397,8 +392,6 @@ a metaclass class method.'}
                 self.add_message('inherit-non-class',
                                  args=base.as_string(), node=node)
 
-    @check_messages('access-member-before-definition',
-                    'attribute-defined-outside-init')
     def leave_classdef(self, cnode):
         """close a class node:
         check that instance attributes are defined in __init__ and check


### PR DESCRIPTION
…f the ClassChecker

Those methods are actually not only emitting the listed messages but also updating
some internal state that is used from other, unrestricted, messages. We should
work on separating responsabilities if we want to restrict method entries upon
messages restriction.

Closes issue #789