### PR TITLE
Un-deprecate inspect.getfullargspec

### DIFF
--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -165,7 +165,7 @@ class StdlibChecker(BaseChecker):
             ],
             (3, 5, 0): [
                 'fractions.gcd',
-                'inspect.getfullargspec', 'inspect.getargvalues',
+                'inspect.getargvalues',
                 'inspect.formatargspec', 'inspect.formatargvalues',
                 'inspect.getcallargs',
                 'platform.linux_distribution', 'platform.dist',


### PR DESCRIPTION
The inspect.getfullargspec() command was un-deprecated in Python 3.6, so it should be removed from the deprecated list.
https://docs.python.org/3/library/inspect.html#inspect.getfullargspec

### Fixes / new features
- Remove getfullargspec from the 'deprecated' list
