### PR TITLE
Add support for Sphinx keyword synonyms

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -105,6 +105,9 @@ Release date: tba
 
       Closes issue #984.
 
+    * Fix false positives of 'missing-[raises|params|type]-doc' due to not
+      recognizing keyword synonyms supported by Sphinx.
+
     * Added a new refactoring message, 'consider-merging-isinstance', which is
       emitted whenever we can detect that consecutive isinstance calls can be
       merged together.

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -147,6 +147,9 @@ Bug fixes
   occurred when a class docstring uses the 'For the parameters, see'
   magic string but the class ``__init__`` docstring does not, or vice versa.
 
+* Fix false positives of ``missing-[raises|params|type]-doc`` due to not
+  recognizing valid keyword synonyms supported by Sphinx.
+
 Removed Changes
 ===============
 

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -132,7 +132,12 @@ class SphinxDocstring(Docstring):
         """.format(re_type)
 
     re_param_in_docstring = re.compile(r"""
-        :param                  # Sphinx keyword
+        :                       # initial colon
+        (?:                     # Sphinx keywords
+        param|parameter|
+        arg|argument|
+        key|keyword
+        )
         \s+                     # whitespace
 
         (?:                     # optional type declaration
@@ -154,7 +159,11 @@ class SphinxDocstring(Docstring):
         """.format(type=re_type), re.X | re.S)
 
     re_raise_in_docstring = re.compile(r"""
-        :raises                 # Sphinx keyword
+        :                       # initial colon
+        (?:                     # Sphinx keyword
+        raises?|
+        except|exception
+        )
         \s+                     # whitespace
 
         (?:                     # type declaration

--- a/pylint/test/extensions/test_check_docs.py
+++ b/pylint/test/extensions/test_check_docs.py
@@ -270,12 +270,12 @@ class ParamDocCheckerTest(CheckerTestCase):
             :param xarg: bla xarg
             :type xarg: int
 
-            :param yarg: bla yarg
+            :parameter yarg: bla yarg
             :type yarg: my.qualified.type
 
-            :param int zarg: bla zarg
+            :arg int zarg: bla zarg
 
-            :param my.qualified.type warg: bla warg
+            :keyword my.qualified.type warg: bla warg
 
             :return: sum
             :rtype: float

--- a/pylint/test/extensions/test_check_raise_docs.py
+++ b/pylint/test/extensions/test_check_raise_docs.py
@@ -115,10 +115,14 @@ class DocstringCheckerRaiseTest(CheckerTestCase):
             """This is a docstring.
 
             :raises RuntimeError: Always
-            :raises NameError: Never
+            :except NameError: Never
+            :raise OSError: Never
+            :exception ValueError: Never
             """
             raise RuntimeError('hi') #@
             raise NameError('hi')
+            raise OSError(2, 'abort!')
+            raise ValueError('foo')
         ''')
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)

--- a/pylint/test/extensions/test_check_raise_docs.py
+++ b/pylint/test/extensions/test_check_raise_docs.py
@@ -109,6 +109,21 @@ class DocstringCheckerRaiseTest(CheckerTestCase):
                 args=('RuntimeError', ))):
             self.checker.visit_raise(raise_node)
 
+    def test_ignore_spurious_sphinx_raises(self):
+        raise_node = astroid.extract_node('''
+        def my_func(self):
+            """This is a docstring.
+
+            :raises RuntimeError: Always
+            :except NameError: Never
+            :raise OSError: Never
+            :exception ValueError: Never
+            """
+            raise RuntimeError('Blah') #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_raise(raise_node)
+
     def test_find_all_sphinx_raises(self):
         raise_node = astroid.extract_node('''
         def my_func(self):


### PR DESCRIPTION
### Fixes / new features
* Fix false positives of ``missing-[raises|params|type]-doc`` due to not recognizing valid keyword synonyms supported by Sphinx.

http://www.sphinx-doc.org/en/stable/domains.html#info-field-lists

Specifically, add support for all of:

* `param`, `parameter`, `arg`, `argument`, `key`, `keyword`: Description of a parameter.
* `raises`, `raise`, `except`, `exception`: That (and when) a specific exception is raised.