### PR TITLE
Avoid checking uninferable values in tuple of exceptions

### DIFF
--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -282,9 +282,8 @@ class ExceptionsChecker(checkers.BaseChecker):
     def _check_catching_non_exception(self, handler, exc, part):
         if isinstance(exc, astroid.Tuple):
             # Check if it is a tuple of exceptions.
-            if astroid.YES in exc.elts:
-                return
-            inferred = [utils.safe_infer(elt) for elt in exc.elts]
+            inferred = [utils.safe_infer(elt) for elt in exc.elts
+                        if elt is not astroid.YES]
             if any(node is astroid.YES for node in inferred):
                 # Don't emit if we don't know every component.
                 return

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -282,6 +282,8 @@ class ExceptionsChecker(checkers.BaseChecker):
     def _check_catching_non_exception(self, handler, exc, part):
         if isinstance(exc, astroid.Tuple):
             # Check if it is a tuple of exceptions.
+            if astroid.YES in exc.elts:
+                return
             inferred = [utils.safe_infer(elt) for elt in exc.elts]
             if any(node is astroid.YES for node in inferred):
                 # Don't emit if we don't know every component.

--- a/pylint/test/functional/github_issue_1326.py
+++ b/pylint/test/functional/github_issue_1326.py
@@ -1,0 +1,12 @@
+"""
+https://github.com/PyCQA/pylint/issues/1326
+"""
+from __future__ import print_function
+import socket
+
+RETRYABLE_EXCEPTIONS = (socket.error,)
+
+try:
+    print("hello")
+except RETRYABLE_EXCEPTIONS + tuple():
+    print("exception caught")


### PR DESCRIPTION
I’ll need more time to debug root cause, but I guess there’s a value in not crashing a linter…

Closes #1326