### PR TITLE
docparams now ignores "optional" specifier on parameter docs

### DIFF
--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -537,7 +537,7 @@ class NumpyDocstring(GoogleDocstring):
     re_param_line = re.compile(r"""
         \s*  (\w+)                      # identifier
         \s*  :
-        \s*  ({type})? # optional type declaration
+        \s*  (?:({type})(?:,\s+optional)?)? # optional type declaration
         \n                              # description starts on a new line
         \s* (.*)                        # description
     """.format(

--- a/pylint/test/extensions/test_check_docs.py
+++ b/pylint/test/extensions/test_check_docs.py
@@ -1315,3 +1315,25 @@ class TestParamDocChecker(CheckerTestCase):
         '''.format(complex_type))
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
+
+    def test_ignores_optional_specifier_numpy(self):
+        node = astroid.extract_node('''
+        def do_something(param, param2='all'):
+            """Do something.
+
+            Parameters
+            ----------
+            param : str
+                Description.
+            param2 : str, optional
+                Description (the default is 'all').
+
+            Returns
+            -------
+            int
+                Description.
+            """
+            return param, param2
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)


### PR DESCRIPTION
Fixes #1383

### Fixes / new features
- Adding ", optional" to the end of the type of a parameter in a numpy docstring no longer makes docparams throw a missing-type-doc warning.