### PR TITLE
[ADD] codecov: Enable codecov instaed of coveralls

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,16 @@ before_install:
   - uname -a
   - lsb_release -a
 install:
-  - pip install tox
+  - pip install tox codecov
   - virtualenv --version
   - easy_install --version
   - pip --version
   - tox --version
+  - codecov --version
 script:
-  - tox -e coverage-erase,$TOXENV
+  - tox -e $TOXENV
 after_success:
-  - tox -e codecov
+  - (cd ${TRAVIS_BUILD_DIR}/.tox/$TOXENV && codecov)
 after_failure:
   - more .tox/log/* | cat
   - more .tox/*/log/* | cat

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
 script:
   - tox -e coverage-erase,$TOXENV
 after_success:
-  - tox -e coveralls,codecov
+  - tox -e codecov
 after_failure:
   - more .tox/log/* | cat
   - more .tox/*/log/* | cat

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,15 @@ before_install:
   - uname -a
   - lsb_release -a
 install:
-  - pip install tox coverage coveralls
+  - pip install tox
   - virtualenv --version
   - easy_install --version
   - pip --version
   - tox --version
-  - coverage --version
 script:
   - tox -e coverage-erase,$TOXENV
 after_success:
-  - tox -e coveralls
+  - tox -e coveralls,codecov
 after_failure:
   - more .tox/log/* | cat
   - more .tox/*/log/* | cat

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
 script:
   - tox -e $TOXENV
 after_success:
+  - cp ${TRAVIS_BUILD_DIR}/.codecov.yml ${TRAVIS_BUILD_DIR}/.tox/$TOXENV/
   - (cd ${TRAVIS_BUILD_DIR}/.tox/$TOXENV && codecov)
 after_failure:
   - more .tox/log/* | cat

--- a/tox.ini
+++ b/tox.ini
@@ -28,21 +28,6 @@ commands =
     python -c "import os;cov_strip_abspath = open(os.environ['COVERAGE_FILE'], 'r').read().replace('.tox' + os.sep + os.path.relpath('{envsitepackagesdir}', '{toxworkdir}') + os.sep, '');open(os.environ['COVERAGE_FILE'], 'w').write(cov_strip_abspath)"
 changedir = {toxworkdir}
 
-[testenv:coveralls]
-setenv =
-    COVERAGE_FILE = {toxinidir}/.coverage
-passenv =
-    *
-deps =
-    coverage
-    coveralls
-skip_install = true
-commands =
-    python {envsitepackagesdir}/coverage combine
-    python {envsitepackagesdir}/coverage report --rcfile={toxinidir}/.coveragerc -m
-    - coveralls --rcfile={toxinidir}/.coveragerc
-changedir = {toxinidir}
-
 [testenv:codecov]
 setenv =
     COVERAGE_FILE = {toxinidir}/.coverage

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,19 @@ commands =
     - coveralls --rcfile={toxinidir}/.coveragerc
 changedir = {toxinidir}
 
+[testenv:codecov]
+setenv =
+    COVERAGE_FILE = {toxinidir}/.coverage
+passenv = CI TRAVIS TRAVIS_*
+deps =
+    codecov
+skip_install = true
+commands =
+    python {envsitepackagesdir}/coverage combine
+    python {envsitepackagesdir}/coverage report --rcfile={toxinidir}/.coveragerc -m
+    - codecov
+changedir = {toxinidir}
+
 [testenv:coverage-erase]
 setenv =
     COVERAGE_FILE = {toxinidir}/.coverage

--- a/tox.ini
+++ b/tox.ini
@@ -17,36 +17,9 @@ deps =
    mccabe
 
 setenv =
-    COVERAGE_FILE = {toxinidir}/.coverage.{envname}
+    COVERAGE_FILE = {envdir}/.coverage
 
 commands =
     python -Wi {envsitepackagesdir}/coverage run -m unittest discover -s {envsitepackagesdir}/pylint/test/ -p {posargs:*test_*}.py
 
-    ; Transform absolute path to relative path
-    ; for compatibility with coveralls.io and fix 'source not available' error.
-    ; If you can find a cleaner way is welcome
-    python -c "import os;cov_strip_abspath = open(os.environ['COVERAGE_FILE'], 'r').read().replace('.tox' + os.sep + os.path.relpath('{envsitepackagesdir}', '{toxworkdir}') + os.sep, '');open(os.environ['COVERAGE_FILE'], 'w').write(cov_strip_abspath)"
 changedir = {toxworkdir}
-
-[testenv:codecov]
-setenv =
-    COVERAGE_FILE = {toxinidir}/.coverage
-passenv = CI TRAVIS TRAVIS_*
-deps =
-    codecov
-skip_install = true
-commands =
-    python {envsitepackagesdir}/coverage combine
-    python {envsitepackagesdir}/coverage report --rcfile={toxinidir}/.coveragerc -m
-    - codecov
-changedir = {toxinidir}
-
-[testenv:coverage-erase]
-setenv =
-    COVERAGE_FILE = {toxinidir}/.coverage
-deps =
-    coverage
-skip_install = true
-commands =
-    python {envsitepackagesdir}/coverage erase
-changedir = {toxinidir}


### PR DESCRIPTION
- Coveralls show a early comment without finish all builds, codecov wait all builds before to show a result.
  ![screen shot 2016-07-15 at 6 45 39 pm](https://cloud.githubusercontent.com/assets/6644187/16891234/5b581f20-4abc-11e6-9b41-e6e7599c233e.png)
- Codecov use the github status to see the coverage of the full project.
- Codecov add a new github status to see the coverage just of the patch of your PR.
  ![codecov](https://cloud.githubusercontent.com/assets/6644187/16782275/61c14050-4844-11e6-8b55-d562be16e856.png)
- Codecov work better (low fails).
- Codecov use a cute UI.
- Remove too much useless code `tox.ini`
- Codecov have integrate [browser plugins](https://github.com/codecov/browser-extension)
- [ ] Enable badge
