### PR TITLE
Add a checker for accessing `Exception.message` in Python 2.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -109,4 +109,5 @@ Order doesn't matter (not that much, at least ;)
 
 * Alexander Todorov: added new errro conditions to 'bad-super-call'.
 
-* Roy Williams (Lyft): added check for implementing __eq__ without implementing __hash__.
+* Roy Williams (Lyft): added check for implementing __eq__ without implementing __hash__,
+  Added Python 3 check for accessing Exception.message

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -231,6 +231,27 @@ New checkers
 
          __div__ = __truediv__
 
+  * A new Python 3 checker was added to warn about accessing the ``message`` attribute on
+    Exceptions.  The message attribute was deprecated in Python 2.7 and was removed in Python 3.
+    See https://www.python.org/dev/peps/pep-0352/#retracted-ideas for more information.
+
+  .. code-block:: python
+
+      try:
+        raise Exception("Oh No!!")
+      except Exception as e:
+        print(e.message)
+
+  Instead of relying on the ``message`` attribute, you should explicitly cast the exception to a
+  string:
+
+  .. code-block:: python
+
+      try:
+        raise Exception("Oh No!!")
+      except Exception as e:
+        print(str(e))
+
 Other Changes
 =============
 

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -535,6 +535,13 @@ class Python3Checker(checkers.BaseChecker):
         except astroid.InferenceError:
             return
 
+    def visit_assignattr(self, node):
+        if isinstance(node.assign_type(), astroid.AugAssign):
+            self.visit_attribute(node)
+
+    def visit_delattr(self, node):
+        self.visit_attribute(node)
+
     @utils.check_messages('exception-message-attribute')
     def visit_attribute(self, node):
         """ Look for accessing message on exceptions. """

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -357,6 +357,11 @@ class Python3Checker(checkers.BaseChecker):
                   '__rdiv__ = __rtruediv__ should be preferred.'
                   '(method is not used by Python 3)',
                   {'maxversion': (3, 0)}),
+        'W1645': ('Exception.message accessed',
+                  'exception-message-attribute',
+                  'Used when the message attribute is accessed on an Exception.  Use '
+                  'str(exception) instead.',
+                  {'maxversion': (3, 0)}),
     }
 
     _bad_builtins = frozenset([
@@ -527,6 +532,19 @@ class Python3Checker(checkers.BaseChecker):
                     continue
                 if utils.inherit_from_std_ex(infered):
                     self.add_message('indexing-exception', node=node)
+        except astroid.InferenceError:
+            return
+
+    @utils.check_messages('exception-message-attribute')
+    def visit_attribute(self, node):
+        """ Look for accessing message on exceptions. """
+        try:
+            for infered in node.expr.infer():
+                if not isinstance(infered, astroid.Instance):
+                    continue
+                if utils.inherit_from_std_ex(infered):
+                    if node.attrname == 'message':
+                        self.add_message('exception-message-attribute', node=node)
         except astroid.InferenceError:
             return
 

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -357,7 +357,7 @@ class Python3Checker(checkers.BaseChecker):
                   '__rdiv__ = __rtruediv__ should be preferred.'
                   '(method is not used by Python 3)',
                   {'maxversion': (3, 0)}),
-        'W1645': ('Exception.message accessed',
+        'W1645': ('Exception.message removed in Python 3',
                   'exception-message-attribute',
                   'Used when the message attribute is accessed on an Exception.  Use '
                   'str(exception) instead.',

--- a/pylint/test/functional/exception_message.py
+++ b/pylint/test/functional/exception_message.py
@@ -1,7 +1,7 @@
 """
 Check accessing Exception.message
 """
-# pylint: disable=import-error, no-absolute-import
+# pylint: disable=import-error, no-absolute-import, broad-except
 
 from unknown import ExtensionException
 __revision__ = 0
@@ -13,3 +13,8 @@ _ = IndexError("test").message # [exception-message-attribute]
 _ = ZeroDivisionError("error").message # [exception-message-attribute]
 _ = ExtensionException("error").message
 _ = SubException("error").message # [exception-message-attribute]
+
+try:
+    raise Exception('e')
+except Exception as exception:
+    _ = exception.message # [exception-message-attribute]

--- a/pylint/test/functional/exception_message.py
+++ b/pylint/test/functional/exception_message.py
@@ -18,3 +18,6 @@ try:
     raise Exception('e')
 except Exception as exception:
     _ = exception.message # [exception-message-attribute]
+    del exception.message # [exception-message-attribute]
+    exception.message += 'hello world' # [exception-message-attribute]
+    exception.message = 'hello world'

--- a/pylint/test/functional/exception_message.py
+++ b/pylint/test/functional/exception_message.py
@@ -1,0 +1,15 @@
+"""
+Check accessing Exception.message
+"""
+# pylint: disable=import-error, no-absolute-import
+
+from unknown import ExtensionException
+__revision__ = 0
+
+class SubException(IndexError):
+    """ empty """
+
+_ = IndexError("test").message # [exception-message-attribute]
+_ = ZeroDivisionError("error").message # [exception-message-attribute]
+_ = ExtensionException("error").message
+_ = SubException("error").message # [exception-message-attribute]

--- a/pylint/test/functional/exception_message.rc
+++ b/pylint/test/functional/exception_message.rc
@@ -1,0 +1,5 @@
+[testoptions]
+max_pyver=3.0
+
+[Messages Control]
+enable=python3

--- a/pylint/test/functional/exception_message.txt
+++ b/pylint/test/functional/exception_message.txt
@@ -1,3 +1,4 @@
-exception-message:12::Exception.message removed in Python 3
-exception-message:13::Exception.message removed in Python 3
-exception-message:15::Exception.message removed in Python 3
+exception-message-attribute:12::Exception.message removed in Python 3
+exception-message-attribute:13::Exception.message removed in Python 3
+exception-message-attribute:15::Exception.message removed in Python 3
+exception-message-attribute:20::Exception.message removed in Python 3

--- a/pylint/test/functional/exception_message.txt
+++ b/pylint/test/functional/exception_message.txt
@@ -1,0 +1,3 @@
+exception-message:12::Exception.message removed in Python 3
+exception-message:13::Exception.message removed in Python 3
+exception-message:15::Exception.message removed in Python 3

--- a/pylint/test/functional/exception_message.txt
+++ b/pylint/test/functional/exception_message.txt
@@ -2,3 +2,5 @@ exception-message-attribute:12::Exception.message removed in Python 3
 exception-message-attribute:13::Exception.message removed in Python 3
 exception-message-attribute:15::Exception.message removed in Python 3
 exception-message-attribute:20::Exception.message removed in Python 3
+exception-message-attribute:21::Exception.message removed in Python 3
+exception-message-attribute:22::Exception.message removed in Python 3

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -409,6 +409,26 @@ class Python3CheckerTest(testutils.CheckerTestCase):
             self.checker.visit_raise(node)
 
     @python2_only
+    def test_exception_message_attribute(self):
+        node = astroid.extract_node("""
+        try:
+            raise Exception("test")
+        except Exception as e:
+            e.message #@
+        """)
+        message = testutils.Message('exception-message-attribute', node=node)
+        with self.assertAddsMessages(message):
+            self.checker.visit_attribute(node)
+
+    @python2_only
+    def test_normal_message_attribute(self):
+        node = astroid.extract_node("""
+        e.message #@
+        """)
+        with self.assertNoMessages():
+            self.checker.visit_attribute(node)
+
+    @python2_only
     def test_raising_string(self):
         node = astroid.extract_node('raise "Test"')
         message = testutils.Message('raising-string', node=node)


### PR DESCRIPTION
**Fixes / new features**

Exception.message has been removed in Python 3.  This checker should be able to find most instances of it's use.
