### PR TITLE
Extend SphinxDocstring class to support Epytext comments

### DIFF
--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -162,7 +162,7 @@ class SphinxDocstring(Docstring):
         `{0}`                         # what to reference
         """.format(re_type)
 
-    re_param_in_docstring = re.compile(r"""
+    re_param_raw = r"""
         :                       # initial colon
         (?:                     # Sphinx keywords
         param|parameter|
@@ -179,17 +179,19 @@ class SphinxDocstring(Docstring):
         (\w+)                   # Parameter name
         \s*                     # whitespace
         :                       # final colon
-        """.format(type=re_type), re.X | re.S)
+        """.format(type=re_type)
+    re_param_in_docstring = re.compile(re_param_raw, re.X | re.S)
 
-    re_type_in_docstring = re.compile(r"""
+    re_type_raw = r"""
         :type                   # Sphinx keyword
         \s+                     # whitespace
         ({type})                # Parameter name
         \s*                     # whitespace
         :                       # final colon
-        """.format(type=re_type), re.X | re.S)
+        """.format(type=re_type)
+    re_type_in_docstring = re.compile(re_type_raw, re.X | re.S)
 
-    re_raise_in_docstring = re.compile(r"""
+    re_raise_raw = r"""
         :                       # initial colon
         (?:                     # Sphinx keyword
         raises?|
@@ -205,7 +207,8 @@ class SphinxDocstring(Docstring):
         (\w+)                   # Parameter name
         \s*                     # whitespace
         :                       # final colon
-        """.format(type=re_type), re.X | re.S)
+        """.format(type=re_type)
+    re_raise_in_docstring = re.compile(re_raise_raw, re.X | re.S)
 
     re_rtype_in_docstring = re.compile(r":rtype:")
 
@@ -271,52 +274,17 @@ class EpytextDocstring(SphinxDocstring):
         https://www.jetbrains.com/help/pycharm/2016.1/creating-documentation-comments.html#d848203e314
         https://www.jetbrains.com/help/pycharm/2016.1/using-docstrings-to-specify-types.html
     """
-    re_type = r"[\w\.]+"
+    re_param_in_docstring = re.compile(
+        SphinxDocstring.re_param_raw.replace(':', '@', 1),
+        re.X | re.S)
 
-    re_param_in_docstring = re.compile(r"""
-        @                       # initial "at" symbol
-        (?:                     # Epytext keywords
-        param|parameter|
-        arg|argument|
-        key|keyword
-        )
-        \s+                     # whitespace
+    re_type_in_docstring = re.compile(
+        SphinxDocstring.re_type_raw.replace(':', '@', 1),
+        re.X | re.S)
 
-        (?:                     # optional type declaration
-        ({type})
-        \s+
-        )?
-
-        (\w+)                   # Parameter name
-        \s*                     # whitespace
-        :                       # final colon
-        """.format(type=re_type), re.X | re.S)
-
-    re_type_in_docstring = re.compile(r"""
-        @type                   # Epytext keyword
-        \s+                     # whitespace
-        ({type})                # Parameter name
-        \s*                     # whitespace
-        :                       # final colon
-        """.format(type=re_type), re.X | re.S)
-
-    re_raise_in_docstring = re.compile(r"""
-        @                       # initial "at" symbol
-        (?:                     # Epytext keyword
-        raises?|
-        except|exception
-        )
-        \s+                     # whitespace
-
-        (?:                     # type declaration
-        ({type})
-        \s+
-        )?
-
-        (\w+)                   # Parameter name
-        \s*                     # whitespace
-        :                       # final colon
-        """.format(type=re_type), re.X | re.S)
+    re_raise_in_docstring = re.compile(
+        SphinxDocstring.re_raise_raw.replace(':', '@', 1),
+        re.X | re.S)
 
     re_rtype_in_docstring = re.compile(r"""
         @                       # initial "at" symbol

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -100,7 +100,7 @@ def possible_exc_types(node):
 
 
 def docstringify(docstring):
-    for docstring_type in [SphinxDocstring, GoogleDocstring, NumpyDocstring]:
+    for docstring_type in [SphinxEpytextDocstring, GoogleDocstring, NumpyDocstring]:
         instance = docstring_type(docstring)
         if instance.is_valid():
             return instance
@@ -153,7 +153,12 @@ class Docstring(object):
         return self.re_for_parameters_see.search(self.doc) is not None
 
 
-class SphinxDocstring(Docstring):
+class SphinxEpytextDocstring(Docstring):
+    """
+    This class implements Sphinx/Epytext comments. The difference is slight:
+    :param name: -- this is Sphinx
+    @param name: -- this is Epytext
+    """
     re_type = r"[\w\.]+"
 
     re_xref = r"""
@@ -162,7 +167,7 @@ class SphinxDocstring(Docstring):
         """.format(re_type)
 
     re_param_in_docstring = re.compile(r"""
-        :                       # initial colon
+        [:@]                    # initial colon or "at" symbol
         (?:                     # Sphinx keywords
         param|parameter|
         arg|argument|
@@ -181,7 +186,7 @@ class SphinxDocstring(Docstring):
         """.format(type=re_type), re.X | re.S)
 
     re_type_in_docstring = re.compile(r"""
-        :type                   # Sphinx keyword
+        [:@]type                # Sphinx keyword
         \s+                     # whitespace
         ({type})                # Parameter name
         \s*                     # whitespace
@@ -189,7 +194,7 @@ class SphinxDocstring(Docstring):
         """.format(type=re_type), re.X | re.S)
 
     re_raise_in_docstring = re.compile(r"""
-        :                       # initial colon
+        [:@]                    # initial colon or "at" symbol
         (?:                     # Sphinx keyword
         raises?|
         except|exception
@@ -206,9 +211,9 @@ class SphinxDocstring(Docstring):
         :                       # final colon
         """.format(type=re_type), re.X | re.S)
 
-    re_rtype_in_docstring = re.compile(r":rtype:")
+    re_rtype_in_docstring = re.compile(r"[:@]rtype:")
 
-    re_returns_in_docstring = re.compile(r":returns?:")
+    re_returns_in_docstring = re.compile(r"[:@]returns?:")
 
     supports_yields = False
 
@@ -261,9 +266,9 @@ class SphinxDocstring(Docstring):
 
 
 class GoogleDocstring(Docstring):
-    re_type = SphinxDocstring.re_type
+    re_type = SphinxEpytextDocstring.re_type
 
-    re_xref = SphinxDocstring.re_xref
+    re_xref = SphinxEpytextDocstring.re_xref
 
     re_container_type = r"""
         (?:{type}|{xref})             # a container type

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -100,7 +100,7 @@ def possible_exc_types(node):
 
 
 def docstringify(docstring):
-    for docstring_type in [SphinxEpytextDocstring, GoogleDocstring, NumpyDocstring]:
+    for docstring_type in [SphinxDocstring, GoogleDocstring, NumpyDocstring]:
         instance = docstring_type(docstring)
         if instance.is_valid():
             return instance
@@ -153,12 +153,7 @@ class Docstring(object):
         return self.re_for_parameters_see.search(self.doc) is not None
 
 
-class SphinxEpytextDocstring(Docstring):
-    """
-    This class implements Sphinx/Epytext comments. The difference is slight:
-    :param name: -- this is Sphinx
-    @param name: -- this is Epytext
-    """
+class SphinxDocstring(Docstring):
     re_type = r"[\w\.]+"
 
     re_xref = r"""
@@ -167,7 +162,7 @@ class SphinxEpytextDocstring(Docstring):
         """.format(re_type)
 
     re_param_in_docstring = re.compile(r"""
-        [:@]                    # initial colon or "at" symbol
+        :                       # initial colon
         (?:                     # Sphinx keywords
         param|parameter|
         arg|argument|
@@ -186,7 +181,7 @@ class SphinxEpytextDocstring(Docstring):
         """.format(type=re_type), re.X | re.S)
 
     re_type_in_docstring = re.compile(r"""
-        [:@]type                # Sphinx keyword
+        :type                   # Sphinx keyword
         \s+                     # whitespace
         ({type})                # Parameter name
         \s*                     # whitespace
@@ -194,7 +189,7 @@ class SphinxEpytextDocstring(Docstring):
         """.format(type=re_type), re.X | re.S)
 
     re_raise_in_docstring = re.compile(r"""
-        [:@]                    # initial colon or "at" symbol
+        :                       # initial colon
         (?:                     # Sphinx keyword
         raises?|
         except|exception
@@ -211,9 +206,9 @@ class SphinxEpytextDocstring(Docstring):
         :                       # final colon
         """.format(type=re_type), re.X | re.S)
 
-    re_rtype_in_docstring = re.compile(r"[:@]rtype:")
+    re_rtype_in_docstring = re.compile(r":rtype:")
 
-    re_returns_in_docstring = re.compile(r"[:@]returns?:")
+    re_returns_in_docstring = re.compile(r":returns?:")
 
     supports_yields = False
 
@@ -266,9 +261,9 @@ class SphinxEpytextDocstring(Docstring):
 
 
 class GoogleDocstring(Docstring):
-    re_type = SphinxEpytextDocstring.re_type
+    re_type = SphinxDocstring.re_type
 
-    re_xref = SphinxEpytextDocstring.re_xref
+    re_xref = SphinxDocstring.re_xref
 
     re_container_type = r"""
         (?:{type}|{xref})             # a container type

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -100,7 +100,8 @@ def possible_exc_types(node):
 
 
 def docstringify(docstring):
-    for docstring_type in [SphinxDocstring, GoogleDocstring, NumpyDocstring]:
+    for docstring_type in [SphinxDocstring, EpytextDocstring,
+                           GoogleDocstring, NumpyDocstring]:
         instance = docstring_type(docstring)
         if instance.is_valid():
             return instance
@@ -258,6 +259,74 @@ class SphinxDocstring(Docstring):
 
         params_with_type.update(re.findall(self.re_type_in_docstring, self.doc))
         return params_with_doc, params_with_type
+
+
+class EpytextDocstring(SphinxDocstring):
+    """
+    Epytext is similar to Sphinx. See the docs:
+        http://epydoc.sourceforge.net/epytext.html
+        http://epydoc.sourceforge.net/fields.html#fields
+
+    It's used in PyCharm:
+        https://www.jetbrains.com/help/pycharm/2016.1/creating-documentation-comments.html#d848203e314
+        https://www.jetbrains.com/help/pycharm/2016.1/using-docstrings-to-specify-types.html
+    """
+    re_type = r"[\w\.]+"
+
+    re_param_in_docstring = re.compile(r"""
+        @                       # initial "at" symbol
+        (?:                     # Epytext keywords
+        param|parameter|
+        arg|argument|
+        key|keyword
+        )
+        \s+                     # whitespace
+
+        (?:                     # optional type declaration
+        ({type})
+        \s+
+        )?
+
+        (\w+)                   # Parameter name
+        \s*                     # whitespace
+        :                       # final colon
+        """.format(type=re_type), re.X | re.S)
+
+    re_type_in_docstring = re.compile(r"""
+        @type                   # Epytext keyword
+        \s+                     # whitespace
+        ({type})                # Parameter name
+        \s*                     # whitespace
+        :                       # final colon
+        """.format(type=re_type), re.X | re.S)
+
+    re_raise_in_docstring = re.compile(r"""
+        @                       # initial "at" symbol
+        (?:                     # Epytext keyword
+        raises?|
+        except|exception
+        )
+        \s+                     # whitespace
+
+        (?:                     # type declaration
+        ({type})
+        \s+
+        )?
+
+        (\w+)                   # Parameter name
+        \s*                     # whitespace
+        :                       # final colon
+        """.format(type=re_type), re.X | re.S)
+
+    re_rtype_in_docstring = re.compile(r"""
+        @                       # initial "at" symbol
+        (?:                     # Epytext keyword
+        rtype|returntype
+        )
+        :                       # final colon
+        """, re.X | re.S)
+
+    re_returns_in_docstring = re.compile(r"@returns?:")
 
 
 class GoogleDocstring(Docstring):


### PR DESCRIPTION
The difference is very small, I'm not sure whether I should have created a new class for that. Also, I didn't touch tests, if there are any.

fix #1029