### PR TITLE
Fix descriptions for E1205 & E1206.

### DIFF
--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -49,7 +49,7 @@ MSGS = {
               the end of a conversion specifier.'),
     'E1205': ('Too many arguments for logging format string',
               'logging-too-many-args',
-              'Used when a logging format string is given too many arguments'),
+              'Used when a logging format string is given too many arguments.'),
     'E1206': ('Not enough arguments for logging format string',
               'logging-too-few-args',
               'Used when a logging format string is given too few arguments.'),

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -49,10 +49,10 @@ MSGS = {
               the end of a conversion specifier.'),
     'E1205': ('Too many arguments for logging format string',
               'logging-too-many-args',
-              'Used when a logging format string is given too few arguments.'),
+              'Used when a logging format string is given too many arguments'),
     'E1206': ('Not enough arguments for logging format string',
               'logging-too-few-args',
-              'Used when a logging format string is given too many arguments'),
+              'Used when a logging format string is given too few arguments.'),
     }
 
 


### PR DESCRIPTION
These two descriptions were reversed, and missing a full stop.
