### PR TITLE
[ADD] bad-docstring-quotes and docstring-first-line-empty based on PEP 0257 - Docstring Conventions - triple double quotes and handling-docstring-indentation

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -84,4 +84,6 @@ Order doesn't matter (not that much, at least ;)
 
 * Łukasz Rogalski: invalid-length-returned
 
-* Moisés López: Support for deprecated-modules in modules not installed.
+* Moisés López (Vauxoo): Support for deprecated-modules in modules not installed.
+
+* Luis Escobar (Vauxoo), Moisés López (Vauxoo): Add bad-docstring-quotes and docstring-first-line-empty

--- a/pylint/extensions/check_docstring.py
+++ b/pylint/extensions/check_docstring.py
@@ -3,14 +3,13 @@ from pylint.interfaces import IAstroidChecker, HIGH
 from pylint.checkers.utils import check_messages
 
 
-class _BasicChecker(BaseChecker):
-    __implements__ = IAstroidChecker
-    name = 'basic'
-
-
-class DocStringAddicChecker(_BasicChecker):
+class DocStringAddicChecker(BaseChecker):
     """Checks format of docstrings based on PEP 0257
     """
+    __implements__ = IAstroidChecker
+    name = 'docstringaddic'
+
+
     msgs = {
         'C0198': ('Bad docstring quotes in %s, expected """, given %s',
                   'bad-docstring-quotes',

--- a/pylint/extensions/check_docstring.py
+++ b/pylint/extensions/check_docstring.py
@@ -1,3 +1,5 @@
+import linecache
+
 from pylint.checkers.base import BaseChecker
 from pylint.interfaces import IAstroidChecker, HIGH
 from pylint.checkers.utils import check_messages
@@ -38,12 +40,11 @@ class DocStringAddicChecker(BaseChecker):
             self.add_message('docstring-first-line-empty', node=node,
                              args=(node_type,), confidence=HIGH)
         # Bad Docstring Quotes
-        # I had to use "file_stream" because node.as_string() renders contents
+        # I had to use "linecache" because node.as_string() renders contents
         # of the file and change triple single quotes by triple double quotes
         elif docstring:
-            lineno = node.fromlineno
-            with open(node.root().file) as stream:
-                line = stream.readlines()[lineno].lstrip()
+            lineno = node.fromlineno + 1
+            line = linecache.getline(node.root().file,lineno).lstrip()
             if line and line.find('"""') == 0:
                 return
             if line and '\'\'\'' in line:

--- a/pylint/extensions/check_docstring.py
+++ b/pylint/extensions/check_docstring.py
@@ -9,7 +9,6 @@ class DocStringAddicChecker(BaseChecker):
     __implements__ = IAstroidChecker
     name = 'docstringaddic'
 
-
     msgs = {
         'C0198': ('Bad docstring quotes in %s, expected """, given %s',
                   'bad-docstring-quotes',
@@ -43,13 +42,18 @@ class DocStringAddicChecker(BaseChecker):
         # of the file and change triple single quotes by triple double quotes
         elif docstring:
             lineno = node.fromlineno
-            line = node.root().file_stream.readlines()[lineno].lstrip()
-            line = line.decode('utf-8')
+            with open(node.root().file) as stream:
+                line = stream.readlines()[lineno].lstrip()
             if line and line.find('"""') == 0:
                 return
-            quotes = line and '\'\'\'' in line and '\'\'\'' or line and \
-                line[0] == '"' and '"' or line and line[0] == '\'' and \
-                '\'' or False
+            if line and '\'\'\'' in line:
+                quotes = '\'\'\''
+            elif line and line[0] == '"':
+                quotes = '"'
+            elif line and line[0] == '\'':
+                quotes = '\''
+            else:
+                quotes = False
             if quotes:
                 self.add_message('bad-docstring-quotes', node=node,
                                  args=(node_type, quotes), confidence=HIGH)

--- a/pylint/extensions/check_docstring.py
+++ b/pylint/extensions/check_docstring.py
@@ -1,0 +1,65 @@
+from pylint.checkers.base import BaseChecker
+from pylint.interfaces import IAstroidChecker, HIGH
+from pylint.checkers.utils import check_messages
+
+
+class _BasicChecker(BaseChecker):
+    __implements__ = IAstroidChecker
+    name = 'basic'
+
+
+class DocStringAddicChecker(_BasicChecker):
+    """Checks format of docstrings based on PEP 0257
+    """
+    msgs = {
+        'C0198': ('Bad docstring quotes in %s, expected """, given %s',
+                  'bad-docstring-quotes',
+                  'Used when docstring do not have triple double quotes.'),
+        'C0199': ('First line empty in %s docstring',
+                  'docstring-first-line-empty',
+                  'Used when blank line from the beginning of the docstring.'),
+        }
+
+    @check_messages('docstring-first-line-empty', 'bad-docstring-quotes')
+    def visit_module(self, node):
+        self._check_docstring('module', node)
+
+    def visit_classdef(self, node):
+        self._check_docstring('class', node)
+
+    def visit_functiondef(self, node):
+        ftype = node.is_method() and 'method' or 'function'
+        self._check_docstring(ftype, node)
+
+    visit_asyncfunctiondef = visit_functiondef
+
+    def _check_docstring(self, node_type, node):
+        docstring = node.doc
+        # Docstring First Line Empty
+        if docstring and docstring[0] == '\n':
+            self.add_message('docstring-first-line-empty', node=node,
+                             args=(node_type,), confidence=HIGH)
+        # Bad Docstring Quotes
+        # I had to use "file_stream" because node.as_string() renders contents
+        # of the file and change triple single quotes by triple double quotes
+        elif docstring:
+            lineno = node.fromlineno
+            line = node.root().file_stream.readlines()[lineno].lstrip()
+            line = line.decode('utf-8')
+            if line and line.find('"""') == 0:
+                return
+            quotes = line and '\'\'\'' in line and '\'\'\'' or line and \
+                line[0] == '"' and '"' or line and line[0] == '\'' and \
+                '\'' or False
+            if quotes:
+                self.add_message('bad-docstring-quotes', node=node,
+                                 args=(node_type, quotes), confidence=HIGH)
+
+
+def register(linter):
+    """Required method to auto register this checker.
+
+    :param linter: Main interface object for Pylint plugins
+    :type linter: Pylint object
+    """
+    linter.register_checker(DocStringAddicChecker(linter))

--- a/pylint/extensions/check_docstring.py
+++ b/pylint/extensions/check_docstring.py
@@ -44,7 +44,7 @@ class DocStringAddicChecker(BaseChecker):
         # of the file and change triple single quotes by triple double quotes
         elif docstring:
             lineno = node.fromlineno + 1
-            line = linecache.getline(node.root().file,lineno).lstrip()
+            line = linecache.getline(node.root().file, lineno).lstrip()
             if line and line.find('"""') == 0:
                 return
             if line and '\'\'\'' in line:

--- a/pylint/test/extensions/data/docstring.py
+++ b/pylint/test/extensions/data/docstring.py
@@ -1,0 +1,43 @@
+"""Checks of Dosctrings 'docstring-first-line-empty' 'bad-docstring-quotes'"""
+
+
+def check_messages(*messages):
+    """docstring"""
+    return messages
+
+
+class FFFF(object):
+    """
+    Test Docstring First Line Empty
+    """
+
+    def method1(self):
+        '''Test Triple Single Quotes docstring
+        '''
+        pass
+
+    def method2(self):
+        "bad docstring 1"
+        pass
+
+    def method3(self):
+        'bad docstring 2'
+        pass
+
+    def method4(self):
+        ' """bad docstring 3 '
+        pass
+
+    @check_messages('bad-open-mode', 'redundant-unittest-assert',
+                    'deprecated-module')
+    def method5(self):
+        """Test OK 1 with decorators"""
+        pass
+
+    def method6(self):
+        r"""Test OK 2 with raw string"""
+        pass
+
+    def method7(self):
+        u"""Test OK 3 with unicode string"""
+        pass

--- a/pylint/test/extensions/data/docstring.py
+++ b/pylint/test/extensions/data/docstring.py
@@ -2,9 +2,13 @@
 
 
 def check_messages(*messages):
-    """docstring"""
+    """
+    docstring"""
     return messages
 
+def function2():
+    """Test Ok"""
+    pass
 
 class FFFF(object):
     """

--- a/pylint/test/extensions/test_docstring_add.py
+++ b/pylint/test/extensions/test_docstring_add.py
@@ -1,0 +1,60 @@
+"""Tests for the pylint checker in :mod:`pylint.extensions.check_docstring
+"""
+
+import os.path as osp
+import unittest
+
+from pylint import checkers
+from pylint.extensions.check_docstring import DocStringAddicChecker
+from pylint.lint import PyLinter
+from pylint.reporters import BaseReporter
+
+
+class TestReporter(BaseReporter):
+
+    def handle_message(self, msg):
+        self.messages.append(msg)
+
+    def on_set_current_module(self, module, filepath):
+        self.messages = []
+
+
+class CheckDocStringAddicTC(unittest.TestCase):
+
+    expected_msg = [
+        'First line empty in class docstring',
+        'Bad docstring quotes in method, expected """, given \'\'\'',
+        'Bad docstring quotes in method, expected """, given "',
+        'Bad docstring quotes in method, expected """, given \'',
+        'Bad docstring quotes in method, expected """, given \'',
+    ]
+    expected_symbol = [
+        'docstring-first-line-empty',
+        'bad-docstring-quotes',
+        'bad-docstring-quotes',
+        'bad-docstring-quotes',
+        'bad-docstring-quotes',
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        cls._linter = PyLinter()
+        cls._linter.set_reporter(TestReporter())
+        checkers.initialize(cls._linter)
+        cls._linter.register_checker(DocStringAddicChecker(cls._linter))
+
+    def test_docstring_message(self):
+        docstring_test = osp.join(osp.dirname(osp.abspath(__file__)), 'data',
+                                  'docstring.py')
+        self._linter.check([docstring_test])
+        msgs = self._linter.reporter.messages
+        self.assertEqual(len(msgs), 5)
+        for msg, expected_symbol, expected_msg in zip(msgs,
+                                                      self.expected_symbol,
+                                                      self.expected_msg):
+            self.assertEqual(msg.symbol, expected_symbol)
+            self.assertEqual(msg.msg, expected_msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pylint/test/extensions/test_docstring_add.py
+++ b/pylint/test/extensions/test_docstring_add.py
@@ -22,6 +22,7 @@ class TestReporter(BaseReporter):
 class CheckDocStringAddicTC(unittest.TestCase):
 
     expected_msg = [
+        'First line empty in function docstring',
         'First line empty in class docstring',
         'Bad docstring quotes in method, expected """, given \'\'\'',
         'Bad docstring quotes in method, expected """, given "',
@@ -29,6 +30,7 @@ class CheckDocStringAddicTC(unittest.TestCase):
         'Bad docstring quotes in method, expected """, given \'',
     ]
     expected_symbol = [
+        'docstring-first-line-empty',
         'docstring-first-line-empty',
         'bad-docstring-quotes',
         'bad-docstring-quotes',
@@ -48,7 +50,7 @@ class CheckDocStringAddicTC(unittest.TestCase):
                                   'docstring.py')
         self._linter.check([docstring_test])
         msgs = self._linter.reporter.messages
-        self.assertEqual(len(msgs), 5)
+        self.assertEqual(len(msgs), 6)
         for msg, expected_symbol, expected_msg in zip(msgs,
                                                       self.expected_symbol,
                                                       self.expected_msg):


### PR DESCRIPTION
The [pep-0257-specification](https://www.python.org/dev/peps/pep-0257/#specification):
```multiline
For consistency, always use """triple double quotes""" around docstrings.
Use r"""raw triple double quotes""" if you use any backslashes in your docstrings.
For Unicode docstrings, use u"""Unicode triple-quoted strings""" .
```

- [handling-docstring-indentation](https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation)

![pep 0257 docstring conventions python org](https://cloud.githubusercontent.com/assets/6644187/14358804/42e95b9e-fcb4-11e5-8ab3-da301e36e03d.png)

They give us a good code:
```python
# Since code is much more precise than words, here is an implementation of the algorithm:

def trim(docstring):
    if not docstring:
        return ''
    # Convert tabs to spaces (following the normal Python rules)
    # and split into a list of lines:
    lines = docstring.expandtabs().splitlines()
    # Determine minimum indentation (first line doesn't count):
    indent = sys.maxint
    for line in lines[1:]:
        stripped = line.lstrip()
        if stripped:
            indent = min(indent, len(line) - len(stripped))
    # Remove indentation (first line is special):
    trimmed = [lines[0].strip()]
    if indent < sys.maxint:
        for line in lines[1:]:
            trimmed.append(line[indent:].rstrip())
    # Strip off trailing and leading blank lines:
    while trimmed and not trimmed[-1]:
        trimmed.pop()
    while trimmed and not trimmed[0]:
        trimmed.pop(0)
    # Return a single string:
    return '\n'.join(trimmed)
```