### PR TITLE
Fix crash if coding with bad encoding goes after docstring fix

### DIFF
--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -23,7 +23,8 @@ MSGS = {
     'W0511': ('%s',
               'fixme',
               'Used when a warning note as FIXME or XXX is detected.'),
-    'W0512': ('Cannot decode using encoding "%s", unexpected byte at position %d',
+    'W0512': ('Cannot decode using encoding "%s",'
+              ' unexpected byte at position %d',
               'invalid-encoded-data',
               'Used when a source line cannot be decoded using the specified '
               'source file encoding.',
@@ -64,7 +65,8 @@ class EncodingChecker(BaseChecker):
         match = notes.search(line)
         if not match:
             return
-        self.add_message('fixme', args=line[match.start(1):].rstrip(), line=lineno)
+        self.add_message('fixme', args=line[match.start(1):].rstrip(),
+                         line=lineno)
 
     def _check_encoding(self, lineno, line, file_encoding):
         try:
@@ -72,6 +74,13 @@ class EncodingChecker(BaseChecker):
         except UnicodeDecodeError as ex:
             self.add_message('invalid-encoded-data', line=lineno,
                              args=(file_encoding, ex.args[2]))
+        except LookupError as ex:
+            if (line.startswith('#') and
+                    "coding" in line and file_encoding in line):
+                self.add_message('syntax-error',
+                                 line=lineno,
+                                 args='Cannot decode using encoding "{}",'
+                                      ' bad encoding'.format(file_encoding))
 
     def process_module(self, module):
         """inspect the source file to find encoding problem or fixmes like

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 import six
 from six.moves import zip
 
+from pylint.utils import safe_decode
 from pylint.interfaces import IRawChecker
 from pylint.checkers import BaseChecker, table_lines_from_stats
 from pylint.reporters.ureports.nodes import Table
@@ -36,7 +37,7 @@ class Similar(object):
         if encoding is None:
             readlines = stream.readlines
         else:
-            readlines = lambda: [line.decode(encoding) for line in stream]
+            readlines = lambda: [safe_decode(line, encoding) for line in stream]
         try:
             self.linesets.append(LineSet(streamid,
                                          readlines(),

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -28,6 +28,7 @@ import six
 from pylint.interfaces import ITokenChecker, IAstroidChecker
 from pylint.checkers import BaseTokenChecker
 from pylint.checkers.utils import check_messages
+from pylint.utils import safe_decode
 
 if sys.version_info[0] >= 3:
     maketrans = str.maketrans
@@ -251,8 +252,7 @@ class SpellingChecker(BaseTokenChecker):
         start_line = node.lineno + 1
         if six.PY2:
             encoding = node.root().file_encoding
-            docstring = docstring.decode(encoding or sys.getdefaultencoding(),
-                                         'replace')
+            docstring = safe_decode(docstring, encoding, 'replace')
 
         # Go through lines of docstring
         for idx, line in enumerate(docstring.splitlines()):

--- a/pylint/test/functional/invalid_encoding_py27.py
+++ b/pylint/test/functional/invalid_encoding_py27.py
@@ -1,0 +1,3 @@
+"""Test data file with wrong encoding and if coding is not first line."""
+# coding: utd-8 # [syntax-error]
+STR = 'some text'

--- a/pylint/test/functional/invalid_encoding_py27.rc
+++ b/pylint/test/functional/invalid_encoding_py27.rc
@@ -1,0 +1,2 @@
+[testoptions]
+max_pyver=3.0

--- a/pylint/test/functional/invalid_encoding_py27.txt
+++ b/pylint/test/functional/invalid_encoding_py27.txt
@@ -1,0 +1,1 @@
+syntax-error:2::Cannot decode using encoding "utd-8", bad encoding

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -118,9 +118,16 @@ def category_id(cid):
         return cid
     return MSG_TYPES_LONG.get(cid)
 
+def safe_decode(line, encoding, *args, **kwargs):
+    '''return decoded line from encoding or decode with default encoding'''
+    try:
+        return line.decode(encoding or sys.getdefaultencoding(), *args, **kwargs)
+    except LookupError:
+        return line.decode(sys.getdefaultencoding(), *args, **kwargs)
 
 def _decoding_readline(stream, encoding):
-    return lambda: stream.readline().decode(encoding, 'replace')
+    '''return lambda function for tokenize with safe decode'''
+    return lambda: safe_decode(stream.readline(), encoding, 'replace')
 
 
 def tokenize_module(module):


### PR DESCRIPTION
Resolve #1442 
* Create method for safe_decode in pylint/utils
* Write test for this test_case 'invalid_encoding2.7'
* Refactor all decode methods to safe_decode
* Add specific 'syntax-error' for this bug in checkers/misc

### Fixes / new features
- Fix crash if coding with bad encoding goes after docstring
