### PR TITLE
New warning: stopiteration-raised-in-gen

### DIFF
--- a/pylint/test/functional/stopiteration_raised_in_gen.py
+++ b/pylint/test/functional/stopiteration_raised_in_gen.py
@@ -1,0 +1,26 @@
+# pylint: disable=missing-docstring,invalid-name
+def gen1():
+    yield 1
+    yield 2
+    yield 3
+    raise StopIteration  # [stopiteration-raised-in-gen]
+
+
+def gen2():
+    g = gen1()
+    while True:
+        yield next(g)  # [stopiteration-raised-in-gen]
+
+
+def gen3():
+    g = gen1()
+    while True:
+        try:
+            yield next(g)
+        except StopIteration:
+            return
+
+
+def gen4():
+    for el in gen2():
+        yield el

--- a/pylint/test/functional/stopiteration_raised_in_gen.txt
+++ b/pylint/test/functional/stopiteration_raised_in_gen.txt
@@ -1,0 +1,2 @@
+stopiteration-raised-in-gen:6:gen1:StopIteration exception will be raised in generator. Use return statement to terminate generator early instead
+stopiteration-raised-in-gen:12:gen2:StopIteration exception will be raised in generator. Use return statement to terminate generator early instead

--- a/pylint/test/functional/stopiteration_raised_in_gen_py3.py
+++ b/pylint/test/functional/stopiteration_raised_in_gen_py3.py
@@ -1,0 +1,10 @@
+# pylint: disable=missing-docstring,invalid-name
+def gen1():
+    yield 1
+    yield 2
+    yield 3
+    raise StopIteration  # [stopiteration-raised-in-gen]
+
+
+def gen2():
+    yield from gen1()

--- a/pylint/test/functional/stopiteration_raised_in_gen_py3.rc
+++ b/pylint/test/functional/stopiteration_raised_in_gen_py3.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.3

--- a/pylint/test/functional/stopiteration_raised_in_gen_py3.txt
+++ b/pylint/test/functional/stopiteration_raised_in_gen_py3.txt
@@ -1,0 +1,1 @@
+stopiteration-raised-in-gen:6:gen1:StopIteration exception will be raised in generator. Use return statement to terminate generator early instead


### PR DESCRIPTION
- [x] initial implementation
- [ ] figure out relation between generators and async functions to unify warning across both cases
- [ ] add more tests
- [ ] add docs entries

