### PR TITLE
Respect checks for Python 2

### DIFF
--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -8,7 +8,10 @@
 from __future__ import absolute_import, print_function
 
 import re
+import sys
 import tokenize
+
+from collections import namedtuple
 
 import six
 
@@ -92,6 +95,7 @@ def _is_conditional_import(node):
     return isinstance(parent, (astroid.TryExcept, astroid.ExceptHandler,
                                astroid.If, astroid.IfExp))
 
+Branch = namedtuple('Branch', ['node', 'is_py2_only'])
 
 class Python3Checker(checkers.BaseChecker):
 
@@ -483,13 +487,54 @@ class Python3Checker(checkers.BaseChecker):
         }
     }
 
+    if (3, 4) <= sys.version_info < (3, 4, 4):
+        # Python 3.4.0 -> 3.4.3 has a bug which breaks `repr_tree()`:
+        # https://bugs.python.org/issue23572
+        _python_2_tests = frozenset()
+    else:
+        _python_2_tests = frozenset(
+            [astroid.extract_node(x).repr_tree() for x in [
+                'sys.version_info[0] == 2',
+                'sys.version_info[0] < 3',
+                'sys.version_info == (2, 7)',
+                'sys.version_info <= (2, 7)',
+                'sys.version_info < (3, 0)',
+            ]])
+
     def __init__(self, *args, **kwargs):
         self._future_division = False
         self._future_absolute_import = False
         self._modules_warned_about = set()
+        self._branch_stack = []
         super(Python3Checker, self).__init__(*args, **kwargs)
 
-    def visit_module(self, node): # pylint: disable=unused-argument
+    def add_message(self, msg_id, always_warn=False,  # pylint: disable=arguments-differ
+                    *args, **kwargs):
+        if always_warn or not (self._branch_stack and self._branch_stack[-1].is_py2_only):
+            super(Python3Checker, self).add_message(msg_id, *args, **kwargs)
+
+    def _is_py2_test(self, node):
+        if isinstance(node.test, astroid.Attribute) and isinstance(node.test.expr, astroid.Name):
+            if node.test.expr.name == 'six' and node.test.attrname == 'PY2':
+                return True
+        elif (isinstance(node.test, astroid.Compare) and
+              node.test.repr_tree() in self._python_2_tests):
+            return True
+        return False
+
+    def visit_if(self, node):
+        self._branch_stack.append(Branch(node, self._is_py2_test(node)))
+
+    def leave_if(self, node):
+        assert self._branch_stack.pop().node == node
+
+    def visit_ifexp(self, node):
+        self._branch_stack.append(Branch(node, self._is_py2_test(node)))
+
+    def leave_ifexp(self, node):
+        assert self._branch_stack.pop().node == node
+
+    def visit_module(self, node):  # pylint: disable=unused-argument
         """Clear checker state after previous module."""
         self._future_division = False
         self._future_absolute_import = False
@@ -517,7 +562,7 @@ class Python3Checker(checkers.BaseChecker):
 
     @utils.check_messages('print-statement')
     def visit_print(self, node):
-        self.add_message('print-statement', node=node)
+        self.add_message('print-statement', node=node, always_warn=True)
 
     def _warn_if_deprecated(self, node, module, attributes):
         for message, module_map in six.iteritems(self._bad_python3_module_map):

--- a/pylint/test/functional/print_always_warns.py
+++ b/pylint/test/functional/print_always_warns.py
@@ -1,0 +1,8 @@
+"""Check print statement always warns even if in Python 2 block """
+
+from __future__ import absolute_import
+
+import six
+
+if six.PY2:
+    print "Python 3 fails to parse print statements." # [print-statement]

--- a/pylint/test/functional/print_always_warns.rc
+++ b/pylint/test/functional/print_always_warns.rc
@@ -1,0 +1,5 @@
+[testoptions]
+max_pyver=3.0
+
+[Messages Control]
+enable=python3

--- a/pylint/test/functional/print_always_warns.txt
+++ b/pylint/test/functional/print_always_warns.txt
@@ -1,0 +1,1 @@
+print-statement:8::print statement used

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -705,6 +705,69 @@ class Python3CheckerTest(testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_call(node)
 
+    def test_non_py2_conditional(self):
+        code = '''
+        from __future__ import absolute_import
+        import sys
+        x = {}
+        if sys.maxsize:
+            x.iterkeys()  #@
+        '''
+        node = astroid.extract_node(code)
+        module = node.parent.parent
+        message = testutils.Message('dict-iter-method', node=node)
+        with self.assertAddsMessages(message):
+            self.walk(module)
+
+    def test_six_conditional(self):
+        code = '''
+        from __future__ import absolute_import
+        import six
+        x = {}
+        if six.PY2:
+            x.iterkeys()
+        '''
+        module = astroid.parse(code)
+        with self.assertNoMessages():
+            self.walk(module)
+
+    @python2_only
+    def test_versioninfo_conditional(self):
+        code = '''
+        from __future__ import absolute_import
+        import sys
+        x = {}
+        if sys.version_info[0] == 2:
+            x.iterkeys()
+        '''
+        module = astroid.parse(code)
+        with self.assertNoMessages():
+            self.walk(module)
+
+    @python2_only
+    def test_versioninfo_tuple_conditional(self):
+        code = '''
+        from __future__ import absolute_import
+        import sys
+        x = {}
+        if sys.version_info == (2, 7):
+            x.iterkeys()
+        '''
+        module = astroid.parse(code)
+        with self.assertNoMessages():
+            self.walk(module)
+
+    @python2_only
+    def test_six_ifexp_conditional(self):
+        code = '''
+        from __future__ import absolute_import
+        import six
+        import string
+        string.translate if six.PY2 else None
+        '''
+        module = astroid.parse(code)
+        with self.assertNoMessages():
+            self.walk(module)
 
 @python2_only
 class Python3TokenCheckerTest(testutils.CheckerTestCase):


### PR DESCRIPTION
Frequently 2and3 code will gate some Python 3 specific code with something like:

```python
if six.PY2:
  #  something python 2 only
```

This PR will respect those branches.

One thing I wasn't able to do was handle `else` branches here.  e.g.:

```python
if six.PY3:
  # something python 3 only
else:
  # something python 2 only
```

I'd love some feedback on how I can accomplish this, but AFAICT there is no `else` node
in `astroid`.