### PR TITLE
Python 3.6 invalid escape sequence deprecation fixes

### DIFF
--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -29,7 +29,7 @@ _ZERO = re.compile("^0+$")
 def _is_old_octal(literal):
     if _ZERO.match(literal):
         return False
-    if re.match('0\d+', literal):
+    if re.match(r'0\d+', literal):
         try:
             int(literal, 8)
         except ValueError:

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -555,7 +555,7 @@ accessed. Python regular expressions are accepted.'}
         if isinstance(self.config.generated_members, six.string_types):
             gen = shlex.shlex(self.config.generated_members)
             gen.whitespace += ','
-            gen.wordchars += '[]-+\.*?()|'
+            gen.wordchars += r'[]-+\.*?()|'
             self.config.generated_members = tuple(tok.strip('"') for tok in gen)
 
     @check_messages('invalid-metaclass')

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -391,7 +391,7 @@ class _ManHelpFormatter(optparse.HelpFormatter):
     def format_short_description(pgm, short_desc):
         return '''.SH NAME
 .B %s
-\- %s
+\\- %s
 ''' % (pgm, short_desc.strip())
 
     @staticmethod

--- a/pylint/test/test_self.py
+++ b/pylint/test/test_self.py
@@ -155,7 +155,7 @@ class TestRunTC(object):
         output = out.getvalue()
         # Get rid of the pesky messages that pylint emits if the
         # configuration file is not found.
-        master = re.search("\[MASTER", output)
+        master = re.search(r"\[MASTER", output)
         out = six.StringIO(output[master.start():])
         parser = six.moves.configparser.RawConfigParser()
         parser.readfp(out)

--- a/pylint/test/unittest_config.py
+++ b/pylint/test/unittest_config.py
@@ -37,13 +37,13 @@ def test__csv_validator_spaces():
         assert result[i] == value
 
 def test__regexp_csv_validator_valid():
-    pattern_strings = ["test_.*", "foo\.bar", "^baz$"]
+    pattern_strings = ["test_.*", "foo\\.bar", "^baz$"]
     result = config._regexp_csv_validator(None, None, ",".join(pattern_strings))
     for i, regex in enumerate(result):
         assert isinstance(regex, re._pattern_type)
         assert regex.pattern == pattern_strings[i]
 
 def test__regexp_csv_validator_invalid():
-    pattern_strings = ["test_.*", "foo\.bar", "^baz)$"]
+    pattern_strings = ["test_.*", "foo\\.bar", "^baz)$"]
     with pytest.raises(sre_constants.error):
         config._regexp_csv_validator(None, None, ",".join(pattern_strings))

--- a/pylint/test/unittest_lint.py
+++ b/pylint/test/unittest_lint.py
@@ -499,7 +499,7 @@ def test_full_documentation(linter):
         "^Pylint global options and switches$",
         "Verbatim name of the checker is ``python3``",
         # messages
-        "^:old-octal-literal \(E1608\):",
+        "^:old-octal-literal \\(E1608\\):",
         # options
         "^:dummy-variables-rgx:",
     ]:


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior
