### PR TITLE
used-before-assignment: ignore global lookup when there's assign statement in checked scope

### DIFF
--- a/pylint/test/functional/used_before_assignment_issue1081.py
+++ b/pylint/test/functional/used_before_assignment_issue1081.py
@@ -1,0 +1,32 @@
+# pylint: disable=missing-docstring,invalid-name,redefined-outer-name
+
+x = 24
+
+
+def used_before_assignment_1(a):
+    if x == a:  # [used-before-assignment]
+        for x in [1, 2]:
+            pass
+
+
+def used_before_assignment_2(a):
+    if x == a:  # [used-before-assignment]
+        pass
+    x = 2
+
+
+def used_before_assignment_3(a):
+    if x == a:  # [used-before-assignment]
+        if x > 3:
+            x = 2
+
+
+def not_used_before_assignment(a):
+    if x == a:
+        pass
+
+
+def not_used_before_assignment_2(a):
+    x = 3
+    if x == a:
+        pass

--- a/pylint/test/functional/used_before_assignment_issue1081.py
+++ b/pylint/test/functional/used_before_assignment_issue1081.py
@@ -1,24 +1,24 @@
-# pylint: disable=missing-docstring,invalid-name,redefined-outer-name
+# pylint: disable=missing-docstring,invalid-name
 
 x = 24
 
 
 def used_before_assignment_1(a):
     if x == a:  # [used-before-assignment]
-        for x in [1, 2]:
+        for x in [1, 2]:  # [redefined-outer-name]
             pass
 
 
 def used_before_assignment_2(a):
     if x == a:  # [used-before-assignment]
         pass
-    x = 2
+    x = 2  # [redefined-outer-name]
 
 
 def used_before_assignment_3(a):
     if x == a:  # [used-before-assignment]
         if x > 3:
-            x = 2
+            x = 2  # [redefined-outer-name]
 
 
 def not_used_before_assignment(a):
@@ -27,6 +27,6 @@ def not_used_before_assignment(a):
 
 
 def not_used_before_assignment_2(a):
-    x = 3
+    x = 3  # [redefined-outer-name]
     if x == a:
         pass

--- a/pylint/test/functional/used_before_assignment_issue1081.txt
+++ b/pylint/test/functional/used_before_assignment_issue1081.txt
@@ -1,3 +1,7 @@
 used-before-assignment:7:used_before_assignment_1:Using variable 'x' before assignment
+redefined-outer-name:8:used_before_assignment_1:Redefining name 'x' from outer scope (line 3)
 used-before-assignment:13:used_before_assignment_2:Using variable 'x' before assignment
+redefined-outer-name:15:used_before_assignment_2:Redefining name 'x' from outer scope (line 3)
 used-before-assignment:19:used_before_assignment_3:Using variable 'x' before assignment
+redefined-outer-name:21:used_before_assignment_3:Redefining name 'x' from outer scope (line 3)
+redefined-outer-name:30:not_used_before_assignment_2:Redefining name 'x' from outer scope (line 3)

--- a/pylint/test/functional/used_before_assignment_issue1081.txt
+++ b/pylint/test/functional/used_before_assignment_issue1081.txt
@@ -1,0 +1,3 @@
+used-before-assignment:7:used_before_assignment_1:Using variable 'x' before assignment
+used-before-assignment:13:used_before_assignment_2:Using variable 'x' before assignment
+used-before-assignment:19:used_before_assignment_3:Using variable 'x' before assignment


### PR DESCRIPTION
Fixes #1081