### PR TITLE
elisp: allow guessed indent string to be passed to pylint

### DIFF
--- a/elisp/pylint.el
+++ b/elisp/pylint.el
@@ -64,6 +64,11 @@ Notice that using \\[next-error] or \\[compile-goto-error] modifies
   :type '(repeat string)
   :group 'pylint)
 
+(defcustom pylint-use-python-indent-offset nil
+  "If non-nil, use `python-indent-offset' to set indent-string."
+  :type 'boolean
+  :group 'pylint)
+
 (defcustom pylint-command "pylint"
   "PYLINT command."
   :type '(file)
@@ -179,6 +184,11 @@ appending to an existing list)."
   "Keymap for PYLINT buffers.
 `compilation-minor-mode-map' is a cdr of this.")
 
+(defun pylint--make-indent-string ()
+  "Make a string for the `--indent-string' option."
+  (format "--indent-string='%s'"
+          (make-string python-indent-offset ?\ )))
+
 ;;;###autoload
 (defun pylint (&optional arg)
   "Run PYLINT, and collect output in a buffer, much like `compile'.
@@ -199,6 +209,10 @@ output buffer, to go to the lines where pylint found matches.
          (pylint-command (if arg
                              pylint-alternate-pylint-command
                            pylint-command))
+         (pylint-options (if (not pylint-use-python-indent-offset)
+                             pylint-options
+                           (append pylint-options
+                                   (list (pylint--make-indent-string)))))
          (command (mapconcat
                    'identity
                    (append `(,pylint-command) pylint-options `(,filename))


### PR DESCRIPTION
Emacs guesses the indent of a python file and stores it in a buffer-local variable.  This patch allows pylint.el to set `--indent-string` based on the guessed indent.  

I worked at a place with the weird policy of 3 space indent.  Emacs guessed this correctly, but pylint would complain about the indentation.  I didn't want to set it to 3 for everything because my personal scripts and other projects use the normal 4 space indent.  So this does the Right Thing on a per-file basis.