### PR TITLE
Show fatal messages when disabling no-error messages

### DIFF
--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -581,7 +581,8 @@ class PyLinter(config.OptionsManagerMixIn,
 
     def disable_noerror_messages(self):
         for msgcat, msgids in six.iteritems(self.msgs_store._msgs_by_category):
-            if msgcat == 'E':
+            # enable only messages with 'error' severity and above ('fatal')
+            if msgcat in ['E', 'F']:
                 for msgid in msgids:
                     self.enable(msgid)
             else:
@@ -696,9 +697,8 @@ class PyLinter(config.OptionsManagerMixIn,
         # get needed checkers
         neededcheckers = [self]
         for checker in self.get_checkers()[1:]:
-            # fatal errors should not trigger enable / disabling a checker
             messages = set(msg for msg in checker.msgs
-                           if msg[0] != 'F' and self.is_message_enabled(msg))
+                           if self.is_message_enabled(msg))
             if (messages or
                     any(self.report_is_enabled(r[0]) for r in checker.reports)):
                 neededcheckers.append(checker)


### PR DESCRIPTION
Currently 'pylint -E' disables all no-error messages. Instead,
it should disable messages types which severity is lower than
error.