### PR TITLE
epylint: corrects msg-template object

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -280,6 +280,7 @@ Release date: tba
       Fixes #1031
 
     * Let the user modify msg-template when Pylint is called from a Python script
+    
       Fixes #1269
 
 What's new in Pylint 1.6.3?

--- a/ChangeLog
+++ b/ChangeLog
@@ -279,12 +279,7 @@ Release date: tba
 
       Fixes #1031
 
-What's new in Pylint 1.6.4?
-===========================
-
-Release date: 2016-07-19
-
-    * Lets the user modify msg-template when Pylint is called from a Python script
+    * Let the user modify msg-template when Pylint is called from a Python script
       Fixes #1269
 
 What's new in Pylint 1.6.3?

--- a/ChangeLog
+++ b/ChangeLog
@@ -275,6 +275,14 @@ Release date: tba
 
       Closes #738
 
+What's new in Pylint 1.6.4?
+===========================
+
+Release date: 2016-07-19
+
+    * Lets the user modify msg-template when Pylint is called from a Python script
+      Fixes #1269
+
 What's new in Pylint 1.6.3?
 ===========================
 

--- a/pylint/epylint.py
+++ b/pylint/epylint.py
@@ -87,9 +87,9 @@ def lint(filename, options=None):
     # Ensure we use the python and pylint associated with the running epylint
     run_cmd = "import sys; from pylint.lint import Run; Run(sys.argv[1:])"
     options = options or ['--disable=C,R,I']
-    cmd = [sys.executable, "-c", run_cmd] + options + [
+    cmd = [sys.executable, "-c", run_cmd] + [
         '--msg-template', '{path}:{line}: {category} ({msg_id}, {symbol}, {obj}) {msg}',
-        '-r', 'n', child_path]
+        '-r', 'n', child_path] + options
     process = Popen(cmd, stdout=PIPE, cwd=parent_path, env=_get_env(),
                     universal_newlines=True)
 


### PR DESCRIPTION
The way this object is defined won't let the user modify the message
template when pylint is called from a python script. Rearranging the
order of variables on its definition prevents this behavior.

Fixes #1269

Signed-off-by: Daniela Plascencia <daniela.plascencia@linux.intel.com>

### Fixes / new features
- Fixes #1269