### PR TITLE
Made list of property-like decorators configurable.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -96,3 +96,5 @@ Order doesn't matter (not that much, at least ;)
   Refactory wrong-import-position to skip try-import and nested cases.
 
 * Luis Escobar (Vauxoo), Moisés López (Vauxoo): Add bad-docstring-quotes and docstring-first-line-empty
+
+* Yannick Brehon: contributor.

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@ ChangeLog for Pylint
 
 
 --
+    * Made the list of property-defining decorators configurable.
+
     * Fix a false positive for keyword variadics with regard to keyword only arguments.
 
       If a keyword only argument was necessary for a function, but that function was called

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -147,6 +147,21 @@ else:
     BUILTIN_PROPERTY = 'builtins.property'
 
 
+def _get_properties(config):
+    """Returns a tuple of property classes and names.
+
+    Property classes are fully qualified, such as 'abc.abstractproperty' and
+    property names are the actual names, such as 'abstract_property'.
+    """
+    property_classes = set((BUILTIN_PROPERTY,))
+    property_names = set()  # Not returning 'property', it has its own check.
+    if config is not None:
+        property_classes.update(config.property_classes)
+        property_names.update((prop.rsplit('.', 1)[-1]
+                               for prop in config.property_classes))
+    return property_classes, property_names
+
+
 def _determine_function_name_type(node, config=None):
     """Determine the name type whose regex the a function's name should match.
 
@@ -154,12 +169,7 @@ def _determine_function_name_type(node, config=None):
     :param config: Configuration from which to pull additional property classes.
     :returns: One of ('function', 'method', 'attr')
     """
-    property_classes = set((BUILTIN_PROPERTY,))
-    property_names = set()
-    if config is not None:
-      property_classes.update(config.property_classes)
-      property_names.update((prop.rsplit('.', 1)[-1]
-                             for prop in config.property_classes))
+    property_classes, property_names = _get_properties(config)
     if not node.is_method():
         return 'function'
     if node.decorators:
@@ -1161,7 +1171,7 @@ class NameChecker(_BasicChecker):
                 {'default': False, 'type' : 'yn', 'metavar' : '<y_or_n>',
                  'help': 'Include a hint for the correct naming format with invalid-name'}
                ),
-               ('property_classes',
+               ('property-classes',
                 {'default': ('abc.abstractproperty',),
                  'type': 'csv',
                  'metavar': '<decorator names>',

--- a/pylintrc
+++ b/pylintrc
@@ -252,6 +252,9 @@ no-docstring-rgx=__.*__
 # ones are exempt.
 docstring-min-length=-1
 
+# List of decorators that define properties, such as abc.abstractproperty.
+property-classes=abc.abstractproperty
+
 
 [TYPECHECK]
 


### PR DESCRIPTION
### Fixes / new features

This makes it possible to configure pylint to accept custom decorators
similar to @property without the need to explicitly add a pylint
directive #pylint disable=invalid-name