### PR TITLE
Cache some expensive computations

### DIFF
--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -719,23 +719,31 @@ def supports_delitem(value):
 
 
 # TODO(cpopa): deprecate these or leave them as aliases?
+_INFERENCE_CACHE = {}
 def safe_infer(node, context=None):
     """Return the inferred value for the given node.
 
     Return None if inference failed or if there is some ambiguity (more than
     one node has been inferred).
     """
+    node_key = id(node)
+    if node_key in _INFERENCE_CACHE:
+        return _INFERENCE_CACHE[node_key]
+
     try:
         inferit = node.infer(context=context)
         value = next(inferit)
     except astroid.InferenceError:
+        _INFERENCE_CACHE[node_key] = None
         return
     try:
         next(inferit)
+        _INFERENCE_CACHE[node_key] = None
         return # None if there is ambiguity on the inferred node
     except astroid.InferenceError:
         return # there is some kind of ambiguity
     except StopIteration:
+        _INFERENCE_CACHE[node_key] = value
         return value
 
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -490,6 +490,8 @@ def decorated_with(func, qnames):
         if dec and dec.qname() in qnames:
             return True
 
+_ABSTRACT_METHOD_CACHE = {
+}
 
 def unimplemented_abstract_methods(node, is_abstract_cb=None):
     """
@@ -503,6 +505,10 @@ def unimplemented_abstract_methods(node, is_abstract_cb=None):
     For the rest of them, it will return a dictionary of abstract method
     names and their inferred objects.
     """
+    node_key = id(node)
+    if node_key in _ABSTRACT_METHOD_CACHE:
+        return _ABSTRACT_METHOD_CACHE[node_key]
+
     if is_abstract_cb is None:
         is_abstract_cb = functools.partial(
             decorated_with, qnames=ABC_METHODS)
@@ -546,6 +552,7 @@ def unimplemented_abstract_methods(node, is_abstract_cb=None):
                     visited[obj.name] = infered
                 elif not abstract and obj.name in visited:
                     del visited[obj.name]
+    _ABSTRACT_METHOD_CACHE[node_key] = visited
     return visited
 
 


### PR DESCRIPTION
We have a 30k LOC app that takes about 2 minutes to run Pylint on, so I tried profiling a bit to speed it up. These commits cache type inference and abstract method counting, which speeds up pylint by about 10% on our code.

This was just to see how far I could get in a couple hours, so this code is very bad and I'm mostly wondering how I should do it right instead. Particular problems:
- I couldn't get master to run because of dependency issues so I branched this off of 1.5.5, but I couldn't get Github to compare the diff against the 1.5.5 so I just rebased onto master before submitting the PR.
- I don't understand the pylint/astroid architecture well enough to be sure whether the caching ever returns a wrong result, or whether it's caching everything it could be. (In particular, it seemed from testing like `id(node)` is actually stable, i.e. it's the same node every time, but I don't know if that's always the case.) FWIW, I did get the exact same results on our codebase with and without the caching.
- I don't really even know if caching is the right approach to speeding things up, this was just the most obvious thing to do from the profiles I took. For instance, the pylint codebase itself is around the same size as ours and takes only about 20 seconds to run, so 6x faster. (Granted, ours has many more warnings! Perhaps that's why?)

If you think this is a productive strategy and you let me know how I'd need to improve this before merging, I'd be happy to oblige :)
