### PR TITLE
Make list of contextmanager decorators configurable.

### DIFF
--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -305,6 +305,15 @@ class should be ignored. A mixin class is detected if its name ends with \
 missed by pylint inference system, and so shouldn\'t trigger E1101 when \
 accessed. Python regular expressions are accepted.'}
                ),
+               ('contextmanager-decorators',
+                {'default': ['contextlib.contextmanager'],
+                 'type': 'csv',
+                 'metavar': '<decorator names>',
+                 'help': 'List of decorators that produce context managers, '
+                         'such as contextlib.contextmanager. Add to this list '
+                         'to register other decorators that produce valid '
+                         'context managers.'}
+               ),
               )
 
     def open(self):
@@ -773,7 +782,8 @@ accessed. Python regular expressions are accepted.'}
             if isinstance(infered, bases.Generator):
                 # Check if we are dealing with a function decorated
                 # with contextlib.contextmanager.
-                if decorated_with(infered.parent, ['contextlib.contextmanager']):
+                if decorated_with(infered.parent,
+                                  self.config.contextmanager_decorators):
                     continue
                 # If the parent of the generator is not the context manager itself,
                 # that means that it could have been returned from another
@@ -789,7 +799,8 @@ accessed. Python regular expressions are accepted.'}
                     scope = path.scope()
                     if not isinstance(scope, astroid.FunctionDef):
                         continue
-                    if decorated_with(scope, ['contextlib.contextmanager']):
+                    if decorated_with(scope,
+                                      self.config.contextmanager_decorators):
                         break
                 else:
                     self.add_message('not-context-manager',

--- a/pylint/test/unittest_checker_typecheck.py
+++ b/pylint/test/unittest_checker_typecheck.py
@@ -89,6 +89,23 @@ class TypeCheckerTest(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_attribute(node)
 
+    @set_config(contextmanager_decorators=('contextlib.contextmanager',
+                                           '.custom_contextmanager'))
+    def test_custom_context_manager(self):
+        """Test that @custom_contextmanager is recognized as configured."""
+        node = test_utils.extract_node('''
+        from contextlib import contextmanager
+        def custom_contextmanager(f):
+            return contextmanager(f)
+        @custom_contextmanager
+        def dec():
+            yield
+        with dec():
+            pass
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_with(node)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pylintrc
+++ b/pylintrc
@@ -273,6 +273,10 @@ ignored-classes=SQLObject, optparse.Values
 # expressions are accepted.
 generated-members=REQUEST,acl_users,aq_parent
 
+# List of decorators that create context managers from functions, such as
+# contextlib.contextmanager.
+contextmanager-decorators=contextlib.contextmanager
+
 
 [SPELLING]
 


### PR DESCRIPTION
This makes it possible to configure pylint to recognize backports of contextlib or other decorators similar to `@contextmanager` without the need for an explicit `#pylint disable=not-context-manager`.

Tested with a backport of contextlib from Python 3 onto Python 2 imported under a different name.

cc @dbaum who suggested making this configurable upstream.
