### PR TITLE
Add compatibility with old versions of setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,11 @@ install:
   - pip --version
   - tox --version
   - coverage --version
-  - pip install -U setuptools
 script:
+    # Test install with current version of setuptools
+  - pip install .
+    # Run the tests with newest version of setuptools
+  - pip install -U setuptools
   - tox -e coverage-erase,$TOXENV
 after_success:
   - tox -e coveralls

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -7,10 +7,14 @@
 
 # pylint: disable=W0622,C0103
 """pylint packaging information"""
+
 from __future__ import absolute_import
 
 from os.path import join
+from sys import version_info as py_version
 
+from pkg_resources import parse_version
+from setuptools import __version__ as setuptools_version
 
 modname = distname = 'pylint'
 
@@ -31,8 +35,25 @@ dependency_links = [
 
 extras_require = {}
 extras_require[':sys_platform=="win32"'] = ['colorama']
-extras_require[':python_version=="2.7"'] = ['configparser', 'backports.functools_lru_cache']
-extras_require[':python_version<"3.4"'] = ['singledispatch']
+
+
+def has_environment_marker_range_operators_support():
+    """Code extracted from 'pytest/setup.py'
+    https://github.com/pytest-dev/pytest/blob/7538680c/setup.py#L31
+    The first known release to support environment marker with range operators
+    it is 17.1, see: https://setuptools.readthedocs.io/en/latest/history.html#id113
+    """
+    return parse_version(setuptools_version) >= parse_version('17.1')
+
+
+if has_environment_marker_range_operators_support():
+    extras_require[':python_version=="2.7"'] = ['configparser', 'backports.functools_lru_cache']
+    extras_require[':python_version<"3.4"'] = ['singledispatch']
+else:
+    if (py_version.major, py_version.minor) == (2, 7):
+        install_requires.extend(['configparser', 'backports.functools_lru_cache'])
+    if py_version < (3, 4):
+        install_requires.extend(['singledispatch'])
 
 
 license = 'GPL'


### PR DESCRIPTION
### Fixes / new features
- Environment markers can be used only in recent versions of
setuptools. Instead of relying on extras_require, we are falling back to
install_requires when we detect an incompatibility between the installed
setuptools version and what pylint expects.

Steps to reproduce a error before of this change:
```bash
virtualenv pylint_old_setuptools
source pylint_old_setuptools/bin/activate
pip install setuptools==1.1.6
pip install --no-deps git+https://github.com/PyCQA/pylint@master
Collecting git+https://github.com/PyCQA/pylint@master
  Cloning https://github.com/PyCQA/pylint (to master) to /var/folders/zc/1m37yppx4z5596yfyzg385140000gn/T/pip-l78WRL-build
    Complete output from command python setup.py egg_info:
    error in pylint setup command: Invalid environment marker: python_version<"3.4"
```

Using this change:
`pip install --no-deps -U .`

```bash
Installing collected packages: pylint
  Found existing installation: pylint 2.0.0
    Not uninstalling pylint at /Users/moylop260/odoo/pylint, outside environment /private/tmp/pylint_old_setuptools
  Running setup.py install for pylint ... done
Successfully installed pylint-2.0.0
```


- [x] docs: IMHO the docs is not required for this case because we don't have a release with a incompatibility with old setuptools.