### PR TITLE
Fixed Windows startup scripts so they redirect to the executable files generated by setuptools.

### DIFF
--- a/bin/epylint.bat
+++ b/bin/epylint.bat
@@ -2,4 +2,4 @@
 rem Use python to execute the python script having the same name as this batch
 rem file, but without any extension, located in the same directory as this
 rem batch file
-python "%~dpn0" %*
+"%~dpn0" %*

--- a/bin/pylint-gui.bat
+++ b/bin/pylint-gui.bat
@@ -2,4 +2,4 @@
 rem Use python to execute the python script having the same name as this batch
 rem file, but without any extension, located in the same directory as this
 rem batch file
-python "%~dpn0" %*
+"%~dpn0" %*

--- a/bin/pylint.bat
+++ b/bin/pylint.bat
@@ -2,4 +2,4 @@
 rem Use python to execute the python script having the same name as this batch
 rem file, but without any extension, located in the same directory as this
 rem batch file
-python "%~dpn0" %*
+"%~dpn0" %*

--- a/bin/pyreverse.bat
+++ b/bin/pyreverse.bat
@@ -2,4 +2,4 @@
 rem Use python to execute the python script having the same name as this batch
 rem file, but without any extension, located in the same directory as this
 rem batch file
-python "%~dpn0" %*
+"%~dpn0" %*

--- a/bin/symilar.bat
+++ b/bin/symilar.bat
@@ -2,4 +2,4 @@
 rem Use python to execute the python script having the same name as this batch
 rem file, but without any extension, located in the same directory as this
 rem batch file
-python "%~dpn0" %*
+"%~dpn0" %*


### PR DESCRIPTION
When deploying to Windows, the Python script files (ie: those with no file extensions) that would typically be deployed to Linux platforms are automatically converted to native executables. Those executables are then accompanied by batch files which were meant to act as a redirect on Windows to allow the system shell to run the extension-less files using the current Python interpreter. Unfortunately these scripts never took into account this conversion process that happens during deployment.

As such I've reworked the batch files so they simply redirect their calls to the native executable files that still share the same name as their batch file counterparts.