### PR TITLE
Refactor pytest fixtures.

### DIFF
--- a/pylint/test/conftest.py
+++ b/pylint/test/conftest.py
@@ -1,0 +1,52 @@
+# pylint: disable=redefined-outer-name
+import os
+import pytest
+
+from pylint import checkers
+from pylint.lint import PyLinter
+# pylint: disable=no-name-in-module
+from pylint.testutils import MinimalTestReporter
+
+
+@pytest.fixture
+def linter(checker, register, enable, disable, reporter):
+    _linter = PyLinter()
+    _linter.set_reporter(reporter())
+    checkers.initialize(_linter)
+    if register:
+        register(_linter)
+    if checker:
+        _linter.register_checker(checker(_linter))
+    if disable:
+        for msg in disable:
+            _linter.disable(msg)
+    if enable:
+        for msg in enable:
+            _linter.enable(msg)
+    os.environ.pop('PYLINTRC', None)
+    return _linter
+
+
+@pytest.fixture(scope='module')
+def checker():
+    return None
+
+
+@pytest.fixture(scope='module')
+def register():
+    return None
+
+
+@pytest.fixture(scope='module')
+def enable():
+    return None
+
+
+@pytest.fixture(scope='module')
+def disable():
+    return None
+
+
+@pytest.fixture(scope='module')
+def reporter():
+    return MinimalTestReporter

--- a/pylint/test/extensions/test_bad_builtin.py
+++ b/pylint/test/extensions/test_bad_builtin.py
@@ -10,10 +10,8 @@ import os.path as osp
 
 import pytest
 
-from pylint import checkers
 from pylint.extensions.bad_builtin import BadBuiltinChecker
-from pylint.lint import PyLinter, fix_import_path
-from pylint.testutils import MinimalTestReporter
+from pylint.lint import fix_import_path
 
 
 EXPECTED = [
@@ -22,14 +20,14 @@ EXPECTED = [
 ]
 
 
-@pytest.fixture(scope="module")
-def linter():
-    linter = PyLinter()
-    linter.set_reporter(MinimalTestReporter())
-    checkers.initialize(linter)
-    linter.register_checker(BadBuiltinChecker(linter))
-    linter.disable('I')
-    return linter
+@pytest.fixture(scope='module')
+def checker(checker):
+    return BadBuiltinChecker
+
+
+@pytest.fixture(scope='module')
+def disable(disable):
+    return ['I']
 
 
 def test_types_redefined(linter):

--- a/pylint/test/extensions/test_check_mccabe.py
+++ b/pylint/test/extensions/test_check_mccabe.py
@@ -11,10 +11,7 @@ import os.path as osp
 
 import pytest
 
-from pylint import checkers
-from pylint.extensions.mccabe import register
-from pylint.lint import PyLinter
-from pylint.testutils import MinimalTestReporter
+from pylint.extensions import mccabe
 
 EXPECTED_MSGS = [
     "'f1' is too complex. The McCabe rating is 1",
@@ -35,14 +32,18 @@ EXPECTED_MSGS = [
 
 
 @pytest.fixture(scope="module")
-def linter():
-    linter = PyLinter()
-    linter.set_reporter(MinimalTestReporter())
-    checkers.initialize(linter)
-    register(linter)
-    linter.disable('all')
-    linter.enable('too-complex')
-    return linter
+def enable(enable):
+    return ['too-complex']
+
+
+@pytest.fixture(scope="module")
+def disable(disable):
+    return ['all']
+
+
+@pytest.fixture(scope="module")
+def register(register):
+    return mccabe.register
 
 
 @pytest.fixture

--- a/pylint/test/extensions/test_docstyle.py
+++ b/pylint/test/extensions/test_docstyle.py
@@ -11,10 +11,7 @@ import os.path as osp
 
 import pytest
 
-from pylint import checkers
 from pylint.extensions.docstyle import DocStringStyleChecker
-from pylint.lint import PyLinter
-from pylint.testutils import MinimalTestReporter
 
 
 EXPECTED_MSGS = [
@@ -39,12 +36,8 @@ EXPECTED_SYMBOLS = [
 
 
 @pytest.fixture(scope="module")
-def linter():
-    linter = PyLinter()
-    linter.set_reporter(MinimalTestReporter())
-    checkers.initialize(linter)
-    linter.register_checker(DocStringStyleChecker(linter))
-    return linter
+def checker(checker):
+    return DocStringStyleChecker
 
 
 def test_docstring_message(linter):

--- a/pylint/test/extensions/test_elseif_used.py
+++ b/pylint/test/extensions/test_elseif_used.py
@@ -11,19 +11,12 @@ import os.path as osp
 
 import pytest
 
-from pylint import checkers
 from pylint.extensions.check_elif import ElseifUsedChecker
-from pylint.lint import PyLinter
-from pylint.testutils import MinimalTestReporter
 
 
 @pytest.fixture(scope="module")
-def linter():
-    linter = PyLinter()
-    linter.set_reporter(MinimalTestReporter())
-    checkers.initialize(linter)
-    linter.register_checker(ElseifUsedChecker(linter))
-    return linter
+def checker(checker):
+    return ElseifUsedChecker
 
 
 def test_elseif_message(linter):

--- a/pylint/test/extensions/test_emptystring.py
+++ b/pylint/test/extensions/test_emptystring.py
@@ -6,49 +6,30 @@
 """Tests for the pylint checker in :mod:`pylint.extensions.emptystring
 """
 
-import os
 import os.path as osp
-import unittest
+import pytest
 
-from pylint import checkers
 from pylint.extensions.emptystring import CompareToEmptyStringChecker
-from pylint.lint import PyLinter
-from pylint.reporters import BaseReporter
 
 
-class EmptyStringTestReporter(BaseReporter):
-
-    def handle_message(self, msg):
-        self.messages.append(msg)
-
-    def on_set_current_module(self, module, filepath):
-        self.messages = []
+@pytest.fixture(scope='module')
+def checker(checker):
+    return CompareToEmptyStringChecker
 
 
-class CheckEmptyStringUsedTC(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        cls._linter = PyLinter()
-        cls._linter.set_reporter(EmptyStringTestReporter())
-        checkers.initialize(cls._linter)
-        cls._linter.register_checker(CompareToEmptyStringChecker(cls._linter))
-        cls._linter.disable('I')
-
-    def test_emptystring_message(self):
-        elif_test = osp.join(osp.dirname(osp.abspath(__file__)), 'data',
-                             'empty_string_comparison.py')
-        self._linter.check([elif_test])
-        msgs = self._linter.reporter.messages
-        self.assertEqual(len(msgs), 4)
-        for msg in msgs:
-            self.assertEqual(msg.symbol, 'compare-to-empty-string')
-            self.assertEqual(msg.msg, 'Avoid comparisons to empty string')
-        self.assertEqual(msgs[0].line, 6)
-        self.assertEqual(msgs[1].line, 9)
-        self.assertEqual(msgs[2].line, 12)
-        self.assertEqual(msgs[3].line, 15)
+@pytest.fixture(scope='module')
+def disable(disable):
+    return ['I']
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_emptystring_message(linter):
+    elif_test = osp.join(osp.dirname(osp.abspath(__file__)), 'data',
+                         'empty_string_comparison.py')
+    linter.check([elif_test])
+    msgs = linter.reporter.messages
+    expected_lineno = [6, 9, 12, 15]
+    assert len(msgs) == len(expected_lineno)
+    for msg, lineno in zip(msgs, expected_lineno):
+        assert msg.symbol == 'compare-to-empty-string'
+        assert msg.msg == 'Avoid comparisons to empty string'
+        assert msg.line == lineno

--- a/pylint/test/extensions/test_overlapping_exceptions.py
+++ b/pylint/test/extensions/test_overlapping_exceptions.py
@@ -7,22 +7,19 @@
 from sys import version_info
 from os.path import join, dirname
 
-from pylint import checkers
-from pylint.lint import PyLinter
 from pylint.extensions.overlapping_exceptions import OverlappingExceptionsChecker
-from pylint.testutils import MinimalTestReporter
 
 import pytest
 
 
-@pytest.fixture
-def linter():
-    linter = PyLinter()
-    linter.set_reporter(MinimalTestReporter())
-    checkers.initialize(linter)
-    linter.register_checker(OverlappingExceptionsChecker(linter))
-    linter.disable('I')
-    return linter
+@pytest.fixture(scope='module')
+def checker(checker):
+    return OverlappingExceptionsChecker
+
+
+@pytest.fixture(scope='module')
+def disable(disable):
+    return ['I']
 
 
 def test_overlapping_exceptions(linter):

--- a/pylint/test/extensions/test_redefined.py
+++ b/pylint/test/extensions/test_redefined.py
@@ -10,10 +10,8 @@ import os.path as osp
 
 import pytest
 
-from pylint import checkers
 from pylint.extensions.redefined_variable_type import MultipleTypesChecker
-from pylint.lint import PyLinter, fix_import_path
-from pylint.testutils import MinimalTestReporter
+from pylint.lint import fix_import_path
 
 
 EXPECTED = [
@@ -30,13 +28,13 @@ EXPECTED = [
 
 
 @pytest.fixture(scope="module")
-def linter():
-    linter = PyLinter()
-    linter.set_reporter(MinimalTestReporter())
-    checkers.initialize(linter)
-    linter.register_checker(MultipleTypesChecker(linter))
-    linter.disable('I')
-    return linter
+def checker(checker):
+    return MultipleTypesChecker
+
+
+@pytest.fixture(scope="module")
+def disable(disable):
+    return ['I']
 
 
 def test_types_redefined(linter):

--- a/pylint/test/test_regr.py
+++ b/pylint/test/test_regr.py
@@ -16,9 +16,7 @@ import pytest
 
 import astroid
 import pylint.testutils as testutils
-from pylint import checkers
 from pylint import epylint
-from pylint import lint
 
 
 REGR_DATA = join(dirname(abspath(__file__)), 'regrtest_data')
@@ -31,14 +29,13 @@ except AttributeError:
 
 
 @pytest.fixture(scope="module")
-def linter():
-    test_reporter = testutils.TestReporter()
-    linter = lint.PyLinter()
-    linter.set_reporter(test_reporter)
-    linter.disable('I')
-    linter.config.persistent = 0
-    checkers.initialize(linter)
-    return linter
+def reporter(reporter):
+    return testutils.TestReporter
+
+
+@pytest.fixture(scope="module")
+def disable(disable):
+    return ['I']
 
 
 @pytest.fixture

--- a/pylint/test/unittest_lint.py
+++ b/pylint/test/unittest_lint.py
@@ -200,15 +200,14 @@ def test_more_args(fake_path, case):
         assert sys.path == fake_path
 
 
-@pytest.fixture
-def linter():
-    linter = PyLinter()
-    linter.disable('I')
-    linter.config.persistent = 0
-    # register checkers
-    checkers.initialize(linter)
-    linter.set_reporter(testutils.TestReporter())
-    return linter
+@pytest.fixture(scope='module')
+def disable(disable):
+    return ['I']
+
+
+@pytest.fixture(scope='module')
+def reporter(reporter):
+    return testutils.TestReporter
 
 
 @pytest.fixture

--- a/pylint/test/unittest_reporting.py
+++ b/pylint/test/unittest_reporting.py
@@ -4,7 +4,6 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
-import os
 import warnings
 
 import six
@@ -15,15 +14,14 @@ from pylint.reporters.text import TextReporter, ParseableTextReporter
 import pytest
 
 
-@pytest.fixture
-def linter():
-    linter = PyLinter(reporter=TextReporter())
-    linter.disable('I')
-    linter.config.persistent = 0
-    # register checkers
-    checkers.initialize(linter)
-    os.environ.pop('PYLINTRC', None)
-    return linter
+@pytest.fixture(scope='module')
+def reporter(reporter):
+    return TextReporter
+
+
+@pytest.fixture(scope='module')
+def disable(disable):
+    return ['I']
 
 
 def test_template_option(linter):


### PR DESCRIPTION
### Fixes / new features
- Refactor pytest fixtures to centralize definition of linter used in unit tests.
