### PR TITLE
avoid pylint crash on ill-formatted template strings

### DIFF
--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -185,7 +185,10 @@ def parse_format_method_string(format_string):
                 # to different output between 2 and 3
                 manual_pos_arg.add(str(keyname))
                 keyname = int(keyname)
-            keys.append((keyname, list(fielditerator)))
+            try:
+                keys.append((keyname, list(fielditerator)))
+            except ValueError:
+                raise utils.IncompleteFormatString()
         else:
             num_args += 1
     return keys, num_args, len(manual_pos_arg)


### PR DESCRIPTION
We use pylint to evaluate student submission on an electronic learning environments. Pylint crashed while evaluating this submitted code snippet:

``` python
A = int(input())
B = int(input())
C = int(input())

M = ((A - C) * (B - C)) / C

print("There are {.:2f} undiscovered errors.".format(M))
```

Clearly the template string is ill-structured (dot and colon should be swapped) and pylint should annotate this as such (not crash). Here's the stack trace:

```
Traceback (most recent call last):
  File "/mnt/d20bjaD5tEDaCnle2gIkwg/judge/lint_judge.py", line 136, in run_pylint
    exit=False
  File "/opt/conda/lib/python3.5/site-packages/pylint/lint.py", line 1310, in __init__
    linter.check(args)
  File "/opt/conda/lib/python3.5/site-packages/pylint/lint.py", line 732, in check
    self._do_check(files_or_modules)
  File "/opt/conda/lib/python3.5/site-packages/pylint/lint.py", line 863, in _do_check
    self.check_astroid_module(ast_node, walker, rawcheckers, tokencheckers)
  File "/opt/conda/lib/python3.5/site-packages/pylint/lint.py", line 944, in check_astroid_module
    walker.walk(ast_node)
  File "/opt/conda/lib/python3.5/site-packages/pylint/utils.py", line 944, in walk
    self.walk(child)
  File "/opt/conda/lib/python3.5/site-packages/pylint/utils.py", line 944, in walk
    self.walk(child)
  File "/opt/conda/lib/python3.5/site-packages/pylint/utils.py", line 944, in walk
    self.walk(child)
  File "/opt/conda/lib/python3.5/site-packages/pylint/utils.py", line 941, in walk
    cb(astroid)
  File "/opt/conda/lib/python3.5/site-packages/pylint/checkers/strings.py", line 330, in visit_call
    self._check_new_format(node, func)
  File "/opt/conda/lib/python3.5/site-packages/pylint/checkers/strings.py", line 364, in _check_new_format
    fields, num_args, manual_pos = parse_format_method_string(strnode.value)
  File "/opt/conda/lib/python3.5/site-packages/pylint/checkers/strings.py", line 187, in parse_format_method_string
    keys.append((keyname, list(fielditerator)))
ValueError: Empty attribute in format string
```

I have caught the exception in the `parse_format_method_string` and raised an `utils.IncompleteFormatString()` exception instead in this pull request. This should avoid the pylint crash. Someone should check if the error handling results in the correct pylint annotation, or to see if the problem could be handled earlier (because format string is not valid according to PEP 3101).
