### PR TITLE
Small mistake in build_message_def

### DIFF
--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -164,9 +164,9 @@ def build_message_def(checker, msgid, msg_tuple):
         default_scope = WarningScope.NODE
     options = {}
     if len(msg_tuple) > 3:
-        (msg, symbol, descr, options) = msg_tuple
+        (msg, symbol, descr, options) = msg_tuple[:4]
     elif len(msg_tuple) > 2:
-        (msg, symbol, descr) = msg_tuple[:3]
+        (msg, symbol, descr) = msg_tuple
     else:
         # messages should have a symbol, but for backward compatibility
         # they may not.


### PR DESCRIPTION
The slicing is useless in the len > 2 case since any input which would have required it will have matched len > 3 above.

However the slicing would be useful in said case above to avoid an error for developers passing 5+-sized tuples.

Since I'm guessing the original intention was to avoid errors on overlong definition tuples, move the slicing.

Note: maybe there could be a (documented) namedtuple definition for the 4-items case for somewhat clearer checker definitions? Currently differentiating/remembering the difference between items 0 (lint message) and item 2 (lint help/description) can be annoying.