### PR TITLE
Upgrade tox to v2.x for py35 compatability (#1220)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ $(PIP):
 	virtualenv $(PYVE)
 
 $(TOX): $(PIP)
-	$(PIP) install tox==1.7
+	$(PIP) install tox~=2.0
 
 
 ifdef TOXENV


### PR DESCRIPTION
### Fixes / new features
- Fixes #1220 by upgrading tox to version 2.x which is compatible with py35

