### PR TITLE
Spelling Improvements

### DIFF
--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -19,6 +19,9 @@ try:
     from enchant.tokenize import get_tokenizer, Filter, EmailFilter, URLFilter, WikiWordFilter
 except ImportError:
     enchant = None
+    class Filter:
+        pass
+
 import six
 
 from pylint.interfaces import ITokenChecker, IAstroidChecker

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -205,7 +205,7 @@ class SpellingChecker(BaseTokenChecker):
                 self.add_message(msgid, line=line_num,
                                  args=(orig_word, line,
                                        indicator,
-                                       "' or '".join(suggestions)))
+                                       "'{0}'".format("' or '".join(suggestions))))
 
     def process_tokens(self, tokens):
         if not self.initialized:

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -20,7 +20,8 @@ try:
 except ImportError:
     enchant = None
     class Filter:
-        pass
+        def _skip(self, word):
+            raise NotImplementedError
 
 import six
 

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -50,8 +50,7 @@ table = maketrans("", "")
 
 
 class WordsWithDigigtsFilter(Filter):
-    """
-    Skips words with digits
+    """Skips words with digits.
     """
 
     def _skip(self, word):
@@ -62,8 +61,8 @@ class WordsWithDigigtsFilter(Filter):
 
 
 class WordsWithUnderscores(Filter):
-    """
-    Skips words with underscores.
+    """Skips words with underscores.
+
     They are probably function parameter names.
     """
     def _skip(self, word):

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -67,7 +67,7 @@ class WordsWithUnderscores(Filter):
     They are probably function parameter names.
     """
     def _skip(self, word):
-        return word.count('_') > 0
+        return '_' in word
 
 
 class SpellingChecker(BaseTokenChecker):

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -53,11 +53,11 @@ class WordsWithDigigtsFilter(Filter):
     """
     Skips words with digits
     """
-    _pattern = re.compile(r"\d")
 
     def _skip(self, word):
-        if self._pattern.findall(word):
-            return True
+        for char in word:
+            if char.isdigit():
+                return True
         return False
 
 

--- a/pylint/test/unittest_checker_spelling.py
+++ b/pylint/test/unittest_checker_spelling.py
@@ -37,60 +37,35 @@ class TestSpellingChecker(CheckerTestCase):
     @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_check_bad_coment(self):
-        try:
-            with self.assertAddsMessages(
-                Message('wrong-spelling-in-comment', line=1,
-                        args=('coment', '# bad coment',
-                              '      ^^^^^^',
-                              "comet' or 'comment' or 'moment' or 'foment"))):
-                self.checker.process_tokens(tokenize_str("# bad coment"))
-        except AssertionError:
-            # In Arch Linux, at least, the suggestions do not match
-            with self.assertAddsMessages(
-                Message('wrong-spelling-in-comment', line=1,
-                        args=('coment', '# bad coment',
-                              '      ^^^^^^',
-                              "comet' or 'comment' or 'cement' or 'cogent"))):
-                self.checker.process_tokens(tokenize_str("# bad coment"))
+        suggestions = self.checker.spelling_dict.suggest('coment')[:4]
+        with self.assertAddsMessages(
+            Message('wrong-spelling-in-comment', line=1,
+                    args=('coment', '# bad coment',
+                          '      ^^^^^^',
+                          "'{0}'".format("' or '".join(suggestions))))):
+            self.checker.process_tokens(tokenize_str("# bad coment"))
 
     @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_check_bad_docstring(self):
+        suggestions = self.checker.spelling_dict.suggest('coment')[:4]
         stmt = astroid.extract_node(
             'def fff():\n   """bad coment"""\n   pass')
-        try:
-            with self.assertAddsMessages(
-                Message('wrong-spelling-in-docstring', line=2,
-                        args=('coment', 'bad coment',
-                              '    ^^^^^^',
-                              "comet' or 'comment' or 'moment' or 'foment"))):
-                self.checker.visit_functiondef(stmt)
-        except AssertionError:
-            # In Arch Linux, at least, the suggestions do not match
-            with self.assertAddsMessages(
-                Message('wrong-spelling-in-docstring', line=2,
-                        args=('coment', 'bad coment',
-                              '    ^^^^^^',
-                              "comet' or 'comment' or 'cement' or 'cogent"))):
-                self.checker.visit_functiondef(stmt)
+        with self.assertAddsMessages(
+            Message('wrong-spelling-in-docstring', line=2,
+                    args=('coment', 'bad coment',
+                          '    ^^^^^^',
+                          "'{0}'".format("' or '".join(suggestions))))):
+            self.checker.visit_functiondef(stmt)
 
         stmt = astroid.extract_node(
             'class Abc(object):\n   """bad coment"""\n   pass')
-        try:
-            with self.assertAddsMessages(
-                Message('wrong-spelling-in-docstring', line=2,
-                        args=('coment', 'bad coment',
-                              '    ^^^^^^',
-                              "comet' or 'comment' or 'moment' or 'foment"))):
-                self.checker.visit_classdef(stmt)
-        except AssertionError:
-            # In Arch Linux, at least, the suggestions do not match
-            with self.assertAddsMessages(
-                Message('wrong-spelling-in-docstring', line=2,
-                        args=('coment', 'bad coment',
-                              '    ^^^^^^',
-                              "comet' or 'comment' or 'cement' or 'cogent"))):
-                self.checker.visit_classdef(stmt)
+        with self.assertAddsMessages(
+            Message('wrong-spelling-in-docstring', line=2,
+                    args=('coment', 'bad coment',
+                          '    ^^^^^^',
+                          "'{0}'".format("' or '".join(suggestions))))):
+            self.checker.visit_classdef(stmt)
 
     @pytest.mark.skipif(True, reason='pyenchant\'s tokenizer strips these')
     @skip_on_missing_package_or_dict
@@ -147,23 +122,15 @@ class TestSpellingChecker(CheckerTestCase):
     @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_skip_camel_cased_words(self):
+        suggestions = self.checker.spelling_dict.suggest('coment')[:4]
         stmt = astroid.extract_node(
             'class ComentAbc(object):\n   """ComentAbc with a bad coment"""\n   pass')
-        try:
-            with self.assertAddsMessages(
-                Message('wrong-spelling-in-docstring', line=2,
-                        args=('coment', 'ComentAbc with a bad coment',
-                              '                     ^^^^^^',
-                              "comet' or 'comment' or 'moment' or 'foment"))):
-                self.checker.visit_classdef(stmt)
-        except AssertionError:
-            # In Arch Linux, at least, the suggestions do not match
-            with self.assertAddsMessages(
-                Message('wrong-spelling-in-docstring', line=2,
-                        args=('coment', 'ComentAbc with a bad coment',
-                              '                     ^^^^^^',
-                              "comet' or 'comment' or 'cement' or 'cogent"))):
-                self.checker.visit_classdef(stmt)
+        with self.assertAddsMessages(
+            Message('wrong-spelling-in-docstring', line=2,
+                    args=('coment', 'ComentAbc with a bad coment',
+                          '                     ^^^^^^',
+                          "'{0}'".format("' or '".join(suggestions))))):
+            self.checker.visit_classdef(stmt)
 
     @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)

--- a/pylint/test/unittest_checker_spelling.py
+++ b/pylint/test/unittest_checker_spelling.py
@@ -92,6 +92,7 @@ class TestSpellingChecker(CheckerTestCase):
                               "comet' or 'comment' or 'cement' or 'cogent"))):
                 self.checker.visit_classdef(stmt)
 
+    @pytest.mark.skipif(True, reason='pyenchant\'s tokenizer strips these')
     @pytest.mark.skipif(spell_dict is None,
                         reason="missing python-enchant package or missing "
                         "spelling dictionaries")

--- a/pylint/test/unittest_checker_spelling.py
+++ b/pylint/test/unittest_checker_spelling.py
@@ -175,3 +175,13 @@ class TestSpellingChecker(CheckerTestCase):
                               '                     ^^^^^^',
                               "comet' or 'comment' or 'cement' or 'cogent"))):
                 self.checker.visit_classdef(stmt)
+
+    @pytest.mark.skipif(spell_dict is None,
+                        reason="missing python-enchant package or missing "
+                        "spelling dictionaries")
+    @set_config(spelling_dict=spell_dict)
+    def test_skip_words_with_underscores(self):
+        stmt = astroid.extract_node(
+            'def fff(param_name):\n   """test param_name"""\n   pass')
+        self.checker.visit_functiondef(stmt)
+        assert self.linter.release_messages() == []

--- a/pylint/test/unittest_checker_spelling.py
+++ b/pylint/test/unittest_checker_spelling.py
@@ -103,3 +103,11 @@ class TestSpellingChecker(CheckerTestCase):
             Message('invalid-characters-in-docstring', line=2,
                     args=('test\x00',))):
             self.checker.visit_functiondef(stmt)
+
+    @pytest.mark.skipif(spell_dict is None,
+                        reason="missing python-enchant package or missing "
+                        "spelling dictionaries")
+    @set_config(spelling_dict=spell_dict)
+    def test_skip_shebangs(self):
+        self.checker.process_tokens(tokenize_str('#!/usr/bin/env python'))
+        assert self.linter.release_messages() == []

--- a/pylint/test/unittest_checker_spelling.py
+++ b/pylint/test/unittest_checker_spelling.py
@@ -35,12 +35,21 @@ class TestSpellingChecker(CheckerTestCase):
                         "spelling dictionaries")
     @set_config(spelling_dict=spell_dict)
     def test_check_bad_coment(self):
-        with self.assertAddsMessages(
-            Message('wrong-spelling-in-comment', line=1,
-                    args=('coment', '# bad coment',
-                          '      ^^^^^^',
-                          "comet' or 'comment' or 'moment' or 'foment"))):
-            self.checker.process_tokens(tokenize_str("# bad coment"))
+        try:
+            with self.assertAddsMessages(
+                Message('wrong-spelling-in-comment', line=1,
+                        args=('coment', '# bad coment',
+                              '      ^^^^^^',
+                              "comet' or 'comment' or 'moment' or 'foment"))):
+                self.checker.process_tokens(tokenize_str("# bad coment"))
+        except AssertionError:
+            # In Arch Linux, at least, the suggestions do not match
+            with self.assertAddsMessages(
+                Message('wrong-spelling-in-comment', line=1,
+                        args=('coment', '# bad coment',
+                              '      ^^^^^^',
+                              "comet' or 'comment' or 'cement' or 'cogent"))):
+                self.checker.process_tokens(tokenize_str("# bad coment"))
 
     @pytest.mark.skipif(spell_dict is None,
                         reason="missing python-enchant package or missing "
@@ -49,21 +58,39 @@ class TestSpellingChecker(CheckerTestCase):
     def test_check_bad_docstring(self):
         stmt = astroid.extract_node(
             'def fff():\n   """bad coment"""\n   pass')
-        with self.assertAddsMessages(
-            Message('wrong-spelling-in-docstring', line=2,
-                    args=('coment', 'bad coment',
-                          '    ^^^^^^',
-                          "comet' or 'comment' or 'moment' or 'foment"))):
-            self.checker.visit_functiondef(stmt)
+        try:
+            with self.assertAddsMessages(
+                Message('wrong-spelling-in-docstring', line=2,
+                        args=('coment', 'bad coment',
+                              '    ^^^^^^',
+                              "comet' or 'comment' or 'moment' or 'foment"))):
+                self.checker.visit_functiondef(stmt)
+        except AssertionError:
+            # In Arch Linux, at least, the suggestions do not match
+            with self.assertAddsMessages(
+                Message('wrong-spelling-in-docstring', line=2,
+                        args=('coment', 'bad coment',
+                              '    ^^^^^^',
+                              "comet' or 'comment' or 'cement' or 'cogent"))):
+                self.checker.visit_functiondef(stmt)
 
         stmt = astroid.extract_node(
             'class Abc(object):\n   """bad coment"""\n   pass')
-        with self.assertAddsMessages(
-            Message('wrong-spelling-in-docstring', line=2,
-                    args=('coment', 'bad coment',
-                          '    ^^^^^^',
-                          "comet' or 'comment' or 'moment' or 'foment"))):
-            self.checker.visit_classdef(stmt)
+        try:
+            with self.assertAddsMessages(
+                Message('wrong-spelling-in-docstring', line=2,
+                        args=('coment', 'bad coment',
+                              '    ^^^^^^',
+                              "comet' or 'comment' or 'moment' or 'foment"))):
+                self.checker.visit_classdef(stmt)
+        except AssertionError:
+            # In Arch Linux, at least, the suggestions do not match
+            with self.assertAddsMessages(
+                Message('wrong-spelling-in-docstring', line=2,
+                        args=('coment', 'bad coment',
+                              '    ^^^^^^',
+                              "comet' or 'comment' or 'cement' or 'cogent"))):
+                self.checker.visit_classdef(stmt)
 
     @pytest.mark.skipif(spell_dict is None,
                         reason="missing python-enchant package or missing "

--- a/pylint/test/unittest_checker_spelling.py
+++ b/pylint/test/unittest_checker_spelling.py
@@ -194,3 +194,11 @@ class TestSpellingChecker(CheckerTestCase):
     def test_skip_email_address(self):
         self.checker.process_tokens(tokenize_str('# uname@domain.tld'))
         assert self.linter.release_messages() == []
+
+    @pytest.mark.skipif(spell_dict is None,
+                        reason="missing python-enchant package or missing "
+                        "spelling dictionaries")
+    @set_config(spelling_dict=spell_dict)
+    def test_skip_urls(self):
+        self.checker.process_tokens(tokenize_str('# https://github.com/rfk/pyenchant'))
+        assert self.linter.release_messages() == []

--- a/pylint/test/unittest_checker_spelling.py
+++ b/pylint/test/unittest_checker_spelling.py
@@ -30,9 +30,11 @@ if enchant is not None:
 class TestSpellingChecker(CheckerTestCase):
     CHECKER_CLASS = spelling.SpellingChecker
 
-    @pytest.mark.skipif(spell_dict is None,
-                        reason="missing python-enchant package or missing "
-                        "spelling dictionaries")
+    skip_on_missing_package_or_dict = pytest.mark.skipif(
+        spell_dict is None,
+        reason="missing python-enchant package or missing spelling dictionaries")
+
+    @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_check_bad_coment(self):
         try:
@@ -51,9 +53,7 @@ class TestSpellingChecker(CheckerTestCase):
                               "comet' or 'comment' or 'cement' or 'cogent"))):
                 self.checker.process_tokens(tokenize_str("# bad coment"))
 
-    @pytest.mark.skipif(spell_dict is None,
-                        reason="missing python-enchant package or missing "
-                        "spelling dictionaries")
+    @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_check_bad_docstring(self):
         stmt = astroid.extract_node(
@@ -93,9 +93,7 @@ class TestSpellingChecker(CheckerTestCase):
                 self.checker.visit_classdef(stmt)
 
     @pytest.mark.skipif(True, reason='pyenchant\'s tokenizer strips these')
-    @pytest.mark.skipif(spell_dict is None,
-                        reason="missing python-enchant package or missing "
-                        "spelling dictionaries")
+    @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_invalid_docstring_characters(self):
         stmt = astroid.extract_node(
@@ -105,17 +103,13 @@ class TestSpellingChecker(CheckerTestCase):
                     args=('test\x00',))):
             self.checker.visit_functiondef(stmt)
 
-    @pytest.mark.skipif(spell_dict is None,
-                        reason="missing python-enchant package or missing "
-                        "spelling dictionaries")
+    @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_skip_shebangs(self):
         self.checker.process_tokens(tokenize_str('#!/usr/bin/env python'))
         assert self.linter.release_messages() == []
 
-    @pytest.mark.skipif(spell_dict is None,
-                        reason="missing python-enchant package or missing "
-                        "spelling dictionaries")
+    @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_skip_python_coding_comments(self):
         self.checker.process_tokens(tokenize_str(
@@ -138,25 +132,19 @@ class TestSpellingChecker(CheckerTestCase):
             '#!/usr/bin/env python\n# vim: set fileencoding=utf-8 :'))
         assert self.linter.release_messages() == []
 
-    @pytest.mark.skipif(spell_dict is None,
-                        reason="missing python-enchant package or missing "
-                        "spelling dictionaries")
+    @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_skip_top_level_pylint_enable_disable_comments(self):
         self.checker.process_tokens(tokenize_str('# Line 1\n Line 2\n# pylint: disable=ungrouped-imports'))
         assert self.linter.release_messages() == []
 
-    @pytest.mark.skipif(spell_dict is None,
-                        reason="missing python-enchant package or missing "
-                        "spelling dictionaries")
+    @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_skip_words_with_numbers(self):
         self.checker.process_tokens(tokenize_str('\n# 0ne\n# Thr33\n# Sh3ll'))
         assert self.linter.release_messages() == []
 
-    @pytest.mark.skipif(spell_dict is None,
-                        reason="missing python-enchant package or missing "
-                        "spelling dictionaries")
+    @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_skip_camel_cased_words(self):
         stmt = astroid.extract_node(
@@ -177,9 +165,7 @@ class TestSpellingChecker(CheckerTestCase):
                               "comet' or 'comment' or 'cement' or 'cogent"))):
                 self.checker.visit_classdef(stmt)
 
-    @pytest.mark.skipif(spell_dict is None,
-                        reason="missing python-enchant package or missing "
-                        "spelling dictionaries")
+    @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_skip_words_with_underscores(self):
         stmt = astroid.extract_node(
@@ -187,17 +173,13 @@ class TestSpellingChecker(CheckerTestCase):
         self.checker.visit_functiondef(stmt)
         assert self.linter.release_messages() == []
 
-    @pytest.mark.skipif(spell_dict is None,
-                        reason="missing python-enchant package or missing "
-                        "spelling dictionaries")
+    @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_skip_email_address(self):
         self.checker.process_tokens(tokenize_str('# uname@domain.tld'))
         assert self.linter.release_messages() == []
 
-    @pytest.mark.skipif(spell_dict is None,
-                        reason="missing python-enchant package or missing "
-                        "spelling dictionaries")
+    @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_skip_urls(self):
         self.checker.process_tokens(tokenize_str('# https://github.com/rfk/pyenchant'))

--- a/pylint/test/unittest_checker_spelling.py
+++ b/pylint/test/unittest_checker_spelling.py
@@ -150,3 +150,11 @@ class TestSpellingChecker(CheckerTestCase):
                           "fut' or 'uhf"))):
             self.checker.process_tokens(tokenize_str(
                 '# Line 1\n# Line 2\n# vim: set fileencoding=utf-8 :'))
+
+    @pytest.mark.skipif(spell_dict is None,
+                        reason="missing python-enchant package or missing "
+                        "spelling dictionaries")
+    @set_config(spelling_dict=spell_dict)
+    def test_skip_top_level_pylint_enable_disable_comments(self):
+        self.checker.process_tokens(tokenize_str('# Line 1\n Line 2\n# pylint: disable=ungrouped-imports'))
+        assert self.linter.release_messages() == []

--- a/pylint/test/unittest_checker_spelling.py
+++ b/pylint/test/unittest_checker_spelling.py
@@ -136,20 +136,6 @@ class TestSpellingChecker(CheckerTestCase):
         self.checker.process_tokens(tokenize_str(
             '#!/usr/bin/env python\n# vim: set fileencoding=utf-8 :'))
         assert self.linter.release_messages() == []
-        # Howerver, if not found on the first 2 lines...
-        with self.assertAddsMessages(
-            Message('wrong-spelling-in-comment', line=3,
-                    args=('fileencoding',
-                          '# vim: set fileencoding=utf-8 :',
-                          '           ^^^^^^^^^^^^',
-                          "file encoding' or 'file-encoding' or 'filigreeing")),
-            Message('wrong-spelling-in-comment', line=3,
-                    args=('utf',
-                          '# vim: set fileencoding=utf-8 :',
-                          '                        ^^^',
-                          "fut' or 'uhf"))):
-            self.checker.process_tokens(tokenize_str(
-                '# Line 1\n# Line 2\n# vim: set fileencoding=utf-8 :'))
 
     @pytest.mark.skipif(spell_dict is None,
                         reason="missing python-enchant package or missing "
@@ -157,4 +143,12 @@ class TestSpellingChecker(CheckerTestCase):
     @set_config(spelling_dict=spell_dict)
     def test_skip_top_level_pylint_enable_disable_comments(self):
         self.checker.process_tokens(tokenize_str('# Line 1\n Line 2\n# pylint: disable=ungrouped-imports'))
+        assert self.linter.release_messages() == []
+
+    @pytest.mark.skipif(spell_dict is None,
+                        reason="missing python-enchant package or missing "
+                        "spelling dictionaries")
+    @set_config(spelling_dict=spell_dict)
+    def test_skip_words_with_numbers(self):
+        self.checker.process_tokens(tokenize_str('\n# 0ne\n# Thr33\n# Sh3ll'))
         assert self.linter.release_messages() == []

--- a/pylint/test/unittest_checker_spelling.py
+++ b/pylint/test/unittest_checker_spelling.py
@@ -186,3 +186,11 @@ class TestSpellingChecker(CheckerTestCase):
             'def fff(param_name):\n   """test param_name"""\n   pass')
         self.checker.visit_functiondef(stmt)
         assert self.linter.release_messages() == []
+
+    @pytest.mark.skipif(spell_dict is None,
+                        reason="missing python-enchant package or missing "
+                        "spelling dictionaries")
+    @set_config(spelling_dict=spell_dict)
+    def test_skip_email_address(self):
+        self.checker.process_tokens(tokenize_str('# uname@domain.tld'))
+        assert self.linter.release_messages() == []


### PR DESCRIPTION
This pull request let's pyenchant do it's thing.

### Fixes / new features
- Previous skips still work(but pyenchant takes care of them)
- Skips email addresses
- Skips URLs

However, invalid characters on docstrings are also stripped by enchant thus we loose the ability to raise `invalid-characters-in-docstring`. I'll need guidance on how to proceed here.
I also would like some examples where the python literals trigger spelling errors since there's no current tests for that. My guess is that pyenchant already takes care of those for us.
