### PR TITLE
Improved docstring matching in check_docs

### DIFF
--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -114,7 +114,7 @@ class SphinxDocstring(Docstring):
         """, re.X | re.S)
 
     re_raise_in_docstring = re.compile(r"""
-        :raises                  # Sphinx keyword
+        :raises                 # Sphinx keyword
         \s+                     # whitespace
 
         (?:                     # type declaration
@@ -184,7 +184,7 @@ class GoogleDocstring(Docstring):
 
     re_container_type = r"""
         (?:{type}|{xref})             # a container type
-        [\(\[] [^\n]+ [\)\]]              # with the contents of the container
+        [\(\[] [^\n]+ [\)\]]          # with the contents of the container
     """.format(type=re_type, xref=re_xref)
 
     _re_section_template = r"""
@@ -201,8 +201,8 @@ class GoogleDocstring(Docstring):
         \s*  \*{{0,2}}(\w+)             # identifier potentially with asterisks
         \s*  ( [(]
             (?:{container_type}|{type})
-            [)] )? \s* :   # optional type declaration
-        \s*  (.*)                 # beginning of optional description
+            [)] )? \s* :                # optional type declaration
+        \s*  (.*)                       # beginning of optional description
     """.format(
         type=re_type,
         container_type=re_container_type
@@ -215,7 +215,7 @@ class GoogleDocstring(Docstring):
 
     re_raise_line = re.compile(r"""
         \s*  ({type}) \s* :              # identifier
-        \s*  (.*)                       # beginning of optional description
+        \s*  (.*)                        # beginning of optional description
     """.format(type=re_type), re.X | re.S | re.M)
 
     re_returns_section = re.compile(
@@ -225,7 +225,7 @@ class GoogleDocstring(Docstring):
 
     re_returns_line = re.compile(r"""
         \s* ({container_type}:|{type}:)?  # identifier
-        \s* (.*)                         # beginning of description
+        \s* (.*)                          # beginning of description
     """.format(
         type=re_type,
         container_type=re_container_type
@@ -353,7 +353,7 @@ class NumpyDocstring(GoogleDocstring):
         \s*  (\w+)                      # identifier
         \s*  :
         \s*  ({container_type}|{type})? # optional type declaration
-        \n                               # description starts on a new line
+        \n                              # description starts on a new line
         \s* (.*)                        # description
     """.format(
         type=GoogleDocstring.re_type,


### PR DESCRIPTION
The common section parsing code has been merged into a single method.

### Fixes / new features
Fixed matching of complex types (eg mymodule.MyClass), references (eg :class:`AClass`), and container types (eg list(:class:`AClass`) or tuple(str, int)).
Fixed numpy docs not requiring descriptions.