### PR TITLE
Fix for detecting NameError

### DIFF
--- a/pylint/test/functional/used_before_assignment_CR18660.py
+++ b/pylint/test/functional/used_before_assignment_CR18660.py
@@ -1,0 +1,8 @@
+"""checking pylint question"""
+# pylint: disable=invalid-name
+needed = False
+
+if needed:
+    test1 = "appelflap"
+else:
+    test1['somekey'] = 1234 # [used-before-assignment]

--- a/pylint/test/functional/used_before_assignment_CR18660.txt
+++ b/pylint/test/functional/used_before_assignment_CR18660.txt
@@ -1,0 +1,1 @@
+used-before-assignment:8::Using variable 'test1' before assignment

--- a/pylint/test/functional/used_before_assignment_CR18660_2.py
+++ b/pylint/test/functional/used_before_assignment_CR18660_2.py
@@ -1,0 +1,10 @@
+"""checking pylint question"""
+# pylint: disable=invalid-name,using-constant-test
+needed = False
+
+if needed:
+    test1 = "appelflap"
+elif True:
+    test1['test'] = 1234 # [used-before-assignment]
+else:
+    test1['somekey'] = 1234

--- a/pylint/test/functional/used_before_assignment_CR18660_2.txt
+++ b/pylint/test/functional/used_before_assignment_CR18660_2.txt
@@ -1,0 +1,1 @@
+used-before-assignment:8::Using variable 'test1' before assignment


### PR DESCRIPTION
### Fixes / new features
- Added check for NameError when a variable is defined in another branch

This concerns the following example
```
needed = False

if needed:
    test1 = "appelflap"
else:
    test1['somekey'] = 1234
```

Running this in a Python interpreter results in:
> NameError: name 'test1' is not defined
This fix let's Pylint detect this problem.

The fix was made based on pylint 1.6.4, since this is the person who reported this problem was using, but it can be merged quite easily to later versions as well. It includes tests and passes all existing tests.