### PR TITLE
MessagesHandlerMixIn: extract common private method

### DIFF
--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -237,8 +237,8 @@ class MessagesHandlerMixIn(object):
         assert scope in ('package', 'module')
 
         if msgid == 'all':
-            for msgid_ in MSG_TYPES:
-                self._set_msg_status(msgid_, enable, scope, line, ignore_unknown)
+            for _msgid in MSG_TYPES:
+                self._set_msg_status(_msgid, enable, scope, line, ignore_unknown)
             if enable and not self._python3_porting_mode:
                 # Don't activate the python 3 porting checker if it wasn't activated explicitly.
                 self.disable('python3')
@@ -247,17 +247,17 @@ class MessagesHandlerMixIn(object):
         # msgid is a category?
         catid = category_id(msgid)
         if catid is not None:
-            for message_id in self.msgs_store._msgs_by_category.get(catid):
-                self._set_msg_status(message_id, enable, scope, line)
+            for _msgid in self.msgs_store._msgs_by_category.get(catid):
+                self._set_msg_status(_msgid, enable, scope, line)
             return
 
         # msgid is a checker name?
         if msgid.lower() in self._checkers:
             msgs_store = self.msgs_store
             for checker in self._checkers[msgid.lower()]:
-                for msgid_ in checker.msgs:
-                    if msgid_ in msgs_store._alternative_names:
-                        self._set_msg_status(msgid_, enable, scope, line)
+                for _msgid in checker.msgs:
+                    if _msgid in msgs_store._alternative_names:
+                        self._set_msg_status(_msgid, enable, scope, line)
             return
 
         # msgid is report id?

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -225,22 +225,13 @@ class MessagesHandlerMixIn(object):
 
     def disable(self, msgid, scope='package', line=None, ignore_unknown=False):
         """don't output message of the given id"""
-        self._set_msg_status(msgid, False, scope, line, ignore_unknown)
-
-    def _message_symbol(self, msgid):
-        """Get the message symbol of the given message id
-
-        Return the original message id if the message does not
-        exist.
-        """
-        try:
-            return self.msgs_store.check_message_id(msgid).symbol
-        except UnknownMessageError:
-            return msgid
+        self._set_msg_status(msgid, enable=False, scope=scope,
+                             line=line, ignore_unknown=ignore_unknown)
 
     def enable(self, msgid, scope='package', line=None, ignore_unknown=False):
         """reenable message of the given id"""
-        self._set_msg_status(msgid, True, scope, line, ignore_unknown)
+        self._set_msg_status(msgid, enable=True, scope=scope,
+                             line=line, ignore_unknown=ignore_unknown)
 
     def _set_msg_status(self, msgid, enable, scope='package', line=None, ignore_unknown=False):
         assert scope in ('package', 'module')
@@ -301,6 +292,17 @@ class MessagesHandlerMixIn(object):
                                   in sorted(six.iteritems(msgs)) if val]
             self.config.disable = [self._message_symbol(mid) for mid, val
                                    in sorted(six.iteritems(msgs)) if not val]
+
+    def _message_symbol(self, msgid):
+        """Get the message symbol of the given message id
+
+        Return the original message id if the message does not
+        exist.
+        """
+        try:
+            return self.msgs_store.check_message_id(msgid).symbol
+        except UnknownMessageError:
+            return msgid
 
     def get_message_state_scope(self, msgid, line=None, confidence=UNDEFINED):
         """Returns the scope at which a message was enabled/disabled."""

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -225,52 +225,7 @@ class MessagesHandlerMixIn(object):
 
     def disable(self, msgid, scope='package', line=None, ignore_unknown=False):
         """don't output message of the given id"""
-        assert scope in ('package', 'module')
-        # handle disable=all by disabling all categories
-        if msgid == 'all':
-            for message_id in MSG_TYPES:
-                self.disable(message_id, scope, line)
-            return
-        # msgid is a category?
-        catid = category_id(msgid)
-        if catid is not None:
-            for _msgid in self.msgs_store._msgs_by_category.get(catid):
-                self.disable(_msgid, scope, line)
-            return
-        # msgid is a checker name?
-        if msgid.lower() in self._checkers:
-            msgs_store = self.msgs_store
-            for checker in self._checkers[msgid.lower()]:
-                for _msgid in checker.msgs:
-                    if _msgid in msgs_store._alternative_names:
-                        self.disable(_msgid, scope, line)
-            return
-        # msgid is report id?
-        if msgid.lower().startswith('rp'):
-            self.disable_report(msgid)
-            return
-
-        try:
-            # msgid is a symbolic or numeric msgid.
-            msg = self.msgs_store.check_message_id(msgid)
-        except UnknownMessageError:
-            if ignore_unknown:
-                return
-            raise
-
-        if scope == 'module':
-            self.file_state.set_msg_status(msg, line, False)
-            if msg.symbol != 'locally-disabled':
-                self.add_message('locally-disabled', line=line,
-                                 args=(msg.symbol, msg.msgid))
-
-        else:
-            msgs = self._msgs_state
-            msgs[msg.msgid] = False
-            # sync configuration object
-            self.config.disable = [self._message_symbol(mid)
-                                   for mid, val in sorted(six.iteritems(msgs))
-                                   if not val]
+        self._set_msg_status(msgid, False, scope, line, ignore_unknown)
 
     def _message_symbol(self, msgid):
         """Get the message symbol of the given message id
@@ -285,30 +240,41 @@ class MessagesHandlerMixIn(object):
 
     def enable(self, msgid, scope='package', line=None, ignore_unknown=False):
         """reenable message of the given id"""
+        self._set_msg_status(msgid, True, scope, line, ignore_unknown)
+
+    def _set_msg_status(self, msgid, enable, scope='package', line=None, ignore_unknown=False):
         assert scope in ('package', 'module')
+
         if msgid == 'all':
             for msgid_ in MSG_TYPES:
-                self.enable(msgid_, scope=scope, line=line)
-            if not self._python3_porting_mode:
-                # Don't activate the python 3 porting checker if it
-                # wasn't activated explicitly.
+                self._set_msg_status(msgid_, enable, scope, line, ignore_unknown)
+            if enable and not self._python3_porting_mode:
+                # Don't activate the python 3 porting checker if it wasn't activated explicitly.
                 self.disable('python3')
             return
-        catid = category_id(msgid)
+
         # msgid is a category?
+        catid = category_id(msgid)
         if catid is not None:
             for message_id in self.msgs_store._msgs_by_category.get(catid):
-                self.enable(message_id, scope, line)
+                self._set_msg_status(message_id, enable, scope, line)
             return
+
         # msgid is a checker name?
         if msgid.lower() in self._checkers:
+            msgs_store = self.msgs_store
             for checker in self._checkers[msgid.lower()]:
                 for msgid_ in checker.msgs:
-                    self.enable(msgid_, scope, line)
+                    if msgid_ in msgs_store._alternative_names:
+                        self._set_msg_status(msgid_, enable, scope, line)
             return
+
         # msgid is report id?
         if msgid.lower().startswith('rp'):
-            self.enable_report(msgid)
+            if enable:
+                self.enable_report(msgid)
+            else:
+                self.disable_report(msgid)
             return
 
         try:
@@ -320,13 +286,21 @@ class MessagesHandlerMixIn(object):
             raise
 
         if scope == 'module':
-            self.file_state.set_msg_status(msg, line, True)
-            self.add_message('locally-enabled', line=line, args=(msg.symbol, msg.msgid))
+            self.file_state.set_msg_status(msg, line, enable)
+            if enable:
+                self.add_message('locally-enabled', line=line,
+                                 args=(msg.symbol, msg.msgid))
+            elif msg.symbol != 'locally-disabled':
+                self.add_message('locally-disabled', line=line,
+                                 args=(msg.symbol, msg.msgid))
         else:
             msgs = self._msgs_state
-            msgs[msg.msgid] = True
+            msgs[msg.msgid] = enable
             # sync configuration object
-            self.config.enable = [mid for mid, val in sorted(six.iteritems(msgs)) if val]
+            self.config.enable = [self._message_symbol(mid) for mid, val
+                                  in sorted(six.iteritems(msgs)) if val]
+            self.config.disable = [self._message_symbol(mid) for mid, val
+                                   in sorted(six.iteritems(msgs)) if not val]
 
     def get_message_state_scope(self, msgid, line=None, confidence=UNDEFINED):
         """Returns the scope at which a message was enabled/disabled."""


### PR DESCRIPTION
Remove code duplication by extracting private method for enabling/disabling messages.

Note that code is not equivalent:
- `msgs_store._alternative_names` is looked up on both enable and disable path (was: only on disable path)
- config object is synced for both `enable` and `disable` attributes after each enable/disable (was: one of two depending on performed action)
