### PR TITLE
[ADD] .github: Add standard folder .github to add github templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please read here the [contribute doc](https://github.com/PyCQA/pylint/blob/master/doc/contribute.rst)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+### Steps to reproduce
+1. 
+2. 
+3. 
+
+### Current behavior
+
+
+### Expected behavior
+
+
+### pylint --version output
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,2 @@
+### Fixes / new features
+- 


### PR DESCRIPTION
- Auto fill a template format for issues and pull request of github
- Add a contributing link in issues.

Example:
![guidelines](https://cloud.githubusercontent.com/assets/6644187/15222075/aeb27dd4-1833-11e6-9023-3b995c06cb4f.png)
