### PR TITLE
Omit convention warnings on assignment with type hints

### DIFF
--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -606,23 +606,21 @@ class FormatChecker(BaseTokenChecker):
         """Extended check of PEP-484 type hint presence"""
         if not self._inside_brackets('('):
             return False
-        pos = i - 1
         bracket_level = 0
-        while pos:
-            if tokens[pos][1] == ':' and pos < i-1:
+        for token in tokens[i-1::-1]:
+            if token[1] == ':':
                 return True
-            if tokens[pos][1] == '(':
+            if token[1] == '(':
                 return False
-            if tokens[pos][1] == ']':
+            if token[1] == ']':
                 bracket_level += 1
-            elif tokens[pos][1] == '[':
+            elif token[1] == '[':
                 bracket_level -= 1
-            elif tokens[pos][1] == ',':
+            elif token[1] == ',':
                 if not bracket_level:
                     return False
-            elif tokens[pos][0] not in (tokenize.NAME, tokenize.STRING):
+            elif token[0] not in (tokenize.NAME, tokenize.STRING):
                 return False
-            pos -= 1
         return False
 
     def _check_equals_spacing(self, tokens, i):

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -604,7 +604,8 @@ class FormatChecker(BaseTokenChecker):
 
     def _check_equals_spacing(self, tokens, i):
         """Check the spacing of a single equals sign."""
-        if self._inside_brackets('(') and tokens[i-2][1] == ':' and tokens[i-1][0] in (1, 3):
+        if (self._inside_brackets('(') and tokens[i-2][1] == ':' and
+                tokens[i-1][0] in (tokenize.NAME, tokenize.STRING)):
             self._check_space(tokens, i, (_MUST, _MUST))
         elif self._inside_brackets('(') or self._inside_brackets('lambda'):
             self._check_space(tokens, i, (_MUST_NOT, _MUST_NOT))

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -604,7 +604,7 @@ class FormatChecker(BaseTokenChecker):
 
     def _check_equals_spacing(self, tokens, i):
         """Check the spacing of a single equals sign."""
-        if self._inside_brackets('(') and tokens[i-2][1] == ':' and tokens[i-1].type in (1, 3):
+        if self._inside_brackets('(') and tokens[i-2][1] == ':' and tokens[i-1][0] in (1, 3):
             self._check_space(tokens, i, (_MUST, _MUST))
         elif self._inside_brackets('(') or self._inside_brackets('lambda'):
             self._check_space(tokens, i, (_MUST_NOT, _MUST_NOT))

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -604,7 +604,9 @@ class FormatChecker(BaseTokenChecker):
 
     def _check_equals_spacing(self, tokens, i):
         """Check the spacing of a single equals sign."""
-        if self._inside_brackets('(') or self._inside_brackets('lambda'):
+        if self._inside_brackets('(') and tokens[i-2][1] == ':' and tokens[i-1].type in (1, 3):
+            self._check_space(tokens, i, (_MUST, _MUST))
+        elif self._inside_brackets('(') or self._inside_brackets('lambda'):
             self._check_space(tokens, i, (_MUST_NOT, _MUST_NOT))
         else:
             self._check_space(tokens, i, (_MUST, _MUST))

--- a/pylint/test/unittest_checker_format.py
+++ b/pylint/test/unittest_checker_format.py
@@ -186,7 +186,9 @@ class TestCheckSpace(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.process_tokens(tokenize_str('foo(foo=bar)\n'))
             self.checker.process_tokens(tokenize_str('foo(foo: int = bar)\n'))
+            self.checker.process_tokens(tokenize_str('foo(foo: Dict[int, str] = bar)\n'))
             self.checker.process_tokens(tokenize_str('foo(foo: \'int\' = bar)\n'))
+            self.checker.process_tokens(tokenize_str('foo(foo: Dict[int, \'str\'] = bar)\n'))
             self.checker.process_tokens(tokenize_str('lambda x=1: x\n'))
 
     def testKeywordSpacingBad(self):
@@ -225,6 +227,12 @@ class TestCheckSpace(CheckerTestCase):
                     args=('Exactly one', 'required', 'around', 'keyword argument assignment',
                           '(foo: int=bar)\n         ^'))):
             self.checker.process_tokens(tokenize_str('(foo: int=bar)\n'))
+
+        with self.assertAddsMessages(
+            Message('bad-whitespace', line=1,
+                    args=('Exactly one', 'required', 'around', 'keyword argument assignment',
+                          '(foo: List[int]=bar)\n               ^'))):
+            self.checker.process_tokens(tokenize_str('(foo: List[int]=bar)\n'))
 
     def testOperatorSpacingGood(self):
         good_cases = [

--- a/pylint/test/unittest_checker_format.py
+++ b/pylint/test/unittest_checker_format.py
@@ -185,6 +185,8 @@ class TestCheckSpace(CheckerTestCase):
     def testKeywordSpacingGood(self):
         with self.assertNoMessages():
             self.checker.process_tokens(tokenize_str('foo(foo=bar)\n'))
+            self.checker.process_tokens(tokenize_str('foo(foo: int = bar)\n'))
+            self.checker.process_tokens(tokenize_str('foo(foo: \'int\' = bar)\n'))
             self.checker.process_tokens(tokenize_str('lambda x=1: x\n'))
 
     def testKeywordSpacingBad(self):
@@ -205,6 +207,24 @@ class TestCheckSpace(CheckerTestCase):
                     args=('No', 'allowed', 'around', 'keyword argument assignment',
                           '(foo = bar)\n     ^'))):
             self.checker.process_tokens(tokenize_str('(foo = bar)\n'))
+
+        with self.assertAddsMessages(
+            Message('bad-whitespace', line=1,
+                    args=('Exactly one', 'required', 'before', 'keyword argument assignment',
+                          '(foo: int= bar)\n         ^'))):
+            self.checker.process_tokens(tokenize_str('(foo: int= bar)\n'))
+
+        with self.assertAddsMessages(
+            Message('bad-whitespace', line=1,
+                    args=('Exactly one', 'required', 'after', 'keyword argument assignment',
+                          '(foo: int =bar)\n          ^'))):
+            self.checker.process_tokens(tokenize_str('(foo: int =bar)\n'))
+
+        with self.assertAddsMessages(
+            Message('bad-whitespace', line=1,
+                    args=('Exactly one', 'required', 'around', 'keyword argument assignment',
+                          '(foo: int=bar)\n         ^'))):
+            self.checker.process_tokens(tokenize_str('(foo: int=bar)\n'))
 
     def testOperatorSpacingGood(self):
         good_cases = [


### PR DESCRIPTION
Code such as:
```python
"""
test
"""

from typing import Dict

def my_function(my_attr: Dict = None):
    """
    foo
    """
    print(my_attr)
```

caused convention warnings because of the spaces around kwarg assignment. Yet, this syntax is correct when type hints are used.

### Fixes
- Require spaces around kwarg assignment if type hint used
