### PR TITLE
Add __div__ to special methods

### DIFF
--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -81,7 +81,7 @@ _SPECIAL_METHODS_PARAMS = {
         '__itruediv__', '__ifloordiv__', '__imod__', '__ilshift__',
         '__irshift__', '__iand__', '__ixor__', '__ior__', '__ipow__',
         '__setstate__', '__reduce_ex__', '__deepcopy__', '__cmp__',
-        '__matmul__', '__rmatmul__'),
+        '__matmul__', '__rmatmul__', '__div__'),
 
     2: ('__setattr__', '__get__', '__set__', '__setitem__'),
 


### PR DESCRIPTION
__div__ is used in python2 decimal and numbers packages as well as 3rd
party modules so treat it like the other special methods.

This should fix issue #807 and should also be backported to the 1.5.0 branch.
