### PR TITLE
[FIX] redundant-returns-doc: Consider *yield* as a type or *return*

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -83,6 +83,10 @@ Release date: tba
       emitted when item deletion is tried on an object which doesn't
       have this ability. Closes issue #592.
 
+    * Fix false negative 'redundant-returns-doc' using 'yield'.
+
+      Closes issue #984.
+
 
 What's new in Pylint 1.6.2?
 ===========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -16,6 +16,10 @@ Other Changes
 
 * None yet.
 
+Bug fixes
+=========
+
+* Fix false negative 'redundant-returns-doc' using 'yield'.
 
 Removed Changes
 ===============

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -86,6 +86,9 @@ class Docstring(object):
         For\s+the\s+(other)?\s*parameters\s*,\s+see
         """, re.X | re.S)
 
+    # Set True if the docstring supports a "yield" section
+    support_yield = None
+
     # These methods are designed to be overridden
     # pylint: disable=no-self-use
     def __init__(self, doc):
@@ -157,6 +160,8 @@ class SphinxDocstring(Docstring):
     re_rtype_in_docstring = re.compile(r":rtype:")
 
     re_returns_in_docstring = re.compile(r":returns?:")
+
+    support_yield = False
 
     def is_valid(self):
         return bool(self.re_param_in_docstring.search(self.doc) or
@@ -254,6 +259,8 @@ class GoogleDocstring(Docstring):
         type=re_type,
         container_type=re_container_type
     ), re.X | re.S | re.M)
+
+    support_yield = True
 
     def is_valid(self):
         return bool(self.re_param_section.search(self.doc) or
@@ -406,6 +413,8 @@ class NumpyDocstring(GoogleDocstring):
         type=GoogleDocstring.re_type,
         container_type=GoogleDocstring.re_container_type
     ), re.X | re.S | re.M)
+
+    support_yield = True
 
     @staticmethod
     def min_section_indent(section_match):

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -41,6 +41,21 @@ def returns_something(return_node):
     return not (isinstance(returns, astroid.Const) and returns.value is None)
 
 
+def inside_yields(node):
+    """Check if a yield node is defined in child of node.
+
+    :param node: The node to search yield.
+    :type node: astroid.FunctionDef
+
+    :rtype: bool
+    :return: True if a yield node is declared.
+    """
+    try:
+        next(node.nodes_of_class(astroid.Yield))
+        return True
+    except StopIteration:
+        return False
+
 def possible_exc_types(node):
     """
     Gets all of the possible raised exception types for the given raise node.

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -41,21 +41,6 @@ def returns_something(return_node):
     return not (isinstance(returns, astroid.Const) and returns.value is None)
 
 
-def inside_yields(node):
-    """Check if a yield node is defined in child of node.
-
-    :param node: The node to search yield.
-    :type node: astroid.FunctionDef
-
-    :rtype: bool
-    :return: True if a yield node is declared.
-    """
-    try:
-        next(node.nodes_of_class(astroid.Yield))
-        return True
-    except StopIteration:
-        return False
-
 def possible_exc_types(node):
     """
     Gets all of the possible raised exception types for the given raise node.

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -115,7 +115,7 @@ class DocstringParameterChecker(BaseChecker):
             node_doc, node.args, node, node_allow_no_param)
 
     def check_functiondef_returns(self, node, node_doc):
-        if utils.inside_yields(node):
+        if node.is_generator():
             # A *yield None* or *yield* is a type of *return* returning a generator
             return
         return_nodes = node.nodes_of_class(astroid.Return)

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -115,6 +115,9 @@ class DocstringParameterChecker(BaseChecker):
             node_doc, node.args, node, node_allow_no_param)
 
     def check_functiondef_returns(self, node, node_doc):
+        if utils.inside_yields(node):
+            # A *yield None* or *yield* is a type of *return* returning a generator
+            return
         return_nodes = node.nodes_of_class(astroid.Return)
         if (node_doc.has_returns() and
                 not any(utils.returns_something(ret_node) for ret_node in return_nodes)):

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -115,8 +115,7 @@ class DocstringParameterChecker(BaseChecker):
             node_doc, node.args, node, node_allow_no_param)
 
     def check_functiondef_returns(self, node, node_doc):
-        if node.is_generator():
-            # A *yield None* or *yield* is a type of *return* returning a generator
+        if not node_doc.support_yield and node.is_generator():
             return
         return_nodes = node.nodes_of_class(astroid.Return)
         if (node_doc.has_returns() and

--- a/pylint/test/extensions/test_check_return_docs.py
+++ b/pylint/test/extensions/test_check_return_docs.py
@@ -381,20 +381,6 @@ class DocstringCheckerReturnTest(CheckerTestCase):
                 node=node)):
             self.checker.visit_functiondef(node)
 
-    def test_ignore_sphinx_redundant_return_doc_with_yield(self):
-        node = astroid.extract_node('''
-        def my_func_with_yield(self):
-            """This is a docstring.
-
-            :returns: One
-            :rtype: generator
-            """
-            for value in range(3):
-                yield value
-        ''')
-        with self.assertNoMessages():
-            self.checker.visit_functiondef(node)
-
     def test_warns_google_redundant_return_doc(self):
         node = astroid.extract_node('''
         def my_func(self):
@@ -480,6 +466,55 @@ class DocstringCheckerReturnTest(CheckerTestCase):
         ''')
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
+
+    def test_ignore_sphinx_redundant_return_doc_yield(self):
+        node = astroid.extract_node('''
+        def my_func_with_yield(self):
+            """This is a docstring.
+
+            :returns: One
+            :rtype: generator
+            """
+            for value in range(3):
+                yield value
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
+
+    def test_warns_google_redundant_return_doc_yield(self):
+        node = astroid.extract_node('''
+        def my_func(self):
+            """This is a docstring.
+
+            Returns:
+                int: One
+            """
+            yield 1
+        ''')
+        with self.assertAddsMessages(
+            Message(
+                msg_id='redundant-returns-doc',
+                node=node)):
+            self.checker.visit_functiondef(node)
+
+    def test_warns_numpy_redundant_return_doc_yield(self):
+        node = astroid.extract_node('''
+        def my_func(self):
+            """This is a docstring.
+
+            Returns
+            -------
+                int
+                    One
+            """
+            yield 1
+        ''')
+        with self.assertAddsMessages(
+            Message(
+                msg_id='redundant-returns-doc',
+                node=node)):
+            self.checker.visit_functiondef(node)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pylint/test/extensions/test_check_return_docs.py
+++ b/pylint/test/extensions/test_check_return_docs.py
@@ -381,6 +381,20 @@ class DocstringCheckerReturnTest(CheckerTestCase):
                 node=node)):
             self.checker.visit_functiondef(node)
 
+    def test_ignore_sphinx_redundant_return_doc_with_yield(self):
+        node = astroid.extract_node('''
+        def my_func_with_yield(self):
+            """This is a docstring.
+
+            :returns: One
+            :rtype: generator
+            """
+            for value in range(3):
+                yield value
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
+
     def test_warns_google_redundant_return_doc(self):
         node = astroid.extract_node('''
         def my_func(self):


### PR DESCRIPTION
### Fixes / new features

- Fix https://github.com/PyCQA/pylint/issues/984

FYI 

> @AWhetter 
Use a new utils.yields_something. 

For the case of returns we need a `utils.returns_something` because a `return None` returns None (obviously)
But a `yield None` or a `yield` (empty) returns a generator with [None, None...]
IMHO if there is a `yield` empty, None or with value is a valid `rtype`

What do you think?

- [x] Support for "yield" section
- [x] Add test for "yield" section
- [x] Add doc for news and changelog