### PR TITLE
[ADD] mccabe: Add check for mccabe complexity cyclomatic threshold

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -85,7 +85,8 @@ Order doesn't matter (not that much, at least ;)
 * Łukasz Rogalski: invalid-length-returned
 
 * Moisés López (Vauxoo): Support for deprecated-modules in modules not installed,
-  Refactory wrong-import-order to integrate it with `isort` library.
+  Refactory wrong-import-order to integrate it with `isort` library
+  Add check too-complex with mccabe for cyclomatic complexity
 
 * Luis Escobar (Vauxoo), Moisés López (Vauxoo): Add bad-docstring-quotes and docstring-first-line-empty
 

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -30,6 +30,7 @@ install_requires = [
     'astroid >= 1.5.0,<1.6.0',
     'six',
     'isort >= 4.2.5',
+    'mccabe ==  0.4.0',
 ]
 
 if sys.platform == 'win32':

--- a/pylint/extensions/check_mccabe.py
+++ b/pylint/extensions/check_mccabe.py
@@ -9,13 +9,13 @@ from pylint.checkers.utils import check_messages
 from pylint.interfaces import HIGH, IAstroidChecker
 
 
-class MethodMcCabeChecker(BaseChecker):
+class McCabeMethodChecker(BaseChecker):
     """Checks McCabe complexity cyclomatic threshold in methods and functions
     to validate a too complex code.
     """
 
     __implements__ = IAstroidChecker
-    name = 'methodmccabechecker'
+    name = 'design'
 
     msgs = {
         'R1260': (
@@ -26,7 +26,6 @@ class MethodMcCabeChecker(BaseChecker):
     }
     options = (
         ('max-complexity', {
-            'group': 'design',
             'default': 10,
             'type': 'int',
             'metavar': '<int>',
@@ -37,7 +36,7 @@ class MethodMcCabeChecker(BaseChecker):
     @staticmethod
     def _get_ast_tree(node):
         """Get a compile python tree of nodes from code"""
-        # TODO: Check if astroid get build a similar tree
+        # TODO: Check if astroid build a similar tree
         code = node.as_string()
         tree = compile(code, '', "exec", ast.PyCF_ONLY_AST)
         return tree
@@ -69,4 +68,4 @@ def register(linter):
     :param linter: Main interface object for Pylint plugins
     :type linter: Pylint object
     """
-    linter.register_checker(MethodMcCabeChecker(linter))
+    linter.register_checker(McCabeMethodChecker(linter))

--- a/pylint/extensions/check_mccabe.py
+++ b/pylint/extensions/check_mccabe.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module to add McCabe checker class for pylint. """
 
 from mccabe import PathGraph as Mccabe_PathGraph, \
@@ -142,8 +141,9 @@ class McCabeMethodChecker(BaseChecker):
         }),
     )
 
-    def _check_too_complex(self, node):
-        """Check too complex rating and
+    @check_messages('too-complex')
+    def visit_module(self, node):
+        """visit an astroid.Module node to check too complex rating and
         add message if is greather than max_complexity stored from options"""
         visitor = PathGraphingAstVisitor()
         for child in node.body:
@@ -160,11 +160,6 @@ class McCabeMethodChecker(BaseChecker):
             self.add_message(
                 'too-complex', node=node, confidence=HIGH,
                 args=(node_name, complexity))
-
-    @check_messages('too-complex')
-    def visit_module(self, node):
-        """visit an astroid.Module node"""
-        self._check_too_complex(node)
 
 
 def register(linter):

--- a/pylint/extensions/check_mccabe.py
+++ b/pylint/extensions/check_mccabe.py
@@ -60,19 +60,11 @@ class PathGraphingAstVisitor(Mccabe_PathGraphingAstVisitor):
         visitPass = visitContinue = visitBreak = visitGlobal = visitReturn = \
         visitExpr = visitAwait = visitSimpleStatement
 
-    def visitIf(self, node):
-        name = "If %d" % node.lineno
-        self._subgraph(node, name)
-
-    def visitTryExcept(self, node):
-        name = "TryExcept %d" % node.lineno
-        self._subgraph(node, name, extra_blocks=node.handlers)
-
-    visitTry = visitTryExcept
-
     def visitWith(self, node):
         self._append_node(node)
         self.dispatch_list(node.body)
+
+    visitAsyncWith = visitWith
 
     def _append_node(self, node):
         if not self.tail:

--- a/pylint/extensions/check_mccabe.py
+++ b/pylint/extensions/check_mccabe.py
@@ -19,7 +19,7 @@ class MethodMcCabeChecker(BaseChecker):
 
     msgs = {
         'R1260': (
-            '%s is too complex. The McCabe rating is greather than %d',
+            '%s is too complex. The McCabe rating is %d',
             'too-complex',
             'Used when a method or function is too complex based on '
             'McCabe Complexity Cyclomatic'),
@@ -35,24 +35,25 @@ class MethodMcCabeChecker(BaseChecker):
     )
 
     @staticmethod
-    def _get_ast_tree(code):
+    def _get_ast_tree(node):
         """Get a compile python tree of nodes from code"""
         # TODO: Check if astroid get build a similar tree
+        code = node.as_string()
         tree = compile(code, '', "exec", ast.PyCF_ONLY_AST)
         return tree
 
     def _check_too_complex(self, node):
         """Check too complex rating and
         add message if is greather than max_complexity stored from options"""
-        tree = self._get_ast_tree(node.as_string())
+        tree = self._get_ast_tree(node)
         max_complexity = self.config.max_complexity
         McCabeChecker.max_complexity = max_complexity
         results = McCabeChecker(tree, '').run()
-        if len(list(results)):
-            # TODO: Get mccabe rating
+        for _, _, msg, _ in results:
+            mccabe_rating = int(msg[msg.index('(') + 1:msg.index(')')])
             self.add_message(
                 'too-complex', node=node, confidence=HIGH,
-                args=(node.name, max_complexity - 1)
+                args=(node.name, mccabe_rating)
             )
 
     @check_messages('too-complex')

--- a/pylint/extensions/check_mccabe.py
+++ b/pylint/extensions/check_mccabe.py
@@ -20,8 +20,8 @@ class PathGraphingAstVisitor(Mccabe_PathGraphingAstVisitor):
         self._bottom_counter = 0
 
     def default(self, node, *args):
-        # We don't need original 'iter_child_nodes(node)' here
-        pass
+        for child in node.get_children():
+            self.dispatch(child, *args)
 
     def dispatch(self, node, *args):
         self.node = node

--- a/pylint/extensions/check_mccabe.py
+++ b/pylint/extensions/check_mccabe.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""Module to add McCabe checker class for pylint. """
+
+import ast
+
+from mccabe import McCabeChecker
+from pylint.checkers.base import BaseChecker
+from pylint.checkers.utils import check_messages
+from pylint.interfaces import HIGH, IAstroidChecker
+
+
+class MethodMcCabeChecker(BaseChecker):
+    """Checks McCabe complexity cyclomatic threshold in methods and functions
+    to validate a too complex code.
+    """
+
+    __implements__ = IAstroidChecker
+    name = 'methodmccabechecker'
+
+    msgs = {
+        'R1260': (
+            '%s is too complex. The McCabe rating is greather than %d',
+            'too-complex',
+            'Used when a method or function is too complex based on '
+            'McCabe Complexity Cyclomatic'),
+    }
+    options = (
+        ('max-complexity', {
+            'group': 'design',
+            'default': 10,
+            'type': 'int',
+            'metavar': '<int>',
+            'help': 'McCabe complexity cyclomatic threshold',
+        }),
+    )
+
+    @staticmethod
+    def _get_ast_tree(code):
+        """Get a compile python tree of nodes from code"""
+        # TODO: Check if astroid get build a similar tree
+        tree = compile(code, '', "exec", ast.PyCF_ONLY_AST)
+        return tree
+
+    def _check_too_complex(self, node):
+        """Check too complex rating and
+        add message if is greather than max_complexity stored from options"""
+        tree = self._get_ast_tree(node.as_string())
+        max_complexity = self.config.max_complexity
+        McCabeChecker.max_complexity = max_complexity
+        results = McCabeChecker(tree, '').run()
+        if len(list(results)):
+            # TODO: Get mccabe rating
+            self.add_message(
+                'too-complex', node=node, confidence=HIGH,
+                args=(node.name, max_complexity - 1)
+            )
+
+    @check_messages('too-complex')
+    def visit_functiondef(self, node):
+        """visit an astroid.Function node"""
+        self._check_too_complex(node)
+    visit_asyncfunctiondef = visit_functiondef
+
+
+def register(linter):
+    """Required method to auto register this checker.
+
+    :param linter: Main interface object for Pylint plugins
+    :type linter: Pylint object
+    """
+    linter.register_checker(MethodMcCabeChecker(linter))

--- a/pylint/extensions/check_mccabe.py
+++ b/pylint/extensions/check_mccabe.py
@@ -128,7 +128,7 @@ class McCabeMethodChecker(BaseChecker):
 
     msgs = {
         'R1260': (
-            '%s is too complex. The McCabe rating is %d',
+            "'%s' is too complex. The McCabe rating is %d",
             'too-complex',
             'Used when a method or function is too complex based on '
             'McCabe Complexity Cyclomatic'),
@@ -154,7 +154,7 @@ class McCabeMethodChecker(BaseChecker):
             if node.is_function:
                 node_name = node.name
             else:
-                node_name = "'%s %d'" % (node.__class__.__name__, node.lineno)
+                node_name = "%s %d" % (node.__class__.__name__, node.lineno)
             if complexity <= self.config.max_complexity:
                 continue
             self.add_message(

--- a/pylint/extensions/check_mccabe.py
+++ b/pylint/extensions/check_mccabe.py
@@ -150,11 +150,16 @@ class McCabeMethodChecker(BaseChecker):
             visitor.preorder(child, visitor)
         for graph in visitor.graphs.values():
             complexity = graph.complexity()
-            if complexity >= self.config.max_complexity:
-                node = graph.root
-                self.add_message(
-                    'too-complex', node=node, confidence=HIGH,
-                    args=(node.name, complexity))
+            node = graph.root
+            if node.is_function:
+                node_name = node.name
+            else:
+                node_name = "'%s %d'" % (node.__class__.__name__, node.lineno)
+            if complexity <= self.config.max_complexity:
+                continue
+            self.add_message(
+                'too-complex', node=node, confidence=HIGH,
+                args=(node_name, complexity))
 
     @check_messages('too-complex')
     def visit_module(self, node):

--- a/pylint/extensions/check_mccabe.py
+++ b/pylint/extensions/check_mccabe.py
@@ -119,7 +119,7 @@ class McCabeMethodChecker(BaseChecker):
 
     msgs = {
         'R1260': (
-            "'%s' is too complex. The McCabe rating is %d",
+            "%s is too complex. The McCabe rating is %d",
             'too-complex',
             'Used when a method or function is too complex based on '
             'McCabe Complexity Cyclomatic'),
@@ -143,10 +143,10 @@ class McCabeMethodChecker(BaseChecker):
         for graph in visitor.graphs.values():
             complexity = graph.complexity()
             node = graph.root
-            if node.is_function:
-                node_name = node.name
+            if hasattr(node, 'name'):
+                node_name = "'%s'" % node.name
             else:
-                node_name = "%s %d" % (node.__class__.__name__, node.lineno)
+                node_name = "This '%s'" % node.__class__.__name__.lower()
             if complexity <= self.config.max_complexity:
                 continue
             self.add_message(

--- a/pylint/extensions/check_mccabe.py
+++ b/pylint/extensions/check_mccabe.py
@@ -3,10 +3,130 @@
 
 import ast
 
-from mccabe import McCabeChecker
+from mccabe import McCabeChecker, PathGraph as PathGraphAstroid, PathGraphingAstVisitor
 from pylint.checkers.base import BaseChecker
 from pylint.checkers.utils import check_messages
 from pylint.interfaces import HIGH, IAstroidChecker
+
+
+class PathGraph(PathGraphAstroid):
+    def __init__(self, node):
+        super(PathGraph, self).__init__(name='', entity='', lineno=1)
+        self.root = node
+
+
+class McCabeASTVisitor(PathGraphingAstVisitor):
+    def __init__(self):
+        super(McCabeASTVisitor, self).__init__()
+        self.node = None
+        self._cache = {}
+        self.classname = ""
+        self.graphs = {}
+        self.reset()
+        self._bottom_counter = 0
+
+    def default(self, node, *args):
+        pass
+
+    def dispatch(self, node, *args):
+        self.node = node
+        klass = node.__class__
+        meth = self._cache.get(klass)
+        if meth is None:
+            className = klass.__name__
+            meth = getattr(self.visitor, 'visit' + className, self.default)
+            self._cache[klass] = meth
+        return meth(node, *args)
+
+    def visitFunctionDef(self, node):
+        if self.graph is not None:
+            # closure
+            pathnode = self._append_node(node)
+            self.tail = pathnode
+            self.dispatch_list(node.body)
+            bottom = "%s" % self._bottom_counter
+            self._bottom_counter += 1
+            self.graph.connect(self.tail, bottom)
+            self.graph.connect(node, bottom)
+            self.tail = bottom
+        else:
+            self.graph = PathGraph(node)
+            self.tail = node
+            self.dispatch_list(node.body)
+            self.graphs["%s%s" % (self.classname, node.name)] = self.graph
+            self.reset()
+
+    visitAsyncFunctionDef = visitFunctionDef
+
+    def preorder(self, tree, visitor, *args):
+        """Do preorder walk of tree using visitor"""
+        self.visitor = visitor
+        visitor.visit = self.dispatch
+        self.dispatch(tree, *args)
+
+    def visitSimpleStatement(self, node):
+        self._append_node(node)
+
+    visitAssert = visitAssign = visitAugAssign = visitDelete = visitPrint = \
+            visitRaise = visitYield = visitImport = visitCall = visitSubscript = \
+            visitPass = visitContinue = visitBreak = visitGlobal = visitReturn = \
+            visitExpr = visitAwait = visitSimpleStatement
+
+    def visitIf(self, node):
+        name = "If %d" % node.lineno
+        self._subgraph(node, name)
+
+    def visitTryExcept(self, node):
+        name = "TryExcept %d" % node.lineno
+        self._subgraph(node, name, extra_blocks=node.handlers)
+
+    visitTry = visitTryExcept
+
+    def visitWith(self, node):
+        self._append_node(node)
+        self.dispatch_list(node.body)
+
+    def _append_node(self, node):
+        if not self.tail:
+            return
+        self.graph.connect(self.tail, node)
+        self.tail = node
+        return node
+
+    def _subgraph(self, node, name, extra_blocks=()):
+        """create the subgraphs representing any `if` and `for` statements"""
+        if self.graph is None:
+            # global loop
+            self.graph = PathGraph(node)
+            self._subgraph_parse(node, extra_blocks)
+            self.graphs["%s%s" % (self.classname, name)] = self.graph
+            self.reset()
+        else:
+            self._append_node(node)
+            self._subgraph_parse(node, extra_blocks)
+
+    def _subgraph_parse(self, node, extra_blocks):  # pylint: disable=arguments-differ
+        """parse the body and any `else` block of `if` and `for` statements"""
+        loose_ends = []
+        self.tail = node
+        self.dispatch_list(node.body)
+        loose_ends.append(self.tail)
+        for extra in extra_blocks:
+            self.tail = node
+            self.dispatch_list(extra.body)
+            loose_ends.append(self.tail)
+        if node.orelse:
+            self.tail = node
+            self.dispatch_list(node.orelse)
+            loose_ends.append(self.tail)
+        else:
+            loose_ends.append(node)
+        if node:
+            bottom = "%s" % self._bottom_counter
+            self._bottom_counter += 1
+            for le in loose_ends:
+                self.graph.connect(le, bottom)
+            self.tail = bottom
 
 
 class McCabeMethodChecker(BaseChecker):
@@ -41,7 +161,7 @@ class McCabeMethodChecker(BaseChecker):
         tree = compile(code, '', "exec", ast.PyCF_ONLY_AST)
         return tree
 
-    def _check_too_complex(self, node):
+    def _check_too_complex_deprecated(self, node):
         """Check too complex rating and
         add message if is greather than max_complexity stored from options"""
         tree = self._get_ast_tree(node)
@@ -55,11 +175,30 @@ class McCabeMethodChecker(BaseChecker):
                 args=(node.name, mccabe_rating)
             )
 
+    def _check_too_complex(self, node):
+        """Check too complex rating and
+        add message if is greather than max_complexity stored from options"""
+        visitor = McCabeASTVisitor()
+        for child in node.body:
+            visitor.preorder(child, visitor)
+        for graph in visitor.graphs.values():
+            complexity = graph.complexity()
+            if complexity >= self.config.max_complexity:
+                node = graph.root
+                self.add_message(
+                    'too-complex', node=node,
+                    args=(node.name, complexity))
+
     @check_messages('too-complex')
-    def visit_functiondef(self, node):
-        """visit an astroid.Function node"""
+    def visit_module(self, node):
+        """visit an astroid.Module node"""
         self._check_too_complex(node)
-    visit_asyncfunctiondef = visit_functiondef
+
+    # @check_messages('too-complex')
+    # def visit_functiondef(self, node):
+    #     """visit an astroid.Function node"""
+    #     self._check_too_complex(node)
+    # visit_asyncfunctiondef = visit_functiondef
 
 
 def register(linter):

--- a/pylint/test/extensions/data/mccabe.py
+++ b/pylint/test/extensions/data/mccabe.py
@@ -130,7 +130,6 @@ class MyClass1(object):
 
     def method2(self, param1):
         """McCabe rating: 18"""
-        # FIXME: Should be the rate of 18 but is 12
         if not param1:
             pass
         pass
@@ -202,5 +201,4 @@ def method3(self):
             pass
     finally:
         pass
-    # FIXME: If you delete the `return` the mccabe increase of 1 to 2 in pylint? (flake8 even is 2)
     return True

--- a/pylint/test/extensions/data/mccabe.py
+++ b/pylint/test/extensions/data/mccabe.py
@@ -119,3 +119,19 @@ def f10():
             return myint
         return myint
     return myint
+
+
+class MyClass1(object):
+    """Class of example to test mccabe"""
+    def method1():
+        """McCabe rating: 1"""
+        pass
+
+
+for count in range(10):
+    if count == 1:
+        exit(0)
+    elif count == 2:
+        exit(1)
+    else:
+        exit(2)

--- a/pylint/test/extensions/data/mccabe.py
+++ b/pylint/test/extensions/data/mccabe.py
@@ -123,6 +123,7 @@ def f10():
 
 class MyClass1(object):
     """Class of example to test mccabe"""
+    _name = 'MyClass'  # To force a tail.node=None
 
     def method1():
         """McCabe rating: 1"""

--- a/pylint/test/extensions/data/mccabe.py
+++ b/pylint/test/extensions/data/mccabe.py
@@ -1,0 +1,121 @@
+"""Checks use of "too-complex" check"""
+
+
+def f1():
+    """McCabe rating: 1"""
+    pass
+
+
+def f2(n):
+    """McCabe rating: 1"""
+    k = n + 4
+    s = k + n
+    return s
+
+
+def f3(n):
+    """McCabe rating: 3"""
+    if n > 3:
+        return "bigger than three"
+    elif n > 4:
+        return "is never executed"
+    else:
+        return "smaller than or equal to three"
+
+
+def f4():
+    """McCabe rating: 2"""
+    for i in range(10):
+        print(i)
+
+
+def f5(mylist):
+    """McCabe rating: 2"""
+    for i in mylist:
+        print(i)
+    else:
+        print(None)
+
+
+def f6(n):
+    """McCabe rating: 2"""
+    if n > 4:
+        return f(n - 1)
+    else:
+        return n
+
+
+def f7():
+    """McCabe rating: 3"""
+    def b():
+        """McCabe rating: 2"""
+        def c():
+            """McCabe rating: 1"""
+            pass
+        c()
+    b()
+
+
+def f8():
+    """McCabe rating: 4"""
+    try:
+        print(1)
+    except TypeA:
+        print(2)
+    except TypeB:
+        print(3)
+    else:
+        print(4)
+
+
+def f9():
+    """McCabe rating: 9"""
+    myint = 2
+    if myint > 5:
+        pass
+    else:
+        if myint <= 5:
+            pass
+        else:
+            myint = 3
+            if myint > 2:
+                if myint > 3:
+                    pass
+                elif myint == 3:
+                    pass
+                elif myint < 3:
+                    pass
+                else:
+                    if myint:
+                        pass
+            else:
+                if myint:
+                    pass
+                myint = 4
+
+
+def f10():
+    """McCabe rating: 11"""
+    myint = 2
+    if myint == 5:
+        return myint
+    elif myint == 6:
+        return myint
+    elif myint == 7:
+        return myint
+    elif myint == 8:
+        return myint
+    elif myint == 9:
+        return myint
+    elif myint == 10:
+        if myint == 8:
+            while True:
+                return True
+        elif myint == 8:
+            with myint:
+                return 8
+    else:
+        if myint == 2:
+            return myint
+        return myint
+    return myint

--- a/pylint/test/extensions/data/mccabe.py
+++ b/pylint/test/extensions/data/mccabe.py
@@ -123,9 +123,66 @@ def f10():
 
 class MyClass1(object):
     """Class of example to test mccabe"""
+
     def method1():
         """McCabe rating: 1"""
         pass
+
+    def method2(self, param1):
+        """McCabe rating: 18"""
+        # FIXME: Should be the rate of 18 but is 12
+        if not param1:
+            pass
+        pass
+        if param1:
+            pass
+        else:
+            pass
+
+        pass
+
+        if param1:
+            pass
+        if param1:
+            pass
+        if param1:
+            pass
+        if param1:
+            pass
+        if param1:
+            pass
+        if param1:
+            pass
+        if param1:
+            for value in range(5):
+                pass
+
+        pass
+        for count in range(6):
+            with open('myfile') as fp:
+                count += 1
+            pass
+        pass
+        try:
+            pass
+            if not param1:
+                pass
+            else:
+                pass
+            if param1:
+                raise BaseException('Error')
+            with open('myfile2') as fp2:
+                pass
+            pass
+        finally:
+            if param1 is not None:
+                pass
+            for count2 in range(8):
+                try:
+                    pass
+                except (OSError, IOError), exc:
+                    pass
+        return param1
 
 
 for count in range(10):
@@ -135,3 +192,15 @@ for count in range(10):
         exit(1)
     else:
         exit(2)
+
+
+def method3(self):
+    try:
+        if True:
+            pass
+        else:
+            pass
+    finally:
+        pass
+    # FIXME: If you delete the `return` the mccabe increase of 1 to 2 in pylint? (flake8 even is 2)
+    return True

--- a/pylint/test/extensions/data/mccabe.py
+++ b/pylint/test/extensions/data/mccabe.py
@@ -179,7 +179,7 @@ class MyClass1(object):
             for count2 in range(8):
                 try:
                     pass
-                except (OSError, IOError), exc:
+                except BaseException('Error2'):
                     pass
         return param1
 

--- a/pylint/test/extensions/test_check_mccabe.py
+++ b/pylint/test/extensions/test_check_mccabe.py
@@ -23,18 +23,20 @@ class TestMcCabeMethodChecker(unittest.TestCase):
     """Test McCabe Method Checker"""
 
     expected_msgs = [
-        'f1 is too complex. The McCabe rating is 1',
-        'f2 is too complex. The McCabe rating is 1',
-        'f3 is too complex. The McCabe rating is 3',
-        'f4 is too complex. The McCabe rating is 2',
-        'f5 is too complex. The McCabe rating is 2',
-        'f6 is too complex. The McCabe rating is 2',
-        'f7 is too complex. The McCabe rating is 3',
-        'f8 is too complex. The McCabe rating is 4',
-        'f9 is too complex. The McCabe rating is 9',
-        'f10 is too complex. The McCabe rating is 11',
-        'method1 is too complex. The McCabe rating is 1',
-        "'For 131' is too complex. The McCabe rating is 4",
+        "'f1' is too complex. The McCabe rating is 1",
+        "'f2' is too complex. The McCabe rating is 1",
+        "'f3' is too complex. The McCabe rating is 3",
+        "'f4' is too complex. The McCabe rating is 2",
+        "'f5' is too complex. The McCabe rating is 2",
+        "'f6' is too complex. The McCabe rating is 2",
+        "'f7' is too complex. The McCabe rating is 3",
+        "'f8' is too complex. The McCabe rating is 4",
+        "'f9' is too complex. The McCabe rating is 9",
+        "'f10' is too complex. The McCabe rating is 11",
+        "'method1' is too complex. The McCabe rating is 1",
+        "'method2' is too complex. The McCabe rating is 18",
+        "'For 187' is too complex. The McCabe rating is 4",
+        "'method3' is too complex. The McCabe rating is 2",
     ]
 
     @classmethod

--- a/pylint/test/extensions/test_check_mccabe.py
+++ b/pylint/test/extensions/test_check_mccabe.py
@@ -22,7 +22,7 @@ class TestReporter(BaseReporter):
 class TestMcCabeMethodChecker(unittest.TestCase):
     """Test McCabe Method Checker"""
 
-    expected_msg = [
+    expected_msgs = [
         'f1 is too complex. The McCabe rating is 1',
         'f2 is too complex. The McCabe rating is 1',
         'f3 is too complex. The McCabe rating is 3',
@@ -30,13 +30,10 @@ class TestMcCabeMethodChecker(unittest.TestCase):
         'f5 is too complex. The McCabe rating is 2',
         'f6 is too complex. The McCabe rating is 2',
         'f7 is too complex. The McCabe rating is 3',
-        'b is too complex. The McCabe rating is 2',
-        'c is too complex. The McCabe rating is 1',
         'f8 is too complex. The McCabe rating is 4',
         'f9 is too complex. The McCabe rating is 9',
         'f10 is too complex. The McCabe rating is 11',
     ]
-    expected_symbol = ['too-complex'] * len(expected_msg)
 
     @classmethod
     def setUpClass(cls):
@@ -52,13 +49,8 @@ class TestMcCabeMethodChecker(unittest.TestCase):
         mccabe_test = osp.join(
             osp.dirname(osp.abspath(__file__)), 'data', 'mccabe.py')
         self._linter.check([mccabe_test])
-        msgs = self._linter.reporter.messages
-        self.assertEqual(len(msgs), len(self.expected_msg))
-        for msg, expected_symbol, expected_msg in zip(msgs,
-                                                      self.expected_symbol,
-                                                      self.expected_msg):
-            self.assertEqual(msg.symbol, expected_symbol)
-            self.assertEqual(msg.msg, expected_msg)
+        real_msgs = [message.msg for message in self._linter.reporter.messages]
+        self.assertEqual(sorted(self.expected_msgs), sorted(real_msgs))
 
 
 if __name__ == '__main__':

--- a/pylint/test/extensions/test_check_mccabe.py
+++ b/pylint/test/extensions/test_check_mccabe.py
@@ -33,6 +33,8 @@ class TestMcCabeMethodChecker(unittest.TestCase):
         'f8 is too complex. The McCabe rating is 4',
         'f9 is too complex. The McCabe rating is 9',
         'f10 is too complex. The McCabe rating is 11',
+        'method1 is too complex. The McCabe rating is 1',
+        "'For 131' is too complex. The McCabe rating is 4",
     ]
 
     @classmethod

--- a/pylint/test/extensions/test_check_mccabe.py
+++ b/pylint/test/extensions/test_check_mccabe.py
@@ -32,11 +32,11 @@ class TestMcCabeMethodChecker(unittest.TestCase):
         "'f7' is too complex. The McCabe rating is 3",
         "'f8' is too complex. The McCabe rating is 4",
         "'f9' is too complex. The McCabe rating is 9",
-        "'f10' is too complex. The McCabe rating is 11",
         "'method1' is too complex. The McCabe rating is 1",
-        "'method2' is too complex. The McCabe rating is 18",
         "This 'for' is too complex. The McCabe rating is 4",
         "'method3' is too complex. The McCabe rating is 2",
+        "'f10' is too complex. The McCabe rating is 11",
+        "'method2' is too complex. The McCabe rating is 18",
     ]
 
     @classmethod
@@ -47,14 +47,22 @@ class TestMcCabeMethodChecker(unittest.TestCase):
         cls._linter.register_checker(McCabeMethodChecker(cls._linter))
         cls._linter.disable('all')
         cls._linter.enable('too-complex')
-        cls._linter.global_set_option('max-complexity', 0)
+
+    def setUp(self):
+        self.fname_mccabe_example = osp.join(
+            osp.dirname(osp.abspath(__file__)), 'data', 'mccabe.py')
 
     def test_too_complex_message(self):
-        mccabe_test = osp.join(
-            osp.dirname(osp.abspath(__file__)), 'data', 'mccabe.py')
-        self._linter.check([mccabe_test])
+        self._linter.global_set_option('max-complexity', 0)
+        self._linter.check([self.fname_mccabe_example])
         real_msgs = [message.msg for message in self._linter.reporter.messages]
         self.assertEqual(sorted(self.expected_msgs), sorted(real_msgs))
+
+    def test_max_mccabe_rate(self):
+        self._linter.global_set_option('max-complexity', 9)
+        self._linter.check([self.fname_mccabe_example])
+        real_msgs = [message.msg for message in self._linter.reporter.messages]
+        self.assertEqual(sorted(self.expected_msgs[-2:]), sorted(real_msgs))
 
 
 if __name__ == '__main__':

--- a/pylint/test/extensions/test_check_mccabe.py
+++ b/pylint/test/extensions/test_check_mccabe.py
@@ -35,7 +35,7 @@ class TestMcCabeMethodChecker(unittest.TestCase):
         "'f10' is too complex. The McCabe rating is 11",
         "'method1' is too complex. The McCabe rating is 1",
         "'method2' is too complex. The McCabe rating is 18",
-        "'For 187' is too complex. The McCabe rating is 4",
+        "This 'for' is too complex. The McCabe rating is 4",
         "'method3' is too complex. The McCabe rating is 2",
     ]
 

--- a/pylint/test/extensions/test_check_mccabe.py
+++ b/pylint/test/extensions/test_check_mccabe.py
@@ -5,7 +5,7 @@ import os.path as osp
 import unittest
 
 from pylint import checkers
-from pylint.extensions.check_mccabe import McCabeMethodChecker
+from pylint.extensions.check_mccabe import register
 from pylint.lint import PyLinter
 from pylint.reporters import BaseReporter
 
@@ -44,7 +44,7 @@ class TestMcCabeMethodChecker(unittest.TestCase):
         cls._linter = PyLinter()
         cls._linter.set_reporter(TestReporter())
         checkers.initialize(cls._linter)
-        cls._linter.register_checker(McCabeMethodChecker(cls._linter))
+        register(cls._linter)
         cls._linter.disable('all')
         cls._linter.enable('too-complex')
 

--- a/pylint/test/extensions/test_check_mccabe.py
+++ b/pylint/test/extensions/test_check_mccabe.py
@@ -1,0 +1,65 @@
+"""Tests for the pylint checker in :mod:`pylint.extensions.check_mccabe
+"""
+
+import os.path as osp
+import unittest
+
+from pylint import checkers
+from pylint.extensions.check_mccabe import McCabeMethodChecker
+from pylint.lint import PyLinter
+from pylint.reporters import BaseReporter
+
+
+class TestReporter(BaseReporter):
+
+    def handle_message(self, msg):
+        self.messages.append(msg)
+
+    def on_set_current_module(self, module, filepath):
+        self.messages = []
+
+
+class TestMcCabeMethodChecker(unittest.TestCase):
+    """Test McCabe Method Checker"""
+
+    expected_msg = [
+        'f1 is too complex. The McCabe rating is 1',
+        'f2 is too complex. The McCabe rating is 1',
+        'f3 is too complex. The McCabe rating is 3',
+        'f4 is too complex. The McCabe rating is 2',
+        'f5 is too complex. The McCabe rating is 2',
+        'f6 is too complex. The McCabe rating is 2',
+        'f7 is too complex. The McCabe rating is 3',
+        'b is too complex. The McCabe rating is 2',
+        'c is too complex. The McCabe rating is 1',
+        'f8 is too complex. The McCabe rating is 4',
+        'f9 is too complex. The McCabe rating is 9',
+        'f10 is too complex. The McCabe rating is 11',
+    ]
+    expected_symbol = ['too-complex'] * len(expected_msg)
+
+    @classmethod
+    def setUpClass(cls):
+        cls._linter = PyLinter()
+        cls._linter.set_reporter(TestReporter())
+        checkers.initialize(cls._linter)
+        cls._linter.register_checker(McCabeMethodChecker(cls._linter))
+        cls._linter.disable('all')
+        cls._linter.enable('too-complex')
+        cls._linter.global_set_option('max-complexity', 0)
+
+    def test_too_complex_message(self):
+        mccabe_test = osp.join(
+            osp.dirname(osp.abspath(__file__)), 'data', 'mccabe.py')
+        self._linter.check([mccabe_test])
+        msgs = self._linter.reporter.messages
+        self.assertEqual(len(msgs), len(self.expected_msg))
+        for msg, expected_symbol, expected_msg in zip(msgs,
+                                                      self.expected_symbol,
+                                                      self.expected_msg):
+            self.assertEqual(msg.symbol, expected_symbol)
+            self.assertEqual(msg.msg, expected_msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
    git+https://github.com/PyCQA/astroid@master
    coverage
    isort
+   mccabe
 
 setenv =
     COVERAGE_FILE = {toxinidir}/.coverage.{envname}


### PR DESCRIPTION
- [x] Add new check
- [x] Add rating value in pylint message
- [x] Check if astroid get build a node tree (without compile) [Asked here](https://github.com/PyCQA/pylint/pull/877#discussion_r60832314)
- [x] Add tests


Integrate a new check to verify the [cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) of a code with mccabe 

Other python Checker QA [flake8](https://flake8.readthedocs.org/en/latest/#quickstart) have this check.

```bash
flake8 offers an extra option: 
  –max-complexity, which will emit a warning 
       if the McCabe complexity of a function is higher than the value. 
       By default it’s deactivated

$ flake8 --max-complexity 12 coolproject
coolproject/mod.py:939:1: C901 'Checker.check_all' is too complex (12)
coolproject/mod.py:1204:1: C901 'selftest' is too complex (14)
```