### PR TITLE
update instruction to install pylint

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -9,7 +9,7 @@ Pylint should be easily installable using pip.
 
 .. code-block:: sh
 
-   python -m pip install pip
+   python -m pip install pylint
 
 
 Source distribution installation


### PR DESCRIPTION
### Fixes / new features
- should be `pip install pylint`, I think ?