### PR TITLE
Fix spelling checker

### DIFF
--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -69,7 +69,7 @@ class CamelCasedWord(Filter):
 
     That is, any words that are camelCasedWords.
     """
-    _pattern = re.compile(r"^([a-z]\w+[A-Z]+\w+)")
+    _pattern = re.compile(r"^([a-z]+[A-Z]+\w+)")
     def _skip(self, word):
         if self._pattern.match(word):
             return True

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -76,6 +76,22 @@ class CamelCasedWord(Filter):
         return False
 
 
+class SphinxDicrectives(Filter):
+    r"""Filter skipping over Sphinx Directives.
+    This filter skips any words matching the following regular expression:
+
+           ^:([a-z]+):`([^`]+)(`)?
+
+    That is, for example, :class:`BaseQuery`
+    """
+    # The final ` in the pattern is optional because enchant strips it out
+    _pattern = re.compile(r"^:([a-z]+):`([^`]+)(`)?")
+    def _skip(self, word):
+        if self._pattern.match(word):
+            return True
+        return False
+
+
 
 class SpellingChecker(BaseTokenChecker):
     """Check spelling in comments and docstrings"""
@@ -155,7 +171,8 @@ class SpellingChecker(BaseTokenChecker):
                                                            WikiWordFilter,
                                                            WordsWithDigigtsFilter,
                                                            WordsWithUnderscores,
-                                                           CamelCasedWord])
+                                                           CamelCasedWord,
+                                                           SphinxDicrectives])
         self.initialized = True
 
     def close(self):

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -78,7 +78,7 @@ class CamelCasedWord(Filter):
 
     That is, any words that are camelCasedWords.
     """
-    _pattern = re.compile(r"^([a-z]+[A-Z]+\w+)")
+    _pattern = re.compile(r"^([a-z]+[A-Z]\w+|[a-z]\w+[A-Z]+)")
     def _skip(self, word):
         if self._pattern.match(word):
             return True

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -180,13 +180,17 @@ class SpellingChecker(BaseTokenChecker):
             self.private_dict_file.close()
 
     def _check_spelling(self, msgid, line, line_num):
+        original_line = line
+        if line.strip().startswith('#'):
+            line = line.strip()[1:]
+            starts_with_comment = True
+        else:
+            starts_with_comment = False
         for word, _ in self.tokenizer(line.strip()):
-
-            try:
-                lower_cased_word = word.casefold()
-            except AttributeError:
-                # Python 2
+            if six.PY2:
                 lower_cased_word = word.lower()
+            else:
+                lower_cased_word = word.casefold()
 
             # Skip words from ignore list.
             if word in self.ignore_list or lower_cased_word in self.ignore_list:
@@ -229,10 +233,13 @@ class SpellingChecker(BaseTokenChecker):
                     col = m.regs[2][0]
                 else:
                     col = line.index(word)
+
+                if starts_with_comment:
+                    col += 1
                 indicator = (" " * col) + ("^" * len(word))
 
                 self.add_message(msgid, line=line_num,
-                                 args=(word, line,
+                                 args=(word, original_line,
                                        indicator,
                                        "'{0}'".format("' or '".join(suggestions))))
 

--- a/pylint/test/unittest_checker_spelling.py
+++ b/pylint/test/unittest_checker_spelling.py
@@ -144,14 +144,25 @@ class TestSpellingChecker(CheckerTestCase):
                           '                     ^^^^^^',
                           "'{0}'".format("' or '".join(suggestions))))):
             self.checker.visit_classdef(stmt)
-        # With just a single lower case letter followed by upper cased
 
+        # With just a single upper case letter in the end
         stmt = astroid.extract_node(
-            'class ComentAbc(object):\n   """cProfile with a bad coment"""\n   pass')
+            'class ComentAbc(object):\n   """argumentN with a bad coment"""\n   pass')
         with self.assertAddsMessages(
             Message('wrong-spelling-in-docstring', line=2,
-                    args=('coment', 'cProfile with a bad coment',
-                          '                    ^^^^^^',
+                    args=('coment', 'argumentN with a bad coment',
+                          '                     ^^^^^^',
+                          "'{0}'".format("' or '".join(suggestions))))):
+            self.checker.visit_classdef(stmt)
+
+        # With just a single lower and upper case letter is not good
+        suggestions = self.checker.spelling_dict.suggest('zN')[:4]
+        stmt = astroid.extract_node(
+            'class ComentAbc(object):\n   """zN with a bad comment"""\n   pass')
+        with self.assertAddsMessages(
+            Message('wrong-spelling-in-docstring', line=2,
+                    args=('zN', 'zN with a bad comment',
+                          '^^',
                           "'{0}'".format("' or '".join(suggestions))))):
             self.checker.visit_classdef(stmt)
 

--- a/pylint/test/unittest_checker_spelling.py
+++ b/pylint/test/unittest_checker_spelling.py
@@ -121,13 +121,26 @@ class TestSpellingChecker(CheckerTestCase):
 
     @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
-    def test_skip_camel_cased_words(self):
+    def test_skip_wiki_words(self):
         suggestions = self.checker.spelling_dict.suggest('coment')[:4]
         stmt = astroid.extract_node(
             'class ComentAbc(object):\n   """ComentAbc with a bad coment"""\n   pass')
         with self.assertAddsMessages(
             Message('wrong-spelling-in-docstring', line=2,
                     args=('coment', 'ComentAbc with a bad coment',
+                          '                     ^^^^^^',
+                          "'{0}'".format("' or '".join(suggestions))))):
+            self.checker.visit_classdef(stmt)
+
+    @skip_on_missing_package_or_dict
+    @set_config(spelling_dict=spell_dict)
+    def test_skip_camel_cased_words(self):
+        suggestions = self.checker.spelling_dict.suggest('coment')[:4]
+        stmt = astroid.extract_node(
+            'class ComentAbc(object):\n   """comentAbc with a bad coment"""\n   pass')
+        with self.assertAddsMessages(
+            Message('wrong-spelling-in-docstring', line=2,
+                    args=('coment', 'comentAbc with a bad coment',
                           '                     ^^^^^^',
                           "'{0}'".format("' or '".join(suggestions))))):
             self.checker.visit_classdef(stmt)

--- a/pylint/test/unittest_checker_spelling.py
+++ b/pylint/test/unittest_checker_spelling.py
@@ -144,6 +144,16 @@ class TestSpellingChecker(CheckerTestCase):
                           '                     ^^^^^^',
                           "'{0}'".format("' or '".join(suggestions))))):
             self.checker.visit_classdef(stmt)
+        # With just a single lower case letter followed by upper cased
+
+        stmt = astroid.extract_node(
+            'class ComentAbc(object):\n   """cProfile with a bad coment"""\n   pass')
+        with self.assertAddsMessages(
+            Message('wrong-spelling-in-docstring', line=2,
+                    args=('coment', 'cProfile with a bad coment',
+                          '                    ^^^^^^',
+                          "'{0}'".format("' or '".join(suggestions))))):
+            self.checker.visit_classdef(stmt)
 
     @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)

--- a/pylint/test/unittest_checker_spelling.py
+++ b/pylint/test/unittest_checker_spelling.py
@@ -187,3 +187,15 @@ class TestSpellingChecker(CheckerTestCase):
                           '                                      ^^^^^^',
                           "'{0}'".format("' or '".join(suggestions))))):
             self.checker.visit_classdef(stmt)
+
+    @skip_on_missing_package_or_dict
+    @set_config(spelling_dict=spell_dict)
+    def test_handle_words_joined_by_forward_slash(self):
+        stmt = astroid.extract_node(
+                'class ComentAbc(object):\n   """This is Comment/Abcz with a bad comment"""\n   pass')
+        with self.assertAddsMessages(
+            Message('wrong-spelling-in-docstring', line=2,
+                    args=('Abcz', 'This is Comment/Abcz with a bad comment',
+                          '                ^^^^',
+                          "'ABC'"))):
+            self.checker.visit_classdef(stmt)


### PR DESCRIPTION
### Fixes / new features
* Remove dead code
* Do not lowercase words prior to spell checking them, "unicode" is a spelling mistake, "Unicode" is not.
* Add a "camelCaseWord" filter because some projects use those as parameter names and we should throw a spelling mistake on those if commented out for example.
