### PR TITLE
Issue a warning on methods implementing `__rdiv__` as well.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -180,8 +180,8 @@ Release date: tba
 
       Closes #1087
 
-    * Added a new Python 3 warning around implementing '__div__' or '__idiv__'
-      as those methods are phased out in Python 3.
+    * Added a new Python 3 warning around implementing '__div__', '__idiv__', or
+      '__rdiv__' as those methods are phased out in Python 3.
 
 
 What's new in Pylint 1.6.3?

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -212,11 +212,11 @@ New checkers
 
       {JustEq(1), JustEq(2)}  # Now throws an exception in both Python 2 and Python 3.
 
-  * 2 new Python 3 checkers were added, ``div-method`` and ``idiv-method``.  The magic methods
-    ``__div__`` and ``__idiv__`` have been phased out in Python 3 in favor of ``__truediv__``.
-    Classes implementing ``__div__`` that still need to be used from Python 2 code not using
-    ``from __future__ import division`` should implement ``__truediv__`` and alias ``__div__``
-    to that implementation.
+  * 3 new Python 3 checkers were added, ``div-method``, ``idiv-method`` and ``rdiv-method``.
+    The magic methods ``__div__`` and ``__idiv__`` have been phased out in Python 3 in favor
+    of ``__truediv__``.  Classes implementing ``__div__`` that still need to be used from Python
+    2 code not using ``from __future__ import division`` should implement ``__truediv__`` and
+    alias ``__div__`` to that implementation.
 
   .. code-block:: python
 

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -351,6 +351,12 @@ class Python3Checker(checkers.BaseChecker):
                   '__idiv__ = __itruediv__ should be preferred.'
                   '(method is not used by Python 3)',
                   {'maxversion': (3, 0)}),
+        'W1644': ('__rdiv__ method defined',
+                  'rdiv-method',
+                  'Used when a __rdiv__ method is defined.  Using `__rtruediv__` and setting'
+                  '__rdiv__ = __rtruediv__ should be preferred.'
+                  '(method is not used by Python 3)',
+                  {'maxversion': (3, 0)}),
     }
 
     _bad_builtins = frozenset([
@@ -385,6 +391,7 @@ class Python3Checker(checkers.BaseChecker):
         '__cmp__',
         '__div__',
         '__idiv__',
+        '__rdiv__',
     ])
 
     def __init__(self, *args, **kwargs):

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -221,6 +221,9 @@ class Python3CheckerTest(testutils.CheckerTestCase):
     def test_idiv_method(self):
         self.defined_method_test('idiv', 'idiv-method')
 
+    def test_rdiv_method(self):
+        self.defined_method_test('rdiv', 'rdiv-method')
+
     def test_eq_and_hash_method(self):
         """Helper for verifying that a certain method is not defined."""
         node = astroid.extract_node("""


### PR DESCRIPTION
Unfortunately I forgot about this in https://github.com/PyCQA/pylint/pull/1121