### PR TITLE
Use ClassDef.instantiate_class()

### DIFF
--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -1109,7 +1109,7 @@ a metaclass class method.'}
                              args=(method1, refmethod), node=method1)
             return
 
-        instance = cls.instanciate_class()
+        instance = cls.instantiate_class()
         method1 = function_to_method(method1, instance)
         refmethod = function_to_method(refmethod, instance)
 


### PR DESCRIPTION
Otherwise we get this from astroid:

```
.../pylint/pylint/checkers/classes.py:1112: PendingDeprecationWarning:
ClassDef.instanciate_class() is deprecated and slated for removal in
astroid 2.0, use ClassDef.instantiate_class() instead.
    instance = cls.instanciate_class()
```