### PR TITLE
permit the user to specify module's name together with the file path

### DIFF
--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -13,17 +13,9 @@
 # You should have received a copy of the GNU General Public License along with
 # this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-""" %prog [options] module_or_package
+"""%prog [options] path
 
-  Check that a module satisfies a coding standard (and more !).
-
-    %prog --help
-
-  Display this help message and exit.
-
-    %prog --help-msg <msg-id>[,<msg-id>]
-
-  Display help messages about given message identifiers and exit.
+Check python code for coding standard, static error, and coding style.
 """
 from __future__ import print_function
 
@@ -54,6 +46,12 @@ from pylint.reporters.ureports import nodes as report_nodes
 
 
 MANAGER = astroid.MANAGER
+USAGE = __doc__ + """
+Argument:
+  path                  Package name, full module name, file path, or full
+                        module name alongside with the file path separated
+                        by the system-specific search path delimiter (e.g.
+                        module.name{0}/path/to/file.py.)""".format(os.pathsep)
 
 
 def _get_new_args(message):
@@ -452,7 +450,7 @@ class PyLinter(config.OptionsManagerMixIn,
         utils.MessagesHandlerMixIn.__init__(self)
         utils.ReportsHandlerMixIn.__init__(self)
         super(PyLinter, self).__init__(
-            usage=__doc__,
+            usage=USAGE,
             version=full_version,
             config_file=pylintrc or config.PYLINTRC)
         checkers.BaseTokenChecker.__init__(self)

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -718,7 +718,6 @@ class MessagesStore(object):
             print(msg.format_help(checkerref=False))
         print("")
 
-
 class ReportsHandlerMixIn(object):
     """a mix-in class containing all the reports and stats manipulation
     related methods for the main lint class
@@ -805,7 +804,11 @@ def _basename_in_blacklist_re(base_name, black_list_re):
 
 def expand_modules(files_or_modules, black_list, black_list_re):
     """take a list of files/modules/packages and return the list of tuple
-    (file, module name) which have to be actually checked
+    (file, module name) which have to be actually checked.
+
+    You might also provide the full module name alongside with the
+    file to be checked. Ex.: package.module.name:/path/to/file.py.
+    This prevent us from guessing the module name from the file path.
     """
     result = []
     errors = []
@@ -820,6 +823,8 @@ def expand_modules(files_or_modules, black_list, black_list_re):
                 filepath = join(something, '__init__.py')
             else:
                 filepath = something
+        elif os.pathsep in something:
+            modname, filepath = something.split(os.pathsep)
         else:
             # suppose it's a module or package
             modname = something


### PR DESCRIPTION
This would solve the relative import problem happening with linter-pylint of Atom editor: https://github.com/AtomLinter/linter-pylint/issues/110

The trouble is that linter-pylint copy the file to be analyzed to a temporary folder for which pylint/astroid infer as being a standalone script, whereas it is actually a module inside a package.

##### Pipeline

1. Users wants to lint the file /PROJECT/PYPACKAGE/PYMODULE.py
2. linter-pylint copies it to a temporary folder (to properly support linting while the user is still typing some code, I suppose).
3. linter-pylint would then call: pylint PYPACKAGE.PYMODULE:/tmp/PYMODULE.py

Thereby preventing astroid to guess PYMODULE's full name.


