### PR TITLE
Add a Python 3 warning for implementing `__eq__` without also implentnting `__hash__`

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -108,3 +108,5 @@ Order doesn't matter (not that much, at least ;)
 * Yuri Bochkarev: Added epytext support to docparams extension.
 
 * Alexander Todorov: added new errro conditions to 'bad-super-call'.
+
+* Roy Williams (Lyft): added check for implementing __eq__ without implementing __hash__.

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -153,6 +153,65 @@ New checkers
   Other places where this check looks are *with* statement name bindings and
   except handler's name binding.
 
+* A new Python 3 check was added, ``eq-without-hash``, which enforces classes that implement
+  ``__eq__`` *also* implement ``__hash__``.  The behavior around classes which implement ``__eq__``
+  but not ``__hash__`` changed in Python 3; in Python 2 such classes would get ``object.__hash__``
+  as their default implementation.  In Python 3, aforementioned classes get ``None`` as their
+  implementation thus making them unhashable.
+
+  .. code-block:: python
+
+      class JustEq(object):
+         def __init__(self, x):
+           self.x = x
+
+         def __eq__(self, other):
+           return self.x == other.x
+
+      class Neither(object):
+        def __init__(self, x):
+          self.x = x
+
+      class HashAndEq(object):
+         def __init__(self, x):
+           self.x = x
+
+         def __eq__(self, other):
+           return self.x == other.x
+
+         def __hash__(self):
+           return hash(self.x)
+
+      {Neither(1), Neither(2)}  # OK in Python 2 and Python 3
+      {HashAndEq(1), HashAndEq(2)}  # OK in Python 2 and Python 3
+      {JustEq(1), JustEq(2)}  # Works in Python 2, throws in Python 3
+
+
+  In general, this is a poor practice which motivated the behavior change.
+
+  .. code-block:: python
+
+      as_set = {JustEq(1), JustEq(2)}
+      print(JustEq(1) in as_set)  # prints False
+      print(JustEq(1) in list(as_set))  # prints True
+
+
+  In order to fix this error and avoid behavior differences between Python 2 and Python 3, classes
+  should either explicitly set ``__hash__`` to ``None`` or implement a hashing function.
+
+  .. code-block:: python
+
+      class JustEq(object):
+         def __init__(self, x):
+           self.x = x
+
+         def __eq__(self, other):
+           return self.x == other.x
+
+         __hash__ = None
+
+      {JustEq(1), JustEq(2)}  # Now throws an exception in both Python 2 and Python 3.
+
 Other Changes
 =============
 

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -333,6 +333,12 @@ class Python3Checker(checkers.BaseChecker):
                   'Python 3. Using either `key` or `functools.cmp_to_key` '
                   'should be preferred.',
                   {'maxversion': (3, 0)}),
+        'W1641': ('Implementing __eq__ without also implementing __hash__',
+                  'eq-without-hash',
+                  'Used when a class implements __eq__ but not __hash__.  In Python 2, objects '
+                  'get object.__hash__ as the default implementation, in Python 3 objects get '
+                  'None as their default __hash__ implementation if they also implement __eq__.',
+                  {'maxversion': (3, 0)}),
     }
 
     _bad_builtins = frozenset([
@@ -426,6 +432,9 @@ class Python3Checker(checkers.BaseChecker):
     def visit_classdef(self, node):
         if '__metaclass__' in node.locals:
             self.add_message('metaclass-assignment', node=node)
+        locals_and_methods = set(node.locals).union(x.name for x in node.mymethods())
+        if '__eq__' in locals_and_methods and '__hash__' not in locals_and_methods:
+            self.add_message('eq-without-hash', node=node)
 
     @utils.check_messages('old-division')
     def visit_binop(self, node):

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -215,6 +215,37 @@ class Python3CheckerTest(testutils.CheckerTestCase):
     def test_cmp_method(self):
         self.defined_method_test('cmp', 'cmp-method')
 
+    def test_eq_and_hash_method(self):
+        """Helper for verifying that a certain method is not defined."""
+        node = astroid.extract_node("""
+            class Foo(object):  #@
+                def __eq__(self, other):
+                    pass
+                def __hash__(self):
+                    pass""")
+        with self.assertNoMessages():
+            self.checker.visit_classdef(node)
+
+    def test_eq_and_hash_is_none(self):
+        """Helper for verifying that a certain method is not defined."""
+        node = astroid.extract_node("""
+            class Foo(object):  #@
+                def __eq__(self, other):
+                    pass
+                __hash__ = None""")
+        with self.assertNoMessages():
+            self.checker.visit_classdef(node)
+
+    def test_eq_without_hash_method(self):
+        """Helper for verifying that a certain method is not defined."""
+        node = astroid.extract_node("""
+            class Foo(object):  #@
+                def __eq__(self, other):
+                    pass""")
+        message = testutils.Message('eq-without-hash', node=node)
+        with self.assertAddsMessages(message):
+            self.checker.visit_classdef(node)
+
     @python2_only
     def test_print_statement(self):
         node = astroid.extract_node('print "Hello, World!" #@')


### PR DESCRIPTION
I've been exploring transitioning our codebase to Python 3, and I've been using the immensely helpful `-3` flag when running tests as described here:

https://docs.python.org/3/howto/pyporting.html#prevent-compatibility-regressions

Unfortunately, one of the most common issues I'm finding is around classes implementing `__eq__` but not `__hash__`.  The behavior around this changed in Python 3.  See below:

```python
class JustEq(object):
   def __init__(self, x):
     self.x = x
   def __eq__(self, other):
     return self.x == other.x

class Neither(object):
  def __init__(self, x):
    self.x = x

class HashAndEq(object):
   def __init__(self, x):
     self.x = x
   def __eq__(self, other):
     return self.x == other.x
   def __hash__(self):
     return hash(self.x)

{Neither(1), Neither(2)}  # OK
{HashAndEq(1), HashAndEq(2)}  # OK
{JustEq(1), JustEq(2)}  # Works in Python 2, throws in Python 3

# In general this is bad practice which is what motivated the behavior change in Python 3.

as_set = {JustEq(1), JustEq(2)}
print(JustEq(1) in as_set)  # prints False
print(JustEq(1) in list(as_set))  # prints True
```

In general this is bad practice for the reasons above, so I'd actually love to have this warn
both as a general warning and as a Python 3 warning, but I don't see a clean way to have the same rule apply in multiple contexts.