### PR TITLE
Check docs improvements

### DIFF
--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -183,7 +183,7 @@ class GoogleDocstring(Docstring):
     )
 
     re_param_line = re.compile(r"""
-        \s*  (\w+)                    # identifier
+        \s*  \*{0,2}(\w+)             # identifier potentially with asterisks
         \s*  ( [(] .*? [)] )? \s* :   # optional type declaration
         \s*  ( \w+ )?                 # beginning of optional description
     """, re.X)

--- a/pylint/extensions/check_docs.py
+++ b/pylint/extensions/check_docs.py
@@ -193,10 +193,10 @@ class DocstringChecker(BaseChecker):
             self.not_needed_param_in_docstring.copy())
 
         if arguments_node.vararg is not None:
-            expected_argument_names.append(arguments_node.vararg)
+            expected_argument_names.add(arguments_node.vararg)
             not_needed_type_in_docstring.add(arguments_node.vararg)
         if arguments_node.kwarg is not None:
-            expected_argument_names.append(arguments_node.kwarg)
+            expected_argument_names.add(arguments_node.kwarg)
             not_needed_type_in_docstring.add(arguments_node.kwarg)
         params_with_doc, params_with_type = doc.match_param_docs()
 

--- a/pylint/test/extensions/test_check_docs.py
+++ b/pylint/test/extensions/test_check_docs.py
@@ -913,6 +913,46 @@ class ParamDocCheckerTest(CheckerTestCase):
                 args=('missing_kwonly', ))):
             self.checker.visit_functiondef(node)
 
+    def test_warns_missing_args(self):
+        node = test_utils.extract_node('''
+        def my_func(named_arg, *args):
+            """The docstring
+
+            :param named_arg: Returned
+            :type named_arg: object
+            :returns: Maybe named_arg
+            :rtype: object or None
+            """
+            if args:
+                return named_arg
+        ''')
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-param-doc',
+                node=node,
+                args=('args',))):
+            self.checker.visit_functiondef(node)
+
+    def test_warns_missing_kwargs(self):
+        node = test_utils.extract_node('''
+        def my_func(named_arg, **kwargs):
+            """The docstring
+
+            :param named_arg: Returned
+            :type named_arg: object
+            :returns: Maybe named_arg
+            :rtype: object or None
+            """
+            if args:
+                return named_arg
+        ''')
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-param-doc',
+                node=node,
+                args=('kwargs',))):
+            self.checker.visit_functiondef(node)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pylint/test/extensions/test_check_docs.py
+++ b/pylint/test/extensions/test_check_docs.py
@@ -913,7 +913,7 @@ class ParamDocCheckerTest(CheckerTestCase):
                 args=('missing_kwonly', ))):
             self.checker.visit_functiondef(node)
 
-    def test_warns_missing_args(self):
+    def test_warns_missing_args_sphinx(self):
         node = test_utils.extract_node('''
         def my_func(named_arg, *args):
             """The docstring
@@ -933,7 +933,7 @@ class ParamDocCheckerTest(CheckerTestCase):
                 args=('args',))):
             self.checker.visit_functiondef(node)
 
-    def test_warns_missing_kwargs(self):
+    def test_warns_missing_kwargs_sphinx(self):
         node = test_utils.extract_node('''
         def my_func(named_arg, **kwargs):
             """The docstring
@@ -943,7 +943,7 @@ class ParamDocCheckerTest(CheckerTestCase):
             :returns: Maybe named_arg
             :rtype: object or None
             """
-            if args:
+            if kwargs:
                 return named_arg
         ''')
         with self.assertAddsMessages(
@@ -951,6 +951,214 @@ class ParamDocCheckerTest(CheckerTestCase):
                 msg_id='missing-param-doc',
                 node=node,
                 args=('kwargs',))):
+            self.checker.visit_functiondef(node)
+
+    def test_warns_missing_args_google(self):
+        node = test_utils.extract_node('''
+        def my_func(named_arg, *args):
+            """The docstring
+
+            Args:
+                named_arg (object): Returned
+
+            Returns:
+                object or None: Maybe named_arg
+            """
+            if args:
+                return named_arg
+        ''')
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-param-doc',
+                node=node,
+                args=('args',))):
+            self.checker.visit_functiondef(node)
+
+    def test_warns_missing_kwargs_google(self):
+        node = test_utils.extract_node('''
+        def my_func(named_arg, **kwargs):
+            """The docstring
+
+            Args:
+                named_arg (object): Returned
+
+            Returns:
+                object or None: Maybe named_arg
+            """
+            if kwargs:
+                return named_arg
+        ''')
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-param-doc',
+                node=node,
+                args=('kwargs',))):
+            self.checker.visit_functiondef(node)
+
+    def test_warns_missing_args_numpy(self):
+        node = test_utils.extract_node('''
+        def my_func(named_arg, *args):
+            """The docstring
+
+            Args
+            ----
+            named_arg : object
+                Returned
+
+            Returns
+            -------
+                object or None
+                    Maybe named_arg
+            """
+            if args:
+                return named_arg
+        ''')
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-param-doc',
+                node=node,
+                args=('args',))):
+            self.checker.visit_functiondef(node)
+
+    def test_warns_missing_kwargs_numpy(self):
+        node = test_utils.extract_node('''
+        def my_func(named_arg, **kwargs):
+            """The docstring
+
+            Args
+            ----
+            named_arg : object
+                Returned
+
+            Returns
+            -------
+                object or None
+                    Maybe named_arg
+            """
+            if kwargs:
+                return named_arg
+        ''')
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-param-doc',
+                node=node,
+                args=('kwargs',))):
+            self.checker.visit_functiondef(node)
+
+    def test_finds_args_without_type_sphinx(self):
+        node = test_utils.extract_node('''
+        def my_func(named_arg, *args):
+            """The docstring
+
+            :param named_arg: Returned
+            :type named_arg: object
+            :param args: Optional arguments
+            :returns: Maybe named_arg
+            :rtype: object or None
+            """
+            if args:
+                return named_arg
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
+
+    def test_finds_kwargs_without_type_sphinx(self):
+        node = test_utils.extract_node('''
+        def my_func(named_arg, **kwargs):
+            """The docstring
+
+            :param named_arg: Returned
+            :type named_arg: object
+            :param kwargs: Keyword arguments
+            :returns: Maybe named_arg
+            :rtype: object or None
+            """
+            if kwargs:
+                return named_arg
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
+
+    def test_finds_args_without_type_google(self):
+        node = test_utils.extract_node('''
+        def my_func(named_arg, *args):
+            """The docstring
+
+            Args:
+                named_arg (object): Returned
+                *args: Optional arguments
+
+            Returns:
+                object or None: Maybe named_arg
+            """
+            if args:
+                return named_arg
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
+
+    def test_finds_kwargs_without_type_google(self):
+        node = test_utils.extract_node('''
+        def my_func(named_arg, **kwargs):
+            """The docstring
+
+            Args:
+                named_arg (object): Returned
+                **kwargs: Keyword arguments
+
+            Returns:
+                object or None: Maybe named_arg
+            """
+            if kwargs:
+                return named_arg
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
+
+    def test_finds_args_without_type_numpy(self):
+        node = test_utils.extract_node('''
+        def my_func(named_arg, *args):
+            """The docstring
+
+            Args
+            ----
+            named_arg : object
+                Returned
+            args :
+                Optional Arguments
+
+            Returns
+            -------
+                object or None
+                    Maybe named_arg
+            """
+            if args:
+                return named_arg
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
+
+    def test_finds_kwargs_without_type_numpy(self):
+        node = test_utils.extract_node('''
+        def my_func(named_arg, **kwargs):
+            """The docstring
+
+            Args
+            ----
+            named_arg : object
+                Returned
+            kwargs :
+                Keyword arguments
+
+            Returns
+            -------
+                object or None
+                    Maybe named_arg
+            """
+            if kwargs:
+                return named_arg
+        ''')
+        with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
 


### PR DESCRIPTION
This fixes a couple of bugs in check_docs.

Linting docstrings with args and kwargs failed because we were still using list operations on variables that were converted to sets. There are now tests for linting the docstring of methods that are args or kwargs.

Google docstrings allow asterisks at the start of args and kwargs in docstrings. We weren't taking this into account. So it would try to match "*args" against "args" and "**kwargs" against "kwargs" and fail. There are now tests for this as well.