### PR TITLE
[REF] exec-used, eval-used: Detects referenced and inferred cases

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -225,6 +225,8 @@ Release date: tba
 
       Closes #1190
 
+	* Detects referenced and inferred cases for exec-used, eval-used.
+
 
 What's new in Pylint 1.6.3?
 ===========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -586,6 +586,8 @@ Other Changes
 
 * Imports aliased with underscore are skipped when checking for unused imports.
 
+* Detects referenced and inferred cases for exec-used, eval-used.
+
 
 Bug fixes
 =========

--- a/pylint/test/functional/eval_used.py
+++ b/pylint/test/functional/eval_used.py
@@ -1,10 +1,30 @@
 """test for eval usage"""
 
-eval('os.listdir(".")') # [eval-used]
+eval('os.listdir(".")')  # [eval-used]
 eval('os.listdir(".")', globals={})  # [eval-used]
 
 eval('os.listdir(".")', globals=globals())  # [eval-used]
 
+
 def func():
     """ eval in local scope"""
     eval('b = 1')  # [eval-used]
+
+
+def func2(param):
+    """eval used from param"""
+    param("c = 2")
+
+
+def func3():
+    """eval used from many ways"""
+    my_dict = {
+        'my_eval': eval,  # [eval-used]
+    }
+    my_list = [eval]  # [eval-used]
+
+    my_var = eval  # [eval-used]
+    # inferred case
+    my_var('d = 3')  # [eval-used]
+    func2(eval)  # [eval-used]
+    return my_dict, my_list

--- a/pylint/test/functional/eval_used.txt
+++ b/pylint/test/functional/eval_used.txt
@@ -1,4 +1,9 @@
 eval-used:3::Use of eval
 eval-used:4::Use of eval
 eval-used:6::Use of eval
-eval-used:10:func:Use of eval
+eval-used:11:func:Use of eval
+eval-used:22:func3:Use of eval
+eval-used:24:func3:Use of eval
+eval-used:26:func3:Use of eval
+eval-used:28:func3:Use of eval
+eval-used:29:func3:Use of eval


### PR DESCRIPTION
### Steps to reproduce
Using the following example code.py:

```python
my_dict = {'eval': eval}
jinja_template.render(my_dict)
```

`pylint -rn -d all -e eval-used code.py`

### Current behavior
`eval-used` is not detected

### Expected behavior
This is more dangerous and hidden case of eval used IMHO should be detected.

Currently for builtin `eval used` checker we are using [visit_call](https://github.com/PyCQA/pylint/blob/2fa18851867e99/pylint/checkers/base.py#L937)
But for bad-builtins from python3 checker we are using [visit_name](https://github.com/PyCQA/pylint/blob/2fa18851867e99e065f083de74be8ab8adad4b41/pylint/checkers/python3.py#L510-L516) instead of `visit_call`. It is more precise for all cases.

This PR use `visit_name` in order to detect many other dangerous cases where now are not detected:
```python
def my_method(param):
   pass
my_method(eval)  # eval-used
my_dict = {'my_eval': eval}  # eval-used
my_var = eval  # eval-used
my_list = [eval]  # eval-used
```

### pylint --version output
```bash
__main__.py 2.0.0,
astroid 1.5.0
Python 2.7.12 (default, Jul 18 2016, 15:02:52)
[GCC 4.8.4]
```

NOTE: I allowed edit this PR for maintainers, feel free of change anything.