### PR TITLE
Fix ifs in formatted strings crashing Pylint

### DIFF
--- a/pylint/test/functional/formatted_string_literal_with_if_py36.py
+++ b/pylint/test/functional/formatted_string_literal_with_if_py36.py
@@ -1,0 +1,8 @@
+"""Test that `if` in formatted string literal won't break Pylint."""
+# pylint: disable=missing-docstring, pointless-statement, using-constant-test
+
+f'{"+" if True else "-"}'
+if True:
+    pass
+elif True:
+    pass

--- a/pylint/test/functional/formatted_string_literal_with_if_py36.rc
+++ b/pylint/test/functional/formatted_string_literal_with_if_py36.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.6


### PR DESCRIPTION
### Fixes / new features
Fixes #1575.

Pylint crashes when run on a code that contains a formatted literal string (new in Python 3.6) which has an if expression inside.

`refactoring.py` uses tokens stream to find all `if`s and `elif`s to distinguish between them during analysis. Each encountered `if` and `elif` is stored as `False` and `True` in the `self._elifs` list. Later, when the AST is examined, all encountered `if` nodes are counted, and if there is a need to distinguish `if`s from `elif`s, appropriate position in that list is checked.

Unfortunately, whole formatted literal string (like `f'{True if True else False}'`) is a single token, but it is 
represented by multiple nodes in the AST, one of them an `IfExp` node. This breaks the counting logic, as there are more `if`s encountered during AST walk than were found during token stream examination.

The solution is to store `elif`s positions instead of relying on counting. To make it more interesting, CPython, Jython and PyPy do not store the `elif`'s position in the AST node, but the position of the next
token instead. IronPython on the other hand stores the actual `elif`'s position. Luckily it's fine to store both on our list as in the syntactically correct program there will be no `if` and `elif` as consecutive tokens.
