### PR TITLE
Moved parallel execution code outside of PyLinter

### DIFF
--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -764,9 +764,8 @@ class PyLinter(config.OptionsManagerMixIn,
 
         # Send files to child linters.
         expanded_files = self.expand_files(files_or_modules)
-        for files_or_module in expanded_files:
-            path = files_or_module['path']
-            tasks_queue.put([path])
+        for module_desc in expanded_files:
+            tasks_queue.put([module_desc.path])
 
         # collect results from child linters
         failed = False
@@ -837,9 +836,10 @@ class PyLinter(config.OptionsManagerMixIn,
             if interfaces.implements(checker, interfaces.IAstroidChecker):
                 walker.add_checker(checker)
         # build ast and check modules or packages
-        for descr in self.expand_files(files_or_modules):
-            modname, filepath = descr['name'], descr['path']
-            if not descr['isarg'] and not self.should_analyze_file(modname, filepath):
+        for module_desc in self.expand_files(files_or_modules):
+            modname = module_desc.name
+            filepath = module_desc.path
+            if not module_desc.isarg and not self.should_analyze_file(modname, filepath):
                 continue
             if self.config.files_output:
                 reportfile = 'pylint_%s.%s' % (modname, self.reporter.extension)
@@ -852,7 +852,7 @@ class PyLinter(config.OptionsManagerMixIn,
             # XXX to be correct we need to keep module_msgs_state for every
             # analyzed module (the problem stands with localized messages which
             # are only detected in the .close step)
-            self.file_state = utils.FileState(descr['basename'])
+            self.file_state = utils.FileState(module_desc.basename)
             self._ignore_file = False
             # fix the current file (if the source file was not available or
             # if it's actually a c extension)

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -797,6 +797,15 @@ def _modpath_from_file(filename, is_namespace):
     return modutils.modpath_from_file_with_callback(filename, is_package_cb=_is_package_cb)
 
 
+ModuleDescription = collections.namedtuple('ModuleDescription', [
+    'path',
+    'name',
+    'basepath',
+    'basename',
+    'isarg',
+])
+
+
 def expand_modules(files_or_modules, black_list, black_list_re):
     """take a list of files/modules/packages and return the list of tuple
     (file, module name) which have to be actually checked
@@ -841,8 +850,14 @@ def expand_modules(files_or_modules, black_list, black_list_re):
             is_directory = spec.type == modutils.ModuleType.PKG_DIRECTORY
 
         if not is_namespace:
-            result.append({'path': filepath, 'name': modname, 'isarg': True,
-                           'basepath': filepath, 'basename': modname})
+            mod_desc = ModuleDescription(
+                filepath,
+                modname,
+                filepath,
+                modname,
+                isarg=True
+            )
+            result.append(mod_desc)
 
         has_init = (not (modname.endswith('.__init__') or modname == '__init__')
                     and '__init__.py' in filepath)
@@ -857,9 +872,14 @@ def expand_modules(files_or_modules, black_list, black_list_re):
 
                 modpath = _modpath_from_file(subfilepath, is_namespace)
                 submodname = '.'.join(modpath)
-                result.append({'path': subfilepath, 'name': submodname,
-                               'isarg': False,
-                               'basepath': filepath, 'basename': modname})
+                mod_desc = ModuleDescription(
+                    subfilepath,
+                    submodname,
+                    filepath,
+                    modname,
+                    isarg=False
+                )
+                result.append(mod_desc)
     return result, errors
 
 


### PR DESCRIPTION
The PyLinter object is still very dependent on having certain operation performed on it in order. Hence why the parallel code is often calling methods on `self.linter`. As we move towards a linter object being used for a single file, it would be good to eliminate these.

Implements #936 