### PR TITLE
Fix unused-imports: import and class element name clash.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,14 @@ What's New in Pylint 2.0?
 
 Release date: tba
 
+	* Detect class level redefinition of outer name.
+
+	* Properly detect if imported name is assigned to same name in different
+	  scope.
+
+	  Close #636
+
+
     * 'trailing-comma-tuple' check was added
 
       This message is emitted when pylint finds an one-element tuple,

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -31,6 +31,7 @@ from pylint.utils import get_global_option
 from pylint.checkers import BaseChecker
 from pylint.checkers import utils
 
+
 SPECIAL_OBJ = re.compile("^_{2}[a-z]+_{2}$")
 FUTURE = '__future__'
 # regexp for ignored argument name
@@ -555,6 +556,7 @@ class VariablesChecker(BaseChecker):
         """visit class: update consumption analysis variable
         """
         self._to_consume.append((copy.copy(node.locals), {}, 'class'))
+        self._check_redefined(node)
 
     def leave_classdef(self, _):
         """leave class: update consumption analysis variable
@@ -610,6 +612,9 @@ class VariablesChecker(BaseChecker):
         """visit function: update consumption analysis variable and check locals
         """
         self._to_consume.append((copy.copy(node.locals), {}, 'function'))
+        self._check_redefined(node)
+
+    def _check_redefined(self, node):
         if not (self.linter.is_message_enabled('redefined-outer-name') or
                 self.linter.is_message_enabled('redefined-builtin')):
             return
@@ -617,7 +622,13 @@ class VariablesChecker(BaseChecker):
         for name, stmt in node.items():
             if utils.is_inside_except(stmt):
                 continue
+            if isinstance(stmt.frame(), astroid.ClassDef):
+                if name in ['__slots__', '__metaclass__']:
+                    continue
             if name in globs and not isinstance(stmt, astroid.Global):
+                if (isinstance(node, astroid.ClassDef)
+                        and isinstance(stmt, astroid.FunctionDef)):
+                    continue
                 definition = globs[name][0]
                 if (isinstance(definition, astroid.ImportFrom)
                         and definition.modname == FUTURE):
@@ -630,7 +641,14 @@ class VariablesChecker(BaseChecker):
                     self.add_message('redefined-outer-name',
                                      args=(name, line), node=stmt)
 
-            elif utils.is_builtin(name) and not self._should_ignore_redefined_builtin(stmt):
+            elif utils.is_builtin(name):
+                if self._should_ignore_redefined_builtin(stmt):
+                    continue
+                if (isinstance(node, astroid.ClassDef) and
+                        isinstance(stmt, astroid.FunctionDef) and
+                        name == 'next'):
+                    continue
+
                 # do not print Redefining builtin for additional builtins
                 self.add_message('redefined-builtin', args=name, node=stmt)
 
@@ -883,6 +901,7 @@ class VariablesChecker(BaseChecker):
                                recursive_klass):
         maybee0601 = True
         annotation_return = False
+        use_outer_definition = False
         if frame is not defframe:
             maybee0601 = _detect_global_scope(node, frame, defframe)
         elif defframe.parent is None:
@@ -895,6 +914,8 @@ class VariablesChecker(BaseChecker):
             # defined in global or builtin scope
             if defframe.root().lookup(name)[1]:
                 maybee0601 = False
+                use_outer_definition = stmt == defstmt and \
+                    not isinstance(defnode, astroid.node_classes.Comprehension)
             else:
                 # check if we have a nonlocal
                 if name in defframe.locals:
@@ -950,7 +971,7 @@ class VariablesChecker(BaseChecker):
                     # same line as the function definition
                     maybee0601 = False
 
-        return maybee0601, annotation_return
+        return maybee0601, annotation_return, use_outer_definition
 
     def _ignore_class_scope(self, node, name, frame):
         # Detect if we are in a local class scope, as an assignment.
@@ -1022,9 +1043,7 @@ class VariablesChecker(BaseChecker):
                 self._loopvar_name(node, name)
                 break
             found_node = self._next_to_consume(node, name, to_consume)
-            if found_node:
-                consumed[name] = found_node
-            else:
+            if found_node is None:
                 continue
             # checks for use before assignment
             defnode = utils.assign_parent(to_consume[name][0])
@@ -1038,10 +1057,13 @@ class VariablesChecker(BaseChecker):
                                    isinstance(defframe, astroid.ClassDef) and
                                    node.name == defframe.name)
 
-                maybee0601, annotation_return = self._is_variable_violation(
+                maybee0601, annotation_return, use_outer_definition = self._is_variable_violation(
                     node, name, defnode, stmt, defstmt,
                     frame, defframe,
                     base_scope_type, recursive_klass)
+
+                if use_outer_definition:
+                    continue
 
                 if (maybee0601
                         and not utils.is_defined_before(node)
@@ -1084,6 +1106,7 @@ class VariablesChecker(BaseChecker):
                             self.add_message('undefined-variable',
                                              node=node, args=name)
 
+            consumed[name] = found_node
             del to_consume[name]
             # check it's not a loop variable used outside the loop
             self._loopvar_name(node, name)
@@ -1108,6 +1131,7 @@ class VariablesChecker(BaseChecker):
             parts = name.split('.')
             try:
                 module = next(node.infer_name_module(parts[0]))
+
             except astroid.ResolveError:
                 continue
             self._check_module_attrs(node, module, parts[1:])

--- a/pylint/test/functional/undefined_variable.py
+++ b/pylint/test/functional/undefined_variable.py
@@ -149,7 +149,7 @@ class KeywordArgument(object):
     func = lambda arg=arg: arg * arg # [undefined-variable]
 
     arg2 = 0
-    func2 = lambda arg2=arg2: arg2 * arg2
+    func3 = lambda arg2=arg2: arg2 * arg2
 
 # Don't emit if the code is protected by NameError
 try:
@@ -175,3 +175,10 @@ except ValueError:
 # See https://bitbucket.org/logilab/pylint/issue/111/
 try: raise IOError(1, "a")
 except IOError as err: print(err)
+
+
+def test_conditional_comprehension():
+    methods = ['a', 'b', '_c', '_d']
+    my_methods = sum(1 for method in methods
+                     if not method.startswith('_'))
+    return my_methods

--- a/pylint/test/functional/undefined_variable_py30.py
+++ b/pylint/test/functional/undefined_variable_py30.py
@@ -1,7 +1,7 @@
 """Test warnings about access to undefined variables
 for various Python 3 constructs. """
 # pylint: disable=too-few-public-methods, no-init, no-self-use
-# pylint: disable=wrong-import-position, invalid-metaclass
+# pylint: disable=wrong-import-position, invalid-metaclass, redefined-outer-name
 class Undefined:
     """ test various annotation problems. """
 

--- a/pylint/test/functional/unused_import.py
+++ b/pylint/test/functional/unused_import.py
@@ -1,5 +1,5 @@
 """unused import"""
-# pylint: disable=undefined-all-variable, import-error, no-absolute-import, too-few-public-methods, missing-docstring,wrong-import-position
+# pylint: disable=undefined-all-variable, import-error, no-absolute-import, too-few-public-methods, missing-docstring,wrong-import-position, redefined-outer-name
 import xml.etree  # [unused-import]
 import xml.sax  # [unused-import]
 import os.path as test  # [unused-import]

--- a/pylint/test/functional/unused_import_assigned_to.py
+++ b/pylint/test/functional/unused_import_assigned_to.py
@@ -1,0 +1,7 @@
+# pylint: disable=missing-docstring, import-error, invalid-name
+# pylint: disable=too-few-public-methods
+from .a import x
+
+
+class Y(object):
+    x = x[0] # [redefined-outer-name]

--- a/pylint/test/functional/unused_import_assigned_to.txt
+++ b/pylint/test/functional/unused_import_assigned_to.txt
@@ -1,0 +1,1 @@
+redefined-outer-name:7:Y:Redefining name 'x' from outer scope (line 3)

--- a/pylint/test/input/func_noerror_object_as_class_attribute.py
+++ b/pylint/test/input/func_noerror_object_as_class_attribute.py
@@ -1,4 +1,5 @@
 # pylint: disable=R0903
+# pylint: disable=redefined-builtin
 """Test case for the problem described below :
  - A class extends 'object'
  - This class defines its own __init__()

--- a/pylint/testutils.py
+++ b/pylint/testutils.py
@@ -268,6 +268,7 @@ class LintTestUsingModule(object):
     INPUT_DIR = None
     DEFAULT_PACKAGE = 'input'
     package = DEFAULT_PACKAGE
+    # pylint: disable=redefined-outer-name
     linter = linter
     module = None
     depends = None


### PR DESCRIPTION
### Fixes / new features
- Detect class level redefinition of outer name.
- Properly detect if imported name is assigned to same name in different scope.

Close #636 
