### PR TITLE
Fix mailto URIs

### DIFF
--- a/man/pylint.1
+++ b/man/pylint.1
@@ -307,7 +307,7 @@ been issued by analysing pylint output status code
 
 .SH BUGS
 Please report bugs on the project's mailing list:
-mailto://code-quality@python.org
+mailto:code-quality@python.org
 
 .SH AUTHOR
 Logilab <python-projects@lists.logilab.org>

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -42,7 +42,7 @@ if sys.version_info[0] == 2:
 license = 'GPL'
 description = "python code static checker"
 web = 'http://www.pylint.org'
-mailinglist = "mailto://code-quality@python.org"
+mailinglist = "mailto:code-quality@python.org"
 author = 'Logilab'
 author_email = 'python-projects@lists.logilab.org'
 


### PR DESCRIPTION
As per RFC 6068, there should be no slashes after `mailto:`.