### PR TITLE
Fix false positive for missing-[type,param]-doc

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -102,6 +102,9 @@ Release date: tba
 
       Closes issue #968
 
+    * Fix a false positive of 'missing-param-doc' and 'missing-type-doc',
+      occurred when a class docstring uses the 'For the parameters, see'
+      magic string but the class __init__ docstring does not, or vice versa.
 
 What's new in Pylint 1.6.2?
 ===========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -91,6 +91,10 @@ Bug fixes
 * Fix a false positive of 'redundant-returns-doc', occurred when the documented
   function was using *yield* instead of *return*.
 
+* Fix a false positive of 'missing-param-doc' and 'missing-type-doc',
+  occurred when a class docstring uses the 'For the parameters, see'
+  magic string but the class ``__init__`` docstring does not, or vice versa.
+
 Removed Changes
 ===============
 

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -117,8 +117,16 @@ class DocstringParameterChecker(BaseChecker):
 
                 # __init__ or class docstrings can have no parameters documented
                 # as long as the other documents them.
-                node_allow_no_param = class_doc.has_params() or None
-                class_allow_no_param = node_doc.has_params() or None
+                node_allow_no_param = (
+                    class_doc.has_params() or
+                    class_doc.params_documented_elsewhere() or
+                    None
+                )
+                class_allow_no_param = (
+                    node_doc.has_params() or
+                    node_doc.params_documented_elsewhere() or
+                    None
+                )
 
                 self.check_arguments_in_docstring(
                     class_doc, node.args, class_node, class_allow_no_param)

--- a/pylint/test/extensions/test_check_docs.py
+++ b/pylint/test/extensions/test_check_docs.py
@@ -123,7 +123,7 @@ class ParamDocCheckerTest(CheckerTestCase):
     def test_don_t_tolerate_no_param_documentation_at_all(self):
         """Example of a function with no parameter documentation at all
 
-        No error message is emitted.
+        Missing documentation error message is emitted.
         """
         node = astroid.extract_node("""
         def function_foo(x, y):
@@ -142,6 +142,22 @@ class ParamDocCheckerTest(CheckerTestCase):
                 node=node,
                 args=('x, y',))
         ):
+            self.checker.visit_functiondef(node)
+
+    @set_config(accept_no_param_doc=False)
+    def test_see_tolerate_no_param_documentation_at_all(self):
+        """Example for the usage of "For the parameters, see"
+        to suppress missing-param warnings.
+        """
+        node = astroid.extract_node("""
+        def function_foo(x, y):
+            '''docstring ...
+
+            For the parameters, see :func:`blah`
+            '''
+            pass
+        """)
+        with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def _visit_methods_of_class(self, node):
@@ -737,6 +753,43 @@ class ParamDocCheckerTest(CheckerTestCase):
                 args=('x, y',))
         ):
             self._visit_methods_of_class(node)
+
+    @set_config(accept_no_param_doc=False)
+    def test_see_sentence_for_constr_params_in_class(self):
+        """Example usage of "For the parameters, see" in class docstring"""
+        node = astroid.extract_node("""
+        class ClassFoo(object):
+            '''docstring foo
+
+            For the parameters, see :func:`bla`
+            '''
+
+            def __init__(self, x, y):
+                '''init'''
+                pass
+
+        """)
+        with self.assertNoMessages():
+            self._visit_methods_of_class(node)
+
+    @set_config(accept_no_param_doc=False)
+    def test_see_sentence_for_constr_params_in_init(self):
+        """Example usage of "For the parameters, see" in init docstring"""
+        node = astroid.extract_node("""
+        class ClassFoo(object):
+            '''foo'''
+
+            def __init__(self, x, y):
+                '''docstring foo constructor
+
+                For the parameters, see :func:`bla`
+                '''
+                pass
+
+        """)
+        with self.assertNoMessages():
+            self._visit_methods_of_class(node)
+
 
     def test_constr_params_in_class_and_init_sphinx(self):
         """Example of a class with missing constructor parameter documentation


### PR DESCRIPTION
### Fixes / new features
- Fix a false positive of 'missing-param-doc' and 'missing-type-doc' that occurred when a class docstring uses the 'For the parameters, see' magic string but the class __init__ docstring does not, or vice versa.

```python
"Foo and Bar"

class Foo(object):
    """Foo.

    For the parameters, see AnotherClass.
    """
    def __init__(self, x):
        """Foo the bar.
        """
        self.x = x

class Bar(object):
    """Bar.
    """
    def __init__(self, x):
        """Bar the foo.

        For the parameters, see AnotherClass.
        """
        self.x = x
```

Before:

```
$ pylint --load-plugins=pylint.extensions.docparams --accept-no-param-doc=n for_the_parameters.py
************* Module for_the_parameters
W:  8, 4: "x" missing or differing in parameter documentation (missing-param-doc)
W:  8, 4: "x" missing or differing in parameter type documentation (missing-type-doc)
W: 13, 0: "x" missing or differing in parameter documentation (missing-param-doc)
W: 13, 0: "x" missing or differing in parameter type documentation (missing-type-doc)
```

After:

```
$ pylint --load-plugins=pylint.extensions.docparams --accept-no-param-doc=n for_the_parameters.py
$
```