### PR TITLE
Split missing+differing docstring param checks

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -133,3 +133,5 @@ Order doesn't matter (not that much, at least ;)
 * Derek Gustafson: contributor
 
 * Petr Pulc: require whitespace around annotations
+
+* John Paraskevopoulos: add 'differing-param-doc' and 'differing-type-doc'

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,12 @@ What's New in Pylint 2.0?
 
 Release date: tba
 
+    * Split the 'missing or differing' in parameter documentation in different error.
+      'differing-param-doc' covers the differing part of the old 'missing-param-doc',
+      and 'differing-type-doc' covers the differing part of the old 'missing-type-doc'
+
+      Close #1342
+
     * Added a new error, 'used-prior-global-declaration', which is emitted when a name
       is used prior a global declaration in a function. This causes a SyntaxError in
       Python 3.6

--- a/doc/whatsnew/1.7.rst
+++ b/doc/whatsnew/1.7.rst
@@ -768,6 +768,9 @@ Other Changes
   * Imports checker supports new switch ``allow-wildcard-with-all`` which disables
     warning on wildcard import when imported module defines `__all__` variable.
 
+* ``differing-param-doc`` is now used for the differing part of the old ``missing-param-doc``,
+  and ``differing-type-doc`` for the differing part of the old ``missing-type-doc``.
+
 
 Bug fixes
 =========

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -45,10 +45,10 @@ class DocstringParameterChecker(BaseChecker):
 
     name = 'parameter_documentation'
     msgs = {
-        'W9003': ('"%s" missing or differing in parameter documentation',
+        'W9003': ('"%s" missing in parameter documentation',
                   'missing-param-doc',
                   'Please add parameter declarations for all parameters.'),
-        'W9004': ('"%s" missing or differing in parameter type documentation',
+        'W9004': ('"%s" missing in parameter type documentation',
                   'missing-type-doc',
                   'Please add parameter type declarations for all parameters.'),
         'W9005': ('"%s" has constructor parameters documented in class and __init__',

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -83,6 +83,12 @@ class DocstringParameterChecker(BaseChecker):
                   # we can't use the same old_name for two different warnings
                   # {'old_names': [('W9009', 'missing-yields-doc')]},
                  ),
+        'W9015': ('"%s" differing in parameter documentation',
+                  'differing-param-doc',
+                  'Please check parameter names in declarations.'),
+        'W9016': ('"%s" differing in parameter type documentation',
+                  'differing-type-doc',
+                  'Please check parameter names in type declarations.'),
     }
 
     options = (('accept-no-param-doc',
@@ -311,11 +317,12 @@ class DocstringParameterChecker(BaseChecker):
                 and accept_no_param_doc):
             tolerate_missing_params = True
 
-        def _compare_args(found_argument_names, message_id, not_needed_names):
+        def _compare_missing_args(found_argument_names, message_id,
+                                  not_needed_names):
             """Compare the found argument names with the expected ones and
-            generate a message if there are inconsistencies.
+            generate a message if there are arguments missing.
 
-            :param list found_argument_names: argument names found in the
+            :param set found_argument_names: argument names found in the
                 docstring
 
             :param str message_id: pylint message id
@@ -324,25 +331,49 @@ class DocstringParameterChecker(BaseChecker):
             :type not_needed_names: set of str
             """
             if not tolerate_missing_params:
-                missing_or_differing_argument_names = (
-                    (expected_argument_names ^ found_argument_names)
+                missing_argument_names = (
+                    (expected_argument_names - found_argument_names)
                     - not_needed_names)
-            else:
-                missing_or_differing_argument_names = (
-                    (found_argument_names - expected_argument_names)
-                    - not_needed_names)
+                if missing_argument_names:
+                    self.add_message(
+                        message_id,
+                        args=(', '.join(
+                            sorted(missing_argument_names)),),
+                        node=warning_node)
 
-            if missing_or_differing_argument_names:
+        def _compare_different_args(found_argument_names, message_id,
+                                    not_needed_names):
+            """Compare the found argument names with the expected ones and
+            generate a message if there are extra arguments found.
+
+            :param set found_argument_names: argument names found in the
+                docstring
+
+            :param str message_id: pylint message id
+
+            :param not_needed_names: names that may be omitted
+            :type not_needed_names: set of str
+            """
+            differing_argument_names = (
+                (expected_argument_names ^ found_argument_names)
+                - not_needed_names - expected_argument_names)
+
+            if differing_argument_names:
                 self.add_message(
                     message_id,
                     args=(', '.join(
-                        sorted(missing_or_differing_argument_names)),),
+                        sorted(differing_argument_names)),),
                     node=warning_node)
 
-        _compare_args(params_with_doc, 'missing-param-doc',
-                      self.not_needed_param_in_docstring)
-        _compare_args(params_with_type, 'missing-type-doc',
-                      not_needed_type_in_docstring)
+        _compare_missing_args(params_with_doc, 'missing-param-doc',
+                              self.not_needed_param_in_docstring)
+        _compare_missing_args(params_with_type, 'missing-type-doc',
+                              not_needed_type_in_docstring)
+
+        _compare_different_args(params_with_doc, 'differing-param-doc',
+                                self.not_needed_param_in_docstring)
+        _compare_different_args(params_with_type, 'differing-type-doc',
+                                not_needed_type_in_docstring)
 
     def check_single_constructor_params(self, class_doc, init_doc, class_node):
         if class_doc.has_params() and init_doc.has_params():

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -45,12 +45,6 @@ class DocstringParameterChecker(BaseChecker):
 
     name = 'parameter_documentation'
     msgs = {
-        'W9003': ('"%s" missing in parameter documentation',
-                  'missing-param-doc',
-                  'Please add parameter declarations for all parameters.'),
-        'W9004': ('"%s" missing in parameter type documentation',
-                  'missing-type-doc',
-                  'Please add parameter type declarations for all parameters.'),
         'W9005': ('"%s" has constructor parameters documented in class and __init__',
                   'multiple-constructor-doc',
                   'Please remove parameter declarations in the class or constructor.'),
@@ -83,12 +77,22 @@ class DocstringParameterChecker(BaseChecker):
                   # we can't use the same old_name for two different warnings
                   # {'old_names': [('W9009', 'missing-yields-doc')]},
                  ),
-        'W9015': ('"%s" differing in parameter documentation',
+        'W9015': ('"%s" missing in parameter documentation',
+                  'missing-param-doc',
+                  'Please add parameter declarations for all parameters.',
+                  {'old_names': [('W9003', 'missing-param-doc')]}),
+        'W9016': ('"%s" missing in parameter type documentation',
+                  'missing-type-doc',
+                  'Please add parameter type declarations for all parameters.',
+                  {'old_names': [('W9004', 'missing-type-doc')]}),
+        'W9017': ('"%s" differing in parameter documentation',
                   'differing-param-doc',
-                  'Please check parameter names in declarations.'),
-        'W9016': ('"%s" differing in parameter type documentation',
+                  'Please check parameter names in declarations.',
+                 ),
+        'W9018': ('"%s" differing in parameter type documentation',
                   'differing-type-doc',
-                  'Please check parameter names in type declarations.'),
+                  'Please check parameter names in type declarations.',
+                 ),
     }
 
     options = (('accept-no-param-doc',

--- a/pylint/test/extensions/test_check_docs.py
+++ b/pylint/test/extensions/test_check_docs.py
@@ -367,11 +367,19 @@ class TestParamDocChecker(CheckerTestCase):
             Message(
                 msg_id='missing-param-doc',
                 node=node,
-                args=('xarg, xarg1, zarg, zarg1',)),
+                args=('xarg, zarg',)),
             Message(
                 msg_id='missing-type-doc',
                 node=node,
-                args=('yarg, yarg1, zarg, zarg1',)),
+                args=('yarg, zarg',)),
+            Message(
+                    msg_id='differing-param-doc',
+                    node=node,
+                    args=('xarg1, zarg1',)),
+            Message(
+                msg_id='differing-type-doc',
+                node=node,
+                args=('yarg1, zarg1',)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -388,13 +396,13 @@ class TestParamDocChecker(CheckerTestCase):
         """)
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-param-doc',
+                msg_id='differing-param-doc',
                 node=node,
                 args=('yarg1',)),
             Message(
-                msg_id='missing-type-doc',
+                msg_id='differing-type-doc',
                 node=node,
-                args=('yarg1',))
+                args=('yarg1',)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -418,11 +426,19 @@ class TestParamDocChecker(CheckerTestCase):
             Message(
                 msg_id='missing-param-doc',
                 node=node,
-                args=('xarg, xarg1, zarg, zarg1',)),
+                args=('xarg, zarg',)),
             Message(
                 msg_id='missing-type-doc',
                 node=node,
-                args=('xarg, xarg1, zarg, zarg1',)),
+                args=('xarg, zarg',)),
+            Message(
+                msg_id='differing-param-doc',
+                node=node,
+                args=('xarg1, zarg1',)),
+            Message(
+                msg_id='differing-type-doc',
+                node=node,
+                args=('xarg1, zarg1',)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -439,11 +455,11 @@ class TestParamDocChecker(CheckerTestCase):
         """)
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-param-doc',
+                msg_id='differing-param-doc',
                 node=node,
                 args=('yarg1',)),
             Message(
-                msg_id='missing-type-doc',
+                msg_id='differing-type-doc',
                 node=node,
                 args=('yarg1',))
         ):
@@ -473,11 +489,19 @@ class TestParamDocChecker(CheckerTestCase):
             Message(
                 msg_id='missing-param-doc',
                 node=node,
-                args=('xarg, xarg1, zarg, zarg1',)),
+                args=('xarg, zarg',)),
             Message(
                 msg_id='missing-type-doc',
                 node=node,
-                args=('xarg, xarg1, zarg, zarg1',)),
+                args=('xarg, zarg',)),
+            Message(
+                msg_id='differing-param-doc',
+                node=node,
+                args=('xarg1, zarg1',)),
+            Message(
+                msg_id='differing-type-doc',
+                node=node,
+                args=('xarg1, zarg1',)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -496,11 +520,11 @@ class TestParamDocChecker(CheckerTestCase):
         """)
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-param-doc',
+                msg_id='differing-param-doc',
                 node=node,
                 args=('yarg1',)),
             Message(
-                msg_id='missing-type-doc',
+                msg_id='differing-type-doc',
                 node=node,
                 args=('yarg1',))
         ):


### PR DESCRIPTION
Add 2 different error codes for different params defined
Split param name checking in two functions, one for missing checks
and another for different names checks
Check for missing params and then check for differing params
Minor fix in type of found_argument_names [list --> set]

### Fixes / new features
- Fixes #1342
