### PR TITLE
More intelligent property docstring checking

### DIFF
--- a/doc/whatsnew/1.8.rst
+++ b/doc/whatsnew/1.8.rst
@@ -60,3 +60,27 @@ Summary -- Release highlights
           def __next__(self):
               return 42
           next = __next__
+
+* The docparams extension now allows a property docstring to document both
+  the property and the setter. Therefore setters can also have no docstring.
+
+* The docparams extension now understands property type syntax.
+
+  .. code-block:: python
+
+      class Foo(object):
+          @property
+          def foo(self):
+              """My Sphinx style docstring description.
+
+              :type: int
+              """
+              return 10
+
+  .. code-block:: python
+
+    class Foo(object):
+        @property
+        def foo(self):
+            """int: My Numpy and Google docstring style description."""
+            return 10

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -295,7 +295,8 @@ class SphinxDocstring(Docstring):
         return bool(self.re_param_in_docstring.search(self.doc) or
                     self.re_raise_in_docstring.search(self.doc) or
                     self.re_rtype_in_docstring.search(self.doc) or
-                    self.re_returns_in_docstring.search(self.doc))
+                    self.re_returns_in_docstring.search(self.doc) or
+                    self.re_property_type_in_docstring.search(self.doc))
 
     def exceptions(self):
         types = set()
@@ -318,7 +319,7 @@ class SphinxDocstring(Docstring):
 
         # If this is a property docstring, the summary is the return doc.
         if self.re_property_type_in_docstring.search(self.doc):
-            first_line = self.doc.lsplit().split('\n', 1)[0]
+            first_line = self.doc.lstrip().split('\n', 1)[0]
             # The summary line is the first line without a directive.
             return not first_line.startswith(':')
 
@@ -456,7 +457,8 @@ class GoogleDocstring(Docstring):
         return bool(self.re_param_section.search(self.doc) or
                     self.re_raise_section.search(self.doc) or
                     self.re_returns_section.search(self.doc) or
-                    self.re_yields_section.search(self.doc))
+                    self.re_yields_section.search(self.doc) or
+                    self.re_property_returns_line.search(self._first_line()))
 
     def has_params(self):
         if not self.doc:
@@ -478,8 +480,7 @@ class GoogleDocstring(Docstring):
             if return_desc:
                 return True
 
-        first_line = self.doc.lstrip().split('\n', 1)[0]
-        return bool(self.re_property_returns_line.match(first_line))
+        return bool(self.re_property_returns_line.match(self._first_line()))
 
     def has_rtype(self):
         if not self.doc:
@@ -495,8 +496,7 @@ class GoogleDocstring(Docstring):
             if return_type:
                 return True
 
-        first_line = self.doc.lstrip().split('\n', 1)[0]
-        return bool(self.re_property_returns_line.match(first_line))
+        return bool(self.re_property_returns_line.match(self._first_line()))
 
     def has_yields(self):
         if not self.doc:
@@ -566,6 +566,9 @@ class GoogleDocstring(Docstring):
                 params_with_doc.add(param_name)
 
         return params_with_doc, params_with_type
+
+    def _first_line(self):
+        return self.doc.lstrip().split('\n', 1)[0]
 
     @staticmethod
     def min_section_indent(section_match):

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -193,6 +193,13 @@ class DocstringParameterChecker(BaseChecker):
         if not expected_excs:
             return
 
+        if not func_node.doc:
+            # If this is a property setter,
+            # the property should have the docstring instead.
+            property_ = utils.get_setters_property(func_node)
+            if property_:
+                func_node = property_
+
         doc = utils.docstringify(func_node.doc)
         if not doc.is_valid():
             if doc.doc:

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -14,7 +14,7 @@ import astroid
 
 from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
-from pylint.checkers.utils import node_frame_class
+from pylint.checkers import utils as checker_utils
 import pylint.extensions._check_docs_utils as utils
 
 
@@ -139,7 +139,7 @@ class DocstringParameterChecker(BaseChecker):
     def check_functiondef_params(self, node, node_doc):
         node_allow_no_param = None
         if node.name in self.constructor_names:
-            class_node = node_frame_class(node)
+            class_node = checker_utils.node_frame_class(node)
             if class_node is not None:
                 class_doc = utils.docstringify(class_node.doc)
                 self.check_single_constructor_params(class_doc, node_doc, class_node)
@@ -222,13 +222,17 @@ class DocstringParameterChecker(BaseChecker):
         if not doc.is_valid() and self.config.accept_no_return_doc:
             return
 
-        if not doc.has_returns():
+        is_property = checker_utils.decorated_with_property(func_node)
+
+        if not (doc.has_returns() or
+                (doc.has_property_returns() and is_property)):
             self.add_message(
                 'missing-return-doc',
                 node=func_node
             )
 
-        if not doc.has_rtype():
+        if not (doc.has_rtype() or
+                (doc.has_property_type() and is_property)):
             self.add_message(
                 'missing-return-type-doc',
                 node=func_node

--- a/pylint/test/extensions/test_check_docs.py
+++ b/pylint/test/extensions/test_check_docs.py
@@ -1337,3 +1337,18 @@ class TestParamDocChecker(CheckerTestCase):
         ''')
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
+
+    def test_finds_short_name_exception(self):
+        node = astroid.extract_node('''
+        from fake_package import BadError
+
+        def do_something(): #@
+            """Do something.
+
+            Raises:
+                ~fake_package.exceptions.BadError: When something bad happened.
+            """
+            raise BadError("A bad thing happened.")
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)

--- a/pylint/test/extensions/test_check_docs.py
+++ b/pylint/test/extensions/test_check_docs.py
@@ -1623,15 +1623,12 @@ class TestParamDocChecker(CheckerTestCase):
         """)
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-return-doc',
-                node=property_node),
-            Message(
                 msg_id='missing-return-type-doc',
                 node=property_node),
         ):
             self.checker.visit_return(node)
 
-    def test_finds_property_return_type_google(self):
+    def test_finds_missing_property_return_type_google(self):
         """Example of a property having return documentation in
         a Google style docstring
         """
@@ -1649,15 +1646,12 @@ class TestParamDocChecker(CheckerTestCase):
         """)
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-return-doc',
-                node=property_node),
-            Message(
                 msg_id='missing-return-type-doc',
                 node=property_node),
         ):
             self.checker.visit_return(node)
 
-    def test_finds_property_return_type_numpy(self):
+    def test_finds_missing_property_return_type_numpy(self):
         """Example of a property having return documentation in
         a numpy style docstring
         """
@@ -1677,10 +1671,82 @@ class TestParamDocChecker(CheckerTestCase):
         """)
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-return-doc',
-                node=property_node),
-            Message(
                 msg_id='missing-return-type-doc',
                 node=property_node),
+        ):
+            self.checker.visit_return(node)
+
+    def test_ignores_non_property_return_type_sphinx(self):
+        """Example of a class function trying to use `type` as return
+        documentation in a Sphinx style docstring
+        """
+        func_node, node = astroid.extract_node("""
+        class Foo(object):
+            def foo(self): #@
+                '''docstring ...
+
+                :type: int
+                '''
+                return 10 #@
+        """)
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-return-doc',
+                node=func_node),
+            Message(
+                msg_id='missing-return-type-doc',
+                node=func_node),
+        ):
+            self.checker.visit_return(node)
+
+    def test_ignores_non_property_return_type_google(self):
+        """Example of a class function trying to use `type` as return
+        documentation in a Google style docstring
+        """
+        func_node, node = astroid.extract_node("""
+        class Foo(object):
+            def foo(self): #@
+                '''int: docstring ...
+
+                Raises:
+                    RuntimeError: Always
+                '''
+                raise RuntimeError()
+                return 10 #@
+        """)
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-return-doc',
+                node=func_node),
+            Message(
+                msg_id='missing-return-type-doc',
+                node=func_node),
+        ):
+            self.checker.visit_return(node)
+
+    def test_ignores_non_property_return_type_numpy(self):
+        """Example of a class function trying to use `type` as return
+        documentation in a numpy style docstring
+        """
+        func_node, node = astroid.extract_node("""
+        class Foo(object):
+            def foo(self): #@
+                '''int: docstring ...
+
+                Raises
+                ------
+                RuntimeError
+                    Always
+                '''
+                raise RuntimeError()
+                return 10 #@
+        """)
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-return-doc',
+                node=func_node),
+            Message(
+                msg_id='missing-return-type-doc',
+                node=func_node),
         ):
             self.checker.visit_return(node)


### PR DESCRIPTION
### Fixes / new features
- Properties can use the new property type syntax.
- Property setters without a docstring can use the relevant property docstring to search for missing raises documentation.

Fixes #1125