### PR TITLE
Add new error conditions for 'bad-super-call'

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -106,3 +106,5 @@ Order doesn't matter (not that much, at least ;)
 * Elias Dorneles: minor adjust to config defaults and docs
 
 * Yuri Bochkarev: Added epytext support to docparams extension.
+
+* Alexander Todorov: added new errro conditions to 'bad-super-call'.

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,11 @@ What's New in Pylint 2.0?
 
 Release date: tba
 
+    * Added new error conditions for 'bad-super-call'
+
+      Now detects ``super(type(self), self)`` and ``super(self.__class__, self)``
+      which can lead to recursion loop in derived classes.
+
     * PyLinter.should_analyze_file has a new optional parameter, called `is_argument`	
 
       Close #1079

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -89,6 +89,26 @@ New checkers
           def not_useless_1(self, first, *args):
               return super(Impl, self).not_useless_1(first + some_value, *args)
 
+* We've added new error conditions for ``bad-super-call`` which now detect
+  the usage of ``super(type(self), self)`` and ``super(self.__class__, self)``
+  patterns. These can lead to recursion loop in derived classes. The problem
+  is visible only if you override a class that uses these incorrect invocations
+  of ``super()``.
+
+  For instance, ``Derived.__init__()`` will correctly call ``Base.__init__``.
+  At this point ``type(self)`` will be equal to ``Derived`` and the call again
+  goes to ``Base.__init__`` and we enter a recursion loop.
+
+  .. code-block:: python
+
+      class Base(object):
+          def __init__(self, param1, param2):
+              super(type(self), self).__init__(param1, param2)
+
+      class Derived(Base):
+          def __init__(self, param1, param2):
+              super(Derived, self).__init__(param1, param2)
+
 * The warnings ``missing-returns-doc`` and ``missing-yields-doc`` have each
   been replaced with two new warnings - ``missing-[return|yield]-doc`` and
   ``missing-[return|yield]-type-doc``. Having these as separate warnings

--- a/pylint/test/functional/super_checks.py
+++ b/pylint/test/functional/super_checks.py
@@ -112,3 +112,14 @@ except AttributeError:
             returncode = -1
             self.timeout = -1
             super(TimeoutExpired, self).__init__(returncode)
+
+
+class SuperWithType(object):
+    """type(self) may lead to recursion loop in derived classes"""
+    def __init__(self):
+        super(type(self), self).__init__() # [bad-super-call]
+
+class SuperWithSelfClass(object):
+    """self.__class__ may lead to recursion loop in derived classes"""
+    def __init__(self):
+        super(self.__class__, self).__init__() # [bad-super-call]

--- a/pylint/test/functional/super_checks.txt
+++ b/pylint/test/functional/super_checks.txt
@@ -17,3 +17,5 @@ too-many-function-args:93:InvalidSuperChecks.__init__:Too many positional argume
 no-value-for-parameter:95:InvalidSuperChecks.__init__:No value for argument 'param' in method call
 unexpected-keyword-arg:95:InvalidSuperChecks.__init__:Unexpected keyword argument 'lala' in method call
 no-member:98:InvalidSuperChecks.__init__:Super of 'InvalidSuperChecks' has no 'attribute_error' member:INFERENCE
+bad-super-call:120:SuperWithType.__init__:Bad first argument 'type' given to super()
+bad-super-call:125:SuperWithSelfClass.__init__:Bad first argument 'self.__class__' given to super()


### PR DESCRIPTION
Now detects `super(type(self), self)` and `super(self.__class__, self)` which can lead to recursion loop in derived classes. For more info on the topic see:
http://stackoverflow.com/questions/18208683/when-calling-super-in-a-derived-class-can-i-pass-in-self-class

**NOTE**:  currently there is also a regression wrt *Bad first argument 'type' given to super()* being detected. I have an older version (pylint-1.3.1-1.el7.noarch) which emits this error but the code in master doesn't. I think commit 2943e24 broke this but I'm not certain. In case you'd like to debug the regression first I'm posting the entire diff between my local version and master.

```
$ diff -u /usr/lib/python2.7/site-packages/pylint/checkers/newstyle.py pylint/checkers/newstyle.py
--- /usr/lib/python2.7/site-packages/pylint/checkers/newstyle.py	2014-08-24 22:13:07.000000000 +0300
+++ pylint/checkers/newstyle.py	2016-09-14 12:24:02.829150399 +0300
@@ -1,27 +1,22 @@
-# Copyright (c) 2005-2014 LOGILAB S.A. (Paris, FRANCE).
-# http://www.logilab.fr/ -- mailto:contact@logilab.fr
-#
-# This program is free software; you can redistribute it and/or modify it under
-# the terms of the GNU General Public License as published by the Free Software
-# Foundation; either version 2 of the License, or (at your option) any later
-# version.
-#
-# This program is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along with
-# this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+# Copyright (c) 2006, 2008-2011, 2013-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
+# Copyright (c) 2013-2016 Claudiu Popa <pcmanticore@gmail.com>
+
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
 """check for new / old style related problems
 """
 import sys
 
 import astroid
 
-from pylint.interfaces import IAstroidChecker
+from pylint.interfaces import IAstroidChecker, INFERENCE, INFERENCE_FAILURE, HIGH
 from pylint.checkers import BaseChecker
-from pylint.checkers.utils import check_messages
+from pylint.checkers.utils import (
+    check_messages,
+    node_frame_class,
+    has_known_bases
+)
 
 MSGS = {
     'E1001': ('Use of __slots__ on an old style class',
@@ -43,13 +38,13 @@
               {'maxversion': (3, 0)}),
     'W1001': ('Use of "property" on an old style class',
               'property-on-old-class',
-              'Used when PyLint detect the use of the builtin "property" \
+              'Used when Pylint detect the use of the builtin "property" \
               on an old style class while this is relying on new style \
               classes features.',
               {'maxversion': (3, 0)}),
     'C1001': ('Old-style class defined.',
               'old-style-class',
-              'Used when a class is defined that does not inherit from another'
+              'Used when a class is defined that does not inherit from another '
               'class and does not inherit explicitly from "object".',
               {'maxversion': (3, 0)})
     }
@@ -73,77 +68,110 @@
     options = ()
 
     @check_messages('slots-on-old-class', 'old-style-class')
-    def visit_class(self, node):
-        """check __slots__ usage
+    def visit_classdef(self, node):
+        """ Check __slots__ in old style classes and old
+        style class definition.
         """
         if '__slots__' in node and not node.newstyle:
-            self.add_message('slots-on-old-class', node=node)
+            confidence = (INFERENCE if has_known_bases(node)
+                          else INFERENCE_FAILURE)
+            self.add_message('slots-on-old-class', node=node,
+                             confidence=confidence)
         # The node type could be class, exception, metaclass, or
         # interface.  Presumably, the non-class-type nodes would always
         # have an explicit base class anyway.
-        if not node.bases and node.type == 'class':
-            self.add_message('old-style-class', node=node)
+        if not node.bases and node.type == 'class' and not node.metaclass():
+            # We use confidence HIGH here because this message should only ever
+            # be emitted for classes at the root of the inheritance hierarchyself.
+            self.add_message('old-style-class', node=node, confidence=HIGH)
 
     @check_messages('property-on-old-class')
-    def visit_callfunc(self, node):
+    def visit_call(self, node):
         """check property usage"""
         parent = node.parent.frame()
-        if (isinstance(parent, astroid.Class) and
+        if (isinstance(parent, astroid.ClassDef) and
                 not parent.newstyle and
                 isinstance(node.func, astroid.Name)):
+            confidence = (INFERENCE if has_known_bases(parent)
+                          else INFERENCE_FAILURE)
             name = node.func.name
             if name == 'property':
-                self.add_message('property-on-old-class', node=node)
+                self.add_message('property-on-old-class', node=node,
+                                 confidence=confidence)
 
     @check_messages('super-on-old-class', 'bad-super-call', 'missing-super-argument')
-    def visit_function(self, node):
+    def visit_functiondef(self, node):
         """check use of super"""
         # ignore actual functions or method within a new style class
         if not node.is_method():
             return
         klass = node.parent.frame()
-        for stmt in node.nodes_of_class(astroid.CallFunc):
+        for stmt in node.nodes_of_class(astroid.Call):
+            if node_frame_class(stmt) != node_frame_class(node):
+                # Don't look down in other scopes.
+                continue
+
             expr = stmt.func
-            if not isinstance(expr, astroid.Getattr):
+            if not isinstance(expr, astroid.Attribute):
                 continue
+
             call = expr.expr
             # skip the test if using super
-            if isinstance(call, astroid.CallFunc) and \
-               isinstance(call.func, astroid.Name) and \
-               call.func.name == 'super':
-                if not klass.newstyle:
-                    # super should not be used on an old style class
-                    self.add_message('super-on-old-class', node=node)
-                else:
-                    # super first arg should be the class
-                    if not call.args and sys.version_info[0] == 3:
-                        # unless Python 3
-                        continue
+            if not (isinstance(call, astroid.Call) and
+                    isinstance(call.func, astroid.Name) and
+                    call.func.name == 'super'):
+                continue
 
-                    try:
-                        supcls = (call.args and call.args[0].infer().next()
-                                  or None)
-                    except astroid.InferenceError:
+            if not klass.newstyle and has_known_bases(klass):
+                # super should not be used on an old style class
+                self.add_message('super-on-old-class', node=node)
+            else:
+                # super first arg should be the class
+                if not call.args:
+                    if sys.version_info[0] == 3:
+                        # unless Python 3
                         continue
-
-                    if supcls is None:
+                    else:
                         self.add_message('missing-super-argument', node=call)
                         continue
 
-                    if klass is not supcls:
-                        name = None
-                        # if supcls is not YES, then supcls was infered
-                        # and use its name. Otherwise, try to look
-                        # for call.args[0].name
-                        if supcls is not astroid.YES:
-                            name = supcls.name
-                        else:
-                            if hasattr(call.args[0], 'name'):
-                                name = call.args[0].name
-                        if name is not None:
-                            self.add_message('bad-super-call',
-                                             node=call,
-                                             args=(name, ))
+
+                try:
+                    supcls = call.args and next(call.args[0].infer(), None)
+                except astroid.InferenceError:
+                    continue
+
+                if klass is not supcls:
+                    name = None
+                    # if supcls is not YES, then supcls was infered
+                    # and use its name. Otherwise, try to look
+                    # for call.args[0].name
+                    if supcls:
+                        name = supcls.name
+                    elif call.args and hasattr(call.args[0], 'name'):
+                        name = call.args[0].name
+                    if name:
+                        self.add_message('bad-super-call', node=call, args=(name, ))
+
+    visit_asyncfunctiondef = visit_functiondef
 ```



