### PR TITLE
Warn when raising an exception with a format string and some arguments

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -135,3 +135,5 @@ Order doesn't matter (not that much, at least ;)
 * Petr Pulc: require whitespace around annotations
 
 * John Paraskevopoulos: add 'differing-param-doc' and 'differing-type-doc'
+
+* Martin von Gagern (Google): Added 'raising-format-tuple' warning.

--- a/ChangeLog
+++ b/ChangeLog
@@ -40,6 +40,9 @@ What's New in Pylint 1.8?
       and the value is the message id.
       Close #1512
 
+    * Added a new warning, ``raising-format-tuple``, to detect multi-argument
+      exception construction instead of message string formatting.
+
 What's New in Pylint 1.7.1?
 =========================
 

--- a/doc/whatsnew/1.8.rst
+++ b/doc/whatsnew/1.8.rst
@@ -89,6 +89,27 @@ New checkers
      d.items()[0]
      d.values() + d.keys()
 
+* A new warning, ``raising-format-tuple``, will catch situations where the
+  intent was likely raising an exception with a formatted message string,
+  but the actual code did omit the formatting and instead passes template
+  string and value parameters as separate arguments to the exception
+  constructor.  So it detects things like
+
+  .. code-block:: python
+
+      raise SomeError('message about %s', foo)
+      raise SomeError('message about {}', foo)
+
+  which likely were meant instead as
+
+  .. code-block:: python
+
+      raise SomeError('message about %s' % foo)
+      raise SomeError('message about {}'.format(foo))
+
+  This warning can be ignored on projects which deliberately use lazy
+  formatting of messages in all user-facing exception handlers.
+
 
 
 Other Changes

--- a/pylint/test/functional/raising_format_tuple.py
+++ b/pylint/test/functional/raising_format_tuple.py
@@ -1,0 +1,46 @@
+'''
+Complain about multi-argument exception constructors where the first argument
+contains a percent sign, thus suggesting a % string formatting was intended
+instead.  The same holds for a string containing {...} suggesting str.format()
+was intended.
+'''
+
+def bad_percent(arg):
+    '''Raising a percent-formatted string and an argument'''
+    raise KeyError('Bad key: %r', arg)  # [raising-format-tuple]
+
+def good_percent(arg):
+    '''Instead of passing multiple arguments, format the message'''
+    raise KeyError('Bad key: %r' % arg)
+
+def bad_multiarg(name, value):
+    '''Raising a formatted string and multiple additional arguments'''
+    raise ValueError('%s measures %.2f', name, value)  # [raising-format-tuple]
+
+def good_multiarg(name, value):
+    '''The arguments have to be written as a tuple for formatting'''
+    raise ValueError('%s measures %.2f' % (name, value))
+
+def bad_braces(arg):
+    '''Curly braces as placeholders'''
+    raise KeyError('Bad key: {:r}', arg)  # [raising-format-tuple]
+
+def good_braces(arg):
+    '''Call str.format() instead'''
+    raise KeyError('Bad key: {:r}'.format(arg))
+
+def bad_multistring(arg):
+    '''Multiple adjacent string literals'''
+    raise AssertionError(  # [raising-format-tuple]
+        'Long message about %s '
+        "split over several adjacent literals", arg)
+
+def bad_triplequote(arg):
+    '''String literals with triple quotes'''
+    raise AssertionError(  # [raising-format-tuple]
+        '''Long message about %s
+        split over several adjacent literals''', arg)
+
+def bad_unicode(arg):
+    '''Unicode string literal'''
+    raise ValueError(u'Bad %s', arg)  # [raising-format-tuple]

--- a/pylint/test/functional/raising_format_tuple.txt
+++ b/pylint/test/functional/raising_format_tuple.txt
@@ -1,0 +1,6 @@
+raising-format-tuple:10:bad_percent:Arguments to KeyError suggest string formatting might be intended
+raising-format-tuple:18:bad_multiarg:Arguments to ValueError suggest string formatting might be intended
+raising-format-tuple:26:bad_braces:Arguments to KeyError suggest string formatting might be intended
+raising-format-tuple:34:bad_multistring:Arguments to AssertionError suggest string formatting might be intended
+raising-format-tuple:40:bad_triplequote:Arguments to AssertionError suggest string formatting might be intended
+raising-format-tuple:46:bad_unicode:Arguments to ValueError suggest string formatting might be intended


### PR DESCRIPTION
Bad (now causing a new warning):
*  `raise SomeError('message about %s', foo)`
*  `raise SomeError('message about {}', foo)`

Good (likely intended):
*  `raise SomeError('message about %s' % foo)`
*  `raise SomeError('message about {}'.format(foo))`

People used to `printf` in C might accidentally write a comma to separate a
message format containing `%` placeholders from the arguments to substitute,
instead of the `%` sign required to actually do the formatting and build the
error message as a single string.  But even when using `{…}` as a placeholder,
some libraries will prefer deferred evaluation for e.g. logging calls, so a
user might have a habit of using commas instead of a `str.format()` call for
those, too.  This warning points out such use cases.  It can be ignored on
projects which deliberately use lazy formatting at all user-facing exception
handlers.

### Fixes / new features
- New warning for multi-argument exception construction with string literal containing placeholders followed by additional arguments