### PR TITLE
Prevent data overwrite by old_names in register_messages

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -140,6 +140,9 @@ Release date: tba
     * InvalidMessageError, UnknownMessage, and EmptyReport exceptions are
       moved to the new pylint.exceptions submodule.
 
+    * UnknownMessage and EmptyReport are renamed to UnknownMessageError and
+      EmptyReportError.
+
 What's new in Pylint 1.6.3?
 ===========================
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -137,6 +137,9 @@ Release date: tba
     * More thorough validation in MessagesStore.register_messages() to avoid
       one message accidentally overwriting another.
 
+    * InvalidMessageError, UnknownMessage, and EmptyReport exceptions are
+      moved to the new pylint.exceptions submodule.
+
 What's new in Pylint 1.6.3?
 ===========================
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -131,6 +131,11 @@ Release date: tba
 
     * Added proper exception type inference for 'missing-raises-doc'.
 
+    * Added InvalidMessageError exception class to replace asserts in
+      pylint.utils.
+
+    * More thorough validation in MessagesStore.register_messages() to avoid
+      one message accidentally overwriting another.
 
 What's new in Pylint 1.6.3?
 ===========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -145,7 +145,8 @@ Other Changes
 * Add ``InvalidMessageError`` exception class and replace ``assert`` in
   pylint.utils with ``raise InvalidMessageError``.
 
-* ``UnknownMessage`` and ``EmptyReport`` are now provided by the new
+* ``UnknownMessageError`` (formerly ``UnknownMessage``) and
+  ``EmptyReportError`` (formerly ``EmptyReport``) are now provided by the new
   ``pylint.exceptions`` submodule instead of ``pylint.utils`` as before.
 
 Bug fixes

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -142,6 +142,9 @@ Other Changes
   applies to variable names, only with an inverse rule: you want long
   descriptive names for variables with bigger scope, like globals.
 
+* Add ``InvalidMessageError`` exception class and replace ``assert`` in
+  pylint.utils with ``raise InvalidMessageError``.
+
 
 Bug fixes
 =========
@@ -167,6 +170,10 @@ Bug fixes
 
 * Fix false positives of ``missing-[raises|params|type]-doc`` due to not
   recognizing valid keyword synonyms supported by Sphinx.
+
+* More thorough validation in ``MessagesStore.register_messages()`` to detect
+  conflicts between a new message and any existing message id, symbol,
+  or ``old_names``.
 
 
 Removed Changes

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -145,6 +145,8 @@ Other Changes
 * Add ``InvalidMessageError`` exception class and replace ``assert`` in
   pylint.utils with ``raise InvalidMessageError``.
 
+* ``UnknownMessage`` and ``EmptyReport`` are now provided by the new
+  ``pylint.exceptions`` submodule instead of ``pylint.utils`` as before.
 
 Bug fixes
 =========

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -20,7 +20,7 @@ from astroid import are_exclusive, InferenceError
 
 from pylint.interfaces import (IAstroidChecker, ITokenChecker, INFERENCE,
                                INFERENCE_FAILURE, HIGH)
-from pylint.exceptions import EmptyReport
+from pylint.exceptions import EmptyReportError
 from pylint.reporters import diff_string
 from pylint.checkers import BaseChecker, BaseTokenChecker
 from pylint.checkers.utils import (
@@ -228,7 +228,7 @@ def report_by_type_stats(sect, stats, old_stats):
         try:
             total = stats[node_type]
         except KeyError:
-            raise EmptyReport()
+            raise EmptyReportError()
         nice_stats[node_type] = {}
         if total != 0:
             try:

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -20,7 +20,7 @@ from astroid import are_exclusive, InferenceError
 
 from pylint.interfaces import (IAstroidChecker, ITokenChecker, INFERENCE,
                                INFERENCE_FAILURE, HIGH)
-from pylint.utils import EmptyReport
+from pylint.exceptions import EmptyReport
 from pylint.reporters import diff_string
 from pylint.checkers import BaseChecker, BaseTokenChecker
 from pylint.checkers.utils import (

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -18,7 +18,8 @@ from astroid.modutils import (get_module_part, is_standard_module)
 import isort
 
 from pylint.interfaces import IAstroidChecker
-from pylint.utils import EmptyReport, get_global_option
+from pylint.utils import get_global_option
+from pylint.exceptions import EmptyReport
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import (
     check_messages,

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -19,7 +19,7 @@ import isort
 
 from pylint.interfaces import IAstroidChecker
 from pylint.utils import get_global_option
-from pylint.exceptions import EmptyReport
+from pylint.exceptions import EmptyReportError
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import (
     check_messages,
@@ -673,7 +673,7 @@ given file (report RP0402 must not be disabled)'}
         """return a verbatim layout for displaying dependencies"""
         dep_info = _make_tree_defs(six.iteritems(self._external_dependencies_info()))
         if not dep_info:
-            raise EmptyReport()
+            raise EmptyReportError()
         tree_str = _repr_tree_defs(dep_info)
         sect.append(VerbatimText(tree_str))
 
@@ -683,7 +683,7 @@ given file (report RP0402 must not be disabled)'}
         if not dep_info or not (self.config.import_graph
                                 or self.config.ext_import_graph
                                 or self.config.int_import_graph):
-            raise EmptyReport()
+            raise EmptyReportError()
         filename = self.config.import_graph
         if filename:
             _make_graph(filename, dep_info, sect, '')

--- a/pylint/checkers/raw_metrics.py
+++ b/pylint/checkers/raw_metrics.py
@@ -12,7 +12,7 @@ Raw metrics checker
 import tokenize
 
 from pylint.interfaces import ITokenChecker
-from pylint.utils import EmptyReport
+from pylint.exceptions import EmptyReport
 from pylint.checkers import BaseTokenChecker
 from pylint.reporters import diff_string
 from pylint.reporters.ureports.nodes import Table

--- a/pylint/checkers/raw_metrics.py
+++ b/pylint/checkers/raw_metrics.py
@@ -12,7 +12,7 @@ Raw metrics checker
 import tokenize
 
 from pylint.interfaces import ITokenChecker
-from pylint.exceptions import EmptyReport
+from pylint.exceptions import EmptyReportError
 from pylint.checkers import BaseTokenChecker
 from pylint.reporters import diff_string
 from pylint.reporters.ureports.nodes import Table
@@ -23,7 +23,7 @@ def report_raw_stats(sect, stats, old_stats):
     """
     total_lines = stats['total_lines']
     if not total_lines:
-        raise EmptyReport()
+        raise EmptyReportError()
     sect.description = '%s lines have been analyzed' % total_lines
     lines = ('type', 'number', '%', 'previous', 'difference')
     for node_type in ('code', 'docstring', 'comment', 'empty'):

--- a/pylint/exceptions.py
+++ b/pylint/exceptions.py
@@ -6,3 +6,9 @@
 
 class InvalidMessageError(Exception):
     """raised when a message creation, registration or addition is rejected"""
+
+class UnknownMessage(Exception):
+    """raised when a unregistered message id is encountered"""
+
+class EmptyReport(Exception):
+    """raised when a report is empty and so should not be displayed"""

--- a/pylint/exceptions.py
+++ b/pylint/exceptions.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2016 Glenn F. Matthews <glenn@e-dad.net>
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/pylint/exceptions.py
+++ b/pylint/exceptions.py
@@ -1,0 +1,8 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+"""Exception classes raised by various operations within pylint."""
+
+
+class InvalidMessageError(Exception):
+    """raised when a message creation, registration or addition is rejected"""

--- a/pylint/exceptions.py
+++ b/pylint/exceptions.py
@@ -7,8 +7,8 @@
 class InvalidMessageError(Exception):
     """raised when a message creation, registration or addition is rejected"""
 
-class UnknownMessage(Exception):
+class UnknownMessageError(Exception):
     """raised when a unregistered message id is encountered"""
 
-class EmptyReport(Exception):
+class EmptyReportError(Exception):
     """raised when a report is empty and so should not be displayed"""

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -645,7 +645,7 @@ class PyLinter(config.OptionsManagerMixIn,
                             self._ignore_file = True
                             return
                         meth(msgid, 'module', start[0])
-                    except exceptions.UnknownMessage:
+                    except exceptions.UnknownMessageError:
                         self.add_message('bad-option-value', args=msgid, line=start[0])
             else:
                 self.add_message('unrecognized-inline-option', args=opt, line=start[0])
@@ -996,7 +996,7 @@ def report_messages_stats(sect, stats, _):
     """make messages type report"""
     if not stats['by_msg']:
         # don't print this report when we didn't detected any errors
-        raise exceptions.EmptyReport()
+        raise exceptions.EmptyReportError()
     in_order = sorted([(value, msg_id)
                        for msg_id, value in six.iteritems(stats['by_msg'])
                        if not msg_id.startswith('I')])
@@ -1010,7 +1010,7 @@ def report_messages_by_module_stats(sect, stats, _):
     """make errors / warnings by modules report"""
     if len(stats['by_module']) == 1:
         # don't print this report when we are analysing a single module
-        raise exceptions.EmptyReport()
+        raise exceptions.EmptyReportError()
     by_mod = collections.defaultdict(dict)
     for m_type in ('fatal', 'error', 'warning', 'refactor', 'convention'):
         total = stats[m_type]
@@ -1039,7 +1039,7 @@ def report_messages_by_module_stats(sect, stats, _):
         for val in line[:-1]:
             lines.append('%.2f' % val)
     if len(lines) == 5:
-        raise exceptions.EmptyReport()
+        raise exceptions.EmptyReportError()
     sect.append(report_nodes.Table(children=lines, cols=5, rheaders=1))
 
 

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -37,6 +37,7 @@ from astroid import modutils
 from pylint import checkers
 from pylint import interfaces
 from pylint import reporters
+from pylint import exceptions
 from pylint import utils
 from pylint import config
 from pylint.__pkginfo__ import version
@@ -644,7 +645,7 @@ class PyLinter(config.OptionsManagerMixIn,
                             self._ignore_file = True
                             return
                         meth(msgid, 'module', start[0])
-                    except utils.UnknownMessage:
+                    except exceptions.UnknownMessage:
                         self.add_message('bad-option-value', args=msgid, line=start[0])
             else:
                 self.add_message('unrecognized-inline-option', args=opt, line=start[0])
@@ -995,7 +996,7 @@ def report_messages_stats(sect, stats, _):
     """make messages type report"""
     if not stats['by_msg']:
         # don't print this report when we didn't detected any errors
-        raise utils.EmptyReport()
+        raise exceptions.EmptyReport()
     in_order = sorted([(value, msg_id)
                        for msg_id, value in six.iteritems(stats['by_msg'])
                        if not msg_id.startswith('I')])
@@ -1009,7 +1010,7 @@ def report_messages_by_module_stats(sect, stats, _):
     """make errors / warnings by modules report"""
     if len(stats['by_module']) == 1:
         # don't print this report when we are analysing a single module
-        raise utils.EmptyReport()
+        raise exceptions.EmptyReport()
     by_mod = collections.defaultdict(dict)
     for m_type in ('fatal', 'error', 'warning', 'refactor', 'convention'):
         total = stats[m_type]
@@ -1038,7 +1039,7 @@ def report_messages_by_module_stats(sect, stats, _):
         for val in line[:-1]:
             lines.append('%.2f' % val)
     if len(lines) == 5:
-        raise utils.EmptyReport()
+        raise exceptions.EmptyReport()
     sect.append(report_nodes.Table(children=lines, cols=5, rheaders=1))
 
 

--- a/pylint/test/unittest_lint.py
+++ b/pylint/test/unittest_lint.py
@@ -22,7 +22,7 @@ from pylint.lint import PyLinter, Run, preprocess_options, \
 from pylint.utils import MSG_STATE_SCOPE_CONFIG, MSG_STATE_SCOPE_MODULE, MSG_STATE_CONFIDENCE, \
     MessagesStore, PyLintASTWalker, MessageDefinition, FileState, \
     build_message_def, tokenize_module
-from pylint.exceptions import InvalidMessageError, UnknownMessage
+from pylint.exceptions import InvalidMessageError, UnknownMessageError
 from pylint.testutils import TestReporter
 from pylint.reporters import text
 from pylint import checkers
@@ -636,7 +636,7 @@ class MessagesStoreTC(unittest.TestCase):
     def test_check_message_id(self):
         self.assertIsInstance(self.store.check_message_id('W1234'),
                               MessageDefinition)
-        self.assertRaises(UnknownMessage,
+        self.assertRaises(UnknownMessageError,
                           self.store.check_message_id, 'YB12')
 
     def test_message_help(self):

--- a/pylint/test/unittest_lint.py
+++ b/pylint/test/unittest_lint.py
@@ -22,6 +22,7 @@ from pylint.lint import PyLinter, Run, preprocess_options, \
 from pylint.utils import MSG_STATE_SCOPE_CONFIG, MSG_STATE_SCOPE_MODULE, MSG_STATE_CONFIDENCE, \
     MessagesStore, PyLintASTWalker, MessageDefinition, FileState, \
     build_message_def, tokenize_module, UnknownMessage
+from pylint.exceptions import InvalidMessageError
 from pylint.testutils import TestReporter
 from pylint.reporters import text
 from pylint import checkers
@@ -444,6 +445,26 @@ class PyLinterTC(unittest.TestCase):
             ['C:  1: Line too long (1/2)', 'C:  2: Line too long (3/4)'],
             self.linter.reporter.messages)
 
+    def test_addmessage_invalid(self):
+        self.linter.set_reporter(TestReporter())
+        self.linter.open()
+        self.linter.set_current_module('0123')
+
+        with self.assertRaises(InvalidMessageError) as cm:
+            self.linter.add_message('line-too-long', args=(1,2))
+        self.assertEqual(str(cm.exception),
+                         "Message C0301 must provide line, got None")
+
+        with self.assertRaises(InvalidMessageError) as cm:
+            self.linter.add_message('line-too-long', line=2, node='fake_node', args=(1, 2))
+        self.assertEqual(str(cm.exception),
+                         "Message C0301 must only provide line, got line=2, node=fake_node")
+
+        with self.assertRaises(InvalidMessageError) as cm:
+            self.linter.add_message('C0321')
+        self.assertEqual(str(cm.exception),
+                         "Message C0321 must provide Node, got None")
+
     def test_init_hooks_called_before_load_plugins(self):
         self.assertRaises(RuntimeError,
                           Run, ['--load-plugins', 'unexistant', '--init-hook', 'raise RuntimeError'])
@@ -661,12 +682,26 @@ class MessagesStoreTC(unittest.TestCase):
         self.assertEqual('msg-symbol',
                          self.store.check_message_id('old-bad-name').symbol)
 
+    def test_add_renamed_message_invalid(self):
+        # conflicting message ID
+        with self.assertRaises(InvalidMessageError) as cm:
+            self.store.add_renamed_message(
+                    'W1234', 'old-msg-symbol', 'duplicate-keyword-arg')
+        self.assertEqual(str(cm.exception),
+                         "Message id 'W1234' is already defined")
+        # conflicting message symbol
+        with self.assertRaises(InvalidMessageError) as cm:
+            self.store.add_renamed_message(
+                'W1337', 'msg-symbol', 'duplicate-keyword-arg')
+        self.assertEqual(str(cm.exception),
+                         "Message symbol 'msg-symbol' is already defined")
+
     def test_renamed_message_register(self):
         self.assertEqual('msg-symbol',
                          self.store.check_message_id('W0001').symbol)
         self.assertEqual('msg-symbol',
                          self.store.check_message_id('old-symbol').symbol)
 
-   
+
 if __name__ == '__main__':
     unittest.main()

--- a/pylint/test/unittest_lint.py
+++ b/pylint/test/unittest_lint.py
@@ -21,8 +21,8 @@ from pylint.lint import PyLinter, Run, preprocess_options, \
      ArgumentPreprocessingError
 from pylint.utils import MSG_STATE_SCOPE_CONFIG, MSG_STATE_SCOPE_MODULE, MSG_STATE_CONFIDENCE, \
     MessagesStore, PyLintASTWalker, MessageDefinition, FileState, \
-    build_message_def, tokenize_module, UnknownMessage
-from pylint.exceptions import InvalidMessageError
+    build_message_def, tokenize_module
+from pylint.exceptions import InvalidMessageError, UnknownMessage
 from pylint.testutils import TestReporter
 from pylint.reporters import text
 from pylint import checkers

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -26,14 +26,7 @@ from astroid import modutils
 
 from pylint.interfaces import IRawChecker, ITokenChecker, UNDEFINED, implements
 from pylint.reporters.ureports.nodes import Section
-from pylint.exceptions import InvalidMessageError
-
-
-class UnknownMessage(Exception):
-    """raised when a unregistered message id is encountered"""
-
-class EmptyReport(Exception):
-    """raised when a report is empty and so should not be displayed"""
+from pylint.exceptions import InvalidMessageError, UnknownMessage, EmptyReport
 
 
 MSG_TYPES = {

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -26,7 +26,7 @@ from astroid import modutils
 
 from pylint.interfaces import IRawChecker, ITokenChecker, UNDEFINED, implements
 from pylint.reporters.ureports.nodes import Section
-from pylint.exceptions import InvalidMessageError, UnknownMessage, EmptyReport
+from pylint.exceptions import InvalidMessageError, UnknownMessageError, EmptyReportError
 
 
 MSG_TYPES = {
@@ -246,7 +246,7 @@ class MessagesHandlerMixIn(object):
         try:
             # msgid is a symbolic or numeric msgid.
             msg = self.msgs_store.check_message_id(msgid)
-        except UnknownMessage:
+        except UnknownMessageError:
             if ignore_unknown:
                 return
             raise
@@ -273,7 +273,7 @@ class MessagesHandlerMixIn(object):
         """
         try:
             return self.msgs_store.check_message_id(msgid).symbol
-        except UnknownMessage:
+        except UnknownMessageError:
             return msgid
 
     def enable(self, msgid, scope='package', line=None, ignore_unknown=False):
@@ -307,7 +307,7 @@ class MessagesHandlerMixIn(object):
         try:
             # msgid is a symbolic or numeric msgid.
             msg = self.msgs_store.check_message_id(msgid)
-        except UnknownMessage:
+        except UnknownMessageError:
             if ignore_unknown:
                 return
             raise
@@ -342,7 +342,7 @@ class MessagesHandlerMixIn(object):
                 return False
         try:
             msgid = self.msgs_store.check_message_id(msg_descr).msgid
-        except UnknownMessage:
+        except UnknownMessageError:
             # The linter checks for messages that are not registered
             # due to version mismatch, just treat them as message IDs
             # for now.
@@ -720,7 +720,7 @@ class MessagesStore(object):
 
         msgid may be either a numeric or symbolic id.
 
-        Raises UnknownMessage if the message id is not defined.
+        Raises UnknownMessageError if the message id is not defined.
         """
         if msgid[1:].isdigit():
             msgid = msgid.upper()
@@ -729,7 +729,7 @@ class MessagesStore(object):
                 return source[msgid]
             except KeyError:
                 pass
-        raise UnknownMessage('No such message id %s' % msgid)
+        raise UnknownMessageError('No such message id %s' % msgid)
 
     def get_msg_display_string(self, msgid):
         """Generates a user-consumable representation of a message.
@@ -744,7 +744,7 @@ class MessagesStore(object):
             try:
                 print(self.check_message_id(msgid).format_help(checkerref=True))
                 print("")
-            except UnknownMessage as ex:
+            except UnknownMessageError as ex:
                 print(ex)
                 print("")
                 continue
@@ -811,7 +811,7 @@ class ReportsHandlerMixIn(object):
                 report_sect = Section(r_title)
                 try:
                     r_cb(report_sect, stats, old_stats)
-                except EmptyReport:
+                except EmptyReportError:
                     continue
                 report_sect.report_id = reportid
                 sect.append(report_sect)


### PR DESCRIPTION
### Fixes / new features
-  Add missing validation of message ``old_names`` in ``MessagesStore.register_messages()`` to prevent a newly registered message from overwriting values previously registered by another message.
- Add `InvalidMessageError` to raise in these and similar cases instead of using `assert`.
- Move `EmptyReport` and `UnknownMessage` exceptions (and `InvalidMessageError`) to `pylint.exceptions` submodule.
- Rename `EmptyReport` to `EmptyReportError` and `UnknownMessage` to `UnknownMessageError`

