### PR TITLE
Only check system modules during imports.

### DIFF
--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -620,6 +620,15 @@ class Python3CheckerTest(testutils.CheckerTestCase):
             self.checker.visit_call(node)
 
     @python2_only
+    def test_ok_shadowed_call(self):
+        node = astroid.extract_node('''
+        import six.moves.configparser
+        six.moves.configparser.ConfigParser() #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
+
+    @python2_only
     def test_ok_string_call(self):
         node = astroid.extract_node('''
         import string


### PR DESCRIPTION
Without this change there could be a false-positive with the following code:

```python
import six.moves.configparser
configparser.ConfigParser()
```