### PR TITLE
Moved parallel code out of PyLinter

### DIFF
--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -181,28 +181,27 @@ MSGS = {
 
 
 if multiprocessing is not None:
-    class ChildLinter(multiprocessing.Process):
+    class ChildRunner(multiprocessing.Process):
         def run(self):
             # pylint: disable=no-member, unbalanced-tuple-unpacking
             tasks_queue, results_queue, self._config = self._args
 
-            self._config["jobs"] = 1  # Child does not parallelize any further.
             self._python3_porting_mode = self._config.pop(
                 'python3_porting_mode', None)
             self._plugins = self._config.pop('plugins', None)
 
             # Run linter for received files/modules.
-            for file_or_module in iter(tasks_queue.get, 'STOP'):
-                result = self._run_linter(file_or_module[0])
+            for file_desc in iter(tasks_queue.get, 'STOP'):
+                result = self._run_linter(file_desc)
                 try:
                     results_queue.put(result)
                 except Exception as ex:
                     print("internal error with sending report for module %s" %
-                          file_or_module, file=sys.stderr)
+                          file_desc.modname, file=sys.stderr)
                     print(ex, file=sys.stderr)
                     results_queue.put({})
 
-        def _run_linter(self, file_or_module):
+        def _run_linter(self, file_desc):
             linter = PyLinter()
 
             # Register standard checkers.
@@ -222,10 +221,10 @@ if multiprocessing is not None:
                 linter.python3_porting_mode()
 
             # Run the checks.
-            linter.check(file_or_module)
+            linter.check(file_desc)
 
             msgs = [_get_new_args(m) for m in linter.reporter.messages]
-            return (file_or_module, linter.file_state.base_name, linter.current_name,
+            return (file_desc, linter.file_state.base_name, linter.current_name,
                     msgs, linter.stats, linter.msg_status)
 
 
@@ -712,24 +711,35 @@ class PyLinter(config.OptionsManagerMixIn,
         """
         return path.endswith('.py')
 
-    def check(self, files_or_modules):
-        """main checking entry: check a list of files or modules from their
-        name.
-        """
+    def check(self, file_desc):
+        """main checking entry: check a file description."""
         # initialize msgs_state now that all messages have been registered into
         # the store
         for msg in self.msgs_store.messages:
             if not msg.may_be_emitted():
                 self._msgs_state[msg.msgid] = False
 
-        if not isinstance(files_or_modules, (list, tuple)):
-            files_or_modules = (files_or_modules,)
 
-        if self.config.jobs == 1:
-            self._do_check(files_or_modules)
-        else:
-            with _patch_sysmodules():
-                self._parallel_check(files_or_modules)
+        if not isinstance(file_desc, utils.FileDescriptor):
+            warnings.warn(
+                "PyLinter.check() will soon accept only a file descriptor",
+                PendingDeprecationWarning
+            )
+            # TODO: Remove this line with #938 as it is only required for
+            # expand_files to be able to store messages on the linter.
+            self.open()
+
+            file_descs = utils.expand_files(
+                [file_desc],
+                self,
+                self.config.black_list,
+                self.config.black_list_re
+            )
+            for file_desc in file_descs:
+                self._do_check(file_desc)
+            return
+
+        self._do_check(file_desc)
 
     def _get_jobs_config(self):
         child_config = collections.OrderedDict()
@@ -747,83 +757,7 @@ class PyLinter(config.OptionsManagerMixIn,
         child_config['plugins'] = self._dynamic_plugins
         return child_config
 
-    def _parallel_task(self, files_or_modules):
-        # Prepare configuration for child linters.
-        child_config = self._get_jobs_config()
-
-        children = []
-        manager = multiprocessing.Manager()
-        tasks_queue = manager.Queue()
-        results_queue = manager.Queue()
-
-        for _ in range(self.config.jobs):
-            child_linter = ChildLinter(args=(tasks_queue, results_queue,
-                                             child_config))
-            child_linter.start()
-            children.append(child_linter)
-
-        # Send files to child linters.
-        expanded_files = self.expand_files(files_or_modules)
-        for files_or_module in expanded_files:
-            path = files_or_module['path']
-            tasks_queue.put([path])
-
-        # collect results from child linters
-        failed = False
-        for _ in expanded_files:
-            try:
-                result = results_queue.get()
-            except Exception as ex:
-                print("internal error while receiving results from child linter",
-                      file=sys.stderr)
-                print(ex, file=sys.stderr)
-                failed = True
-                break
-            yield result
-
-        # Stop child linters and wait for their completion.
-        for _ in range(self.config.jobs):
-            tasks_queue.put('STOP')
-        for child in children:
-            child.join()
-
-        if failed:
-            print("Error occured, stopping the linter.", file=sys.stderr)
-            sys.exit(32)
-
-    def _parallel_check(self, files_or_modules):
-        # Reset stats.
-        self.open()
-
-        all_stats = []
-        module = None
-        for result in self._parallel_task(files_or_modules):
-            (
-                _,
-                self.file_state.base_name,
-                module,
-                messages,
-                stats,
-                msg_status
-            ) = result
-
-            for msg in messages:
-                msg = utils.Message(*msg)
-                self.set_current_module(module)
-                self.reporter.handle_message(msg)
-
-            all_stats.append(stats)
-            self.msg_status |= msg_status
-
-        self.stats = _merge_stats(all_stats)
-        self.current_name = module
-
-        # Insert stats data to local checkers.
-        for checker in self.get_checkers():
-            if checker is not self:
-                checker.stats = self.stats
-
-    def _do_check(self, files_or_modules):
+    def _do_check(self, file_desc):
         walker = utils.PyLintASTWalker(self)
         _checkers = self.prepare_checkers()
         tokencheckers = [c for c in _checkers
@@ -836,50 +770,38 @@ class PyLinter(config.OptionsManagerMixIn,
             checker.open()
             if interfaces.implements(checker, interfaces.IAstroidChecker):
                 walker.add_checker(checker)
-        # build ast and check modules or packages
-        for descr in self.expand_files(files_or_modules):
-            modname, filepath = descr['name'], descr['path']
-            if not descr['isarg'] and not self.should_analyze_file(modname, filepath):
-                continue
+
+        # build ast and check
+        modname = file_desc.name
+        filepath = file_desc.path
+        if file_desc.isarg or self.should_analyze_file(modname, filepath):
             if self.config.files_output:
                 reportfile = 'pylint_%s.%s' % (modname, self.reporter.extension)
                 self.reporter.set_output(open(reportfile, 'w'))
+
             self.set_current_module(modname, filepath)
+
             # get the module representation
             ast_node = self.get_ast(filepath, modname)
-            if ast_node is None:
-                continue
-            # XXX to be correct we need to keep module_msgs_state for every
-            # analyzed module (the problem stands with localized messages which
-            # are only detected in the .close step)
-            self.file_state = utils.FileState(descr['basename'])
-            self._ignore_file = False
-            # fix the current file (if the source file was not available or
-            # if it's actually a c extension)
-            self.current_file = ast_node.file # pylint: disable=maybe-no-member
-            self.check_astroid_module(ast_node, walker, rawcheckers, tokencheckers)
-            # warn about spurious inline messages handling
-            spurious_messages = self.file_state.iter_spurious_suppression_messages(self.msgs_store)
-            for msgid, line, args in spurious_messages:
-                self.add_message(msgid, line, None, args)
+            if ast_node is not None:
+                # XXX to be correct we need to keep module_msgs_state for every
+                # analyzed module (the problem stands with localized messages which
+                # are only detected in the .close step)
+                self.file_state = utils.FileState(file_desc.basename)
+                self._ignore_file = False
+                # fix the current file (if the source file was not available or
+                # if it's actually a c extension)
+                self.current_file = ast_node.file # pylint: disable=maybe-no-member
+                self.check_astroid_module(ast_node, walker, rawcheckers, tokencheckers)
+                # warn about spurious inline messages handling
+                spurious_messages = self.file_state.iter_spurious_suppression_messages(self.msgs_store)
+                for msgid, line, args in spurious_messages:
+                    self.add_message(msgid, line, None, args)
+
         # notify global end
         self.stats['statement'] = walker.nbstatements
         for checker in reversed(_checkers):
             checker.close()
-
-    def expand_files(self, modules):
-        """get modules and errors from a list of modules and handle errors
-        """
-        result, errors = utils.expand_modules(modules, self.config.black_list,
-                                              self.config.black_list_re)
-        for error in errors:
-            message = modname = error["mod"]
-            key = error["key"]
-            self.set_current_module(modname)
-            if key == "fatal":
-                message = str(error["ex"]).replace(os.getcwd() + os.sep, '')
-            self.add_message(key, args=message)
-        return result
 
     def set_current_module(self, modname, filepath=None):
         """set the name of the currently analyzed module and
@@ -1286,6 +1208,7 @@ group are mutually exclusive.'),
             if exc.code == 2: # bad options
                 exc.code = 32
             raise
+
         if not args:
             print(linter.help())
             sys.exit(32)
@@ -1294,22 +1217,119 @@ group are mutually exclusive.'),
             print("Jobs number (%d) should be greater than 0"
                   % linter.config.jobs, file=sys.stderr)
             sys.exit(32)
+
         if linter.config.jobs > 1 or linter.config.jobs == 0:
             if multiprocessing is None:
                 print("Multiprocessing library is missing, "
                       "fallback to single process", file=sys.stderr)
                 linter.set_option("jobs", 1)
-            else:
-                if linter.config.jobs == 0:
-                    linter.config.jobs = multiprocessing.cpu_count()
+            elif linter.config.jobs == 0:
+                linter.config.jobs = multiprocessing.cpu_count()
 
         # insert current working directory to the python path to have a correct
         # behaviour
         with fix_import_path(args):
-            linter.check(args)
+            if linter.config.jobs == 1:
+                # TODO: Remove this line with #938 as it is only required for
+                # expand_files to be able to store messages on the linter.
+                linter.open()
+
+                expanded_files = utils.expand_files(
+                    args,
+                    self.linter,
+                    self.linter.config.black_list,
+                    self.linter.config.black_list_re
+                )
+                for desc in expanded_files:
+                    linter.check(desc)
+            else:
+                self._parallel_run(args)
+
             linter.generate_reports()
+
         if exit:
-            sys.exit(self.linter.msg_status)
+            sys.exit(linter.msg_status)
+
+    def _parallel_run(self, args):
+        with _patch_sysmodules():
+            # Reset stats.
+            self.linter.open()
+
+            all_stats = []
+            module = None
+            for result in self._parallel_task(args):
+                (
+                    _,
+                    self.linter.file_state.base_name,
+                    module,
+                    messages,
+                    stats,
+                    msg_status
+                ) = result
+
+                for msg in messages:
+                    msg = utils.Message(*msg)
+                    self.linter.set_current_module(module)
+                    self.linter.reporter.handle_message(msg)
+
+                all_stats.append(stats)
+                self.linter.msg_status |= msg_status
+
+            self.linter.stats = _merge_stats(all_stats)
+            self.linter.current_name = module
+
+            # Insert stats data to local checkers.
+            for checker in self.linter.get_checkers():
+                if checker is not self.linter:
+                    checker.stats = self.linter.stats
+
+
+    def _parallel_task(self, files_or_modules):
+        child_config = self.linter._get_jobs_config()
+
+        children = []
+        manager = multiprocessing.Manager()
+        tasks_queue = manager.Queue()
+        results_queue = manager.Queue()
+
+        for _ in range(self.linter.config.jobs):
+            child_linter = ChildRunner(args=(tasks_queue, results_queue,
+                                             child_config))
+            child_linter.start()
+            children.append(child_linter)
+
+        # Send files to child linters.
+        expanded_files = utils.expand_files(
+            files_or_modules,
+            self.linter,
+            self.linter.config.black_list,
+            self.linter.config.black_list_re
+        )
+        for file_desc in expanded_files:
+            tasks_queue.put(file_desc)
+
+        # collect results from child linters
+        failed = False
+        for _ in expanded_files:
+            try:
+                result = results_queue.get()
+            except Exception as ex:
+                print("internal error while receiving results from child linter",
+                      file=sys.stderr)
+                print(ex, file=sys.stderr)
+                failed = True
+                break
+            yield result
+
+        # Stop child linters and wait for their completion.
+        for _ in range(self.linter.config.jobs):
+            tasks_queue.put('STOP')
+        for child in children:
+            child.join()
+
+        if failed:
+            print("Error occured, stopping the linter.", file=sys.stderr)
+            sys.exit(32)
 
     def cb_set_rcfile(self, name, value):
         """callback for option preprocessing (i.e. before option parsing)"""

--- a/pylint/test/extensions/test_bad_builtin.py
+++ b/pylint/test/extensions/test_bad_builtin.py
@@ -41,7 +41,7 @@ class BadBuiltinTestCase(unittest.TestCase):
         elif_test = osp.join(osp.dirname(osp.abspath(__file__)), 'data',
                              'bad_builtin.py')
         with fix_import_path([elif_test]):
-            self._linter.check([elif_test])
+            self._linter.check(elif_test)
         msgs = sorted(self._linter.reporter.messages, key=lambda item: item.line)
         self.assertEqual(len(msgs), 2)
         for msg, expected in zip(msgs, self.expected):

--- a/pylint/test/extensions/test_check_mccabe.py
+++ b/pylint/test/extensions/test_check_mccabe.py
@@ -57,13 +57,13 @@ class TestMcCabeMethodChecker(unittest.TestCase):
 
     def test_too_complex_message(self):
         self._linter.global_set_option('max-complexity', 0)
-        self._linter.check([self.fname_mccabe_example])
+        self._linter.check(self.fname_mccabe_example)
         real_msgs = [message.msg for message in self._linter.reporter.messages]
         self.assertEqual(sorted(self.expected_msgs), sorted(real_msgs))
 
     def test_max_mccabe_rate(self):
         self._linter.global_set_option('max-complexity', 9)
-        self._linter.check([self.fname_mccabe_example])
+        self._linter.check(self.fname_mccabe_example)
         real_msgs = [message.msg for message in self._linter.reporter.messages]
         self.assertEqual(sorted(self.expected_msgs[-2:]), sorted(real_msgs))
 

--- a/pylint/test/extensions/test_docstring_add.py
+++ b/pylint/test/extensions/test_docstring_add.py
@@ -53,7 +53,7 @@ class CheckDocStringAddicTC(unittest.TestCase):
     def test_docstring_message(self):
         docstring_test = osp.join(osp.dirname(osp.abspath(__file__)), 'data',
                                   'docstring.py')
-        self._linter.check([docstring_test])
+        self._linter.check(docstring_test)
         msgs = self._linter.reporter.messages
         self.assertEqual(len(msgs), 7)
         for msg, expected_symbol, expected_msg in zip(msgs,

--- a/pylint/test/extensions/test_elseif_used.py
+++ b/pylint/test/extensions/test_elseif_used.py
@@ -35,7 +35,7 @@ class CheckElseIfUsedTC(unittest.TestCase):
     def test_elseif_message(self):
         elif_test = osp.join(osp.dirname(osp.abspath(__file__)), 'data',
                              'elif.py')
-        self._linter.check([elif_test])
+        self._linter.check(elif_test)
         msgs = self._linter.reporter.messages
         self.assertEqual(len(msgs), 2)
         for msg in msgs:

--- a/pylint/test/extensions/test_redefined.py
+++ b/pylint/test/extensions/test_redefined.py
@@ -50,7 +50,7 @@ class CheckElseIfUsedTC(unittest.TestCase):
         elif_test = osp.join(osp.dirname(osp.abspath(__file__)), 'data',
                              'redefined.py')
         with fix_import_path([elif_test]):
-            self._linter.check([elif_test])
+            self._linter.check(elif_test)
         msgs = sorted(self._linter.reporter.messages, key=lambda item: item.line)
         self.assertEqual(len(msgs), 9)
         for msg, expected in zip(msgs, self.expected):

--- a/pylint/test/test_functional.py
+++ b/pylint/test/test_functional.py
@@ -293,7 +293,7 @@ class LintModuleTest(unittest.TestCase):
         return received_msgs, received_output_lines
 
     def _runTest(self):
-        self._linter.check([self._test_file.module])
+        self._linter.check(self._test_file.module)
 
         expected_messages, expected_text = self._get_expected()
         received_messages, received_text = self._get_received()

--- a/pylint/testutils.py
+++ b/pylint/testutils.py
@@ -278,7 +278,8 @@ class LintTestUsingModule(unittest.TestCase):
         else:
             self.linter.disable('I')
         try:
-            self.linter.check(tocheck)
+            for item in tocheck:
+                self.linter.check(item)
         except Exception as ex:
             # need finalization to restore a correct state
             self.linter.reporter.finalize()


### PR DESCRIPTION
As part of this, expand_files was also moved out of PyLinter.
PyLinter.check now only accepts a single file descriptor from expand_files.

This feels a bit work in progress. I don't know if we want to keep code for #618 in a separate branch? Could be difficult to keep that branch and master going together though but it might give us more freedom to break things until at least the refactor is fully complete.

Implements #936 