### PR TITLE
bad-whitespace checking around dotted type hint

### DIFF
--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -631,6 +631,8 @@ class FormatChecker(BaseTokenChecker):
             elif token[1] == ',':
                 if not bracket_level:
                     return False
+            elif token[1] == '.':
+                continue
             elif token[0] not in (tokenize.NAME, tokenize.STRING):
                 return False
         return False

--- a/pylint/test/unittest_checker_format.py
+++ b/pylint/test/unittest_checker_format.py
@@ -217,6 +217,7 @@ class TestCheckSpace(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.process_tokens(tokenize_str('foo(foo=bar)\n'))
             self.checker.process_tokens(tokenize_str('foo(foo: int = bar)\n'))
+            self.checker.process_tokens(tokenize_str('foo(foo: module.classname = bar)\n'))
             self.checker.process_tokens(tokenize_str('foo(foo: Dict[int, str] = bar)\n'))
             self.checker.process_tokens(tokenize_str('foo(foo: \'int\' = bar)\n'))
             self.checker.process_tokens(tokenize_str('foo(foo: Dict[int, \'str\'] = bar)\n'))


### PR DESCRIPTION
Fixes #1429 

### Fixes / new features
- Additional test and fix for bad-whitespace when type hint has a dot in it
