### PR TITLE
Added return docstring checking to check_docs

### DIFF
--- a/pylint/extensions/check_docs.py
+++ b/pylint/extensions/check_docs.py
@@ -49,6 +49,9 @@ class DocstringChecker(BaseChecker):
         'W9006': ('"%s" not documented as being raised',
                   'missing-raises-doc',
                   'Please document exceptions for all raised exception types.'),
+        'W9007': ('Missing return type documentation',
+                  'missing-returns-doc',
+                  'Please add documentation about what this method returns.'),
     }
 
     options = (('accept-no-param-doc',
@@ -62,6 +65,12 @@ class DocstringChecker(BaseChecker):
                  'help': 'Whether to accept totally missing raises'
                          'documentation in a docstring of a function that'
                          'raises an exception.'
+                }),
+               ('accept-no-return-doc',
+                {'default': True, 'type' : 'yn', 'metavar' : '<y or n>',
+                 'help': 'Whether to accept totally missing return'
+                         'documentation in a docstring of a function that'
+                         'returns a statement.'
                 }),
               )
 
@@ -114,6 +123,24 @@ class DocstringChecker(BaseChecker):
         found_excs = doc.exceptions()
         missing_excs = expected_excs - found_excs
         self._add_raise_message(missing_excs, func_node)
+
+    def visit_return(self, node):
+        if node.value is None:
+            return
+
+        func_node = node.frame()
+        if not isinstance(func_node, astroid.FunctionDef):
+            return
+
+        doc = utils.docstringify(func_node.doc)
+        if not doc.is_valid() and self.config.accept_no_return_doc:
+            return
+
+        if not doc.has_returns():
+            self.add_message(
+                'missing-returns-doc',
+                node=func_node
+            )
 
     def check_arguments_in_docstring(self, doc, arguments_node, warning_node,
                                      accept_no_param_doc=None):

--- a/pylint/extensions/check_docs.py
+++ b/pylint/extensions/check_docs.py
@@ -47,7 +47,7 @@ class DocstringChecker(BaseChecker):
                   'multiple-constructor-doc',
                   'Please remove parameter declarations in the class or constructor.'),
         'W9006': ('"%s" not documented as being raised',
-                  'missing-raise-doc',
+                  'missing-raises-doc',
                   'Please document exceptions for all raised exception types.'),
     }
 

--- a/pylint/test/extensions/test_check_return_docs.py
+++ b/pylint/test/extensions/test_check_return_docs.py
@@ -1,0 +1,234 @@
+"""Unit tests for the return documentation checking in the
+`DocstringChecker` in :mod:`pylint.extensions.check_docs`
+"""
+from __future__ import division, print_function, absolute_import
+
+import unittest
+
+import astroid
+from astroid import test_utils
+from pylint.testutils import CheckerTestCase, Message, set_config
+
+from pylint.extensions.check_docs import DocstringChecker
+
+
+class DocstringCheckerReturnTest(CheckerTestCase):
+    """Tests for pylint_plugin.RaiseDocChecker"""
+    CHECKER_CLASS = DocstringChecker
+
+    def test_ignores_no_docstring(self):
+        return_node = test_utils.extract_node('''
+        def my_func(self):
+            return False #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_return(return_node)
+
+    @set_config(accept_no_return_doc=False)
+    def test_warns_no_docstring(self):
+        node = test_utils.extract_node('''
+        def my_func(self):
+            return False
+        ''')
+        return_node = node.body[0]
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-returns-doc',
+                node=node)):
+            self.checker.visit_return(return_node)
+
+    def test_ignores_unknown_style(self):
+        return_node = test_utils.extract_node('''
+        def my_func(self):
+            """This is a docstring."""
+            return False #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_return(return_node)
+
+    def test_warn_partial_sphinx_returns(self):
+        node = test_utils.extract_node('''
+        def my_func(self):
+            """This is a docstring.
+
+            :returns: Always False
+            """
+            return False
+        ''')
+        return_node = node.body[0]
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-returns-doc',
+                node=node)):
+            self.checker.visit_return(return_node)
+
+    def test_warn_partial_sphinx_returns_type(self):
+        node = test_utils.extract_node('''
+        def my_func(self):
+            """This is a docstring.
+
+            :rtype: bool
+            """
+            return False
+        ''')
+        return_node = node.body[0]
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-returns-doc',
+                node=node)):
+            self.checker.visit_return(return_node)
+
+    def test_warn_missing_sphinx_returns(self):
+        node = test_utils.extract_node('''
+        def my_func(self, doc_type):
+            """This is a docstring.
+
+            :param doc_type: Sphinx
+            :type doc_type: str
+            """
+            return False
+        ''')
+        return_node = node.body[0]
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-returns-doc',
+                node=node)):
+            self.checker.visit_return(return_node)
+
+    def test_warn_partial_google_returns(self):
+        node = test_utils.extract_node('''
+        def my_func(self):
+            """This is a docstring.
+
+            Returns:
+                Always False
+            """
+            return False
+        ''')
+        return_node = node.body[0]
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-returns-doc',
+                node=node)):
+            self.checker.visit_return(return_node)
+
+    def test_warn_missing_google_returns(self):
+        node = test_utils.extract_node('''
+        def my_func(self, doc_type):
+            """This is a docstring.
+
+            Parameters:
+                doc_type (str): Google
+            """
+            return False
+        ''')
+        return_node = node.body[0]
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-returns-doc',
+                node=node)):
+            self.checker.visit_return(return_node)
+
+    def test_warn_missing_numpy_returns(self):
+        node = test_utils.extract_node('''
+        def my_func(self, doc_type):
+            """This is a docstring.
+
+            Arguments
+            ---------
+            doc_type : str
+                Numpy
+            """
+            return False
+        ''')
+        return_node = node.body[0]
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-returns-doc',
+                node=node)):
+            self.checker.visit_return(return_node)
+
+    def test_find_sphinx_returns(self):
+        return_node = test_utils.extract_node('''
+        def my_func(self):
+            """This is a docstring.
+
+            :return: Always False
+            :rtype: bool
+            """
+            return False #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_return(return_node)
+
+    def test_find_google_returns(self):
+        return_node = test_utils.extract_node('''
+        def my_func(self):
+            """This is a docstring.
+
+            Returns:
+                bool: Always False
+            """
+            return False #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_return(return_node)
+
+    def test_find_numpy_returns(self):
+        return_node = test_utils.extract_node('''
+        def my_func(self):
+            """This is a docstring.
+
+            Returns
+            -------
+            bool
+                Always False
+            """
+            return False #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_return(return_node)
+
+    def test_ignores_sphinx_return_none(self):
+        return_node = test_utils.extract_node('''
+        def my_func(self, doc_type):
+            """This is a docstring.
+
+            :param doc_type: Sphinx
+            :type doc_type: str
+            """
+            return #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_return(return_node)
+
+    def test_ignores_google_return_none(self):
+        return_node = test_utils.extract_node('''
+        def my_func(self, doc_type):
+            """This is a docstring.
+
+            Args:
+                doc_type (str): Google
+            """
+            return #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_return(return_node)
+
+    def test_ignores_numpy_return_none(self):
+        return_node = test_utils.extract_node('''
+        def my_func(self, doc_type):
+            """This is a docstring.
+
+            Arguments
+            ---------
+            doc_type : str
+                Numpy
+            """
+            return #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_return(return_node)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds checking that a docstring documents information about what is returned in the method when the method returns a statement.

If no docstring exists then a warning will be raised. The user has the option to turn this off with the `accept_no_return_doc` option.