### PR TITLE
more readable --generate-rcfile output

### DIFF
--- a/pylint/test/test_self.py
+++ b/pylint/test/test_self.py
@@ -21,6 +21,7 @@ from pylint.reporters import BaseReporter
 from pylint.reporters.text import *
 from pylint.reporters.json import JSONReporter
 import pytest
+from pylint import utils
 
 HERE = abspath(dirname(__file__))
 
@@ -159,7 +160,7 @@ class TestRunTC(object):
         out = six.StringIO(output[master.start():])
         parser = six.moves.configparser.RawConfigParser()
         parser.readfp(out)
-        messages = parser.get('MESSAGES CONTROL', 'disable').split(",")
+        messages = utils._splitstrip(parser.get('MESSAGES CONTROL', 'disable'))
         assert 'suppressed-message' in messages
 
     def test_generate_rcfile_no_obsolete_methods(self):

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -1056,7 +1056,8 @@ def _splitstrip(string, sep=','):
     ['a', 'b', 'c', '4']
     >>> _splitstrip('a')
     ['a']
-    >>>
+    >>> _splitstrip('a,\nb,\nc,')
+    ['a', 'b', 'c']
 
     :type string: str or unicode
     :param string: a csv line
@@ -1164,6 +1165,12 @@ def _ini_format(stream, options, encoding):
             print('#%s=' % optname, file=stream)
         else:
             value = _encode(value, encoding).strip()
+            if re.match(r'^([\w-]+,)+[\w-]+$', str(value)):
+                separator = '\n ' + ' ' * len(optname)
+                value = separator.join(
+                    x + ',' for x in str(value).split(','))
+                # remove trailing ',' from last element of the list
+                value = value[:-1]
             print('%s=%s' % (optname, value), file=stream)
 
 format_section = _ini_format_section


### PR DESCRIPTION
makes list-like output in the 'MESSAGES CONTROL' section more
readable (one item per line).

With this PR the output of the 'disable' option looks as follows

```ini
# --disable=W"
disable=invalid-name,
        missing-docstring,
        too-many-lines,
        import-error,
        no-member,
        print-statement,
        parameter-unpacking,
        ....
```
I've restricted this improvement to the 'MESSAGES CONTROL' section, since the regular expressions in the 'BASIC' section shall not be changed.