### PR TITLE
Docs refinement

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@
 Pylint's ChangeLog
 ------------------
 
-What's New in Pylint 2.0?
+What's New in Pylint 1.7?
 =========================
 
 Release date: tba

--- a/doc/development_guide/contribute.rst
+++ b/doc/development_guide/contribute.rst
@@ -88,7 +88,7 @@ your patch gets accepted.
 - Document your change, if it is a non-trivial one.
 
 - Send a pull request from GitHub (see `About pull requests`_ for more insight
-  abou this topic)
+  about this topic)
 
 
 Functional tests

--- a/doc/development_guide/contribute.rst
+++ b/doc/development_guide/contribute.rst
@@ -24,7 +24,7 @@ Note that if you don't find something you have expected in Pylint's
 issue tracker, it may be because it is an issue with one of its dependencies, namely
 astroid:
 
-* https://github.com/pycqa/astroid
+* https://github.com/PyCQA/astroid
 
 Mailing lists
 -------------
@@ -46,8 +46,8 @@ Pylint is developed using the git_ distributed version control system.
 
 You can clone Pylint and its dependencies from ::
 
-  git clone https://github.com/pycqa/pylint
-  git clone https://github.com/pycqa/astroid
+  git clone https://github.com/PyCQA/pylint
+  git clone https://github.com/PyCQA/astroid
 
 .. _git: https://git-scm.com/
 
@@ -82,11 +82,13 @@ your patch gets accepted.
 - Write a comprehensive commit message
 
 - Relate your change to an issue in the tracker if such an issue exists (see
-  `this page`_ of the GitHub documentation for more information on this)
+  `Closing issues via commit messages`_ of the GitHub documentation for more
+   information on this)
 
 - Document your change, if it is a non-trivial one.
 
-- Send a pull request from GitHub (more on this here_)
+- Send a pull request from GitHub (see `About pull requests`_ for more insight
+  abou this topic)
 
 
 Functional tests
@@ -123,6 +125,6 @@ current environment in order to have faster feedback. Run with::
 
     python pylint/test/test_functional.py
 
-.. _`this page`: https://help.github.com/articles/closing-issues-via-commit-messages/
-.. _here: https://help.github.com/articles/using-pull-requests/
+.. _`Closing issues via commit messages`: https://help.github.com/articles/closing-issues-via-commit-messages/
+.. _`About pull requests`: https://help.github.com/articles/using-pull-requests/
 .. _tox: http://tox.readthedocs.io/en/latest/

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -25,16 +25,16 @@ standard, and tries to enforce a coding style.
 2.1 How do I install Pylint?
 ----------------------------
 
-Everything should be explained on http://docs.pylint.org/installation
+Everything should be explained on http://pylint.readthedocs.io/en/latest/installation
 
 2.2 What kind of versioning system does Pylint use?
 ---------------------------------------------------
 
 Pylint uses the git distributed version control system. The URL of the
-repository is: https://github.com/pycqa/pylint . To get the latest version of
+repository is: https://github.com/PyCQA/pylint . To get the latest version of
 Pylint from the repository, simply invoke ::
 
-    git clone https://github.com/pycqa/pylint
+    git clone https://github.com/PyCQA/pylint
 
 .. _git: http://git-scm.com/
 
@@ -116,7 +116,7 @@ For example::
 3.4 I'd rather not run Pylint from the command line. Can I integrate it with my editor?
 ---------------------------------------------------------------------------------------
 
-Much probably. Read http://docs.pylint.org/ide-integration
+Much probably. Read http://pylint.readthedocs.io/en/latest/ide-integration
 
 4. Message Control
 ==================
@@ -226,9 +226,9 @@ above expression.
 6.2 I think I found a bug in Pylint. What should I do?
 -------------------------------------------------------
 
-Read http://docs.pylint.org/contribute#bug-reports-feedback
+Read http://pylint.readthedocs.io/en/latest/contribute#bug-reports-feedback
 
 6.3 I have a question about Pylint that isn't answered here.
 ------------------------------------------------------------
 
-Read http://docs.pylint.org/contribute#mailing-lists
+Read http://pylint.readthedocs.io/en/latest/contribute#mailing-lists


### PR DESCRIPTION
- Use correct capitalisation of PyCQA organisation in Github links
- Use current version number (1.7) in ChangeLog file
- Use readhedocs URL instead of outdated docs.pylint.org
- Avoid _here_ in links in favor of actual info on link we're pointing to (http://ux.stackexchange.com/questions/12100/why-shouldnt-we-use-words-such-as-here-and-this-in-textlinks)