### PR TITLE
Report when __slots__ is a simple string and not a non-string container

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -113,3 +113,5 @@ Order doesn't matter (not that much, at least ;)
   Added Python 3 check for accessing Exception.message
 
 * Erik Eriksson - Added overlapping-except error check.
+
+* Anthony Foglia (Google): Added simple string slots check.

--- a/ChangeLog
+++ b/ChangeLog
@@ -189,6 +189,10 @@ Release date: tba
 
     * Avoid crashing on ill-formatted strings when checking for string formatting errors.
 
+    * Added new coding convention message, 'single-string-used-for-slots'.
+
+      Closes #1166
+
 
 What's new in Pylint 1.6.3?
 ===========================

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -421,6 +421,10 @@ MSGS = {
               'no-staticmethod-decorator',
               'Used when a static method is defined without using the decorator '
               'syntax.'),
+    'C0205': ('Class __slots__ should be a non-string iterable',
+              'single-string-used-for-slots',
+              'Used when a class __slots__ is a simple string, rather '
+              'than an iterable.'),
     }
 
 
@@ -720,6 +724,7 @@ a metaclass class method.'}
 
             if isinstance(slots, astroid.Const):
                 # a string, ignore the following checks
+                self.add_message('single-string-used-for-slots', node=node)
                 continue
             if not hasattr(slots, 'itered'):
                 # we can't obtain the values, maybe a .deque?

--- a/pylint/test/functional/slots_checks.py
+++ b/pylint/test/functional/slots_checks.py
@@ -28,12 +28,9 @@ class FourthGood(object):
     __slots__ = ('a%s' % i for i in range(10))
 
 class FifthGood(object):
-    __slots__ = "a"
-
-class SixthGood(object):
     __slots__ = deque(["a", "b", "c"])
 
-class SeventhGood(object):
+class SixthGood(object):
     __slots__ = {"a": "b", "c": "d"}
 
 class Bad(object): # [invalid-slots]
@@ -51,14 +48,20 @@ class FourthBad(object):  # [invalid-slots]
 class FifthBad(object):
     __slots__ = ("a", "b", "")  # [invalid-slots-object]
 
+class SixthBad(object):  # [single-string-used-for-slots]
+    __slots__ = "a"
+
+class SeventhBad(object):  # [single-string-used-for-slots]
+    __slots__ = ('foo')
+
+class EighthBad(object):  # [single-string-used-for-slots]
+    __slots__ = deque.__name__
+
 class PotentiallyGood(object):
     __slots__ = func()
 
 class PotentiallySecondGood(object):
     __slots__ = ('a', deque.__name__)
-
-class PotentiallyThirdGood(object):
-    __slots__ = deque.__name__
 
 
 import six
@@ -75,5 +78,8 @@ class Metaclass(type):
 class IterableClass(object):
     pass
 
-class PotentiallyFourthGood(object):
+class PotentiallyThirdGood(object):
     __slots__ = IterableClass
+
+class PotentiallyFourthGood(object):
+    __slots__ = Good.__slots__

--- a/pylint/test/functional/slots_checks.txt
+++ b/pylint/test/functional/slots_checks.txt
@@ -1,5 +1,8 @@
-invalid-slots:39:Bad:Invalid __slots__ object
-invalid-slots:42:SecondBad:Invalid __slots__ object
-invalid-slots-object:46:ThirdBad:Invalid object '2' in __slots__, must contain only non empty strings
-invalid-slots:48:FourthBad:Invalid __slots__ object
-invalid-slots-object:52:FifthBad:"Invalid object ""''"" in __slots__, must contain only non empty strings"
+invalid-slots:36:Bad:Invalid __slots__ object
+invalid-slots:39:SecondBad:Invalid __slots__ object
+invalid-slots-object:43:ThirdBad:Invalid object '2' in __slots__, must contain only non empty strings
+invalid-slots:45:FourthBad:Invalid __slots__ object
+invalid-slots-object:49:FifthBad:"Invalid object ""''"" in __slots__, must contain only non empty strings"
+single-string-used-for-slots:51:SixthBad:Class __slots__ should be a non-string iterable
+single-string-used-for-slots:54:SeventhBad:Class __slots__ should be a non-string iterable
+single-string-used-for-slots:57:EighthBad:Class __slots__ should be a non-string iterable


### PR DESCRIPTION
### Fixes / new features
- Addresses issue 1166: [detect \_\_slots\_\_ = "single_attr" as being bad](https://github.com/PyCQA/pylint/issues/1166)
