### PR TITLE
Implement an ignore-regex-members option

### DIFF
--- a/pylint/checkers/async.py
+++ b/pylint/checkers/async.py
@@ -5,6 +5,9 @@
 
 """Checker for anything related to the async protocol (PEP 492)."""
 
+import ast
+import re
+
 import astroid
 from astroid import exceptions
 
@@ -32,6 +35,8 @@ class AsyncChecker(checkers.BaseChecker):
 
     def open(self):
         self._ignore_mixin_members = utils.get_global_option(self, 'ignore-mixin-members')
+        self._ignore_regex_list = ast.literal_eval(
+            utils.get_global_option(self, 'ignore-regex-members', default='[]'))
 
     @checker_utils.check_messages('yield-inside-async-function')
     def visit_asyncfunctiondef(self, node):
@@ -60,6 +65,11 @@ class AsyncChecker(checkers.BaseChecker):
                         if self._ignore_mixin_members:
                             if infered.name[-5:].lower() == 'mixin':
                                 continue
+                        # Ignore matching regex classes.
+                        if self._ignore_regex_list:
+                            for regex in self._ignore_regex_list:
+                                if re.search(regex, infered.name):
+                                    continue
                 else:
                     continue
 

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -18,6 +18,8 @@ from collections import defaultdict
 import sys
 
 import six
+import ast
+import re
 
 import astroid
 from astroid.bases import Generator, BUILTINS
@@ -537,6 +539,14 @@ a metaclass class method.'}
             # something is missing, since it is most likely that it will
             # miss.
             return
+        ignore_regex_list = get_global_option(self, 'ignore-regex-members',
+                                              default=None)
+
+        if ignore_regex_list:
+            for regex in ast.literal_eval(ignore_regex_list):
+                if re.search(regex, cnode.name):
+                    return
+
 
         accessed = self._accessed.pop()
         if cnode.type != 'metaclass':

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -405,11 +405,16 @@ class TypeChecker(BaseChecker):
     priority = -1
     # configuration options
     options = (('ignore-mixin-members',
-                {'default' : True, 'type' : 'yn', 'metavar': '<y_or_n>',
-                 'help' : 'Tells whether missing members accessed in mixin \
-class should be ignored. A mixin class is detected if its name ends with \
-"mixin" (case insensitive).'}
-               ),
+                {'default': True, 'type': 'yn', 'metavar': '<y_or_n>',
+                 'help': 'Tells whether missing members accessed in mixin '
+                 'class should be ignored. A mixin class is detected if its '
+                 'name ends with "mixin" (case insensitive).'}
+                ),
+               ('ignore-regex-members',
+                {'default': '', 'type': 'string', 'metavar': '<regex list>',
+                 'help': 'Missing members for the class that match any of the'
+                         ' regex in the list will be ignored.'}
+                ),
                ('ignored-modules',
                 {'default': (),
                  'type': 'csv',
@@ -420,28 +425,28 @@ class should be ignored. A mixin class is detected if its name ends with \
                          'thus existing member attributes cannot be '
                          'deduced by static analysis. It supports qualified '
                          'module names, as well as Unix pattern matching.'}
-               ),
+                ),
                # the defaults here are *stdlib* names that (almost) always
                # lead to false positives, since their idiomatic use is
                # 'too dynamic' for pylint to grok.
                ('ignored-classes',
-                {'default' : ('optparse.Values', 'thread._local', '_thread._local'),
-                 'type' : 'csv',
-                 'metavar' : '<members names>',
-                 'help' : 'List of class names for which member attributes '
-                          'should not be checked (useful for classes with '
-                          'dynamically set attributes). This supports '
-                          'the use of qualified names.'}
-               ),
+                {'default': ('optparse.Values', 'thread._local', '_thread._local'),
+                 'type': 'csv',
+                 'metavar': '<members names>',
+                 'help': 'List of class names for which member attributes '
+                         'should not be checked (useful for classes with '
+                         'dynamically set attributes). This supports '
+                         'the use of qualified names.'}
+                ),
 
                ('generated-members',
-                {'default' : (),
-                 'type' : 'string',
-                 'metavar' : '<members names>',
-                 'help' : 'List of members which are set dynamically and \
-missed by pylint inference system, and so shouldn\'t trigger E1101 when \
-accessed. Python regular expressions are accepted.'}
-               ),
+                {'default': (),
+                 'type': 'string',
+                 'metavar': '<members names>',
+                 'help': 'List of members which are set dynamically and '
+                 'missed by pylint inference system, and so shouldn\'t trigger E1101 when '
+                 'accessed. Python regular expressions are accepted.'}
+                ),
                ('contextmanager-decorators',
                 {'default': ['contextlib.contextmanager'],
                  'type': 'csv',
@@ -450,8 +455,8 @@ accessed. Python regular expressions are accepted.'}
                          'such as contextlib.contextmanager. Add to this list '
                          'to register other decorators that produce valid '
                          'context managers.'}
-               ),
-              )
+                ),
+               )
 
     def open(self):
         # do this in open since config not fully initialized in __init__


### PR DESCRIPTION
### Context

Hi, we are using FactoryBoy with Django here at work and pylint completly fail to see any of the members of a Factory

http://factoryboy.readthedocs.io/en/latest/orms.html#the-djangomodelfactory-subclass

What we would need is to be able to ignore member the members on *Factory classes like with *Mixin classes, but I believe that from this point forward it is obvious we need a more generic feature to disable member checks. This is why I came up with this regex solution.

I am unable to run the test this as it seems the master requires Python 3 but if you point me to the stable release and how to install dependencies (this project need to provide a requirement file by the way) and and the command to run the tests I am willing to make the effort to push this PR forward!

Cheers
Batiste
