### PR TITLE
Py26 compatibility

### DIFF
--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -50,7 +50,7 @@ if has_environment_marker_range_operators_support():
     extras_require[':python_version=="2.7"'] = ['configparser', 'backports.functools_lru_cache']
     extras_require[':python_version<"3.4"'] = ['singledispatch']
 else:
-    if (py_version.major, py_version.minor) == (2, 7):
+    if py_version <= (2, 7):
         install_requires.extend(['configparser', 'backports.functools_lru_cache'])
     if py_version < (3, 4):
         install_requires.extend(['singledispatch'])

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1343,7 +1343,7 @@ class DocStringChecker(_BasicChecker):
 
     @staticmethod
     def _is_setter_or_deleter(node):
-        names = {'setter', 'deleter'}
+        names = set(['setter', 'deleter'])
         for decorator in node.decorators.nodes:
             if (isinstance(decorator, astroid.Attribute)
                     and decorator.attrname in names):

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -40,7 +40,7 @@ if sys.version_info >= (3, 0):
     NEXT_METHOD = '__next__'
 else:
     NEXT_METHOD = 'next'
-INVALID_BASE_CLASSES = {'bool', 'range', 'slice', 'memoryview'}
+INVALID_BASE_CLASSES = set(['bool', 'range', 'slice', 'memoryview'])
 
 
 # Dealing with useless override detection, with regard

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -25,7 +25,7 @@ def _builtin_exceptions():
         return isinstance(obj, type) and issubclass(obj, BaseException)
 
     members = inspect.getmembers(six.moves.builtins, predicate)
-    return {exc.__name__ for (_, exc) in members}
+    return set([exc.__name__ for (_, exc) in members])
 
 
 def _annotated_unpack_infer(stmt, context=None):

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -494,7 +494,11 @@ given file (report RP0402 must not be disabled)'}
     def _check_same_line_imports(self, node):
         # Detect duplicate imports on the same line.
         names = (name for name, _ in node.names)
-        counter = collections.Counter(names)
+        try:
+            counter = collections.Counter(names)
+        except AttributeError:  # Python 2.6 and older compatibility
+            names = list(names)
+            counter = dict((name, names.count(name)) for name in set(names))
         for name, count in counter.items():
             if count > 1:
                 self.add_message('reimported', node=node,

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -44,8 +44,8 @@ def _check_dict_node(node):
 def _is_builtin(node):
     return getattr(node, 'name', None) in ('__builtin__', 'builtins')
 
-_ACCEPTS_ITERATOR = {'iter', 'list', 'tuple', 'sorted', 'set', 'sum', 'any',
-                     'all', 'enumerate', 'dict'}
+_ACCEPTS_ITERATOR = set(['iter', 'list', 'tuple', 'sorted', 'set', 'sum',
+                         'any', 'all', 'enumerate', 'dict'])
 
 def _in_iterating_context(node):
     """Check if the node is being used as an iterator.

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -306,8 +306,8 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             all_types[isinstance_object].update(elems)
 
         # Remove all keys which not duplicated
-        return {key: value for key, value in all_types.items()
-                if key in duplicated_objects}
+        return dict((key, value) for (key, value) in all_types.items()
+                    if key in duplicated_objects)
 
     @utils.check_messages('consider-merging-isinstance')
     def visit_boolop(self, node):

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -20,7 +20,7 @@ from pylint.checkers import BaseChecker
 from pylint.checkers import utils
 
 
-OPEN_FILES = {'open', 'file'}
+OPEN_FILES = set(['open', 'file'])
 UNITTEST_CASE = 'unittest.case'
 if sys.version_info >= (3, 0):
     OPEN_MODULE = '_io'

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -198,8 +198,8 @@ def get_args(callfunc):
     is the keyword arguments in a dict.
     """
     if callfunc.keywords:
-        named = {arg.arg: utils.safe_infer(arg.value)
-                 for arg in callfunc.keywords}
+        named = dict((arg.arg, utils.safe_infer(arg.value))
+                     for arg in callfunc.keywords)
     else:
         named = {}
     positional = len(callfunc.args)

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -469,7 +469,7 @@ def error_of_type(handler, error_type):
 
     if not isinstance(error_type, tuple):
         error_type = (error_type, )
-    expected_errors = {stringify_error(error) for error in error_type}
+    expected_errors = set([stringify_error(error) for error in error_type])
     if not handler.type:
         # bare except. While this indeed catches anything, if the desired errors
         # aren't specified directly, then we just ignore it.

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -93,11 +93,11 @@ _SPECIAL_METHODS_PARAMS = {
     (0, 1): ('__round__', ),
 }
 
-SPECIAL_METHODS_PARAMS = {
-    name: params
-    for params, methods in _SPECIAL_METHODS_PARAMS.items()
+SPECIAL_METHODS_PARAMS = dict(
+    (name, params)
+    for (params, methods) in _SPECIAL_METHODS_PARAMS.items()
     for name in methods
-}
+)
 PYMETHODS = set(SPECIAL_METHODS_PARAMS)
 
 

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -113,7 +113,7 @@ class DocstringParameterChecker(BaseChecker):
     priority = -2
 
     constructor_names = set(['__init__', '__new__'])
-    not_needed_param_in_docstring = {'self', 'cls'}
+    not_needed_param_in_docstring = set(['self', 'cls'])
 
     def visit_functiondef(self, node):
         """Called for function and method definitions (def).

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -112,7 +112,7 @@ class DocstringParameterChecker(BaseChecker):
 
     priority = -2
 
-    constructor_names = {'__init__', '__new__'}
+    constructor_names = set(['__init__', '__new__'])
     not_needed_param_in_docstring = {'self', 'cls'}
 
     def visit_functiondef(self, node):

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -611,7 +611,7 @@ class PyLinter(config.OptionsManagerMixIn,
         """process tokens from the current module to search for module/block
         level options
         """
-        control_pragmas = {'disable', 'enable'}
+        control_pragmas = set(['disable', 'enable'])
         for (tok_type, content, start, _, _) in tokens:
             if tok_type != tokenize.COMMENT:
                 continue
@@ -730,7 +730,7 @@ class PyLinter(config.OptionsManagerMixIn,
 
     def _get_jobs_config(self):
         child_config = collections.OrderedDict()
-        filter_options = {'long-help'}
+        filter_options = set(['long-help'])
         filter_options.update((opt_name for opt_name, _ in self._external_opts))
         for opt_providers in six.itervalues(self._all_options):
             for optname, optdict, val in opt_providers.options_and_values():

--- a/pylint/reporters/text.py
+++ b/pylint/reporters/text.py
@@ -219,8 +219,8 @@ class ColorizedTextReporter(TextReporter):
         color, style = self._get_decoration(msg.C)
 
         msg = msg._replace(
-            **{attr: colorize_ansi(getattr(msg, attr), color, style)
-               for attr in ('msg', 'symbol', 'category', 'C')})
+            **dict((attr, colorize_ansi(getattr(msg, attr), color, style))
+                   for attr in ('msg', 'symbol', 'category', 'C')))
         self.write_message(msg)
 
 

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -44,7 +44,7 @@ MSG_TYPES = {
     'E' : 'error',
     'F' : 'fatal'
     }
-MSG_TYPES_LONG = {v: k for k, v in six.iteritems(MSG_TYPES)}
+MSG_TYPES_LONG = dict((v, k) for (k, v) in six.iteritems(MSG_TYPES))
 
 MSG_TYPES_STATUS = {
     'I' : 0,


### PR DESCRIPTION
### Fixes
- Add Python 2.6 compatibility

Justification: On Red Hat Enterprise Linux 6 the only available Python version is 2.6. The compatibility with this version is needed for running pylint as a part of CI tests.
Thanks @misli for help.