### PR TITLE
New checker: comparison to empty string constant

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -121,7 +121,8 @@ Order doesn't matter (not that much, at least ;)
 * Yuri Bochkarev: Added epytext support to docparams extension.
 
 * Alexander Todorov: added new error conditions to 'bad-super-call',
-  Added new check for incorrect len(SEQUENCE) usage
+  Added new check for incorrect len(SEQUENCE) usage,
+  Added new extension for comparison against empty string constants
 
 * Erik Eriksson - Added overlapping-except error check.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,11 +8,13 @@ What's New in Pylint 2.0?
 Release date: tba
 
     * Treat keyword only arguments the same as positional arguments with regard to unused-argument check
-    
+
     * Don't try to access variables defined in a separate scope when checking for ``protected-access``
-     
+
     * Added new check to detect incorrect usage of len(SEQUENCE) inside
       test conditions.
+
+    * Added new extension to detect comparisons against empty string constants
 
     * Added new error conditions for 'bad-super-call'
 

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -132,6 +132,40 @@ New checkers
   See https://www.python.org/dev/peps/pep-0008/#programming-recommendations
   for more information.
 
+* A new extension was added, ``emptystring.py`` which detects whenever
+  we detect comparisons to empty string constants. This extension is disabled
+  by default. For instance, the examples below:
+
+  .. code-block:: python
+
+      if S != "":
+        pass
+
+      if S == '':
+        pass
+
+  can be written in a more natural way:
+
+  .. code-block:: python
+
+      if S:
+        pass
+
+      if not S:
+        pass
+
+  An exception to this is when empty string is an allowed value whose meaning
+  is treated differently than ``None``. For example the meaning could be
+  user selected no additional options vs. user has not made their selection yet!
+
+  You can activate this checker by adding the line::
+
+      load-plugins=pylint.extensions.emptystring
+
+  to the ``MASTER`` section of your ``.pylintrc`` or using the command::
+
+      $ pylint a.py --load-plugins=pylint.extensions.emptystring
+
 * We've added new error conditions for ``bad-super-call`` which now detect
   the usage of ``super(type(self), self)`` and ``super(self.__class__, self)``
   patterns. These can lead to recursion loop in derived classes. The problem

--- a/pylint/extensions/emptystring.py
+++ b/pylint/extensions/emptystring.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2016 Alexander Todorov <atodorov@MrSenko.com>
+
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+"""Looks for  comparisons to empty string."""
+
+import itertools
+
+import astroid
+
+from pylint import interfaces
+from pylint import checkers
+from pylint.checkers import utils
+
+
+def _is_constant_empty_str(node):
+    return isinstance(node, astroid.Const) and node.value == ''
+
+
+class CompareToEmptyStringChecker(checkers.BaseChecker):
+    """Checks for comparisons to empty string.
+    Most of the times you should use the fact that empty strings are false.
+    An exception to this rule is when an empty string value is allowed in the program
+    and has a different meaning than None!
+    """
+
+    __implements__ = (interfaces.IAstroidChecker,)
+
+    # configuration section name
+    name = 'compare-to-empty-string'
+    msgs = {'C1901': ('Avoid comparisons to empty string',
+                      'compare-to-empty-string',
+                      'Used when Pylint detects comparison to an empty string constant.'),
+           }
+
+    priority = -2
+    options = ()
+
+    @utils.check_messages('compare-to-empty-string')
+    def visit_compare(self, node):
+        _operators = ['!=', '==', 'is not', 'is']
+        # note: astroid.Compare has the left most operand in node.left
+        # while the rest are a list of tuples in node.ops
+        # the format of the tuple is ('compare operator sign', node)
+        # here we squash everything into `ops` to make it easier for processing later
+        ops = [('', node.left)]
+        ops.extend(node.ops)
+        ops = list(itertools.chain(*ops))
+
+        for ops_idx in range(len(ops) - 2):
+            op_1 = ops[ops_idx]
+            op_2 = ops[ops_idx + 1]
+            op_3 = ops[ops_idx + 2]
+            error_detected = False
+
+            # x ?? ""
+            if _is_constant_empty_str(op_1) and op_2 in _operators:
+                error_detected = True
+            # '' ?? X
+            elif op_2 in _operators and _is_constant_empty_str(op_3):
+                error_detected = True
+
+            if error_detected:
+                self.add_message('compare-to-empty-string', node=node)
+
+
+def register(linter):
+    """Required method to auto register this checker."""
+    linter.register_checker(CompareToEmptyStringChecker(linter))

--- a/pylint/test/extensions/data/empty_string_comparison.py
+++ b/pylint/test/extensions/data/empty_string_comparison.py
@@ -1,0 +1,16 @@
+# pylint: disable=literal-comparison,missing-docstring
+
+X = ''
+Y = 'test'
+
+if X is '':  # [compare-to-empty-string]
+    pass
+
+if Y is not "":  # [compare-to-empty-string]
+    pass
+
+if X == "":  # [compare-to-empty-string]
+    pass
+
+if Y != '':  # [compare-to-empty-string]
+    pass

--- a/pylint/test/extensions/test_emptystring.py
+++ b/pylint/test/extensions/test_emptystring.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2016 Alexander Todorov <atodorov@MrSenko.com>
+
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+"""Tests for the pylint checker in :mod:`pylint.extensions.emptystring
+"""
+
+import os
+import os.path as osp
+import unittest
+
+from pylint import checkers
+from pylint.extensions.emptystring import CompareToEmptyStringChecker
+from pylint.lint import PyLinter
+from pylint.reporters import BaseReporter
+
+
+class TestReporter(BaseReporter):
+
+    def handle_message(self, msg):
+        self.messages.append(msg)
+
+    def on_set_current_module(self, module, filepath):
+        self.messages = []
+
+
+class CheckEmptyStringUsedTC(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._linter = PyLinter()
+        cls._linter.set_reporter(TestReporter())
+        checkers.initialize(cls._linter)
+        cls._linter.register_checker(CompareToEmptyStringChecker(cls._linter))
+        cls._linter.disable('I')
+
+    def test_emptystring_message(self):
+        elif_test = osp.join(osp.dirname(osp.abspath(__file__)), 'data',
+                             'empty_string_comparison.py')
+        self._linter.check([elif_test])
+        msgs = self._linter.reporter.messages
+        self.assertEqual(len(msgs), 4)
+        for msg in msgs:
+            self.assertEqual(msg.symbol, 'compare-to-empty-string')
+            self.assertEqual(msg.msg, 'Avoid comparisons to empty string')
+        self.assertEqual(msgs[0].line, 6)
+        self.assertEqual(msgs[1].line, 9)
+        self.assertEqual(msgs[2].line, 12)
+        self.assertEqual(msgs[3].line, 15)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Detects things like

```
if X == '':
    pass
```

Note that in some cases this is what the author needs but my experience tells me most of the times empty string value doesn't have a special meaning. 

Note2: this probably belongs to the ComparisonChecker in base.py. This checker however only supports binary comparisons so I will have to fix his limitation first. Let me know how would you like to proceed about that.
