### PR TITLE
[REF] eval-used: Use infered and builtin utils methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -225,6 +225,8 @@ Release date: tba
 
       Closes #1190
 
+	* Detects inferred cases for exec-used, eval-used and bad-reversed-sequence.
+
 
 What's new in Pylint 1.6.3?
 ===========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -586,6 +586,8 @@ Other Changes
 
 * Imports aliased with underscore are skipped when checking for unused imports.
 
+* Detects inferred cases for exec-used, eval-used and bad-reversed-sequence
+
 
 Bug fixes
 =========

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -938,18 +938,19 @@ functions, methods
         """visit a CallFunc node -> check if this is not a blacklisted builtin
         call and check for * or ** use
         """
-        if isinstance(node.func, astroid.Name):
-            name = node.func.name
+        node_infer = utils.safe_infer(node.func)
+        is_builtin = utils.is_builtin_object(node_infer)
+        if not isinstance(node.func, astroid.Name) or not is_builtin:
             # ignore the name if it's not a builtin (i.e. not defined in the
             # locals nor globals scope)
-            if not (name in node.frame() or
-                    name in node.root()):
-                if name == 'exec':
-                    self.add_message('exec-used', node=node)
-                elif name == 'reversed':
-                    self._check_reversed(node)
-                elif name == 'eval':
-                    self.add_message('eval-used', node=node)
+            return
+        name = node_infer.name
+        if name == 'exec':
+            self.add_message('exec-used', node=node)
+        elif name == 'reversed':
+            self._check_reversed(node)
+        elif name == 'eval':
+            self.add_message('eval-used', node=node)
 
     @utils.check_messages('assert-on-tuple')
     def visit_assert(self, node):

--- a/pylint/test/functional/eval_used.py
+++ b/pylint/test/functional/eval_used.py
@@ -8,3 +8,8 @@ eval('os.listdir(".")', globals=globals())  # [eval-used]
 def func():
     """ eval in local scope"""
     eval('b = 1')  # [eval-used]
+
+def func2():
+    """Use of infer node"""
+    seudo_eval = eval
+    seudo_eval('b = 1')  # [eval-used]

--- a/pylint/test/functional/eval_used.txt
+++ b/pylint/test/functional/eval_used.txt
@@ -2,3 +2,4 @@ eval-used:3::Use of eval
 eval-used:4::Use of eval
 eval-used:6::Use of eval
 eval-used:10:func:Use of eval
+eval-used:15:func2:Use of eval


### PR DESCRIPTION
### Fixes / new features
- Now detects the following case:
```python
seudo_eval = eval
seudo_eval('a = 1')  # eval-used
```
- Small refactoring to use return-early in order to reduce nested sentences

- [x] TODO: Create changes in the doc in other commit (waiting feedback to avoid conflicts)