### PR TITLE
Add new checker len-as-condition

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -107,7 +107,8 @@ Order doesn't matter (not that much, at least ;)
 
 * Yuri Bochkarev: Added epytext support to docparams extension.
 
-* Alexander Todorov: added new error conditions to 'bad-super-call'.
+* Alexander Todorov: added new error conditions to 'bad-super-call',
+  Added new check for incorrect len(SEQUENCE) usage
 
 * Roy Williams (Lyft): added check for implementing __eq__ without implementing __hash__,
   Added Python 3 check for accessing Exception.message,

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,9 @@ Release date: tba
     
     * Don't try to access variables defined in a separate scope when checking for ``protected-access``
      
+    * Added new check to detect incorrect usage of len(SEQUENCE) inside
+      test conditions.
+
     * Added new error conditions for 'bad-super-call'
 
       Now detects ``super(type(self), self)`` and ``super(self.__class__, self)``

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -96,6 +96,42 @@ New checkers
           def not_useless_1(self, first, *args):
               return super(Impl, self).not_useless_1(first + some_value, *args)
 
+* A new warning was added, ``len-as-condition``, which is used whenever
+  we detect that a condition uses ``len(SEQUENCE)`` incorrectly. Instead
+  one could use ``if SEQUENCE`` or ``if not SEQUENCE``.
+
+  For instance, all of the examples below:
+
+  .. code-block:: python
+
+      if len(S):
+        pass
+
+      if not len(S):
+        pass
+
+      if len(S) > 0:
+        pass
+
+      if len(S) != 0:
+        pass
+
+      if len(S) == 0:
+        pass
+
+  can be written in a more natural way:
+
+  .. code-block:: python
+
+      if S:
+        pass
+
+      if not S:
+        pass
+
+  See https://www.python.org/dev/peps/pep-0008/#programming-recommendations
+  for more information.
+
 * We've added new error conditions for ``bad-super-call`` which now detect
   the usage of ``super(type(self), self)`` and ``super(self.__class__, self)``
   patterns. These can lead to recursion loop in derived classes. The problem

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -1245,7 +1245,7 @@ class SpecialMethodsChecker(BaseChecker):
         if expected_params is None:
             # This can support a variable number of parameters.
             return
-        if not len(node.args.args) and not node.args.vararg:
+        if not node.args.args and not node.args.vararg:
             # Method has no parameter, will be caught
             # by no-method-argument.
             return

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -139,13 +139,13 @@ class SpellingChecker(BaseTokenChecker):
         words = []
         for word in line2.split():
             # Skip words with digits.
-            if len(re.findall(r"\d", word)) > 0:
+            if re.findall(r"\d", word):
                 continue
 
             # Skip words with mixed big and small letters,
             # they are probaly class names.
-            if (len(re.findall("[A-Z]", word)) > 0 and
-                    len(re.findall("[a-z]", word)) > 0 and
+            if (re.findall("[A-Z]", word) and
+                    re.findall("[a-z]", word) and
                     len(word) > 2):
                 continue
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -691,7 +691,7 @@ accessed. Python regular expressions are accepted.'}
             return
         returns = list(function_node.nodes_of_class(astroid.Return,
                                                     skip_klass=astroid.FunctionDef))
-        if len(returns) == 0:
+        if not returns:
             self.add_message('assignment-from-no-return', node=node)
         else:
             for rnode in returns:

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -172,7 +172,7 @@ def _yn_validator(opt, _, value):
 
 
 def _non_empty_string_validator(opt, _, value):
-    if not len(value):
+    if not value:
         msg = "indent string can't be empty."
         raise optparse.OptionValueError(msg)
     return utils._unquote(value)

--- a/pylint/test/functional/len_checks.py
+++ b/pylint/test/functional/len_checks.py
@@ -1,0 +1,47 @@
+# pylint: disable=too-few-public-methods,import-error, no-absolute-import,missing-docstring
+# pylint: disable=useless-super-delegation,wrong-import-position,invalid-name, wrong-import-order
+
+if len('TEST'): # [len-as-condition]
+    pass
+
+while not len('TEST'): # [len-as-condition]
+    pass
+
+assert len('TEST') > 0 # [len-as-condition]
+
+x = 1 if len('TEST') != 0 else 2 # [len-as-condition]
+
+if len('TEST') == 0: # [len-as-condition]
+    pass
+
+if True and len('TEST') == 0: # [len-as-condition]
+    pass
+
+if 0 == len('TEST') < 10: # [len-as-condition]
+    pass
+
+if 0 < 1 <= len('TEST') < 10: # Should be fine
+    pass
+
+if 10 > len('TEST') != 0: # [len-as-condition]
+    pass
+
+z = False
+if z and len(['T', 'E', 'S', 'T']):  # [len-as-condition]
+    pass
+
+if 10 > len('TEST') > 1 > 0:
+    pass
+
+f_o_o = len('TEST') or 42  # Should be fine
+
+a = x and len(x)  # Should be fine
+
+if 0 <= len('TEST') < 100:  # Should be fine
+    pass
+
+if z or 10 > len('TEST') != 0: # [len-as-condition]
+    pass
+
+def some_func():
+    return len('TEST') > 0  # Should be fine

--- a/pylint/test/functional/len_checks.txt
+++ b/pylint/test/functional/len_checks.txt
@@ -1,0 +1,10 @@
+len-as-condition:4::Do not use `len(SEQUENCE)` as condition value
+len-as-condition:7::Do not use `len(SEQUENCE)` as condition value
+len-as-condition:10::Do not use `len(SEQUENCE)` as condition value
+len-as-condition:12::Do not use `len(SEQUENCE)` as condition value
+len-as-condition:14::Do not use `len(SEQUENCE)` as condition value
+len-as-condition:17::Do not use `len(SEQUENCE)` as condition value
+len-as-condition:20::Do not use `len(SEQUENCE)` as condition value
+len-as-condition:26::Do not use `len(SEQUENCE)` as condition value
+len-as-condition:30::Do not use `len(SEQUENCE)` as condition value
+len-as-condition:43::Do not use `len(SEQUENCE)` as condition value


### PR DESCRIPTION
This new checker implements the following statement from PEP8:

```
For sequences, (strings, lists, tuples), use the fact that empty sequences are false.

Yes: if not seq:
     if seq:

No: if len(seq):
    if not len(seq):
```

This is still a work in progress mainly around lines 76-79 when we have a Compare statement. ATM I'm not handling statements like `0 < len(S) < 5` or `0 != len(S)`, etc. Advice is welcome on how to handle this and what sort of error conditions to consider valid.

Background: Recently I've been working with a code base which has lots of `if len(something) > 0` or `if len(something) != 0` and figured I'll write this patch.