### PR TITLE
Replace getdefaultlocale with getpreferredencoding

### DIFF
--- a/pylint/reporters/__init__.py
+++ b/pylint/reporters/__init__.py
@@ -62,7 +62,7 @@ class BaseReporter(object):
             if not isinstance(string, six.text_type):
                 return string
             encoding = (getattr(self.out, 'encoding', None) or
-                        locale.getdefaultlocale()[1] or
+                        locale.getpreferredencoding(do_setlocale=False) or
                         sys.getdefaultencoding())
             # errors=replace, we don't want to crash when attempting to show
             # source code line that can't be encoded with the current locale


### PR DESCRIPTION
This PR fixes an issue for users of macOS, where by default LC_CTYPE
is set to an invalid locale. See https://bugs.python.org/issue18378
further discussion on this issue.
