### PR TITLE
FAQ: clarify that Pylint 1.7 is required when Py3.6 features are used

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -50,7 +50,9 @@ it is also working on PyPy.
 2.4 What versions of Python is Pylint supporting?
 --------------------------------------------------
 
-Since Pylint 1.4, we support only Python 2.7+ and Python 3.3+.
+Since Pylint 1.4, we support only Python 2.7+ and Python 3.3+. If code
+uses new Python 3.6 syntax, minimal required version is Pylint 1.7.
+
 Using this strategy really helps in maintaining a code base compatible
 with both versions and from this benefits not only the maintainers,
 but the end users as well, because it's easier to add and test


### PR DESCRIPTION
Closes #1399
