### PR TITLE
Ignore unknown members when one of the inferred owners is ignored for typechecks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,11 @@ What's New in Pylint 1.8?
 
 Release date: TBD
 
+    * Ignore unknown members when one of the inferred owners is ignored for
+      type checks.
+
+      Fixes #1276
+
 
 What's New in Pylint 1.7.1?
 =========================
@@ -342,7 +347,6 @@ Release date: 2017-04-13
       cycle is not reported as violation.
 
       Fixes #59
-
 
 What's new in Pylint 1.6.3?
 ===========================

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -661,7 +661,10 @@ accessed. Python regular expressions are accepted.'}
             name = getattr(owner, 'name', None)
             if _is_owner_ignored(owner, name, self.config.ignored_classes,
                                  self.config.ignored_modules):
-                continue
+                # The owner is ignored and as such could legitimately have the
+                # corresponding attribute, no need to check other inferred
+                # owners.
+                break
 
             try:
                 if not [n for n in owner.getattr(node.attrname)

--- a/pylint/test/functional/no_member_ignored_inferred.py
+++ b/pylint/test/functional/no_member_ignored_inferred.py
@@ -1,0 +1,22 @@
+"""Minimal code to reproduce PyLint bug around infered, ignored, no-member."""
+import logging
+import os
+
+
+class MyVeryOwnError(ValueError):
+    """My Exception class."""
+    node = True
+
+
+def main():
+    """Have main code in here so that PyLint does not pick on global vars."""
+    # Use the environment to create a var (owner) that can be one of two types.
+    if os.getenv('CAT') == 'dead':
+        owner = ValueError('dead')
+    else:
+        owner = MyVeryOwnError('alive')
+    if os.getenv('CAT') != 'dead':
+        # In here although owner can only be of type MyVeryOwnError, PyLint
+        # won't detect it and will infer it to be either a ValueError or a
+        # MyVeryOwnError instance.
+        logging.info(owner.node)

--- a/pylint/test/functional/no_member_ignored_inferred.rc
+++ b/pylint/test/functional/no_member_ignored_inferred.rc
@@ -1,0 +1,2 @@
+[TYPECHECK]
+ignored-classes=MyVeryOwnError


### PR DESCRIPTION
### Fixes / new features
Fixes #1276.
