### PR TITLE
[FIX] consider-using-ternary: Fix case: 'True and True and True or True'

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -108,6 +108,7 @@ Order doesn't matter (not that much, at least ;)
   Add check too-complex with mccabe for cyclomatic complexity
   Refactory wrong-import-position to skip try-import and nested cases
   Add consider-merging-isinstance, superfluous-else-return
+  Fix consider-using-ternary for 'True and True and True or True' case
 
 * Luis Escobar (Vauxoo), Moisés López (Vauxoo): Add bad-docstring-quotes and docstring-first-line-empty
 

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -419,7 +419,8 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                 and isinstance(node.values[0], astroid.BoolOp)
                 and not isinstance(node.values[1], astroid.BoolOp)
                 and node.values[0].op == 'and'
-                and not isinstance(node.values[0].values[1], astroid.BoolOp))
+                and not isinstance(node.values[0].values[1], astroid.BoolOp)
+                and len(node.values[0].values) == 2)
 
     @staticmethod
     def _get_and_or_ternary_arguments(node):

--- a/pylint/test/functional/ternary.py
+++ b/pylint/test/functional/ternary.py
@@ -25,3 +25,4 @@ SOME_VALUE4 = some_callable(condition) and 'ERROR' or 'SUCCESS'  # [consider-usi
 SOME_VALUE5 = SOME_VALUE1 > 3 and 'greater' or 'not greater'  # [consider-using-ternary]
 SOME_VALUE6 = (SOME_VALUE2 > 4 and SOME_VALUE3) and 'both' or 'not'  # [consider-using-ternary]
 SOME_VALUE7 = 'both' if (SOME_VALUE2 > 4) and (SOME_VALUE3) else 'not'
+SOME_VALUE8 = SOME_VALUE1 and SOME_VALUE2 and SOME_VALUE3 or SOME_VALUE4


### PR DESCRIPTION
### Fixes / new features
Using a sentence like as: `my_var = True and True and True or True`
Avoid show the following traceback:
```bash
Traceback (most recent call last):
  File "pylint/checkers/refactoring.py", line 400, in visit_assign
    cond, truth_value, false_value = self._get_and_or_ternary_arguments(node.value)
  File "pylint/checkers/refactoring.py", line 427, in _get_and_or_ternary_arguments
    condition, true_value = node.values[0].values
ValueError: too many values to unpack
```

NOTE: I didn't changed ChangeLog because is a fix of a new check from 2.0.0 version (unreleased).