### PR TITLE
Add a Python 3 checker for calls to `encode` or `decode` with non-text codecs.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -110,6 +110,7 @@ Order doesn't matter (not that much, at least ;)
 * Alexander Todorov: added new error conditions to 'bad-super-call'.
 
 * Roy Williams (Lyft): added check for implementing __eq__ without implementing __hash__,
-  Added Python 3 check for accessing Exception.message
+  Added Python 3 check for accessing Exception.message,
+  Added Python 3 check for calling encode/decode with invalid codecs.
 
 * Erik Eriksson - Added overlapping-except error check.

--- a/ChangeLog
+++ b/ChangeLog
@@ -193,6 +193,9 @@ Release date: tba
 
     * Avoid crashing on ill-formatted strings when checking for string formatting errors.
 
+    * Added a new Python 3 warning for calling 'str.encode' or 'str.decode' with a non-text
+      encoding.
+
 
 What's new in Pylint 1.6.3?
 ===========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -253,6 +253,23 @@ New checkers
         print(str(e))
 
 
+* A new Python 3 checker was added to warn about using ``encode`` or ``decode`` on strings
+  with non-text codecs.  This check also checks calls to ``open`` with the keyword argument
+  ``encoding``.  See https://docs.python.org/3/whatsnew/3.4.html#improvements-to-codec-handling
+  for more information.
+
+  .. code-block:: python
+
+      'hello world'.encode('hex')
+
+  Instead of using the ``encode`` method for non-text codecs use the ``codecs`` module.
+
+  .. code-block:: python
+
+      import codecs
+      codecs.encode('hello world', 'hex')
+
+
 * A new warning was added, ``overlapping-except``, which is emitted
   when an except handler treats two exceptions which are *overlapping*.
   This means that one exception is an ancestor of the other one or it is

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -429,6 +429,38 @@ class Python3CheckerTest(testutils.CheckerTestCase):
             self.checker.visit_attribute(node)
 
     @python2_only
+    def test_invalid_codec(self):
+        node = astroid.extract_node('foobar.encode("hex") #@')
+        message = testutils.Message('invalid-str-codec', node=node)
+        with self.assertAddsMessages(message):
+            self.checker.visit_call(node)
+
+    @python2_only
+    def test_valid_codec(self):
+        node = astroid.extract_node('foobar.encode("ascii", "ignore")  #@')
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
+
+    @python2_only
+    def test_visit_call_with_kwarg(self):
+        node = astroid.extract_node('foobar.raz(encoding="hex")  #@')
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
+
+    @python2_only
+    def test_invalid_open_codec(self):
+        node = astroid.extract_node('open(foobar, encoding="hex") #@')
+        message = testutils.Message('invalid-str-codec', node=node)
+        with self.assertAddsMessages(message):
+            self.checker.visit_call(node)
+
+    @python2_only
+    def test_valid_open_codec(self):
+        node = astroid.extract_node('open(foobar, encoding="palmos") #@')
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
+
+    @python2_only
     def test_raising_string(self):
         node = astroid.extract_node('raise "Test"')
         message = testutils.Message('raising-string', node=node)


### PR DESCRIPTION
These codecs were removed from the type restricted convenience methods on
`str`, `bytes`, and `bytearray` in Python 3.4 and produce inconsistent output
with their counterparts in `codecs`