### PR TITLE
Make the help accurate: multiple modules are allowed

### DIFF
--- a/doc/user_guide/run.rst
+++ b/doc/user_guide/run.rst
@@ -7,9 +7,10 @@ Invoking Pylint
 
 Pylint is meant to be called from the command line. The usage is ::
 
-   pylint [options] module_or_package
+   pylint [options] modules_or_packages
 
-You should give Pylint the name of a python package or module. Pylint
+You should give Pylint the name of a python package or module, or some number
+of packages or modules. Pylint
 ``will not import`` this package or module, though uses Python internals
 to locate them and as such is subject to the same rules and configuration.
 You should pay attention to your ``PYTHONPATH``, since it is a common error

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -12,9 +12,9 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
-""" %prog [options] module_or_package
+""" %prog [options] modules_or_packages
 
-  Check that a module satisfies a coding standard (and more !).
+  Check that module(s) satisfy a coding standard (and more !).
 
     %prog --help
 


### PR DESCRIPTION
### Fixes / new features
- Improves the help description, to indicate that multiple modules or packages are allowed.
