### PR TITLE
[FIX] duplicate-code: ignored disable=duplicate-code comments

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -109,6 +109,7 @@ Order doesn't matter (not that much, at least ;)
   Refactory wrong-import-position to skip try-import and nested cases
   Add consider-merging-isinstance, superfluous-else-return
   Fix consider-using-ternary for 'True and True and True or True' case
+  Fix disable/enable pylint comments for duplicate-code
 
 * Luis Escobar (Vauxoo), Moisés López (Vauxoo): Add bad-docstring-quotes and docstring-first-line-empty
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -423,6 +423,10 @@ Release date: 2017-04-13
 
       Fixes #59
 
+    * Fix duplicate-code (R0801) can't be disabled using
+      pylint disable comments.
+
+      Fixes #214
 
 What's new in Pylint 1.6.3?
 ===========================

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -32,7 +32,7 @@ class Similar(object):
         self.ignore_imports = ignore_imports
         self.linesets = []
 
-    def append_stream(self, streamid, stream, encoding=None):
+    def append_stream(self, streamid, stream, encoding=None, state_lines=None):
         """append a file to search for similarities"""
         if encoding is None:
             readlines = stream.readlines
@@ -43,7 +43,7 @@ class Similar(object):
                                          readlines(),
                                          self.ignore_comments,
                                          self.ignore_docstrings,
-                                         self.ignore_imports))
+                                         self.ignore_imports, state_lines))
         except UnicodeDecodeError:
             pass
 
@@ -127,14 +127,17 @@ class Similar(object):
                 for sim in self._find_common(lineset, lineset2):
                     yield sim
 
-def stripped_lines(lines, ignore_comments, ignore_docstrings, ignore_imports):
+def stripped_lines(lines, ignore_comments, ignore_docstrings, ignore_imports, state_lines=None):
     """return lines with leading/trailing whitespace and any ignored code
     features removed
     """
 
     strippedlines = []
     docstring = None
-    for line in lines:
+    for lineno, line in enumerate(lines, start=1):
+        if state_lines and lineno in state_lines and not state_lines[lineno]:
+            strippedlines.append('')
+            continue
         line = line.strip()
         if ignore_docstrings:
             if not docstring and \
@@ -159,12 +162,12 @@ def stripped_lines(lines, ignore_comments, ignore_docstrings, ignore_imports):
 class LineSet(object):
     """Holds and indexes all the lines of a single source file"""
     def __init__(self, name, lines, ignore_comments=False,
-                 ignore_docstrings=False, ignore_imports=False):
+                 ignore_docstrings=False, ignore_imports=False, state_lines=None):
         self.name = name
         self._real_lines = lines
         self._stripped_lines = stripped_lines(lines, ignore_comments,
                                               ignore_docstrings,
-                                              ignore_imports)
+                                              ignore_imports, state_lines)
         self._index = self._mk_index()
 
     def __str__(self):
@@ -291,10 +294,11 @@ class SimilarChecker(BaseChecker, Similar):
 
         stream must implement the readlines method
         """
+        state_lines = self.linter.file_state._module_msgs_state.get('R0801')
         with node.stream() as stream:
             self.append_stream(self.linter.current_name,
                                stream,
-                               node.file_encoding)
+                               node.file_encoding, state_lines)
 
     def close(self):
         """compute and display similarities on closing (i.e. end of parsing)"""

--- a/pylint/test/input/similar_disabled
+++ b/pylint/test/input/similar_disabled
@@ -1,0 +1,27 @@
+# comment 1
+# comment 2
+# pylint: disable=duplicate-code
+import one
+from two import two
+three
+four
+five
+six # comments optionally ignored
+seven
+# pylint: enable=duplicate-code
+eight
+nine
+''' ten
+eleven
+twelve '''
+thirteen
+fourteen
+fifteen
+
+
+
+
+sixteen
+# pylint: disable=duplicate-code
+seventeen
+eighteen

--- a/pylint/test/unittest_checker_similar.py
+++ b/pylint/test/unittest_checker_similar.py
@@ -14,6 +14,7 @@ from pylint.checkers import similar
 
 SIMILAR1 = join(dirname(abspath(__file__)), 'input', 'similar1')
 SIMILAR2 = join(dirname(abspath(__file__)), 'input', 'similar2')
+SIMILAR_DISABLED = join(dirname(abspath(__file__)), 'input', 'similar_disabled')
 
 
 def test_ignore_comments():
@@ -127,3 +128,34 @@ def test_no_args():
         pytest.fail('not system exit')
     finally:
         sys.stdout = sys.__stdout__
+
+
+def test_disable_comments():
+        sys.stdout = six.StringIO()
+        with pytest.raises(SystemExit) as ex:
+            similar.Run(['--ignore-comments', SIMILAR1, SIMILAR_DISABLED])
+        assert ex.value.code == 0
+        output = sys.stdout.getvalue()
+        sys.stdout = sys.__stdout__
+        output_trailing_ws = '\n'.join(
+            map(str.rstrip, output.strip('\n').splitlines())).strip()
+        output_expected_trailing_ws = ("""
+13 similar lines in 2 files
+==%s:7
+==%s:11
+   eight
+   nine
+   ''' ten
+   eleven
+   twelve '''
+   thirteen
+   fourteen
+   fifteen
+
+
+
+
+   sixteen
+TOTAL lines=49 duplicates=13 percent=26.53
+""" % (SIMILAR1, SIMILAR_DISABLED)).strip()
+        assert output_trailing_ws == output_expected_trailing_ws


### PR DESCRIPTION
### Fixes / new features
- [x] Fix https://github.com/PyCQA/pylint/issues/214

It's a proposal from last comment https://github.com/PyCQA/pylint/pull/1014#issuecomment-233209686 from 15 days ago.
- [x] It don't depend on PyLinter to do its job
- [x] It was fixed a clean way
- [x] The user can enable/disable the message many times in the same file
- [x] Add docs
- [x] Tested with file [duplicate-code-disable-enable-example.py](https://gist.githubusercontent.com/moylop260/7f499f055576d7c7b0d51565f0ec3c83/raw/e398de5d9b234cdb464cd2bc117a8614acd9ae26/duplicate-code-disable-enable-example.py) and [pylint/test/input/similar1](https://github.com/PyCQA/pylint/blob/bbd42396362e5b7332d6b8867065b364da489a98/pylint/test/input/similar1)

``` bash
# wget goo.gl/jsW67L -o duplicate-code-disable-enable-example.py
# pylint  -rn -d all -e duplicate-code duplicate-code-disable-enable-example.py pylint/test/input/similar1
************* Module input.similar1
R:  1, 0: Similar lines in 2 files
==duplicate-code-disable-enable-example:11
==input.similar1:7
eight
nine
''' ten
eleven
twelve '''
thirteen
fourteen
fifteen




sixteen (duplicate-code)
R:  1, 0: Similar lines in 2 files
==duplicate-code-disable-enable-example:3
==input.similar1:0
import one
from two import two
three
four
five
six # comments optionally ignored
seven (duplicate-code)
```

Note: 
- My apologies for the insistence, I promise this is my last attempt to repair this issue.
  Just I could add a reference in the original issue to other people that want apply this patch.
- We can add the tests (where a pylinter is required for now) for 3.0 version (based on https://github.com/PyCQA/pylint/pull/1014#issuecomment-233185403)