### PR TITLE
Implement a Python3 warning for declaring a method `next` method that would implement the Iterator protocol in Python 2 but not in Python 3.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,9 @@ What's New in Pylint 1.8?
     * Added a new Python 3 check for accessing removed fields from the types
       module like ``UnicodeType`` or ``XRangeType``
 
+    * Added a new Python 3 check for declaring a method ``next`` that would have
+      been treated as an iterator in Python 2 but a normal function in Python 3.
+
 What's New in Pylint 1.7.1?
 =========================
 

--- a/doc/whatsnew/1.8.rst
+++ b/doc/whatsnew/1.8.rst
@@ -40,3 +40,23 @@ Summary -- Release highlights
   .. code-block:: python
 
       print(isinstance([], list))
+
+* A new Python 3 checker was added to warn about declaring a ``next`` method that
+  would have implemented the ``Iterator`` protocol in Python 2 but is now a normal
+  method in Python 3.
+
+  .. code-block:: python
+
+      class Foo(object):
+          def next(self):
+              return 42
+
+  Instead implement a ``__next__`` method and use ``six.Iterator`` as a base class
+  or alias ``next`` to ``__next__``:
+
+  .. code-block:: python
+
+      class Foo(object):
+          def __next__(self):
+              return 42
+          next = __next__

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -798,6 +798,58 @@ class TestPython3Checker(testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.walk(module)
 
+    @python2_only
+    def test_next_defined(self):
+        node = astroid.extract_node("""
+            class Foo(object):
+                def next(self):  #@
+                    pass""")
+        message = testutils.Message('next-method-defined', node=node)
+        with self.assertAddsMessages(message):
+            self.checker.visit_functiondef(node)
+
+    @python2_only
+    def test_next_defined_too_many_args(self):
+        node = astroid.extract_node("""
+            class Foo(object):
+                def next(self, foo=None):  #@
+                    pass""")
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
+
+    @python2_only
+    def test_next_defined_static_method_too_many_args(self):
+        node = astroid.extract_node("""
+            class Foo(object):
+                @staticmethod
+                def next(self):  #@
+                    pass""")
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
+
+    @python2_only
+    def test_next_defined_static_method(self):
+        node = astroid.extract_node("""
+            class Foo(object):
+                @staticmethod
+                def next():  #@
+                    pass""")
+        message = testutils.Message('next-method-defined', node=node)
+        with self.assertAddsMessages(message):
+            self.checker.visit_functiondef(node)
+
+    @python2_only
+    def test_next_defined_class_method(self):
+        node = astroid.extract_node("""
+            class Foo(object):
+                @classmethod
+                def next(cls):  #@
+                    pass""")
+        message = testutils.Message('next-method-defined', node=node)
+        with self.assertAddsMessages(message):
+            self.checker.visit_functiondef(node)
+
+
 @python2_only
 class TestPython3TokenChecker(testutils.CheckerTestCase):
 


### PR DESCRIPTION
In Python 2 implementing a no argument instance method `next` would implement the Iterator protocol, allowing the class to be used
with `next()` or a `for` loop.  In Python 3 this is now `__next__`.