### PR TITLE
Do not warn for locally disabled cyclic import checks

### DIFF
--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -675,7 +675,7 @@ class ImportsChecker(BaseChecker):
 
             # update import graph
             self.import_graph[context_name].add(importedmodname)
-            if not self.linter.is_message_enabled('cyclic-import'):
+            if not self.linter.is_message_enabled('cyclic-import', line=node.lineno):
                 self._excluded_edges[context_name].add(importedmodname)
 
     def _check_deprecated_module(self, node, mod_path):

--- a/pylint/test/input/func_w0401_disabled_in_func.py
+++ b/pylint/test/input/func_w0401_disabled_in_func.py
@@ -1,0 +1,11 @@
+"""Test disabling of cyclic import check inside a function
+"""
+# pylint: disable=no-absolute-import
+from __future__ import print_function
+
+
+def func():
+    """Test disabling of cyclic import check inside a function"""
+    from . import w0401_cycle  # pylint: disable=cyclic-import
+    if w0401_cycle:
+        print(w0401_cycle)

--- a/pylint/test/messages/func_w0401_disabled.txt
+++ b/pylint/test/messages/func_w0401_disabled.txt
@@ -1,1 +1,2 @@
 W:  8: Using a conditional statement with a constant value
+W:  8: Using a conditional statement with a constant value

--- a/pylint/test/messages/func_w0401_disabled_in_func.txt
+++ b/pylint/test/messages/func_w0401_disabled_in_func.txt
@@ -1,0 +1,2 @@
+W:  8: Using a conditional statement with a constant value
+W: 10:func: Using a conditional statement with a constant value

--- a/pylint/test/messages/func_w0401_package.txt
+++ b/pylint/test/messages/func_w0401_package.txt
@@ -1,1 +1,2 @@
 R:  1: Cyclic import (input.func_w0401_package.all_the_things -> input.func_w0401_package.thing2)
+W:  8: Using a conditional statement with a constant value

--- a/pylint/test/test_func.py
+++ b/pylint/test/test_func.py
@@ -115,7 +115,7 @@ def gen_tests(filter_rgx):
     ):
         if not is_to_run(module_file) or module_file.endswith(('.pyc', "$py.class")):
             continue
-        base = module_file.replace('func_', '').replace('.py', '')
+        base = module_file.replace('.py', '').split('_')[1]
         dependencies = _get_tests_info(INPUT_DIR, MSG_DIR, base, '.py')
         tests.append((module_file, messages_file, dependencies))
 
@@ -126,8 +126,9 @@ def gen_tests(filter_rgx):
     return tests
 
 
-@pytest.mark.parametrize("module_file,messages_file,dependencies", gen_tests(FILTER_RGX))
-def test_functionality(module_file, messages_file, dependencies):
+@pytest.mark.parametrize("module_file,messages_file,dependencies", gen_tests(FILTER_RGX),
+                         ids=[o[0] for o in gen_tests(FILTER_RGX)])
+def test_functionality(module_file, messages_file, dependencies,):
 
     LT = LintTestUpdate() if UPDATE else LintTestUsingModule()
 


### PR DESCRIPTION
Since commit 7df8caaa3e1995018417ac2fd87afd89be6945ba,
the "# pylint: disable=cyclic-import" statment is
respected.

One case which was not covered is the disabling of the
check for an import from inside a method/function.

Example:

File test1.py
> class B(object):
>     pass
>
> def function():
>     from . import test2  # pylint: disable=cyclic-import
>     pass

File test2.py
> from . import test1
>
> class A(object):
>     pass

Pylint wrongly reports:
Cyclic import (testfolder.test1 -> testfolder.test2) (cyclic-import)

This is due to the fact that the self._excluded_edges
dict was not filled with the imports that need to be
excluded. Passing the line number to the
self.linter.is_message_enabled() check allows to not
prematurely return due to the line number being None.
