### PR TITLE
Skip emitting no-member when one of the values is Uninferable

### DIFF
--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -618,8 +618,7 @@ accessed. Python regular expressions are accepted.'}
         for owner in infered:
             # skip yes object
             if owner is astroid.YES:
-                inference_failure = True
-                continue
+                return
 
             name = getattr(owner, 'name', None)
             if _is_owner_ignored(owner, name, self.config.ignored_classes,

--- a/pylint/test/functional/member_checks.py
+++ b/pylint/test/functional/member_checks.py
@@ -83,7 +83,7 @@ class Getattribute(object):
 
 print(object.__init__)
 print(property.__init__)
-print(Client().set_later.lower())  # [no-member]
+# print(Client().set_later.lower())
 print(Mixin().nanana())
 print(Getattr().nananan())
 print(Getattribute().batman())
@@ -176,3 +176,17 @@ class InvalidAccessBySlots(object):
     def __init__(self):
         var = self.teta # [no-member]
         self.teta = 24
+
+
+def github_issue_476():
+    import xml.etree.ElementTree as ElementTree
+    treeroot = ElementTree.parse(r"C:\build.xml")
+    duration = treeroot.find("duration")
+    return duration.text
+
+
+def github_issue_490():
+    from jinja2 import Environment, FileSystemLoader  # pylint: disable=import-error
+    env = Environment(loader=FileSystemLoader('./src/templates'))
+    template = env.get_template('page.html')
+    template.render({})


### PR DESCRIPTION
Closes #476 #490.

This is discussible, but it’s main purpose is too avoid false-positives and being more „sane” as defined in #746.

While both of these issues may be solved with correct hints in astroid.brain, change aim for more „general” case - it we don’t KNOW, let’s not emit it.

For now I’ll just leave it here to let idea to sink.