### PR TITLE
[FIX] wrong-import-order: Fix detect local imports

### DIFF
--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -490,6 +490,8 @@ given file (report RP0402 must not be disabled)'}
                 importedname = node.modname
             else:
                 importedname = node.names[0][0].split('.')[0]
+        if node.as_string().startswith('from .'):
+            importedname = '.' + importedname
         self._imports_stack.append((node, importedname))
 
     @staticmethod
@@ -511,7 +513,11 @@ given file (report RP0402 must not be disabled)'}
             known_standard_library=self.config.known_standard_library,
         )
         for node, modname in self._imports_stack:
-            package = modname.split('.')[0]
+            if modname.startswith('.'):
+                package = '.' + modname.split('.')[1]
+            else:
+                package = modname.split('.')[0]
+
             import_category = isort_obj.place_module(package)
             if import_category in ('FUTURE', 'STDLIB'):
                 std_imports.append((node, package))

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -490,7 +490,15 @@ given file (report RP0402 must not be disabled)'}
                 importedname = node.modname
             else:
                 importedname = node.names[0][0].split('.')[0]
-        if node.as_string().startswith('from .'):
+        if isinstance(node, astroid.ImportFrom) and \
+                node.as_string().startswith('from .'):
+            # We need the impotedname with first point to detect local package
+            # Example of node:
+            #  'from .my_package1 import MyClass1'
+            #  the output should be '.my_package1' instead of 'my_package1'
+            # Example of node:
+            #  'from . import my_package2'
+            #  the output should be '.my_package2' instead of '{pyfile}'
             importedname = '.' + importedname
         self._imports_stack.append((node, importedname))
 

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -490,8 +490,7 @@ given file (report RP0402 must not be disabled)'}
                 importedname = node.modname
             else:
                 importedname = node.names[0][0].split('.')[0]
-        if isinstance(node, astroid.ImportFrom) and \
-                node.as_string().startswith('from .'):
+        if isinstance(node, astroid.ImportFrom) and (node.level or 0) >= 1:
             # We need the impotedname with first point to detect local package
             # Example of node:
             #  'from .my_package1 import MyClass1'

--- a/pylint/test/functional/wrong_import_order.py
+++ b/pylint/test/functional/wrong_import_order.py
@@ -1,5 +1,5 @@
 """Checks import order rule"""
-# pylint: disable=unused-import,relative-import,ungrouped-imports,import-error
+# pylint: disable=unused-import,relative-import,ungrouped-imports,import-error,no-name-in-module
 try:
     from six.moves import configparser
 except ImportError:
@@ -11,5 +11,9 @@ from astroid import are_exclusive
 import sys  # [wrong-import-order]
 import datetime  # [wrong-import-order]
 import unused_import
-import totally_missing
-import astroid
+from .package import Class
+import totally_missing  # [wrong-import-order]
+from . import package
+import astroid  # [wrong-import-order]
+from . import package2
+from .package2 import Class2

--- a/pylint/test/functional/wrong_import_order.py
+++ b/pylint/test/functional/wrong_import_order.py
@@ -1,5 +1,5 @@
 """Checks import order rule"""
-# pylint: disable=unused-import,relative-import,ungrouped-imports,import-error,no-name-in-module
+# pylint: disable=unused-import,relative-import,ungrouped-imports,import-error,no-name-in-module,relative-beyond-top-level
 try:
     from six.moves import configparser
 except ImportError:
@@ -17,3 +17,4 @@ from . import package
 import astroid  # [wrong-import-order]
 from . import package2
 from .package2 import Class2
+from ..package3 import Class3

--- a/pylint/test/functional/wrong_import_order.txt
+++ b/pylint/test/functional/wrong_import_order.txt
@@ -1,3 +1,5 @@
 wrong-import-order:9::standard import "import os.path" comes before "from six.moves import configparser"
 wrong-import-order:11::standard import "import sys" comes before "from six.moves import configparser"
 wrong-import-order:12::standard import "import datetime" comes before "from six.moves import configparser"
+wrong-import-order:15::external import "import totally_missing" comes before "from .package import Class"
+wrong-import-order:17::external import "import astroid" comes before "from .package import Class"

--- a/pylint/test/functional/wrong_import_order2.py
+++ b/pylint/test/functional/wrong_import_order2.py
@@ -1,0 +1,16 @@
+"""Checks import order rule in a right case"""
+# pylint: disable=unused-import,relative-import,ungrouped-imports,import-error,no-name-in-module
+
+
+# Standard imports
+import os
+from sys import argv
+
+# external imports
+import lxml
+
+from six import moves
+
+# local_imports
+from . import my_package
+from .my_package import myClass

--- a/pylint/test/input/func_w0233.py
+++ b/pylint/test/input/func_w0233.py
@@ -1,4 +1,4 @@
-# pylint: disable=R0903,W0212,W0403,W0406,no-absolute-import
+# pylint: disable=R0903,W0212,W0403,W0406,no-absolute-import,wrong-import-order
 """test for call to __init__ from a non ancestor class
 """
 from __future__ import print_function


### PR DESCRIPTION
The value node.modname for `from . import package`
or `from .package import Class`
returns `package`
But `isort` needs `.package` to detect a local import.