### PR TITLE
UnittestLinter.is_message_enabled blows up when passed keyword arguments

### DIFF
--- a/pylint/testutils.py
+++ b/pylint/testutils.py
@@ -158,7 +158,7 @@ class UnittestLinter(object):
                     confidence=None):
         self._messages.append(Message(msg_id, line, node, args))
 
-    def is_message_enabled(self, *unused_args):
+    def is_message_enabled(self, *unused_args, **unused_kwargs):
         return True
 
     def add_stats(self, **kwargs):


### PR DESCRIPTION
I find that passing the line parameter of `is_message_enabled` by keyword makes the code more readable, and this seems to be done both [in Pylint code](https://github.com/PyCQA/pylint/blob/master/pylint/test/unittest_lint.py#L261) and in external content like @nedbat's [edx_lint](https://github.com/edx/edx-lint/blob/master/edx_lint/pylint/getattr_check.py#L63), but currently `UnittestLinter.is_message_enabled` doesn't allow keyword arguments, which is annoying when trying to test such lints.

This PR fixes that issue by just allowing and ignoring keyword arguments.