### PR TITLE
Add a Python 3 checker for finding deprecated calls to `str.translate`.

### DIFF
--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -410,6 +410,37 @@ New checkers
       "hello world!".upper()
 
 
+* A new Python 3 checker was added to warn about calling ``str.translate`` with the removed
+  ``deletechars`` parameter.  ``str.translate`` is frequently used as a way to remove characters
+  from a string.
+
+  .. code-block:: python
+
+      'hello world'.translate(None, 'low')
+
+  Unfortunately, there is not an idiomatic way of writing this call in a 2and3 compatible way.  If
+  this code is not in the critical path for your application and the use of ``translate`` was a
+  premature optimization, consider using ``re.sub`` instead:
+
+  .. code-block:: python
+
+      import re
+      chars_to_remove = re.compile('[low]')
+      chars_to_remove.sub('', 'hello world')
+
+  If this code is in your critical path and must be as fast as possible, consider declaring a
+  helper method that varies based upon Python version.
+
+  .. code-block:: python
+
+      if six.PY3:
+          def _remove_characters(text, deletechars):
+              return text.translate({ord(x): None for x in deletechars})
+      else:
+          def _remove_characters(text, deletechars):
+              return text.translate(None, deletechars)
+
+
 Other Changes
 =============
 

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -647,6 +647,40 @@ class Python3CheckerTest(testutils.CheckerTestCase):
         with self.assertAddsMessages(absolute_import_message):
             self.checker.visit_importfrom(node)
 
+    @python2_only
+    def test_bad_str_translate_call_string_literal(self):
+        node = astroid.extract_node('''
+         foobar.translate(None, 'abc123') #@
+         ''')
+        message = testutils.Message('deprecated-str-translate-call', node=node)
+        with self.assertAddsMessages(message):
+            self.checker.visit_call(node)
+
+    @python2_only
+    def test_bad_str_translate_call_variable(self):
+        node = astroid.extract_node('''
+         foobar.translate(None, foobar) #@
+         ''')
+        message = testutils.Message('deprecated-str-translate-call', node=node)
+        with self.assertAddsMessages(message):
+            self.checker.visit_call(node)
+
+    @python2_only
+    def test_ok_str_translate_call_integer(self):
+        node = astroid.extract_node('''
+         foobar.translate(None, 33) #@
+         ''')
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
+
+    @python2_only
+    def test_ok_str_translate_call_keyword(self):
+        node = astroid.extract_node('''
+         foobar.translate(None, 'foobar', raz=33) #@
+         ''')
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
+
 @python2_only
 class Python3TokenCheckerTest(testutils.CheckerTestCase):
 

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -681,6 +681,16 @@ class Python3CheckerTest(testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_call(node)
 
+    @python2_only
+    def test_ok_str_translate_call_not_str(self):
+        node = astroid.extract_node('''
+         foobar = {}
+         foobar.translate(None, 'foobar') #@
+         ''')
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
+
+
 @python2_only
 class Python3TokenCheckerTest(testutils.CheckerTestCase):
 


### PR DESCRIPTION
This checker could possibly have some false positives, but after checking our codebase
and several other large codebases using this implementation, I did not find any false
positives.