### PR TITLE
'import ... as _' skips unused-import check.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -220,6 +220,10 @@ Release date: tba
     * Improve unused-variable checker to warn about unused variables in module scope.
 
       Closes #919
+	
+    * Ignore modules import as _ when checking for unused imports.
+
+      Closes #1190
 
 
 What's new in Pylint 1.6.3?

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -519,6 +519,8 @@ class VariablesChecker(BaseChecker):
                         # Filter special objects (__doc__, __all__) etc.,
                         # because they can be imported for exporting.
                         continue
+                    if as_name == "_":
+                        continue
                     if as_name is None:
                         msg = "import %s" % imported_name
                     else:

--- a/pylint/test/unittest_checker_variables.py
+++ b/pylint/test/unittest_checker_variables.py
@@ -127,6 +127,13 @@ class VariablesCheckerTC(CheckerTestCase):
             self.checker.visit_module(node.root())
             self.checker.visit_functiondef(node)
 
+    def test_import_as_underscore(self):
+        node = astroid.parse('''
+        import math as _
+        ''')
+        with self.assertNoMessages():
+            self.walk(node)
+
 
 class MissingSubmoduleTest(CheckerTestCase):
     CHECKER_CLASS = variables.VariablesChecker


### PR DESCRIPTION
### Fixes / new features
- Now ignores modules imported as _ when checking for unused modules.
- Closes #1190 