### PR TITLE
Fix CLI output for fixme messages

### DIFF
--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -64,7 +64,7 @@ class EncodingChecker(BaseChecker):
         match = notes.search(line)
         if not match:
             return
-        self.add_message('fixme', args=line[match.start(1):-1], line=lineno)
+        self.add_message('fixme', args=line[match.start(1):].rstrip(), line=lineno)
 
     def _check_encoding(self, lineno, line, file_encoding):
         try:

--- a/pylint/test/functional/fixme_bad_formatting_1139.py
+++ b/pylint/test/functional/fixme_bad_formatting_1139.py
@@ -1,0 +1,6 @@
+"""
+Test for issue ##1139 - when CRLF newline characters are used,
+\r is left in msg section. As a result, output line in cmdline
+is overwritten with text after msg"""
+
+# TODO Lorem ipsum dolor sit amet consectetur adipiscing elit  # [fixme]

--- a/pylint/test/functional/fixme_bad_formatting_1139.rc
+++ b/pylint/test/functional/fixme_bad_formatting_1139.rc
@@ -1,0 +1,2 @@
+[MESSAGES CONTROL]
+msg-template={C}:{line:3d},{column:2d}: {obj}: {msg} ({symbol}, {msg_id})

--- a/pylint/test/functional/fixme_bad_formatting_1139.txt
+++ b/pylint/test/functional/fixme_bad_formatting_1139.txt
@@ -1,0 +1,1 @@
+fixme:6::TODO Lorem ipsum dolor sit amet consectetur adipiscing elit  # [fixme]:HIGH


### PR DESCRIPTION
When file has CRLF line separators, CR was kept in msg. This CR made
CLI output behave unexpectedly.

Solves #1139