### PR TITLE
Do not raise unused-argument for singledispatch implementations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -210,6 +210,11 @@ Release date: tba
 
     * Added a new Python 3 check for accessing deprecated string functions.
 
+    * Do not warn about unused arguments or function being redefined in singledispatch
+      registered implementations.
+
+      Closes #1032 and #1034
+
 
 What's new in Pylint 1.6.3?
 ===========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -603,7 +603,25 @@ Bug fixes
          linter.register_checker(DummyPlugin1(linter))
          linter.register_checker(DummyPlugin2(linter))
 
+* We do not yield ``unused-argument`` for singledispatch implementations and
+  do not warn about ``function-redefined`` for multiple implementations with same name.
 
+  .. code-block:: python
+
+     from functools import singledispatch
+
+     @singledispatch
+     def f(x):
+         return 2*x
+
+     @f.register(str)
+     def _(x):
+         return -1
+
+     @f.register(int)
+     @f.register(float)
+     def _(x):
+         return -x
 
 Removed Changes
 ===============

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -384,7 +384,8 @@ class BasicErrorChecker(_BasicChecker):
                           'duplicate-argument-name', 'nonlocal-and-global')
     def visit_functiondef(self, node):
         self._check_nonlocal_and_global(node)
-        if not redefined_by_decorator(node):
+        if (not redefined_by_decorator(node) and
+                not utils.is_registered_in_singledispatch_function(node)):
             self._check_redefinition(node.is_method() and 'method' or 'function', node)
         # checks for max returns, branch, return in __init__
         returns = node.nodes_of_class(astroid.Return,

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -692,6 +692,10 @@ class VariablesChecker(BaseChecker):
         if is_method and node.is_abstract():
             return
 
+        # Don't check arguments of singledispatch.register function.
+        if utils.is_registered_in_singledispatch_function(node):
+            return
+
         global_names = _flattened_scope_names(node.nodes_of_class(astroid.Global))
         nonlocal_names = _flattened_scope_names(node.nodes_of_class(astroid.Nonlocal))
 

--- a/pylint/test/functional/singledispatch_functions.py
+++ b/pylint/test/functional/singledispatch_functions.py
@@ -1,0 +1,63 @@
+# pylint: disable=missing-docstring,import-error,unused-import,assignment-from-no-return
+from __future__ import print_function
+from UNINFERABLE import uninferable_decorator, uninferable_func
+
+try:
+    from functools import singledispatch
+except ImportError:
+    from singledispatch import singledispatch
+
+my_single_dispatch = singledispatch  # pylint: disable=invalid-name
+
+
+@singledispatch
+def func(arg):
+    return arg
+
+
+@func.register(str)
+def _(arg):
+    return 42
+
+
+@func.register(float)
+@func.register(int)
+def _(arg):
+    return 42
+
+
+@my_single_dispatch
+def func2(arg):
+    return arg
+
+
+@func2.register(int)
+def _(arg):
+    return 42
+
+
+@singledispatch
+def with_extra_arg(arg, verbose=False):
+    if verbose:
+        print(arg)
+    return arg
+
+
+@with_extra_arg.register(str)
+def _(arg, verbose=False):
+    return arg[::-1]
+
+
+@uninferable_decorator
+def uninferable(arg):
+    return 2*arg
+
+
+@uninferable.register(str)
+def bad_single_dispatch(arg):
+    return arg
+
+
+@uninferable_func.register(str)
+def test(arg):
+    return arg

--- a/pylint/test/functional/singledispatch_functions.rc
+++ b/pylint/test/functional/singledispatch_functions.rc
@@ -1,0 +1,3 @@
+[testoptions]
+;http://bugs.python.org/issue10445
+max_pyver=3.0

--- a/pylint/test/functional/singledispatch_functions.txt
+++ b/pylint/test/functional/singledispatch_functions.txt
@@ -1,0 +1,1 @@
+unused-argument:51:uninferable:Unused argument 'arg'

--- a/pylint/test/functional/singledispatch_functions_py3.py
+++ b/pylint/test/functional/singledispatch_functions_py3.py
@@ -1,0 +1,63 @@
+# pylint: disable=missing-docstring,import-error,unused-import,assignment-from-no-return
+from __future__ import print_function
+from UNINFERABLE import uninferable_decorator, uninferable_func
+
+try:
+    from functools import singledispatch
+except ImportError:
+    from singledispatch import singledispatch
+
+my_single_dispatch = singledispatch  # pylint: disable=invalid-name
+
+
+@singledispatch
+def func(arg):
+    return arg
+
+
+@func.register(str)
+def _(arg):
+    return 42
+
+
+@func.register(float)
+@func.register(int)
+def _(arg):
+    return 42
+
+
+@my_single_dispatch
+def func2(arg):
+    return arg
+
+
+@func2.register(int)
+def _(arg):
+    return 42
+
+
+@singledispatch
+def with_extra_arg(arg, verbose=False):
+    if verbose:
+        print(arg)
+    return arg
+
+
+@with_extra_arg.register(str)
+def _(arg, verbose=False):
+    return arg[::-1]
+
+
+@uninferable_decorator
+def uninferable(arg):
+    return 2*arg
+
+
+@uninferable.register(str)
+def bad_single_dispatch(arg):
+    return arg
+
+
+@uninferable_func.register(str)
+def test(arg):
+    return arg

--- a/pylint/test/functional/singledispatch_functions_py3.rc
+++ b/pylint/test/functional/singledispatch_functions_py3.rc
@@ -1,0 +1,3 @@
+[testoptions]
+;http://bugs.python.org/issue10445
+min_pyver=3.4

--- a/pylint/test/functional/singledispatch_functions_py3.txt
+++ b/pylint/test/functional/singledispatch_functions_py3.txt
@@ -1,0 +1,1 @@
+unused-argument:51:uninferable:Unused argument 'arg'

--- a/pylint/test/test_functional.py
+++ b/pylint/test/test_functional.py
@@ -238,8 +238,7 @@ class LintModuleTest(unittest.TestCase):
         self._test_file = test_file
 
     def setUp(self):
-        if (sys.version_info < self._test_file.options['min_pyver']
-                or sys.version_info >= self._test_file.options['max_pyver']):
+        if self._should_be_skipped_due_to_version():
             self.skipTest(
                 'Test cannot run with Python %s.' % (sys.version.split(' ')[0],))
         missing = []
@@ -260,6 +259,10 @@ class LintModuleTest(unittest.TestCase):
                 self.skipTest(
                     'Test cannot run with Python implementation %r'
                      % (implementation, ))
+
+    def _should_be_skipped_due_to_version(self):
+        return (sys.version_info < self._test_file.options['min_pyver'] or
+                sys.version_info > self._test_file.options['max_pyver'])
 
     def __str__(self):
         return "%s (%s.%s)" % (self._test_file.base, self.__class__.__module__,


### PR DESCRIPTION
Closes #1034.
There are still some things to do:
- more tests
- second part of issue - "if any of implementation uses them" - currently messages are emitted when leaving each function node, I'm not sure yet how it should be tackled.

Helpers function likely should be moved to another module, especially if we plan on using them to solve e.g. issue #1032 (and possibly more issues related to singledispatch). 
