### PR TITLE
Added threading.local to ignored classes default list

### DIFF
--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -228,7 +228,7 @@ ignored-modules=
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set).
-ignored-classes=SQLObject
+ignored-classes=SQLObject, optparse.Values, thread._local, _thread._local
 
 # When zope mode is activated, add a predefined set of Zope acquired attributes
 # to generated-members.

--- a/man/pylint.1
+++ b/man/pylint.1
@@ -211,7 +211,7 @@ Tells whether missing members accessed in mixin class should be ignored. A mixin
 .IP "--ignored-modules=<module names>"
 List of module names for which member attributes should not be checked (useful for modules/projects where namespaces are manipulated during runtime and thus existing member attributes cannot be deduced by static analysis [current: none]
 .IP "--ignored-classes=<members names>"
-List of classes names for which member attributes should not be checked (useful for classes with attributes dynamically set). [current: SQLObject]
+List of classes names for which member attributes should not be checked (useful for classes with attributes dynamically set). [current: SQLObject, optparse.Values, thread._local, _thread._local]
 .IP "--zope=<y_or_n>"
 When zope mode is activated, add a predefined set of Zope acquired attributes to generated-members. [current: no]
 .IP "--generated-members=<members names>"

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -360,10 +360,10 @@ class should be ignored. A mixin class is detected if its name ends with \
                 {'default' : ('optparse.Values', 'thread._local', '_thread._local'),
                  'type' : 'csv',
                  'metavar' : '<members names>',
-                 'help' : 'List of classes names for which member attributes '
+                 'help' : 'List of class names for which member attributes '
                           'should not be checked (useful for classes with '
-                          'attributes dynamically set). This supports '
-                          'can work with qualified names.'}
+                          'dynamically set attributes). This supports '
+                          'the use of qualified names.'}
                ),
 
                ('generated-members',

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -353,8 +353,11 @@ class should be ignored. A mixin class is detected if its name ends with \
                          'deduced by static analysis. It supports qualified '
                          'module names, as well as Unix pattern matching.'}
                ),
+               # the defaults here are *stdlib* names that (almost) always
+               # lead to false positives, since their idiomatic use is
+               # 'too dynamic' for pylint to grok.
                ('ignored-classes',
-                {'default' : (),
+                {'default' : ('optparse.Values', 'thread._local', '_thread._local'),
                  'type' : 'csv',
                  'metavar' : '<members names>',
                  'help' : 'List of classes names for which member attributes '

--- a/pylintrc
+++ b/pylintrc
@@ -269,7 +269,7 @@ ignored-modules=
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set).
-ignored-classes=SQLObject, optparse.Values
+ignored-classes=SQLObject, optparse.Values, thread._local, _thread._local
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular


### PR DESCRIPTION
### Fixes / new features
- Added "threading.local" to ignored classes default list (as "thread._local" and "_thread._local")

Note that the implementation names for Python 2/3 are used (threading.local is an alias). Also changed related places for consistency.