### PR TITLE
Allow importing `stat` in Python 3, Disallow `sets`

### DIFF
--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -499,8 +499,8 @@ class Python3Checker(checkers.BaseChecker):
             'Bastion', 'bsddb185', 'bsddb3', 'Canvas', 'cfmfile', 'cl', 'commands', 'compiler',
             'dircache', 'dl', 'exception', 'fpformat', 'htmllib', 'ihooks', 'imageop', 'imputil',
             'linuxaudiodev', 'md5', 'mhlib', 'mimetools', 'MimeWriter', 'mimify', 'multifile',
-            'mutex', 'new', 'popen2', 'posixfile', 'pure', 'rexec', 'rfc822', 'sha', 'sgmllib',
-            'sre', 'stringold', 'sunaudio', 'sv', 'test.testall', 'thread', 'timing',
+            'mutex', 'new', 'popen2', 'posixfile', 'pure', 'rexec', 'rfc822', 'sets', 'sha',
+            'sgmllib', 'sre', 'stringold', 'sunaudio', 'sv', 'test.testall', 'thread', 'timing',
             'toaiff', 'user', 'urllib2', 'urlparse'
         ]),
         'deprecated-string-function': {


### PR DESCRIPTION
A previous document I based this list off of was incorrect.