### PR TITLE
Unskip two functional tests skipped by mistake

### DIFF
--- a/pylint/test/functional/iterable_context_py2.rc
+++ b/pylint/test/functional/iterable_context_py2.rc
@@ -1,3 +1,2 @@
 [testoptions]
-max_pyver=2.7
-
+max_pyver=3.0

--- a/pylint/test/functional/mapping_context_py2.py
+++ b/pylint/test/functional/mapping_context_py2.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring,invalid-name,too-few-public-methods
+# pylint: disable=missing-docstring,invalid-name,too-few-public-methods,no-self-use,bad-mcs-method-argument
 from __future__ import print_function
 
 

--- a/pylint/test/functional/mapping_context_py2.rc
+++ b/pylint/test/functional/mapping_context_py2.rc
@@ -1,3 +1,2 @@
 [testoptions]
-max_pyver=2.7
-
+max_pyver=3.0


### PR DESCRIPTION
max_pyver=2.7 caused tests to be not run on Python 2.7.x