### PR TITLE
New refactoring checker: consider-using-ternary

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -233,6 +233,10 @@ Release date: tba
 
       Closes #1177
 
+    * Added refactoring message 'consider-using-ternary'.
+
+      Closes #1204
+
 
 What's new in Pylint 1.6.3?
 ===========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -440,6 +440,20 @@ New checkers
           def _remove_characters(text, deletechars):
               return text.translate(None, deletechars)
 
+* A new refactoring check was added, ``consider-using-ternary``, which is
+  emitted when pylint encounters constructs which were used to emulate
+  ternary statement before it was introduced in Python 2.5.
+  .. code-block:: python
+
+    value = condition and truth_value or false_value
+
+
+  Warning can be fixed by using standard ternary construct:
+
+  .. code-block:: python
+
+    value = truth_value if condition else false_value
+
 
 Other Changes
 =============

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1354,7 +1354,7 @@ class DocStringChecker(_BasicChecker):
     @utils.check_messages('missing-docstring', 'empty-docstring')
     def visit_functiondef(self, node):
         if self.config.no_docstring_rgx.match(node.name) is None:
-            ftype = node.is_method() and 'method' or 'function'
+            ftype = 'method' if node.is_method() else 'function'
             if node.decorators and self._is_setter_or_deleter(node):
                 return
 

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -603,8 +603,9 @@ class Python3Checker(checkers.BaseChecker):
 
     @staticmethod
     def _is_constant_string_or_name(node):
-        return ((isinstance(node, astroid.Const) and isinstance(node.value, six.string_types)) or
-                isinstance(node, astroid.Name))
+        if isinstance(node, astroid.Const):
+            return isinstance(node.value, six.string_types)
+        return isinstance(node, astroid.Name)
 
     @staticmethod
     def _is_none(node):

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -64,7 +64,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         'R1701': ("Consider merging these isinstance calls to isinstance(%s, (%s))",
                   "consider-merging-isinstance",
                   "Used when multiple consecutive isinstance calls can be merged into one."),
-        'R1706': ("Consider using ternary %s if %s else %s",
+        'R1706': ("Consider using ternary (%s if %s else %s)",
                   "consider-using-ternary",
                   "Used when one of known pre-python 2.5 ternary syntax is used."),
         'R1702': ('Too many nested blocks (%s/%s)',

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -387,9 +387,13 @@ class RefactoringChecker(checkers.BaseTokenChecker):
 
     @staticmethod
     def _is_and_or_ternary(node):
-        """Returns true if node is 'condition and true_value else false_value' form.
-        All of: condition, true_value and false_value should not be a complex boolean expression"""
-        return (isinstance(node, astroid.BoolOp) and node.op == 'or' and len(node.values) == 2
+        """
+        Returns true if node is 'condition and true_value else false_value' form.
+
+        All of: condition, true_value and false_value should not be a complex boolean expression
+        """
+        return (isinstance(node, astroid.BoolOp)
+                and node.op == 'or' and len(node.values) == 2
                 and isinstance(node.values[0], astroid.BoolOp)
                 and not isinstance(node.values[1], astroid.BoolOp)
                 and node.values[0].op == 'and'

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -63,7 +63,10 @@ class RefactoringChecker(checkers.BaseTokenChecker):
     msgs = {
         'R1701': ("Consider merging these isinstance calls to isinstance(%s, (%s))",
                   "consider-merging-isinstance",
-                  "Usen when multiple consecutive isinstance calls can be merged into one."),
+                  "Used when multiple consecutive isinstance calls can be merged into one."),
+        'R1706': ("Consider using ternary %s if %s else %s",
+                  "consider-using-ternary",
+                  "Used when one of known pre-python 2.5 ternary syntax is used."),
         'R1702': ('Too many nested blocks (%s/%s)',
                   'too-many-nested-blocks',
                   'Used when a function or a method has too many nested '
@@ -368,6 +371,49 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             self.add_message('consider-merging-isinstance',
                              node=node,
                              args=(duplicated_name, ', '.join(names)))
+
+    @utils.check_messages('consider-using-ternary')
+    def visit_assign(self, node):
+        if self._is_and_or_ternary(node.value):
+            cond, truth_value, false_value = self._get_and_or_ternary_arguments(node.value)
+        elif self._is_seq_based_ternary(node.value):
+            cond, truth_value, false_value = self._get_seq_based_ternary_params(node.value)
+        else:
+            return
+        self.add_message('consider-using-ternary', node=node,
+                         args=(truth_value.as_string(), cond.as_string(), false_value.as_string()),)
+
+    visit_return = visit_assign
+
+    @staticmethod
+    def _is_and_or_ternary(node):
+        """Returns true if node is 'condition and true_value else false_value' form.
+        All of: condition, true_value and false_value should not be a complex boolean expression"""
+        return (isinstance(node, astroid.BoolOp) and node.op == 'or' and len(node.values) == 2
+                and isinstance(node.values[0], astroid.BoolOp)
+                and not isinstance(node.values[1], astroid.BoolOp)
+                and node.values[0].op == 'and'
+                and not (isinstance(node.values[0].values[0], astroid.BoolOp)
+                         or isinstance(node.values[0].values[1], astroid.BoolOp)))
+
+    @staticmethod
+    def _get_and_or_ternary_arguments(node):
+        false_value = node.values[1]
+        condition, true_value = node.values[0].values
+        return condition, true_value, false_value
+
+    @staticmethod
+    def _is_seq_based_ternary(node):
+        """Returns true if node is '[false_value,true_value][condition]' form"""
+        return (isinstance(node, astroid.Subscript)
+                and isinstance(node.value, (astroid.Tuple, astroid.List))
+                and len(node.value.elts) == 2 and isinstance(node.slice, astroid.Index))
+
+    @staticmethod
+    def _get_seq_based_ternary_params(node):
+        false_value, true_value = node.value.elts
+        condition = node.slice.value
+        return condition, true_value, false_value
 
 
 class RecommandationChecker(checkers.BaseChecker):

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -393,8 +393,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                 and isinstance(node.values[0], astroid.BoolOp)
                 and not isinstance(node.values[1], astroid.BoolOp)
                 and node.values[0].op == 'and'
-                and not (isinstance(node.values[0].values[0], astroid.BoolOp)
-                         or isinstance(node.values[0].values[1], astroid.BoolOp)))
+                and not isinstance(node.values[0].values[1], astroid.BoolOp))
 
     @staticmethod
     def _get_and_or_ternary_arguments(node):

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1201,7 +1201,7 @@ class VariablesChecker(BaseChecker):
         if module_names:
             # FIXME: other message if name is not the latest part of
             # module_names ?
-            modname = module and module.name or '__dict__'
+            modname = module.name if module else '__dict__'
             self.add_message('no-name-in-module', node=node,
                              args=('.'.join(module_names), modname))
             return None

--- a/pylint/extensions/docstyle.py
+++ b/pylint/extensions/docstyle.py
@@ -34,7 +34,7 @@ class DocStringStyleChecker(checkers.BaseChecker):
         self._check_docstring('class', node)
 
     def visit_functiondef(self, node):
-        ftype = node.is_method() and 'method' or 'function'
+        ftype = 'method' if node.is_method() else 'function'
         self._check_docstring(ftype, node)
 
     visit_asyncfunctiondef = visit_functiondef

--- a/pylint/test/functional/boolean_datetime.py
+++ b/pylint/test/functional/boolean_datetime.py
@@ -1,5 +1,5 @@
 """ Checks for boolean uses of datetime.time. """
-# pylint: disable=superfluous-parens,print-statement,no-absolute-import
+# pylint: disable=superfluous-parens,print-statement,no-absolute-import,consider-using-ternary
 import datetime
 
 if datetime.time(0, 0, 0): # [boolean-datetime]

--- a/pylint/test/functional/ternary.py
+++ b/pylint/test/functional/ternary.py
@@ -1,0 +1,24 @@
+"""Test for old tenrary constructs"""
+from UNINFERABLE import condition, true_value, false_value, some_callable  # pylint: disable=import-error
+
+SOME_VALUE1 = true_value if condition else false_value
+SOME_VALUE2 = condition and true_value or false_value  # [consider-using-ternary]
+SOME_VALUE3 = (false_value, true_value)[condition]  # [consider-using-ternary]
+
+
+def func1():
+    """Tenrary return value correct"""
+    return true_value if condition else false_value
+
+
+def func2():
+    """Tenrary return value incorrect"""
+    return condition and true_value or false_value  # [consider-using-ternary]
+
+
+def func3():
+    """Tenrary return value incorrect"""
+    return (false_value, true_value)[condition]  # [consider-using-ternary]
+
+
+SOME_VALUE4 = some_callable(condition) and 'ERROR' or 'SUCCESS'  # [consider-using-ternary]

--- a/pylint/test/functional/ternary.py
+++ b/pylint/test/functional/ternary.py
@@ -22,3 +22,6 @@ def func3():
 
 
 SOME_VALUE4 = some_callable(condition) and 'ERROR' or 'SUCCESS'  # [consider-using-ternary]
+SOME_VALUE5 = SOME_VALUE1 > 3 and 'greater' or 'not greater'  # [consider-using-ternary]
+SOME_VALUE6 = (SOME_VALUE2 > 4 and SOME_VALUE3) and 'both' or 'not'  # [consider-using-ternary]
+SOME_VALUE7 = 'both' if (SOME_VALUE2 > 4) and (SOME_VALUE3) else 'not'

--- a/pylint/test/functional/ternary.py
+++ b/pylint/test/functional/ternary.py
@@ -7,17 +7,17 @@ SOME_VALUE3 = (false_value, true_value)[condition]  # [consider-using-ternary]
 
 
 def func1():
-    """Tenrary return value correct"""
+    """Ternary return value correct"""
     return true_value if condition else false_value
 
 
 def func2():
-    """Tenrary return value incorrect"""
+    """Ternary return value incorrect"""
     return condition and true_value or false_value  # [consider-using-ternary]
 
 
 def func3():
-    """Tenrary return value incorrect"""
+    """Ternary return value incorrect"""
     return (false_value, true_value)[condition]  # [consider-using-ternary]
 
 

--- a/pylint/test/functional/ternary.txt
+++ b/pylint/test/functional/ternary.txt
@@ -3,3 +3,5 @@ consider-using-ternary:6::Consider using ternary true_value if condition else fa
 consider-using-ternary:16:func2:Consider using ternary true_value if condition else false_value:HIGH
 consider-using-ternary:21:func3:Consider using ternary true_value if condition else false_value:HIGH
 consider-using-ternary:24::Consider using ternary 'ERROR' if some_callable(condition) else 'SUCCESS':HIGH
+consider-using-ternary:25::Consider using ternary 'greater' if SOME_VALUE1 > 3 else 'not greater':HIGH
+consider-using-ternary:26::Consider using ternary 'both' if (SOME_VALUE2 > 4) and (SOME_VALUE3) else 'not':HIGH

--- a/pylint/test/functional/ternary.txt
+++ b/pylint/test/functional/ternary.txt
@@ -1,0 +1,5 @@
+consider-using-ternary:5::Consider using ternary true_value if condition else false_value:HIGH
+consider-using-ternary:6::Consider using ternary true_value if condition else false_value:HIGH
+consider-using-ternary:16:func2:Consider using ternary true_value if condition else false_value:HIGH
+consider-using-ternary:21:func3:Consider using ternary true_value if condition else false_value:HIGH
+consider-using-ternary:24::Consider using ternary 'ERROR' if some_callable(condition) else 'SUCCESS':HIGH

--- a/pylint/test/functional/ternary.txt
+++ b/pylint/test/functional/ternary.txt
@@ -1,7 +1,7 @@
-consider-using-ternary:5::Consider using ternary true_value if condition else false_value:HIGH
-consider-using-ternary:6::Consider using ternary true_value if condition else false_value:HIGH
-consider-using-ternary:16:func2:Consider using ternary true_value if condition else false_value:HIGH
-consider-using-ternary:21:func3:Consider using ternary true_value if condition else false_value:HIGH
-consider-using-ternary:24::Consider using ternary 'ERROR' if some_callable(condition) else 'SUCCESS':HIGH
-consider-using-ternary:25::Consider using ternary 'greater' if SOME_VALUE1 > 3 else 'not greater':HIGH
-consider-using-ternary:26::Consider using ternary 'both' if (SOME_VALUE2 > 4) and (SOME_VALUE3) else 'not':HIGH
+consider-using-ternary:5::Consider using ternary (true_value if condition else false_value):HIGH
+consider-using-ternary:6::Consider using ternary (true_value if condition else false_value):HIGH
+consider-using-ternary:16:func2:Consider using ternary (true_value if condition else false_value):HIGH
+consider-using-ternary:21:func3:Consider using ternary (true_value if condition else false_value):HIGH
+consider-using-ternary:24::Consider using ternary ('ERROR' if some_callable(condition) else 'SUCCESS'):HIGH
+consider-using-ternary:25::Consider using ternary ('greater' if SOME_VALUE1 > 3 else 'not greater'):HIGH
+consider-using-ternary:26::Consider using ternary ('both' if (SOME_VALUE2 > 4) and (SOME_VALUE3) else 'not'):HIGH

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -1151,7 +1151,7 @@ def _format_option_value(optdict, value):
         # compiled regexp
         value = value.pattern
     elif optdict.get('type') == 'yn':
-        value = value and 'yes' or 'no'
+        value = 'yes' if value else 'no'
     elif isinstance(value, six.string_types) and value.isspace():
         value = "'%s'" % value
     return value


### PR DESCRIPTION
Fixes #1204.

It's a rough draft, which still needs additional tests and refactoring.

Basic assumptions was:
- low (zero) error rate - do not emit message unless multiple conditions are supported. That's why complex boolean operations in `cond and true or false` are ignored and only literal ordered sequences are checked in `(false, true)[cond]` case.
- Reasonable user experience - correct form should be emitted in message

I'll do some additional work on it, but maybe there will be some valuable feedback.