### PR TITLE
Improve metaclass detection in nested scopes in Python 3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -217,6 +217,9 @@ Release date: tba
 
     * Added refactoring message 'no-else-return'.
 
+    * Improve handing of Python 3 classes with metaclasses declared in nested scopes.
+
+      Closes #1177
 
 
 What's new in Pylint 1.6.3?

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1213,11 +1213,12 @@ class VariablesChecker3k(VariablesChecker):
 
     def _check_metaclasses(self, node):
         """ Update consumption analysis for metaclasses. """
-        consumed = []  # (scope_locals_dict, key)
+        consumed = []  # [(scope_locals, consumed_key)]
 
-        for klass in node.get_children():
-            if not isinstance(klass, astroid.ClassDef):
+        for child_node in node.get_children():
+            if not isinstance(child_node, astroid.ClassDef):
                 continue
+            klass = child_node
 
             if not klass._metaclass:
                 # Skip if this class doesn't use
@@ -1235,10 +1236,10 @@ class VariablesChecker3k(VariablesChecker):
             found = None
             if name:
                 # check enclosing scopes starting from most local
-                for scope_not_consumed_locals, _, _ in self._to_consume[::-1]:
-                    found = scope_not_consumed_locals.get(name)
+                for scope_locals, _, _ in self._to_consume[::-1]:
+                    found = scope_locals.get(name)
                     if found:
-                        consumed.append((scope_not_consumed_locals, name))
+                        consumed.append((scope_locals, name))
                         break
 
             if found is None and not metaclass:
@@ -1259,8 +1260,8 @@ class VariablesChecker3k(VariablesChecker):
 
         # Pop the consumed items, in order to avoid having
         # unused-import and unused-variable false positives
-        for scope_locals_dict, name in consumed:
-            scope_locals_dict.pop(name, None)
+        for scope_locals, name in consumed:
+            scope_locals.pop(name, None)
 
 if sys.version_info >= (3, 0):
     VariablesChecker = VariablesChecker3k

--- a/pylint/test/functional/bugfix_local_scope_metaclass_1177.py
+++ b/pylint/test/functional/bugfix_local_scope_metaclass_1177.py
@@ -37,7 +37,7 @@ def mixed_scopes():
     return ClassM
 
 
-def imported_and_nested_scope1():  # fails currently
+def imported_and_nested_scope1():
     class ClassImp1(metaclass=ImportedMetaclass):
         pass
 

--- a/pylint/test/functional/bugfix_local_scope_metaclass_1177.py
+++ b/pylint/test/functional/bugfix_local_scope_metaclass_1177.py
@@ -41,13 +41,16 @@ def imported_and_nested_scope1():  # fails currently
     class ClassImp1(metaclass=ImportedMetaclass):
         pass
 
-    return ClassImp1
+    class ClassImp2(metaclass=ImportedMetaclass):
+        pass
+
+    return ClassImp1, ClassImp2
 
 
 def imported_and_nested_scope2():
     from UNINFERABLE import ImportedMetaclass2
 
-    class ClassImp2(metaclass=ImportedMetaclass2):
+    class ClassImp3(metaclass=ImportedMetaclass2):
         pass
 
-    return ClassImp2
+    return ClassImp3

--- a/pylint/test/functional/bugfix_local_scope_metaclass_1177.py
+++ b/pylint/test/functional/bugfix_local_scope_metaclass_1177.py
@@ -1,0 +1,53 @@
+# pylint: disable=missing-docstring,too-few-public-methods,import-error
+from UNINFERABLE import ImportedMetaclass
+
+
+class Meta(type):
+    pass
+
+
+class Class(metaclass=Meta):
+    pass
+
+
+def func_scope():
+    class Meta2(type):
+        pass
+
+    class Class2(metaclass=Meta2):
+        pass
+
+    return Class2
+
+
+class ClassScope:
+    class Meta3(type):
+        pass
+
+    class Class3(metaclass=Meta3):
+        pass
+
+    instance = Class3()
+
+
+def mixed_scopes():
+    class ClassM(metaclass=Meta):
+        pass
+
+    return ClassM
+
+
+def imported_and_nested_scope1():  # fails currently
+    class ClassImp1(metaclass=ImportedMetaclass):
+        pass
+
+    return ClassImp1
+
+
+def imported_and_nested_scope2():
+    from UNINFERABLE import ImportedMetaclass2
+
+    class ClassImp2(metaclass=ImportedMetaclass2):
+        pass
+
+    return ClassImp2

--- a/pylint/test/functional/bugfix_local_scope_metaclass_1177.rc
+++ b/pylint/test/functional/bugfix_local_scope_metaclass_1177.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.0


### PR DESCRIPTION
TODO:

- [x] write a test that exposes an issue
- [x] implement changes to fix exposed issue
- [x] improve coverage by adding tests for potential failures
- [x] make all new tests pass
- [x] refactor code
- [x] add docs and change log entries

Current fail is triggered, when metaclass is imported in non local (enclosing) scope. I’m not quite sure yet how pushing and popping from `_to_consume` stack should work, but second element of pushed tuple seems to be never populated.

Any input is appreciated.

Closes #1177