### PR TITLE
Update message from len-as-condition checker to provide more detailed…

### DIFF
--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -634,10 +634,12 @@ class LenChecker(checkers.BaseChecker):
 
     # configuration section name
     name = 'len'
-    msgs = {'C1801': ('Do not use `len(SEQUENCE)` as condition value',
+    msgs = {'C1801': ('Do not use `len(SEQUENCE)` to determine if a sequence is empty',
                       'len-as-condition',
-                      'Used when Pylint detects incorrect use of len(sequence) inside '
-                      'conditions.'),
+                      'Used when Pylint detects that len(sequence) is being used inside '
+                      'a condition to determine if a sequence is empty. Instead of '
+                      'comparing the length to 0, rely on the fact that empty sequences '
+                      'are false.'),
            }
 
     priority = -2

--- a/pylint/test/functional/len_checks.txt
+++ b/pylint/test/functional/len_checks.txt
@@ -1,12 +1,12 @@
-len-as-condition:4::Do not use `len(SEQUENCE)` as condition value
-len-as-condition:7::Do not use `len(SEQUENCE)` as condition value
-len-as-condition:10::Do not use `len(SEQUENCE)` as condition value
-len-as-condition:12::Do not use `len(SEQUENCE)` as condition value
-len-as-condition:14::Do not use `len(SEQUENCE)` as condition value
-len-as-condition:17::Do not use `len(SEQUENCE)` as condition value
-len-as-condition:20::Do not use `len(SEQUENCE)` as condition value
-len-as-condition:26::Do not use `len(SEQUENCE)` as condition value
-len-as-condition:30::Do not use `len(SEQUENCE)` as condition value
-len-as-condition:43::Do not use `len(SEQUENCE)` as condition value
-len-as-condition:61:github_issue_1331_v2:Do not use `len(SEQUENCE)` as condition value
-len-as-condition:65:github_issue_1331_v3:Do not use `len(SEQUENCE)` as condition value
+len-as-condition:4::Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:7::Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:10::Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:12::Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:14::Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:17::Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:20::Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:26::Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:30::Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:43::Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:61:github_issue_1331_v2:Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:65:github_issue_1331_v3:Do not use `len(SEQUENCE)` to determine if a sequence is empty


### PR DESCRIPTION
Changes the message from the len-as-condition checker to be more specific about the fact that the thing to be avoided is using len(sequence) to check if sequence is empty or not. Also expands the help message to give a remedy (relying on the falseness of empty sequences).

Partially addresses #1405, although there were some calls in that issue for a larger discussion about whether this check should be enabled by default.
