### PR TITLE
Add a warning when declaring `__div__` or `__idiv__` in Python 2.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -180,6 +180,9 @@ Release date: tba
 
       Closes #1087
 
+    * Added a new Python 3 warning around implementing '__div__' or '__idiv__'
+      as those methods are phased out in Python 3.
+
 
 What's new in Pylint 1.6.3?
 ===========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -212,6 +212,25 @@ New checkers
 
       {JustEq(1), JustEq(2)}  # Now throws an exception in both Python 2 and Python 3.
 
+  * 2 new Python 3 checkers were added, ``div-method`` and ``idiv-method``.  The magic methods
+    ``__div__`` and ``__idiv__`` have been phased out in Python 3 in favor of ``__truediv__``.
+    Classes implementing ``__div__`` that still need to be used from Python 2 code not using
+    ``from __future__ import division`` should implement ``__truediv__`` and alias ``__div__``
+    to that implementation.
+
+  .. code-block:: python
+
+      from __future__ import division
+
+      class DivisibleThing(object):
+         def __init__(self, x):
+           self.x = x
+
+         def __truediv__(self, other):
+           return DivisibleThing(self.x / other.x)
+
+         __div__ = __truediv__
+
 Other Changes
 =============
 

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -339,6 +339,18 @@ class Python3Checker(checkers.BaseChecker):
                   'get object.__hash__ as the default implementation, in Python 3 objects get '
                   'None as their default __hash__ implementation if they also implement __eq__.',
                   {'maxversion': (3, 0)}),
+        'W1642': ('__div__ method defined',
+                  'div-method',
+                  'Used when a __div__ method is defined.  Using `__truediv__` and setting'
+                  '__div__ = __truediv__ should be preferred.'
+                  '(method is not used by Python 3)',
+                  {'maxversion': (3, 0)}),
+        'W1643': ('__idiv__ method defined',
+                  'idiv-method',
+                  'Used when a __idiv__ method is defined.  Using `__itruediv__` and setting'
+                  '__idiv__ = __itruediv__ should be preferred.'
+                  '(method is not used by Python 3)',
+                  {'maxversion': (3, 0)}),
     }
 
     _bad_builtins = frozenset([
@@ -371,6 +383,8 @@ class Python3Checker(checkers.BaseChecker):
         '__hex__',
         '__nonzero__',
         '__cmp__',
+        '__div__',
+        '__idiv__',
     ])
 
     def __init__(self, *args, **kwargs):

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -215,6 +215,12 @@ class Python3CheckerTest(testutils.CheckerTestCase):
     def test_cmp_method(self):
         self.defined_method_test('cmp', 'cmp-method')
 
+    def test_div_method(self):
+        self.defined_method_test('div', 'div-method')
+
+    def test_idiv_method(self):
+        self.defined_method_test('idiv', 'idiv-method')
+
     def test_eq_and_hash_method(self):
         """Helper for verifying that a certain method is not defined."""
         node = astroid.extract_node("""


### PR DESCRIPTION
These methods are removed in Python 3 in favor of `__truediv__`.