### PR TITLE
Shebang has to be the first bytes of a file.

### DIFF
--- a/pylint/__main__.py
+++ b/pylint/__main__.py
@@ -1,7 +1,7 @@
+#!/usr/bin/env python
 
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
-#!/usr/bin/env python
 import pylint
 pylint.run_pylint()


### PR DESCRIPTION
This probably fixes nothing as `__main__.py` has no executable bit, maybe this file should just not have a shebang at all.