### PR TITLE
Revert "Use pytest-xdist for parallel execution of tests in travis (#1246)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,7 @@ script:
   - pip install .
     # Run the tests with newest version of setuptools
   - pip install -U setuptools
-    # pypy is very slow with multiple processes due too long startup time
-  - if [ $TOXENV == "pypy" ]; then POSARGS=""; else POSARGS="-n 4"; fi
-  - tox -e coverage-erase,$TOXENV -- $POSARGS
+  - tox -e coverage-erase,$TOXENV
 after_success:
   - tox -e coveralls
 after_failure:

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
    isort
    mccabe
    pytest
+   pytest-xdist
 
 setenv =
     COVERAGE_FILE = {toxinidir}/.coverage.{envname}

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ deps =
    isort
    mccabe
    pytest
-   pytest-xdist
 
 setenv =
     COVERAGE_FILE = {toxinidir}/.coverage.{envname}


### PR DESCRIPTION
This reverts commit 796b1690bebfee1fc637fcfce5d398646958435b.

Last change introduced regression with sending data to coveralls.