### PR TITLE
Fix #793 [MISCELLANEOUS] code tag without message doesn't track

### DIFF
--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -85,7 +85,7 @@ class EncodingChecker(BaseChecker):
         """
         if self.config.notes:
             notes = re.compile(
-                r'.*?#\s*(%s)(:*\s*.+)' % "|".join(self.config.notes))
+                r'.*?#\s*(%s)(:*\s*.*)' % "|".join(self.config.notes))
         else:
             notes = None
         if module.file_encoding:

--- a/pylint/test/unittest_checker_misc.py
+++ b/pylint/test/unittest_checker_misc.py
@@ -23,25 +23,73 @@ from pylint.testutils import (
 )
 
 
-
 class FixmeTest(CheckerTestCase):
     CHECKER_CLASS = misc.EncodingChecker
 
-    def test_fixme(self):
+    def test_fixme_with_message(self):
         with create_file_backed_module(
-            """a = 1
-            # FIXME """) as module:
+                """a = 1
+                # FIXME message
+                """) as module:
             with self.assertAddsMessages(
-                Message(msg_id='fixme', line=2, args=u'FIXME')):
+                    Message(msg_id='fixme', line=2, args=u'FIXME message')):
+                self.checker.process_module(module)
+
+    def test_todo_without_message(self):
+        with create_file_backed_module(
+                """a = 1
+                # TODO
+                """) as module:
+            with self.assertAddsMessages(
+                    Message(msg_id='fixme', line=2, args=u'TODO')):
+                self.checker.process_module(module)
+
+    def test_xxx_without_space(self):
+        with create_file_backed_module(
+                """a = 1
+                #XXX
+                """) as module:
+            with self.assertAddsMessages(
+                    Message(msg_id='fixme', line=2, args=u'XXX')):
+                self.checker.process_module(module)
+
+    def test_xxx_middle(self):
+        with create_file_backed_module(
+                """a = 1
+                # midle XXX
+                """) as module:
+            with self.assertNoMessages():
+                self.checker.process_module(module)
+
+    def test_without_space_fixme(self):
+        with create_file_backed_module(
+                """a = 1
+                #FIXME
+                """) as module:
+            with self.assertAddsMessages(
+                    Message(msg_id='fixme', line=2, args=u'FIXME')):
                 self.checker.process_module(module)
 
     @set_config(notes=[])
-    def test_empty_fixme_regex(self):
+    def test_absent_codetag(self):
         with create_file_backed_module(
-            """a = 1
-            # fixme
-            """) as module:
+                """a = 1
+                # FIXME
+                # TODO
+                # XXX
+                """) as module:
             with self.assertNoMessages():
+                self.checker.process_module(module)
+
+    @set_config(notes=['CODETAG'])
+    def test_other_present_codetag(self):
+        with create_file_backed_module(
+                """a = 1
+                # CODETAG
+                # FIXME
+                """) as module:
+            with self.assertAddsMessages(
+                    Message(msg_id='fixme', line=2, args=u'CODETAG')):
                 self.checker.process_module(module)
 
 


### PR DESCRIPTION
Hi, I changed the regex : 

https://github.com/PyCQA/pylint/blob/master/pylint/checkers/misc.py#L88.

I did several tests. At the project root, run :

~~~bash
cd pylint/test/
python -m unittest discover -p "unittest_checker_misc.py"
~~~

If you can review that ? I don't know where put this patch. I chose master. 
But if it is available for the new version of pylint 1.6.0, or also for pylint 1.5.4.x, it will be great.

**Required** 
pylint 1.6.0, 
astroid 1.5.0
Python 3.4.3 (default, Oct 14 2015, 20:28:29) 
[GCC 4.8.4]
