### PR TITLE
Allow yield in async function for python3.6.

### DIFF
--- a/pylint/checkers/async.py
+++ b/pylint/checkers/async.py
@@ -5,6 +5,8 @@
 
 """Checker for anything related to the async protocol (PEP 492)."""
 
+import sys
+
 import astroid
 from astroid import exceptions
 
@@ -36,7 +38,8 @@ class AsyncChecker(checkers.BaseChecker):
     @checker_utils.check_messages('yield-inside-async-function')
     def visit_asyncfunctiondef(self, node):
         for child in node.nodes_of_class(astroid.Yield):
-            if child.scope() is node:
+            if child.scope() is node and (sys.version_info[:2] == (3, 5) or
+                                          isinstance(child, astroid.YieldFrom)):
                 self.add_message('yield-inside-async-function', node=child)
 
     @checker_utils.check_messages('not-async-context-manager')

--- a/pylint/test/functional/yield_inside_async_function.rc
+++ b/pylint/test/functional/yield_inside_async_function.rc
@@ -1,2 +1,3 @@
 [testoptions]
 min_pyver=3.5
+max_pyver=3.6

--- a/pylint/test/functional/yield_inside_async_function_py36.py
+++ b/pylint/test/functional/yield_inside_async_function_py36.py
@@ -1,0 +1,12 @@
+"""Test that `yield` or `yield from` can't be used inside an async function."""
+# pylint: disable=missing-docstring, unused-variable
+
+async def good_coro():
+    def _inner():
+        yield 42
+        yield from [1, 2, 3]
+
+
+async def bad_coro():
+    yield 42
+    yield from [1, 2, 3] # [yield-inside-async-function]

--- a/pylint/test/functional/yield_inside_async_function_py36.rc
+++ b/pylint/test/functional/yield_inside_async_function_py36.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.6

--- a/pylint/test/functional/yield_inside_async_function_py36.txt
+++ b/pylint/test/functional/yield_inside_async_function_py36.txt
@@ -1,0 +1,1 @@
+yield-inside-async-function:12:bad_coro:Yield inside async function


### PR DESCRIPTION
### Fixes / new features
- Allow yield in async function for python3.6.
- Closes #1372.
