### PR TITLE
Add Python 3 checker for accessing deprecated functions on the `string` module.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -115,6 +115,7 @@ Order doesn't matter (not that much, at least ;)
   Added Python 3 check for calling encode/decode with invalid codecs.
   Added Python 3 check for accessing sys.maxint.
   Added Python 3 check for bad import statements.
+  Added Python 3 check for accessing deprecated methods on the 'string' module.
 
 * Erik Eriksson - Added overlapping-except error check.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -208,6 +208,8 @@ Release date: tba
 
     * Added a new Python 3 check for bad imports.
 
+    * Added a new Python 3 check for accessing deprecated string functions.
+
 
 What's new in Pylint 1.6.3?
 ===========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -373,6 +373,20 @@ New checkers
   This checker will assume any imports that happen within a conditional or a ``try/except`` block
   are valid.
 
+* A new Python 3 checker was added to warn about accessing deprecated functions on the string
+  module.  Python 3 removed functions that were duplicated from the builtin ``str`` class.  See
+  https://docs.python.org/2/library/string.html#deprecated-string-functions for more information.
+
+  .. code-block:: python
+
+      import string
+      print(string.upper('hello world!'))
+
+  Instead of using ``string.upper``, call the ``upper`` method directly on the string object.
+
+  .. code-block:: python
+
+      "hello world!".upper()
 
 Other Changes
 =============

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -502,6 +502,16 @@ class Python3CheckerTest(testutils.CheckerTestCase):
             self.checker.visit_attribute(node)
 
     @python2_only
+    def test_sys_maxint_imort_from(self):
+        node = astroid.extract_node('''
+        from sys import maxint #@
+        ''')
+        absolute_import_message = testutils.Message('no-absolute-import', node=node)
+        message = testutils.Message('sys-max-int', node=node)
+        with self.assertAddsMessages(absolute_import_message, message):
+            self.checker.visit_importfrom(node)
+
+    @python2_only
     def test_object_maxint(self):
         node = astroid.extract_node('''
         sys = object()
@@ -581,14 +591,58 @@ class Python3CheckerTest(testutils.CheckerTestCase):
             self.checker.visit_importfrom(node)
 
     @python2_only
-    def test_bad_import_else_block(self):
+    def test_bad_string_attribute(self):
         node = astroid.extract_node('''
-        import six
-        if six.PY3:
-            from io import StringIO
-        else:
-            from cStringIO import StringIO #@
+        import string
+        string.maketrans #@
         ''')
+        message = testutils.Message('deprecated-string-function', node=node)
+        with self.assertAddsMessages(message):
+            self.checker.visit_attribute(node)
+
+    @python2_only
+    def test_ok_string_attribute(self):
+        node = astroid.extract_node('''
+        import string
+        string.letters #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_attribute(node)
+
+    @python2_only
+    def test_bad_string_call(self):
+        node = astroid.extract_node('''
+        import string
+        string.upper("hello world") #@
+        ''')
+        message = testutils.Message('deprecated-string-function', node=node)
+        with self.assertAddsMessages(message):
+            self.checker.visit_call(node)
+
+    @python2_only
+    def test_ok_string_call(self):
+        node = astroid.extract_node('''
+        import string
+        string.Foramtter() #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
+
+    @python2_only
+    def test_bad_string_import_from(self):
+        node = astroid.extract_node('''
+         from string import atoi #@
+         ''')
+        absolute_import_message = testutils.Message('no-absolute-import', node=node)
+        message = testutils.Message('deprecated-string-function', node=node)
+        with self.assertAddsMessages(absolute_import_message, message):
+            self.checker.visit_importfrom(node)
+
+    @python2_only
+    def test_ok_string_import_from(self):
+        node = astroid.extract_node('''
+         from string import digits #@
+         ''')
         absolute_import_message = testutils.Message('no-absolute-import', node=node)
         with self.assertAddsMessages(absolute_import_message):
             self.checker.visit_importfrom(node)


### PR DESCRIPTION
This also triggered a "Rule of 3" refactoring for me to generalize warning about
accessing a given attribute on a module.