### PR TITLE
Fixed check_docs doc error (#735)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -98,3 +98,5 @@ Order doesn't matter (not that much, at least ;)
 * Luis Escobar (Vauxoo), Moisés López (Vauxoo): Add bad-docstring-quotes and docstring-first-line-empty
 
 * Yannick Brehon: contributor.
+
+* Glenn Matthews: bug reports, occasional bug fixes

--- a/ChangeLog
+++ b/ChangeLog
@@ -200,6 +200,8 @@ ChangeLog for Pylint
       emitted when item deletion is tried on an object which doesn't
       have this ability. Closes issue #592.
 
+    * Fixed a documentation error for the check_docs extension. Fixes #735.
+
 2016-03-21 -- 1.5.5
 
     * Let visit_importfrom from Python 3 porting checker be called when everything is disabled

--- a/doc/extensions.rst
+++ b/doc/extensions.rst
@@ -143,4 +143,4 @@ still detected.
 
 By default, omitting the parameter documentation of a function altogether is
 tolerated without any warnings. If you want to switch off this behavior,
-set the option ``accept-no-param-doc`` to ``yes`` in your ``.pylintrc``.
+set the option ``accept-no-param-doc`` to ``no`` in your ``.pylintrc``.

--- a/doc/extensions.rst
+++ b/doc/extensions.rst
@@ -142,5 +142,16 @@ Naming inconsistencies in existing parameter and their type documentations are
 still detected.
 
 By default, omitting the parameter documentation of a function altogether is
-tolerated without any warnings. If you want to switch off this behavior,
-set the option ``accept-no-param-doc`` to ``no`` in your ``.pylintrc``.
+tolerated without any warnings. If you want to switch off this behavior
+(forcing functions to document their parameters), set the option
+``accept-no-param-doc`` to ``no`` in your ``.pylintrc``.
+
+By default, omitting the exception raising documentation of a function
+altogether is tolerated without any warnings. If you want to switch off this
+behavior (forcing functions that raise exceptions to document them), set the
+option ``accept-no-raise-doc`` to ``no`` in your ``.pylintrc``.
+
+By default, omitting the return documentation of a function altogether is
+tolerated without any warnings. If you want to switch off this behavior
+(forcing functions to document their returns), set the option
+``accept-no-return-doc`` to ``no`` in your ``.pylintrc``.


### PR DESCRIPTION
### Fixes / new features
- As reported in #735, the documentation for the check_docs extension incorrectly instructs the user to set `accept-no-param-doc=yes` to enable additional checking, but in actuality these checks are enabled by `accept-no-param-doc=no`.

