### PR TITLE
import-error now is correctly emitted for import nodes when lower level messages are disabled

### DIFF
--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -372,8 +372,7 @@ class ImportsChecker(BaseChecker):
             for cycle in get_cycles(graph, vertices=vertices):
                 self.add_message('cyclic-import', args=' -> '.join(cycle))
 
-    @check_messages('wrong-import-position', 'multiple-imports',
-                    'relative-import', 'reimported', 'deprecated-module')
+    @check_messages(*MSGS.keys())
     def visit_import(self, node):
         """triggered when an import statement is seen"""
         self._check_reimport(node)

--- a/pylint/test/functional/import_error.rc
+++ b/pylint/test/functional/import_error.rc
@@ -1,0 +1,2 @@
+[Messages Control]
+disable=C,R,W


### PR DESCRIPTION
Closes #1533