### PR TITLE
Unsuitable asteroid version needed while compiling pylint

### DIFF
--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -27,7 +27,7 @@ numversion = (2, 0, 0)
 version = '.'.join([str(num) for num in numversion])
 
 install_requires = [
-    'astroid >= 1.5.0,<1.6.0',
+    'astroid >= 1.2.0,<1.6.0',
     'six',
 ]
 


### PR DESCRIPTION
Issue:
https://github.com/PyCQA/pylint/issues/822

Steps to reproduce:
python setup.py install

Issue:
https://pypi.python.org/simple/astroid/ doesnot have asteroid version greater than 1.5.0.

Output:
Installing pylint script to /usr/local/bin
Installing epylint script to /usr/local/bin
Installing pyreverse script to /usr/local/bin
Installing pylint-gui script to /usr/local/bin
Installing symilar script to /usr/local/bin

Installed /Library/Python/2.7/site-packages/pylint-2.0.0-py2.7.egg
Processing dependencies for pylint==2.0.0
Searching for astroid>=1.5.0,<1.6.0
Reading http://pypi.python.org/simple/astroid/
No local packages or download links found for astroid>=1.5.0,<1.6.0
error: Could not find suitable distribution for Requirement.parse('astroid>=1.5.0,<1.6.0')
ROHSAINI-M-P03M:pylint rohitsaini$ ls
