### PR TITLE
 [REF] import-checkers: Use of isort

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -84,6 +84,7 @@ Order doesn't matter (not that much, at least ;)
 
 * Łukasz Rogalski: invalid-length-returned
 
-* Moisés López (Vauxoo): Support for deprecated-modules in modules not installed.
+* Moisés López (Vauxoo): Support for deprecated-modules in modules not installed,
+  Refactory wrong-import-order to integrate it with `isort` library.
 
 * Luis Escobar (Vauxoo), Moisés López (Vauxoo): Add bad-docstring-quotes and docstring-first-line-empty

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,14 @@ Installation should be as simple as ::
 
     python -m pip install astroid
 
+Pylint requires isort package (the later the better).
+
+* https://github.com/timothycrosley/isort
+
+Installation should be as simple as ::
+
+    python -m pip install isort
+
 
 If you want to install from a source distribution, extract the tarball and run
 the following commands ::

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -29,6 +29,7 @@ version = '.'.join([str(num) for num in numversion])
 install_requires = [
     'astroid >= 1.5.0,<1.6.0',
     'six',
+    'isort >= 4.2.5',
 ]
 
 if sys.platform == 'win32':

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -516,21 +516,23 @@ given file (report RP0402 must not be disabled)'}
             if import_category in ('FUTURE', 'STDLIB'):
                 std_imports.append((node, package))
                 wrong_import = extern_imports or local_imports
+                if self._is_fallback_import(node, wrong_import):
+                    continue
                 if wrong_import:
                     self.add_message('wrong-import-order', node=node,
                                      args=('standard import "%s"' % node.as_string(),
                                            '"%s"' % wrong_import[0][0].as_string()))
-            elif import_category == 'THIRDPARTY':
+            elif import_category in ('FIRSTPARTY', 'THIRDPARTY'):
                 extern_imports.append((node, package))
                 wrong_import = local_imports
                 if wrong_import:
                     self.add_message('wrong-import-order', node=node,
                                      args=('external import "%s"' % node.as_string(),
                                            '"%s"' % wrong_import[0][0].as_string()))
-            elif import_category in ('FIRSTPARTY', 'LOCALFOLDER'):
+            elif import_category == 'LOCALFOLDER':
                 local_imports.append((node, package))
             else:
-                raise BaseException('Bad import category %s', import_category)
+                raise ValueError('Bad import category %s', import_category)
 
         return std_imports, extern_imports, local_imports
 

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -531,9 +531,6 @@ given file (report RP0402 must not be disabled)'}
                                            '"%s"' % wrong_import[0][0].as_string()))
             elif import_category == 'LOCALFOLDER':
                 local_imports.append((node, package))
-            else:
-                raise ValueError('Bad import category %s', import_category)
-
         return std_imports, extern_imports, local_imports
 
     def _get_imported_module(self, importnode, modname):

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -224,6 +224,11 @@ MSGS = {
               'Used when code and imports are mixed'),
     }
 
+
+DEFAULT_STANDARD_LIBRARY = ()
+DEFAULT_KNOWN_THIRD_PARTY = ('enchant',)
+
+
 class ImportsChecker(BaseChecker):
     """checks for
     * external modules dependencies
@@ -270,6 +275,21 @@ given file (report RP0402 must not be disabled)'}
                  'help' : 'Create a graph of internal dependencies in the \
 given file (report RP0402 must not be disabled)'}
                ),
+               ('known-standard-library',
+                {'default': DEFAULT_STANDARD_LIBRARY,
+                 'type': 'csv',
+                 'metavar': '<modules>',
+                 'help': 'Force import order to recognize a module as part of' \
+                         ' the standard compatibility libraries.'}
+               ),
+               ('known-third-party',
+                {'default': DEFAULT_KNOWN_THIRD_PARTY,
+                 'type': 'csv',
+                 'metavar': '<modules>',
+                 'help': 'Force import order to recognize a module as part of' \
+                         ' a third party library.'}
+               ),
+
               )
 
     def __init__(self, linter=None):
@@ -483,8 +503,10 @@ given file (report RP0402 must not be disabled)'}
         extern_imports = []
         local_imports = []
         std_imports = []
-        # TODO: Add parameters to known libraries category
-        isort_obj = isort.SortImports(file_contents='')
+        isort_obj = isort.SortImports(
+            file_contents='', known_third_party=self.config.known_third_party,
+            known_standard_library=self.config.known_standard_library,
+        )
         for node, modname in self._imports_stack:
             package = modname.split('.')[0]
             import_category = isort_obj.place_module(package)

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -486,7 +486,10 @@ given file (report RP0402 must not be disabled)'}
         """Record the package `node` imports from"""
         importedname = importedmodnode.name if importedmodnode else None
         if not importedname:
-            importedname = node.names[0][0].split('.')[0]
+            if isinstance(node, astroid.ImportFrom):
+                importedname = node.modname
+            else:
+                importedname = node.names[0][0].split('.')[0]
         self._imports_stack.append((node, importedname))
 
     @staticmethod

--- a/pylint/test/functional/import_error.py
+++ b/pylint/test/functional/import_error.py
@@ -1,5 +1,5 @@
 """ Test that import errors are detected. """
-# pylint: disable=invalid-name, unused-import, no-absolute-import, bare-except, broad-except
+# pylint: disable=invalid-name, unused-import, no-absolute-import, bare-except, broad-except, wrong-import-order
 import totally_missing # [import-error]
 
 try:

--- a/pylint/test/functional/reimported.py
+++ b/pylint/test/functional/reimported.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring,unused-import,import-error, wildcard-import,unused-wildcard-import,redefined-builtin,no-name-in-module,ungrouped-imports
+# pylint: disable=missing-docstring,unused-import,import-error, wildcard-import,unused-wildcard-import,redefined-builtin,no-name-in-module,ungrouped-imports,wrong-import-order
 
 from time import sleep, sleep # [reimported]
 from lala import missing, missing # [reimported]

--- a/pylint/test/functional/super_checks.py
+++ b/pylint/test/functional/super_checks.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-few-public-methods,import-error, no-absolute-import,missing-docstring, wrong-import-position,invalid-name
+# pylint: disable=too-few-public-methods,import-error, no-absolute-import,missing-docstring, wrong-import-position,invalid-name, wrong-import-order
 """check use of super"""
 
 from unknown import Missing

--- a/pylint/test/input/func_w0404.py
+++ b/pylint/test/input/func_w0404.py
@@ -9,7 +9,7 @@ from xml.etree import ElementTree
 from email import encoders
 import email.encoders
 
-import sys  #pylint: disable=ungrouped-imports
+import sys  #pylint: disable=ungrouped-imports,wrong-import-order
 __revision__ = 0
 
 def no_reimport():

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skip_missing_interpreters = true
 [testenv:pylint]
 deps =
    git+https://github.com/PyCQA/astroid@master
+   isort
 
 commands = pylint -rn --rcfile={toxinidir}/pylintrc {envsitepackagesdir}/pylint
 
@@ -12,6 +13,7 @@ commands = pylint -rn --rcfile={toxinidir}/pylintrc {envsitepackagesdir}/pylint
 deps =
    git+https://github.com/PyCQA/astroid@master
    coverage
+   isort
 
 setenv =
     COVERAGE_FILE = {toxinidir}/.coverage.{envname}


### PR DESCRIPTION
 - [x] Migrate imports to isort
 - [x] Add known libraries options.
 - [x] Fix red
 - [x] Add new isort package for setup depends
 - [x] Fix https://github.com/PyCQA/pylint/issues/875
 - [x] Fix https://github.com/PyCQA/pylint/issues/876