### PR TITLE
Run tests on Python 2.7.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
+    - python: 2.7.6
+      env: TOXENV=py27
+      # This is used by Ubuntu Trusty
     - python: 3.3
       env: TOXENV=py33
     - python: 3.4

--- a/pylint/test/functional/invalid_encoding_py27.rc
+++ b/pylint/test/functional/invalid_encoding_py27.rc
@@ -1,2 +1,3 @@
 [testoptions]
+min_pyver=2.7.10
 max_pyver=3.0


### PR DESCRIPTION
## Motivation
As I have to develop on Ubuntu Trusty occasionally, I would appreciate tests not failing there by default as they currently do. To achieve this I'd skip one test for extremely old Python versions, and add Python 2.7.6 to the Travis build matrix.

See https://travis-ci.org/gagern/pylint/jobs/253033100 for a failing Travis run using that version.

## Bug report
This PR is a bug report and bug fix in one. So here is the bug report part.

### Steps to reproduce
Run functional test suite using Python 2.7.6 as shipped by Ubuntu Trusty

### Current behavior
Functional test `invalid_encoding_py27` fails because error is reported in line 1 not 2.

### Expected behavior
No tests failing by default, to help development. Perhaps skip that test for old versions of Python.

### pylint --version output
pylint 1.8.0, 
astroid 1.5.3
Python 2.7.6 (default, Oct 26 2016, 20:30:19) 
[GCC 4.8.4]