### PR TITLE
Implement __getitem__ on the Option class to beat type confusion.

### DIFF
--- a/pylint/config.py
+++ b/pylint/config.py
@@ -308,6 +308,9 @@ class Option(optparse.Option):
         return self.take_action(
             self.action, self.dest, opt, value, values, parser)
 
+    def __getitem__(self, key):
+        return getattr(self, key)
+
 
 class OptionParser(optparse.OptionParser):
 


### PR DESCRIPTION
Related to #819.

This adds the `__getitem__` method to the config.Option class which works around a failed conversion of the multiple_choice type somewhere down the line.