### PR TITLE
[REF] config.py: Support multiple classes with same 'name' value

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -159,6 +159,10 @@ Release date: tba
 
       Closes #1029.
 
+    * Support duplicated options category of checkers.
+
+      Closes #1018
+
 
 What's new in Pylint 1.6.3?
 ===========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -241,6 +241,8 @@ Bug fixes
   conflicts between a new message and any existing message id, symbol,
   or ``old_names``.
 
+* Support duplicated options category of checkers.
+
 
 Removed Changes
 ===============

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -500,7 +500,8 @@ class OptionsManagerMixIn(object):
             group.level = provider.level
             self._mygroups[group_name] = group
             # add section to the config file
-            if group_name != "DEFAULT":
+            if group_name != "DEFAULT" and \
+                    group_name not in self.cfgfile_parser._sections:
                 self.cfgfile_parser.add_section(group_name)
         # add provider's specific options
         for opt, optdict in options:

--- a/pylint/test/regrtest_data/dummy_plugin.rc
+++ b/pylint/test/regrtest_data/dummy_plugin.rc
@@ -1,0 +1,6 @@
+[MASTER]
+load-plugins=dummy_plugin
+
+[DUMMY_PLUGIN]
+dummy_option_1="dummy value 1"
+dummy_option_2="dummy value 2"

--- a/pylint/test/regrtest_data/dummy_plugin/dummy_plugin.py
+++ b/pylint/test/regrtest_data/dummy_plugin/dummy_plugin.py
@@ -1,0 +1,30 @@
+from pylint.checkers import BaseChecker
+
+
+class DummyPlugin1(BaseChecker):
+    name = 'dummy_plugin'
+    msgs = {'I9061': ('Dummy short desc 01', 'dummy-message-01', 'Dummy long desc')}
+    options = (
+        ('dummy_option_1', {
+            'type': 'string',
+            'metavar': '<string>',
+            'help': 'Dummy option 1',
+        }),
+    )
+
+
+class DummyPlugin2(BaseChecker):
+    name = 'dummy_plugin'
+    msgs = {'I9060': ('Dummy short desc 02', 'dummy-message-02', 'Dummy long desc')}
+    options = (
+        ('dummy_option_2', {
+            'type': 'string',
+            'metavar': '<string>',
+            'help': 'Dummy option 2',
+        }),
+    )
+
+
+def register(linter):
+    linter.register_checker(DummyPlugin1(linter))
+    linter.register_checker(DummyPlugin2(linter))

--- a/pylint/test/test_self.py
+++ b/pylint/test/test_self.py
@@ -134,7 +134,7 @@ class RunTC(unittest.TestCase):
         output = out.getvalue()
         # Get rid of the pesky messages that pylint emits if the
         # configuration file is not found.
-        master = re.search("\[MASTER", output)        
+        master = re.search("\[MASTER", output)
         out = six.StringIO(output[master.start():])
         parser = six.moves.configparser.RawConfigParser()
         parser.readfp(out)
@@ -335,6 +335,21 @@ class RunTC(unittest.TestCase):
         expected = 'Your code has been rated at 10.00/10'
         self._test_output([path, "--rcfile=%s" % config_path, "-rn"],
                           expected_output=expected)
+
+    def test_pylintrc_plugin_duplicate_options(self):
+        dummy_plugin_path = join(HERE, 'regrtest_data', 'dummy_plugin')
+        # Enable --load-plugins=dummy_plugin
+        sys.path.append(dummy_plugin_path)
+        config_path = join(HERE, 'regrtest_data', 'dummy_plugin.rc')
+        expected = (
+            ":dummy-message-01 (I9061): *Dummy short desc 01*\n"
+            "  Dummy long desc This message belongs to the dummy_plugin checker.\n\n"
+            ":dummy-message-02 (I9060): *Dummy short desc 02*\n"
+            "  Dummy long desc This message belongs to the dummy_plugin checker.")
+        self._test_output(["--rcfile=%s" % config_path,
+                           "--help-msg=dummy-message-01,dummy-message-02"],
+                          expected_output=expected)
+        sys.path.remove(dummy_plugin_path)
 
     def test_pylintrc_comments_in_values(self):
         path = join(HERE, 'regrtest_data', 'test_pylintrc_comments.py')

--- a/pylint/test/test_self.py
+++ b/pylint/test/test_self.py
@@ -349,6 +349,11 @@ class RunTC(unittest.TestCase):
         self._test_output(["--rcfile=%s" % config_path,
                            "--help-msg=dummy-message-01,dummy-message-02"],
                           expected_output=expected)
+        expected = (
+            "[DUMMY_PLUGIN]\n\n# Dummy option 1\ndummy_option_1=dummy value 1\n\n"
+            "# Dummy option 2\ndummy_option_2=dummy value 2")
+        self._test_output(["--rcfile=%s" % config_path, "--generate-rcfile"],
+                          expected_output=expected)
         sys.path.remove(dummy_plugin_path)
 
     def test_pylintrc_comments_in_values(self):


### PR DESCRIPTION
If you create a plugin and you want just one section for all checkers but you need many class to split logic, then you will need repeat the `name` value of the attribute of the classes to have the same section in the configuration file.

Reverting the core change and running the same tests the resut was:
```bash
======================================================================
ERROR: test_pylintrc_plugin_duplicate_options (test_self.RunTC)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/vauxoo-dev/pylint/.tox/py33/lib/python3.3/site-packages/pylint/test/test_self.py", line 351, in test_pylintrc_plugin_duplicate_options
    expected_output=expected)
  File "/root/vauxoo-dev/pylint/.tox/py33/lib/python3.3/site-packages/pylint/test/test_self.py", line 99, in _test_output
    self._run_pylint(args, out=out)
  File "/root/vauxoo-dev/pylint/.tox/py33/lib/python3.3/site-packages/pylint/test/test_self.py", line 94, in _run_pylint
    Run(args, reporter=reporter)
  File "/root/vauxoo-dev/pylint/.tox/py33/lib/python3.3/site-packages/pylint/lint.py", line 1257, in __init__
    linter.load_plugin_modules(plugins)
  File "/root/vauxoo-dev/pylint/.tox/py33/lib/python3.3/site-packages/pylint/lint.py", line 469, in load_plugin_modules
    module.register(self)
  File "/root/vauxoo-dev/pylint/.tox/py33/lib/python3.3/site-packages/pylint/test/regrtest_data/dummy_plugin/dummy_plugin.py", line 29, in register
    linter.register_checker(DummyPlugin1(linter))
  File "/root/vauxoo-dev/pylint/.tox/py33/lib/python3.3/site-packages/pylint/lint.py", line 549, in register_checker
    self.register_options_provider(checker)
  File "/root/vauxoo-dev/pylint/.tox/py33/lib/python3.3/site-packages/pylint/config.py", line 482, in register_options_provider
    non_group_spec_options, provider)
  File "/root/vauxoo-dev/pylint/.tox/py33/lib/python3.3/site-packages/pylint/config.py", line 504, in add_option_group
    self.cfgfile_parser.add_section(group_name)
  File "/usr/lib/python3.3/configparser.py", line 1174, in add_section
    super().add_section(section)
  File "/usr/lib/python3.3/configparser.py", line 634, in add_section
    raise DuplicateSectionError(section)
configparser.DuplicateSectionError: Section 'DUMMY_PLUGIN' already exists

----------------------------------------------------------------------
```

- [x] Add doc
- [x] Add test