### PR TITLE
Allow underscores in unused-variables. (#1058)

### DIFF
--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -328,7 +328,7 @@ class VariablesChecker(BaseChecker):
                  'help' : 'Tells whether we should check for unused import in '
                           '__init__ files.'}),
                ("dummy-variables-rgx",
-                {'default': ('(_+[a-zA-Z0-9]*?$)|dummy'),
+                {'default': ('_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy'),
                  'type' :'regexp', 'metavar' : '<regexp>',
                  'help' : 'A regular expression matching the name of dummy '
                           'variables (i.e. expectedly not used).'}),

--- a/pylint/test/functional/unused_variable.py
+++ b/pylint/test/functional/unused_variable.py
@@ -14,3 +14,4 @@ def test_unused_with_prepended_underscore():
     dummy = 24
     _a_ = 42 # [unused-variable]
     __a__ = 24 # [unused-variable]
+    __never_used = 42


### PR DESCRIPTION
### Fixes
- https://github.com/PyCQA/pylint/issues/1058

### Tests
- Additional check in `pylint/test/functional/unused_variable.py`

### Quagmire
In `pylint/test/functional/unused_argument.py`, the following line should fail; The test is, actually, incorrect.

__unused_argument.py:__
```
def test_unused(first, second, _not_used): # [unused-argument, unused-argument]
    pass
```

However. First of all, I don't know the Pylint codebase well enough know why this is either being skipped or it is marked as a pass; It shouldn't. I want to point a finger to the `pylintrc` file, but I won't be so brash. Running pylint without any arguments,  `pylint pylint/test/functional/unused_argument.py`, appears to confirm my point.

#### pylint output
```
I:  1, 0: Locally disabling missing-docstring (C0111) (locally-disabled)
I:  1, 0: Locally disabling too-few-public-methods (R0903) (locally-disabled)
W:  3,23: Unused argument 'second' (unused-argument)
W:  3,31: Unused argument '_not_used' (unused-argument)
W:  3,16: Unused argument 'first' (unused-argument)
W: 25,29: Unused argument 'aay' (unused-argument)
```

Secondly, my test would fix this broken test. With a little more knowledge on the unittest setup, I would like to break the test to demonstrate that `unused-arguments` are also fixed by my commit.

### tox

Tests have been run using the vanilla `tox` command with all tests passing, except for `jython` because I have a setup issue. I'll have to defer to the CI's judgement.

```
  py27: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  py35: commands succeeded
  pypy: commands succeeded
ERROR:   jython: InvocationError: ...omit.../python2.7 -m virtualenv --python ...omit.../jython jython (see ...omit.../jython-0.log)
  pylint: commands succeeded
```