### PR TITLE
[IMP] Adding exception section for good practice

### DIFF
--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -925,7 +925,7 @@ functions, methods
         # 2 - Is it inside final body of a try...finally bloc ?
         self._check_not_in_finally(node, 'break', (astroid.For, astroid.While,))
 
-    @utils.check_messages('unreachable', 'except-pass')
+    @utils.check_messages('unreachable')
     def visit_raise(self, node):
         """check if the node has a right sibling (if so, that's some unreachable
         code)

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -656,6 +656,10 @@ functions, methods
                   'Emitted when a conditional statement (If or ternary if) '
                   'uses a constant value for its test. This might not be what '
                   'the user intended to do.'),
+        'W0126': ('pass into block except',
+                  'except-pass',
+                  'If you really need to use the pass consider logging that'
+                  'exception'),
         'E0111': ('The first reversed() argument is not a sequence',
                   'bad-reversed-sequence',
                   'Used when the first argument to reversed() builtin '
@@ -921,12 +925,19 @@ functions, methods
         # 2 - Is it inside final body of a try...finally bloc ?
         self._check_not_in_finally(node, 'break', (astroid.For, astroid.While,))
 
-    @utils.check_messages('unreachable')
+    @utils.check_messages('unreachable', 'except-pass')
     def visit_raise(self, node):
         """check if the node has a right sibling (if so, that's some unreachable
         code)
         """
         self._check_unreachable(node)
+
+    @utils.check_messages('except-pass')
+    def visit_tryexcept(self, node):
+        """Visit block try except"""
+        for orelse in node.orelse:
+            if isinstance(orelse, astroid.node_classes.Continue):
+                self.add_message('except-pass', node=node)
 
     @utils.check_messages('exec-used')
     def visit_exec(self, node):

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -935,9 +935,10 @@ functions, methods
     @utils.check_messages('except-pass')
     def visit_tryexcept(self, node):
         """Visit block try except"""
-        for orelse in node.orelse:
-            if isinstance(orelse, astroid.node_classes.Continue):
-                self.add_message('except-pass', node=node)
+        for handler in node.handlers:
+            for body in handler.body:
+                if isinstance(body, astroid.node_classes.Pass):
+                    self.add_message('except-pass', node=node)
 
     @utils.check_messages('exec-used')
     def visit_exec(self, node):

--- a/pylint/test/functional/except_pass.py
+++ b/pylint/test/functional/except_pass.py
@@ -1,6 +1,17 @@
 # coding: utf-8
 """Test Except Pass usage"""
 # pylint: disable=too-few-public-methods, no-self-use, continue-in-finally
+# pylint: disable=undefined-variable, bare-except, continue-in-finally
+# pylint: disable=bad-except-order
+# pylint: disable=import-error
+# pylint: disable=ungrouped-imports, redefine-in-handler
+# pylint: disable=too-many-nested-blocks, misplaced-bare-raise
+# pylint: disable=redefined-argument-from-local
+# pylint: disable=no-name-in-module, unnecessary-pass
+# pylint: disable=redefined-argument-from-local
+# pylint: disable=undefined-variable, bare-except, continue-in-finally
+# pylint: disable=bad-except-order, no-member, wrong-import-position
+# pylint: disable=undefined-variable
 
 
 class TestExceptPass(object):
@@ -10,5 +21,5 @@ class TestExceptPass(object):
         """Test method """
         try:
             raise Exception('Exception')
-        except BaseException:
+        except Exception:
             pass  # [except-pass]

--- a/pylint/test/functional/except_pass.py
+++ b/pylint/test/functional/except_pass.py
@@ -1,0 +1,14 @@
+# coding: utf-8
+"""Test Except Pass usage"""
+# pylint: disable=too-few-public-methods, no-self-use
+
+
+class TestExceptPass(object):
+    """Test Except Pass class """
+
+    def test_method(self):
+        """Test method """
+        try:
+            raise Exception('Exception')
+        except BaseException:
+            pass  # [except-pass]

--- a/pylint/test/functional/except_pass.py
+++ b/pylint/test/functional/except_pass.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 """Test Except Pass usage"""
-# pylint: disable=too-few-public-methods, no-self-use
+# pylint: disable=too-few-public-methods, no-self-use, continue-in-finally
 
 
 class TestExceptPass(object):

--- a/pylint/test/functional/except_pass.py
+++ b/pylint/test/functional/except_pass.py
@@ -1,17 +1,6 @@
 # coding: utf-8
 """Test Except Pass usage"""
-# pylint: disable=too-few-public-methods, no-self-use, continue-in-finally
-# pylint: disable=undefined-variable, bare-except, continue-in-finally
-# pylint: disable=bad-except-order
-# pylint: disable=import-error
-# pylint: disable=ungrouped-imports, redefine-in-handler
-# pylint: disable=too-many-nested-blocks, misplaced-bare-raise
-# pylint: disable=redefined-argument-from-local
-# pylint: disable=no-name-in-module, unnecessary-pass
-# pylint: disable=redefined-argument-from-local
-# pylint: disable=undefined-variable, bare-except, continue-in-finally
-# pylint: disable=bad-except-order, no-member, wrong-import-position
-# pylint: disable=undefined-variable
+# pylint: disable=too-few-public-methods, no-self-use
 
 
 class TestExceptPass(object):

--- a/pylint/test/functional/except_pass.txt
+++ b/pylint/test/functional/except_pass.txt
@@ -1,0 +1,1 @@
+except-pass:14:TestExceptPass.test_method:pass into block except


### PR DESCRIPTION
The `pass` into block except is not a good practice!

  By including the `pass` we assume that our algorithm can continue to function after the exception occurred

  If you really need to use the `pass` consider logging that exception

  ```python
      try:
          sentences
      except:
          pass
          _logger.debug('Pass')
  ```

**TODO:** Fix all try-except-pass after receive a good feedback of this check