### PR TITLE
[ADD] consider-merging-isinstance: Add new check consider-merging-isinstance

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -93,7 +93,8 @@ Order doesn't matter (not that much, at least ;)
 * Moisés López (Vauxoo): Support for deprecated-modules in modules not installed,
   Refactory wrong-import-order to integrate it with `isort` library
   Add check too-complex with mccabe for cyclomatic complexity
-  Refactory wrong-import-position to skip try-import and nested cases.
+  Refactory wrong-import-position to skip try-import and nested cases
+  Add check consider-merging-isinstance
 
 * Luis Escobar (Vauxoo), Moisés López (Vauxoo): Add bad-docstring-quotes and docstring-first-line-empty
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -88,6 +88,9 @@ Release date: tba
 
       Closes issue #984.
 
+    * Added a new refactoring message, 'consider-merging-isinstance', which is
+      used to detect isinstance calls, which can be merged together.
+
 
 What's new in Pylint 1.6.2?
 ===========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -65,5 +65,6 @@ Added features
 .. code-block:: python
 
     $ cat a.py
-    isinstance(x, int) or isinstance(z, int)
-    # R:  1, 0: Consider merging these isinstance calls to x. (consider-merging-isinstance)
+    isinstance(x, int) or isinstance(x, float)
+    $ pylint a.py
+    # R:  1, 0: Consider merging these isinstance calls to isinstance(x, (float, int)) (consider-merging-isinstance)

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -54,3 +54,16 @@ Removed Changes
   issue, since the pathological case would have happen when the
   code was parsed by Python as well, without actually reaching the
   runtime step and as such, we decided to remove the error altogether.
+
+
+Added features
+==============
+
+* Refactoring message, 'consider-merging-isinstance', which is
+  used to detect isinstance calls, which can be merged together. 
+
+.. code-block:: python
+
+    $ cat a.py
+    isinstance(x, int) or isinstance(z, int)
+    # R:  1, 0: Consider merging these isinstance calls to x. (consider-merging-isinstance)

--- a/pylint/checkers/__init__.py
+++ b/pylint/checkers/__init__.py
@@ -20,7 +20,8 @@ Base id of standard checkers (used in msg and report ids):
 14: string_constant
 15: stdlib
 16: python3
-17-50: not yet used: reserved for future internal checkers.
+17: refactoring
+18-50: not yet used: reserved for future internal checkers.
 51-99: perhaps used: reserved for external checkers
 
 The raw_metrics checker has no number associated since it doesn't emit any

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -1,0 +1,68 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+"""Looks for code which can be refactored."""
+
+import collections
+
+import astroid
+
+from pylint.interfaces import IAstroidChecker
+from pylint.checkers import BaseChecker
+from pylint.checkers.utils import check_messages, is_builtin_object, safe_infer
+
+
+def duplicated(items):
+    items_counter = collections.Counter(items)
+    return [item for item, counter in items_counter.items() if counter > 1]
+
+
+class RefactoringChecker(BaseChecker):
+    """Looks for code which can be refactored.
+    """
+
+    __implements__ = (IAstroidChecker,)
+
+    # configuration section name
+    name = 'refactoring'
+
+    msgs = {
+        'R1701': (
+            "Consider merging these isinstance calls to %s.",
+            "consider-merging-isinstance",
+            "Usen when multiple isinstance calls can be grouped into one."),
+    }
+    priority = -2
+
+    @staticmethod
+    def first_args(node):
+        # TODO: Remove after fix https://github.com/PyCQA/pylint/issues/984
+        # pylint: disable=redundant-returns-doc
+        """Get the objects, as strings, from the *isinstance* calls,
+        found in the BoolOp node.
+        :param astroid.BoolOp node: Node to get first argument of values
+        :returns: First arguments as string of all `node.values`
+        :rtype: generator
+        """
+        for value in node.values:
+            if not isinstance(value, astroid.Call) or not value.args:
+                continue
+            inferred = safe_infer(value.func)
+            if not inferred or not is_builtin_object(inferred):
+                continue
+            if inferred.name == 'isinstance':
+                yield value.args[0].as_string()
+
+    @check_messages('consider-merging-isinstance')
+    def visit_boolop(self, node):
+        "Check isinstance calls which can be merged together."
+        if node.op != 'or':
+            return
+        for duplicated_name in duplicated(self.first_args(node)):
+            self.add_message('consider-merging-isinstance', node=node,
+                             args=(duplicated_name,))
+
+
+def register(linter):
+    """required method to auto register this checker """
+    linter.register_checker(RefactoringChecker(linter))

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -244,8 +244,8 @@ def is_func_decorator(node):
         if isinstance(parent, astroid.Decorators):
             return True
         if (parent.is_statement or
-                isinstance(parent, astroid.Lambda) or
-                isinstance(parent, (scoped_nodes.ComprehensionScope,
+                isinstance(parent, (astroid.Lambda,
+                                    scoped_nodes.ComprehensionScope,
                                     scoped_nodes.ListComp))):
             break
         parent = parent.parent

--- a/pylint/test/functional/consider_merging_isinstance.py
+++ b/pylint/test/functional/consider_merging_isinstance.py
@@ -1,0 +1,33 @@
+"""Checks use of consider-merging-isinstance"""
+# pylint:disable=line-too-long
+
+
+def isinstances():
+    "Examples of isinstances"
+    var = range(10)
+
+    # merged
+    if isinstance(var[1], (int, float)):
+        pass
+    result = isinstance(var[2], (int, float))
+
+    # not merged
+    if isinstance(var[3], int) or isinstance(var[3], float) or isinstance(var[3], list) and True:  # [consider-merging-isinstance]
+        pass
+    result = isinstance(var[4], int) or isinstance(var[4], float) or isinstance(var[5], list) and False  # [consider-merging-isinstance]
+
+    result = isinstance(var[5], int) or True or isinstance(var[5], float)  # [consider-merging-isinstance]
+
+    infered_isinstance = isinstance
+    result = infered_isinstance(var[6], int) or infered_isinstance(var[6], float) or infered_isinstance(var[6], list) and False   # [consider-merging-isinstance]
+    result = isinstance(var[10]) or isinstance(var[10], int) and var[8] * 14 or isinstance(var[10], float) and var[5] * 14.4 or isinstance(var[10], list)   # [consider-merging-isinstance]
+
+    # Combination merged and not merged
+    result = isinstance(var[11], (int, float)) or isinstance(var[11], list)  # [consider-merging-isinstance]
+
+    # not merged but valid
+    result = isinstance(var[5], int) and var[5] * 14 or isinstance(var[5], float) and var[5] * 14.4
+    result = isinstance(var[7], int) or not isinstance(var[7], float)
+    result = isinstance(var[6], int) or isinstance(var[7], float)
+    result = isinstance(var[6], int) or isinstance(var[7], int)
+    return result

--- a/pylint/test/functional/consider_merging_isinstance.py
+++ b/pylint/test/functional/consider_merging_isinstance.py
@@ -20,10 +20,14 @@ def isinstances():
 
     infered_isinstance = isinstance
     result = infered_isinstance(var[6], int) or infered_isinstance(var[6], float) or infered_isinstance(var[6], list) and False   # [consider-merging-isinstance]
-    result = isinstance(var[10]) or isinstance(var[10], int) and var[8] * 14 or isinstance(var[10], float) and var[5] * 14.4 or isinstance(var[10], list)   # [consider-merging-isinstance]
+    result = isinstance(var[10], str) or isinstance(var[10], int) and var[8] * 14 or isinstance(var[10], float) and var[5] * 14.4 or isinstance(var[10], list)   # [consider-merging-isinstance]
+    result = isinstance(var[11], int) or isinstance(var[11], int) or isinstance(var[11], float)   # [consider-merging-isinstance]
+
+    result = isinstance(var[20])
+    result = isinstance()
 
     # Combination merged and not merged
-    result = isinstance(var[11], (int, float)) or isinstance(var[11], list)  # [consider-merging-isinstance]
+    result = isinstance(var[12], (int, float)) or isinstance(var[12], list)  # [consider-merging-isinstance]
 
     # not merged but valid
     result = isinstance(var[5], int) and var[5] * 14 or isinstance(var[5], float) and var[5] * 14.4

--- a/pylint/test/functional/consider_merging_isinstance.txt
+++ b/pylint/test/functional/consider_merging_isinstance.txt
@@ -1,0 +1,6 @@
+consider-merging-isinstance:15:isinstances:Consider merging these isinstance calls to var[3].
+consider-merging-isinstance:17:isinstances:Consider merging these isinstance calls to var[4].
+consider-merging-isinstance:19:isinstances:Consider merging these isinstance calls to var[5].
+consider-merging-isinstance:22:isinstances:Consider merging these isinstance calls to var[6].
+consider-merging-isinstance:23:isinstances:Consider merging these isinstance calls to var[10].
+consider-merging-isinstance:26:isinstances:Consider merging these isinstance calls to var[11].

--- a/pylint/test/functional/consider_merging_isinstance.txt
+++ b/pylint/test/functional/consider_merging_isinstance.txt
@@ -1,6 +1,7 @@
-consider-merging-isinstance:15:isinstances:Consider merging these isinstance calls to var[3].
-consider-merging-isinstance:17:isinstances:Consider merging these isinstance calls to var[4].
-consider-merging-isinstance:19:isinstances:Consider merging these isinstance calls to var[5].
-consider-merging-isinstance:22:isinstances:Consider merging these isinstance calls to var[6].
-consider-merging-isinstance:23:isinstances:Consider merging these isinstance calls to var[10].
-consider-merging-isinstance:26:isinstances:Consider merging these isinstance calls to var[11].
+consider-merging-isinstance:15:isinstances:Consider merging these isinstance calls to isinstance(var[3], (float, int))
+consider-merging-isinstance:17:isinstances:Consider merging these isinstance calls to isinstance(var[4], (float, int))
+consider-merging-isinstance:19:isinstances:Consider merging these isinstance calls to isinstance(var[5], (float, int))
+consider-merging-isinstance:22:isinstances:Consider merging these isinstance calls to isinstance(var[6], (float, int))
+consider-merging-isinstance:23:isinstances:Consider merging these isinstance calls to isinstance(var[10], (list, str))
+consider-merging-isinstance:24:isinstances:Consider merging these isinstance calls to isinstance(var[11], (float, int))
+consider-merging-isinstance:30:isinstances:Consider merging these isinstance calls to isinstance(var[12], (float, int, list))


### PR DESCRIPTION
### Fixes / new features
- Fix https://github.com/PyCQA/pylint/issues/968

- [x] Consider just `or` cases (Discard `not`, `and`, ...)
- [x] Move extension to core
- [x] Add doc

- [x] Fix the following cases not detected: 
 - [pylint/checkers/base.py#L186-L187](https://github.com/PyCQA/pylint/blob/5d40a07684be7ed6dbaa54e49c3d436005a533bf/pylint/checkers/base.py#L186-L187)
 - [pylint/checkers/variables.py#L464-L465](https://github.com/PyCQA/pylint/blob/5d40a07684be7ed6dbaa54e49c3d436005a533bf/pylint/checkers/variables.py#L464-L465)
 - The above examples are good not-grouped cases, because they are using: `isinstance(obj1, class_x) and obj1.value1 or isinstance(obj1, class_y) and obj1.value2` and this is a valid not-grouped.

- [x] Maybe we should try to print how should it look exactly?
So in the case of if isinstance(var[3], int) or isinstance(var[3], float) or isinstance(var[3], list) it can look as:
$ pylint a.py
1:R:Consider merging these calls to:
     isinstance(var[3], (int, float, list))