### PR TITLE
Fix 972 argparse

### DIFF
--- a/pylint/config.py
+++ b/pylint/config.py
@@ -77,10 +77,11 @@ def save_results(results, base):
 
 def find_pylintrc_in(search_dir):
     """Find a pylintrc file in the given directory.
+
     :param search_dir: The directory to search.
     :type search_dir: str
-    :returns: The path to the pylintrc file, if found.
-        Otherwise None.
+
+    :returns: The path to the pylintrc file, if found. Otherwise None.
     :rtype: str or None
     """
     path = None
@@ -96,8 +97,10 @@ def find_pylintrc_in(search_dir):
 
 def find_nearby_pylintrc(search_dir=''):
     """Search for the nearest pylint rc file.
+
     :param search_dir: The directory to search.
     :type search_dir: str
+
     :returns: The absolute path to the pylintrc file, if found.
         Otherwise None
     :rtype: str or None
@@ -121,8 +124,8 @@ def find_nearby_pylintrc(search_dir=''):
 
 def find_global_pylintrc():
     """Search for the global pylintrc file.
-    :returns: The absolute path to the pylintrc file, if found.
-        Otherwise None.
+
+    :returns: The absolute path to the pylintrc file, if found. Otherwise None.
     :rtype: str or None
     """
     pylintrc = None
@@ -149,8 +152,8 @@ def find_pylintrc():
     - The current user's home directory
     - The `.config` folder in the current user's home directory
     - /etc/pylintrc
-    :returns: The path to the pylintrc file,
-        or None if one was not found.
+
+    :returns: The path to the pylintrc file, or None if one was not found.
     :rtype: str or None
     """
     # TODO: Find nearby pylintrc files as well
@@ -717,6 +720,7 @@ class Configuration(object):
 class ConfigurationStore(object):
     def __init__(self, global_config):
         """A class to store configuration objects for many paths.
+
         :param global_config: The global configuration object.
         :type global_config: Configuration
         """
@@ -727,6 +731,7 @@ class ConfigurationStore(object):
 
     def add_config_for(self, path, config):
         """Add a configuration object to the store.
+
         :param path: The path to add the config for.
         :type path: str
         :param config: The config object for the given path.
@@ -740,8 +745,10 @@ class ConfigurationStore(object):
 
     def _get_parent_configs(self, path):
         """Get the config objects for all parent directories.
+
         :param path: The absolute path to get the parent configs for.
         :type path: str
+
         :returns: The config objects for all parent directories.
         :rtype: generator(Configuration)
         """
@@ -756,8 +763,10 @@ class ConfigurationStore(object):
         """Get the configuration object for a file or directory.
         This will merge the global config with all of the config objects from
         the root directory to the given path.
+
         :param path: The file or directory to the get configuration object for.
         :type path: str
+
         :returns: The configuration object for the given file or directory.
         :rtype: Configuration
         """
@@ -811,9 +820,11 @@ class ConfigParser(object):
     @abc.abstractmethod
     def parse(self, to_parse, config):
         """Parse the given object into the config object.
-        Args:
-            to_parse (object): The object to parse.
-            config (Configuration): The config object to parse into.
+
+        :param to_parse: The object to parse.
+        :type to_parse: object
+        :param config: The config object to parse into.
+        :type config: Configuration
         """
 
 
@@ -851,16 +862,16 @@ class CLIParser(ConfigParser):
     def _convert_definition(option, definition):
         """Convert an option definition to a set of arguments for add_argument.
 
-        Args:
-            option (str): The name of the option
-            definition (dict): The argument definition to convert.
+        :param option: The name of the option
+        :type option: str
+        :param definition: The argument definition to convert.
+        :type definition: dict
 
-        Returns:
-            tuple(str, list, dict): A tuple of the group to add the argument to,
+        :returns: A tuple of the group to add the argument to,
             plus the args and kwargs for :func:`ArgumentParser.add_argument`.
+        :rtype: tuple(str, list, dict)
 
-        Raises:
-            Exception: When the definition is invalid.
+        :raises ConfigurationError: When the definition is invalid.
         """
         args = []
 
@@ -897,20 +908,24 @@ class CLIParser(ConfigParser):
 
     def parse(self, argv, config):
         """Parse the command line arguments into the given config object.
-        Args:
-            argv (list(str)): The command line arguments to parse.
-            config (Configuration): The config object to parse
-                the command line into.
+
+        :param argv: The command line arguments to parse.
+        :type argv: list(str)
+        :param config: The config object to parse the command line into.
+        :type config: Configuration
         """
         self._parser.parse_args(argv, config)
 
     def preprocess(self, argv, *options):
         """Do some guess work to get a value for the specified option.
-        Args:
-            argv (list(str)): The command line arguments to parse.
-            *options (str): The names of the options to look for.
-        Returns:
-            Configuration: A config with the processed options.
+
+        :param argv: The command line arguments to parse.
+        :type argv: list(str)
+        :param options: The names of the options to look for.
+        :type options: str
+
+        :returns: A config with the processed options.
+        :rtype: Configuration
         """
         config = Config()
         config.add_options(self._option_definitions)
@@ -955,9 +970,13 @@ class IniFileParser(FileParser):
     def _convert_definition(option, definition):
         """Convert an option definition to a set of arguments for the parser.
 
-        Args:
-            option (str): The name of the option.
-            definition (dict): The argument definition to convert.
+        :param option: The name of the option.
+        :type option: str
+        :param definition: The argument definition to convert.
+        :type definition: dict
+
+        :returns: The converted definition.
+        :rtype: tuple(str, dict)
         """
         default = {option: definition.get('default')}
 
@@ -1072,8 +1091,8 @@ class LongHelpArgumentParser(argparse.ArgumentParser):
 
         Patches in the level to each created action instance.
 
-        Returns:
-            argparse.Action: The created action.
+        :returns: The created action.
+        :rtype: argparse.Action
         """
         level = kwargs.pop('level', 0)
         action = super(LongHelpArgumentParser, self).add_argument(*args, **kwargs)

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -17,6 +17,7 @@ import argparse
 import contextlib
 import collections
 import copy
+import functools
 import io
 import optparse
 import os
@@ -508,6 +509,11 @@ Please report bugs on the project\'s mailing list:
 class OptionsManagerMixIn(object):
     """Handle configuration from both a configuration file and command line options"""
 
+    class NullAction(argparse.Action):
+        """Doesn't store the value on the config."""
+        def __call__(self, *args, **kwargs):
+            pass
+
     def __init__(self, usage, config_file=None, version=None, quiet=0):
         self.config_file = config_file
         self.reset_parsers(usage, version=version)
@@ -526,9 +532,7 @@ class OptionsManagerMixIn(object):
         # configuration file parser
         self.cfgfile_parser = IniFileParser()
         # command line parser
-        self.cmdline_parser = OptionParser(usage=usage, version=version)
-        self.cmdline_parser.options_manager = self
-        self._optik_option_attrs = set(self.cmdline_parser.option_class.ATTRS)
+        self.cmdline_parser = CLIParser(description=usage)
 
     def register_options_provider(self, provider, own_group=True):
         """register an options provider"""
@@ -559,10 +563,10 @@ class OptionsManagerMixIn(object):
         if group_name in self._mygroups:
             group = self._mygroups[group_name]
         else:
-            group = optparse.OptionGroup(self.cmdline_parser,
-                                         title=group_name.capitalize())
-            self.cmdline_parser.add_option_group(group)
-            group.level = provider.level
+            group = self.cmdline_parser._parser.add_argument_group(
+                group_name.capitalize()
+            )
+            #group.level = provider.level
             self._mygroups[group_name] = group
             # add section to the config file
             if group_name != "DEFAULT":
@@ -577,37 +581,61 @@ class OptionsManagerMixIn(object):
 
     def add_optik_option(self, provider, optikcontainer, opt, optdict):
         args, optdict = self.optik_option(provider, opt, optdict)
-        option = optikcontainer.add_option(*args, **optdict)
+        if hasattr(optikcontainer, '_parser'):
+            optikcontainer = optikcontainer._parser
+        if 'group' in optdict:
+            optikcontainer = self._mygroups[optdict['group'].upper()]
+            del optdict['group']
+
+        # Some sanity checks for things that trip up argparse
+        assert not any(' ' in arg for arg in args)
+        assert all(optdict.values())
+        assert not ('metavar' in optdict and '[' in optdict['metavar'])
+
+        option = optikcontainer.add_argument(*args, **optdict)
         self._all_options[opt] = provider
-        self._maxlevel = max(self._maxlevel, option.level or 0)
+        self._maxlevel = max(self._maxlevel, optdict.get('level', 0))
 
     def optik_option(self, provider, opt, optdict):
         """get our personal option definition and return a suitable form for
         use with optik/optparse
         """
+        # TODO: Changed to work with argparse but this should call
+        # self.cmdline_parser.add_argument_definitions and not use callbacks
         optdict = copy.copy(optdict)
         if 'action' in optdict:
             self._nocallback_options[provider] = opt
+            if optdict['action'] == 'callback':
+                pass
         else:
-            optdict['action'] = 'callback'
-            optdict['callback'] = self.cb_set_provider_option
+            callback = functools.partial(
+                self.cb_set_provider_option, None, '--' + str(opt), parser=None,
+            )
+            optdict['type'] = callback
+            optdict['action'] = self.NullAction
         # default is handled here and *must not* be given to optik if you
         # want the whole machinery to work
         if 'default' in optdict:
             if ('help' in optdict
                     and optdict.get('default') is not None
                     and optdict['action'] not in ('store_true', 'store_false')):
-                optdict['help'] += ' [current: %default]'
+                optdict['help'] += ' [current: %(default)s]'
             del optdict['default']
         args = ['--' + str(opt)]
         if 'short' in optdict:
             self._short_options[optdict['short']] = opt
             args.append('-' + optdict['short'])
             del optdict['short']
-        # cleanup option definition dict before giving it to optik
-        for key in list(optdict.keys()):
-            if key not in self._optik_option_attrs:
-                optdict.pop(key)
+        if optdict.get('action') == 'callback':
+            optdict['type'] = optdict['callback']
+            del optdict['action']
+            del optdict['callback']
+        if optdict.get('hide'):
+            optdict['help'] = argparse.SUPPRESS
+            del optdict['hide']
+        # TODO: Implement long help
+        if 'level' in optdict:
+            del optdict['level']
         return args, optdict
 
     def cb_set_provider_option(self, option, opt, value, parser):
@@ -622,6 +650,7 @@ class OptionsManagerMixIn(object):
         if value is None:
             value = 1
         self.global_set_option(opt, value)
+        return value
 
     def global_set_option(self, opt, value):
         """set option on the correct option provider"""
@@ -740,30 +769,26 @@ class OptionsManagerMixIn(object):
                 args = sys.argv[1:]
             else:
                 args = list(args)
-            (options, args) = self.cmdline_parser.parse_args(args=args)
             for provider in self._nocallback_options:
-                config = provider.config
-                for attr in config.__dict__.keys():
-                    value = getattr(options, attr, None)
-                    if value is None:
-                        continue
-                    setattr(config, attr, value)
-            return args
+                self.cmdline_parser.parse(args, provider.config)
+            config = Configuration()
+            self.cmdline_parser.parse(args, config)
+            return config.module_or_package
 
     def add_help_section(self, title, description, level=0):
         """add a dummy option section for help purpose """
-        group = optparse.OptionGroup(self.cmdline_parser,
-                                     title=title.capitalize(),
-                                     description=description)
-        group.level = level
+        self.cmdline_parser._parser.add_argument_group(
+            title.capitalize(), description,
+        )
+        #group.level = level
         self._maxlevel = max(self._maxlevel, level)
-        self.cmdline_parser.add_option_group(group)
 
     def help(self, level=0):
         """return the usage string for available options """
-        self.cmdline_parser.formatter.output_level = level
+        # TODO: Not implemented long help yet
+        #self.cmdline_parser.formatter.output_level = level
         with _patch_optparse():
-            return self.cmdline_parser.format_help()
+            return self.cmdline_parser._parser.format_help()
 
 
 class OptionsProviderMixIn(object):
@@ -1052,10 +1077,12 @@ class CLIParser(ConfigParser):
         super(CLIParser, self).__init__()
 
         self._parser = argparse.ArgumentParser(
-            description=description,
+            description=description.replace("%prog", "%(prog)s"),
             # Only set the arguments that are specified.
             argument_default=argparse.SUPPRESS
         )
+        # TODO: Let this be definable elsewhere
+        self._parser.add_argument('module_or_package', nargs=argparse.REMAINDER)
 
     def add_option_definitions(self, option_definitions):
         option_groups = collections.defaultdict(list)
@@ -1068,8 +1095,6 @@ class CLIParser(ConfigParser):
             self._parser.add_argument(*args, **kwargs)
 
         del option_groups['DEFAULT']
-        # TODO: Let this be definable elsewhere
-        self._parser.add_argument('module_or_package')
 
         for group, arguments in six.iteritems(option_groups):
             self._option_groups.add(group)
@@ -1136,10 +1161,7 @@ class CLIParser(ConfigParser):
             config (Configuration): The config object to parse
                 the command line into.
         """
-        args = self._parser.parse_args(argv)
-
-        for option, value in vars(args):
-            config.set_option(option, value)
+        self._parser.parse_args(argv, config)
 
     def preprocess(self, argv, *options):
         """Do some guess work to get a value for the specified option.

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -509,15 +509,19 @@ Please report bugs on the project\'s mailing list:
 class OptionsManagerMixIn(object):
     """Handle configuration from both a configuration file and command line options"""
 
-    class NullAction(argparse.Action):
+    class CallbackAction(argparse.Action):
         """Doesn't store the value on the config."""
-        def __init__(self, *args, nargs=0, **kwargs):
-            super(OptionsManagerMixIn.NullAction, self).__init__(
+        def __init__(self, *args, nargs=None, **kwargs):
+            nargs = nargs or int('metavar' in kwargs)
+            super(OptionsManagerMixIn.CallbackAction, self).__init__(
                 *args, nargs=nargs, **kwargs
             )
 
-        def __call__(self, *args, **kwargs):
-            pass
+        def __call__(self, parser, namespace, values, option_string):
+            # If no value was passed, argparse didn't call the callback via
+            # `type`, so we need to do it ourselves.
+            if not self.nargs and callable(self.type):
+                self.type(self, option_string, values, parser)
 
     def __init__(self, usage, config_file=None, version=None, quiet=0):
         self.config_file = config_file
@@ -613,7 +617,7 @@ class OptionsManagerMixIn(object):
             self._nocallback_options[provider] = opt
             if optdict['action'] == 'callback':
                 optdict['type'] = optdict['callback']
-                optdict['action'] = self.NullAction
+                optdict['action'] = self.CallbackAction
                 del optdict['callback']
         else:
             callback = functools.partial(

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -75,27 +75,6 @@ def save_results(results, base):
         print('Unable to create file %s: %s' % (data_file, ex), file=sys.stderr)
 
 
-# TODO: Put into utils
-def walk_up(from_dir):
-    """Walk up a directory tree
-    :param from_dir: The directory to walk up from.
-        This directory is included in the output.
-    :type from_dir: str
-    :returns: Each parent directory
-    :rtype: generator(str)
-    """
-    cur_dir = None
-    new_dir = os.path.expanduser(from_dir)
-    new_dir = os.path.abspath(new_dir)
-
-    # The parent of the root directory is the root directory.
-    # Once we have reached it, we are done.
-    while cur_dir != new_dir:
-        cur_dir = new_dir
-        yield cur_dir
-        new_dir = os.path.abspath(os.path.join(cur_dir, os.pardir))
-
-
 def find_pylintrc_in(search_dir):
     """Find a pylintrc file in the given directory.
     :param search_dir: The directory to search.
@@ -127,7 +106,7 @@ def find_nearby_pylintrc(search_dir=''):
     path = find_pylintrc_in(search_dir)
 
     if not path:
-        for search_dir in walk_up(search_dir):
+        for search_dir in utils.walk_up(search_dir):
             if not os.path.isfile(os.path.join(search_dir, '__init__.py')):
                 break
             path = find_pylintrc_in(search_dir)
@@ -767,7 +746,7 @@ class ConfigurationStore(object):
         :returns: The config objects for all parent directories.
         :rtype: generator(Configuration)
         """
-        for cfg_dir in walk_up(path):
+        for cfg_dir in utils.walk_up(path):
             if cfg_dir in self._cache:
                 yield self._cache[cfg_dir]
                 break

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -29,7 +29,7 @@ import configparser
 import six
 from six.moves import range
 
-from pylint import utils
+from pylint import exceptions, utils
 
 
 USER_HOME = os.path.expanduser('~')
@@ -678,8 +678,7 @@ class Configuration(object):
     def add_option(self, option_definition):
         name, definition = option_definition
         if name in self._option_definitions:
-            # TODO: Raise something more sensible
-            raise Exception('Option "{0}" already exists.')
+            raise exceptions.ConfigurationError('Option "{0}" already exists.')
         self._option_definitions[name] = definition
 
 
@@ -880,8 +879,7 @@ class CLIParser(ConfigParser):
                 if 'choices' not in definition:
                     msg = 'No choice list given for option "{0}" of type "choice".'
                     msg = msg.format(option)
-                    # TODO: Raise something more sensible
-                    raise Exception(msg)
+                    raise ConfigurationError(msg)
 
                 if definition['type'] == 'multiple_choice':
                     kwargs['type'] = VALIDATORS['csv']
@@ -889,8 +887,7 @@ class CLIParser(ConfigParser):
                 kwargs['choices'] = definition['choices']
             else:
                 msg = 'Unsupported type "{0}"'.format(definition['type'])
-                # TODO: Raise something more sensible
-                raise Exception(msg)
+                raise ConfigurationError(msg)
 
         if definition.get('hide'):
             kwargs['help'] = argparse.SUPPRESS
@@ -952,7 +949,6 @@ class IniFileParser(FileParser):
             else:
                 self._option_groups.add(group)
 
-            # TODO: Do we need to do this?
             self._parser['DEFAULT'].update(default)
 
     @staticmethod

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -126,11 +126,13 @@ def find_nearby_pylintrc(search_dir=''):
     search_dir = os.path.expanduser(search_dir)
     path = find_pylintrc_in(search_dir)
 
-    for search_dir in walk_up(search_dir):
-        if path or not os.path.isfile(os.path.join(search_dir, '__init__.py')):
-            break
-
-        path = find_pylintrc_in(search_dir)
+    if not path:
+        for search_dir in walk_up(search_dir):
+            if not os.path.isfile(os.path.join(search_dir, '__init__.py')):
+                break
+            path = find_pylintrc_in(search_dir)
+            if path:
+                break
 
     if path:
         path = os.path.abspath(path)

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -511,6 +511,11 @@ class OptionsManagerMixIn(object):
 
     class NullAction(argparse.Action):
         """Doesn't store the value on the config."""
+        def __init__(self, *args, nargs=0, **kwargs):
+            super(OptionsManagerMixIn.NullAction, self).__init__(
+                *args, nargs=nargs, **kwargs
+            )
+
         def __call__(self, *args, **kwargs):
             pass
 
@@ -607,13 +612,15 @@ class OptionsManagerMixIn(object):
         if 'action' in optdict:
             self._nocallback_options[provider] = opt
             if optdict['action'] == 'callback':
-                pass
+                optdict['type'] = optdict['callback']
+                optdict['action'] = self.NullAction
+                del optdict['callback']
         else:
             callback = functools.partial(
                 self.cb_set_provider_option, None, '--' + str(opt), parser=None,
             )
             optdict['type'] = callback
-            optdict['action'] = self.NullAction
+            optdict.setdefault('action', 'store')
         # default is handled here and *must not* be given to optik if you
         # want the whole machinery to work
         if 'default' in optdict:

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -532,7 +532,7 @@ class OptionsManagerMixIn(object):
         # configuration file parser
         self.cfgfile_parser = IniFileParser()
         # command line parser
-        self.cmdline_parser = CLIParser(description=usage)
+        self.cmdline_parser = CLIParser(usage)
 
     def register_options_provider(self, provider, own_group=True):
         """register an options provider"""
@@ -564,9 +564,8 @@ class OptionsManagerMixIn(object):
             group = self._mygroups[group_name]
         else:
             group = self.cmdline_parser._parser.add_argument_group(
-                group_name.capitalize()
+                group_name.capitalize(), level=provider.level,
             )
-            #group.level = provider.level
             self._mygroups[group_name] = group
             # add section to the config file
             if group_name != "DEFAULT":
@@ -592,7 +591,9 @@ class OptionsManagerMixIn(object):
         assert all(optdict.values())
         assert not ('metavar' in optdict and '[' in optdict['metavar'])
 
+        level = optdict.pop('level', 0)
         option = optikcontainer.add_argument(*args, **optdict)
+        option.level = level
         self._all_options[opt] = provider
         self._maxlevel = max(self._maxlevel, optdict.get('level', 0))
 
@@ -619,7 +620,10 @@ class OptionsManagerMixIn(object):
             if ('help' in optdict
                     and optdict.get('default') is not None
                     and optdict['action'] not in ('store_true', 'store_false')):
-                optdict['help'] += ' [current: %(default)s]'
+                default = optdict['default']
+                if isinstance(default, (tuple, list)):
+                    default = ','.join(str(x) for x in default)
+                optdict['help'] += ' [current: {0}]'.format(default)
             del optdict['default']
         args = ['--' + str(opt)]
         if 'short' in optdict:
@@ -633,9 +637,6 @@ class OptionsManagerMixIn(object):
         if optdict.get('hide'):
             optdict['help'] = argparse.SUPPRESS
             del optdict['hide']
-        # TODO: Implement long help
-        if 'level' in optdict:
-            del optdict['level']
         return args, optdict
 
     def cb_set_provider_option(self, option, opt, value, parser):
@@ -703,6 +704,7 @@ class OptionsManagerMixIn(object):
         """read the configuration file but do not load it (i.e. dispatching
         values to each options provider)
         """
+        """
         helplevel = 1
         while helplevel <= self._maxlevel:
             opt = '-'.join(['long'] * helplevel) + '-help'
@@ -719,6 +721,7 @@ class OptionsManagerMixIn(object):
             self.add_optik_option(provider, self.cmdline_parser, opt, optdict)
             provider.options += ((opt, optdict),)
             helplevel += 1
+        """
         if config_file is None:
             config_file = self.config_file
         if config_file is not None:
@@ -764,31 +767,26 @@ class OptionsManagerMixIn(object):
 
         return additional arguments
         """
-        with _patch_optparse():
-            if args is None:
-                args = sys.argv[1:]
-            else:
-                args = list(args)
-            for provider in self._nocallback_options:
-                self.cmdline_parser.parse(args, provider.config)
-            config = Configuration()
-            self.cmdline_parser.parse(args, config)
-            return config.module_or_package
+        if args is None:
+            args = sys.argv[1:]
+        else:
+            args = list(args)
+        for provider in self._nocallback_options:
+            self.cmdline_parser.parse(args, provider.config)
+        config = Configuration()
+        self.cmdline_parser.parse(args, config)
+        return config.module_or_package
 
     def add_help_section(self, title, description, level=0):
         """add a dummy option section for help purpose """
-        self.cmdline_parser._parser.add_argument_group(
-            title.capitalize(), description,
+        group = self.cmdline_parser._parser.add_argument_group(
+            title.capitalize(), description, level=level
         )
-        #group.level = level
         self._maxlevel = max(self._maxlevel, level)
 
     def help(self, level=0):
         """return the usage string for available options """
-        # TODO: Not implemented long help yet
-        #self.cmdline_parser.formatter.output_level = level
-        with _patch_optparse():
-            return self.cmdline_parser._parser.format_help()
+        return self.cmdline_parser._parser.format_help(level)
 
 
 class OptionsProviderMixIn(object):
@@ -1073,11 +1071,11 @@ class ConfigParser(object):
 
 
 class CLIParser(ConfigParser):
-    def __init__(self, description=''):
+    def __init__(self, usage=''):
         super(CLIParser, self).__init__()
 
-        self._parser = argparse.ArgumentParser(
-            description=description.replace("%prog", "%(prog)s"),
+        self._parser = LongHelpArgumentParser(
+            usage=usage.replace("%prog", "%(prog)s"),
             # Only set the arguments that are specified.
             argument_default=argparse.SUPPRESS
         )
@@ -1124,7 +1122,7 @@ class CLIParser(ConfigParser):
 
         args.append('--{0}'.format(option))
 
-        copy_keys = ('action', 'default', 'dest', 'help', 'metavar')
+        copy_keys = ('action', 'default', 'dest', 'help', 'metavar', 'level')
         kwargs = {k: definition[k] for k in copy_keys if k in definition}
 
         if 'type' in definition:
@@ -1150,8 +1148,6 @@ class CLIParser(ConfigParser):
             kwargs['help'] = argparse.SUPPRESS
 
         group = definition.get('group', 'DEFAULT').upper()
-        # TODO: Handle the level. This is either going to require subclassing
-        # ArgumentParser or doing the help message printing ourselves.
         return group, args, kwargs
 
     def parse(self, argv, config):
@@ -1238,3 +1234,149 @@ class IniFileParser(FileParser):
 
             for option, value in self._parser.items(section):
                 config.set_option(option, value)
+
+
+class LongHelpFormatter(argparse.HelpFormatter):
+    output_level = None
+
+    def add_argument(self, action):
+        if action.level <= self.output_level:
+            super(LongHelpFormatter, self).add_argument(action)
+
+    def add_usage(self, usage, actions, groups, prefix=None):
+        actions = [action for action in actions if action.level <= self.output_level]
+        super(LongHelpFormatter, self).add_usage(
+            usage, actions, groups, prefix,
+        )
+
+
+class LongHelpAction(argparse.Action):
+    def __init__(self,
+                 option_strings,
+                 dest=argparse.SUPPRESS,
+                 default=argparse.SUPPRESS,
+                 help=None):
+        super(LongHelpAction, self).__init__(
+            option_strings=option_strings,
+            dest=dest,
+            default=default,
+            nargs=0,
+            help=help,
+        )
+        self.level = 0
+
+    @staticmethod
+    def _parse_option_string(option_string):
+        level = 0
+        if option_string:
+            level = option_string.count('l-') or option_string.count('long-')
+        return level
+
+    @staticmethod
+    def build_add_args(level, prefix_chars='-'):
+        default_prefix = '-' if '-' in prefix_chars else prefix_chars[0]
+        return (
+            default_prefix + '-'.join(['l'] * level) + '-h',
+            default_prefix * 2 + '-'.join(['long'] * level) + '-help',
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        level = self._parse_option_string(option_string)
+        parser.print_help(level=level)
+        parser.exit()
+
+
+class LongHelpArgumentParser(argparse.ArgumentParser):
+    def __init__(self, *args, formatter_class=LongHelpFormatter, **kwargs):
+        self._max_level = 0
+        super(LongHelpArgumentParser, self).__init__(
+            *args, formatter_class=formatter_class, **kwargs
+        )
+
+    # Stop ArgumentParser __init__ adding the wrong help formatter
+    def register(self, registry_name, value, object):
+        if registry_name == 'action' and value == 'help':
+            object = LongHelpAction
+
+        super(LongHelpArgumentParser, self).register(
+            registry_name, value, object
+        )
+
+    def _add_help_levels(self):
+        level = max(action.level for action in self._actions)
+        if level > self._max_level and self.add_help:
+            for new_level in range(self._max_level + 1, level + 1):
+                action = super(LongHelpArgumentParser, self).add_argument(
+                    *LongHelpAction.build_add_args(new_level, self.prefix_chars),
+                    action='help',
+                    default=argparse.SUPPRESS,
+                    help=('show this {0} verbose help message and exit'.format(
+                        ' '.join(['really'] * (new_level - 1))
+                    ))
+                )
+                action.level = 0
+            self._max_level = level
+
+    def parse_known_args(self, *args, **kwargs):
+        self._add_help_levels()
+        return super(LongHelpArgumentParser, self).parse_known_args(
+            *args, **kwargs
+        )
+
+    def add_argument(self, *args, **kwargs):
+        """See :func:`argparse.ArgumentParser.add_argument`.
+
+        Patches in the level to each created action instance.
+
+        Returns:
+            argparse.Action: The created action.
+        """
+        level = kwargs.pop('level', 0)
+        action = super(LongHelpArgumentParser, self).add_argument(*args, **kwargs)
+        action.level = level
+        return action
+
+    def add_argument_group(self, *args, level=0, **kwargs):
+        group = super(LongHelpArgumentParser, self).add_argument_group(
+            *args, **kwargs
+        )
+        group.level = level
+        return group
+
+    # These methods use yucky way of passing the level to the formatter class
+    # without having to rely on argparse implementation details.
+    def format_usage(self, level=0):
+        if hasattr(self.formatter_class, 'output_level'):
+            if self.formatter_class.output_level is None:
+                self.formatter_class.output_level = level
+        return super(LongHelpArgumentParser, self).format_usage()
+
+    def format_help(self, level=0):
+        if hasattr(self.formatter_class, 'output_level'):
+            if self.formatter_class.output_level is None:
+                self.formatter_class.output_level = level
+            else:
+                level = self.formatter_class.output_level
+
+        # Unfortunately there's no way of publicly accessing the groups or
+        # an easy way of overriding format_help without using protected methods.
+        old_action_groups = self._action_groups
+        try:
+            self._action_groups = [group for group in self._action_groups if group.level <= level]
+            result = super(LongHelpArgumentParser, self).format_help()
+        finally:
+            self._action_groups = old_action_groups
+
+        return result
+
+    def print_usage(self, file=None, level=0):
+        if hasattr(self.formatter_class, 'output_level'):
+            if self.formatter_class.output_level is None:
+                self.formatter_class.output_level = level
+        super(LongHelpArgumentParser, self).print_usage(file)
+
+    def print_help(self, file=None, level=0):
+        if hasattr(self.formatter_class, 'output_level'):
+            if self.formatter_class.output_level is None:
+                self.formatter_class.output_level = level
+        super(LongHelpArgumentParser, self).print_help(file)

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -297,10 +297,10 @@ class OptionsManagerMixIn(object):
 
     class CallbackAction(argparse.Action):
         """Doesn't store the value on the config."""
-        def __init__(self, *args, nargs=None, **kwargs):
+        def __init__(self, nargs=None, **kwargs):
             nargs = nargs or int('metavar' in kwargs)
             super(OptionsManagerMixIn.CallbackAction, self).__init__(
-                *args, nargs=nargs, **kwargs
+                nargs=nargs, **kwargs
             )
 
         def __call__(self, parser, namespace, values, option_string):
@@ -1054,10 +1054,10 @@ class LongHelpAction(argparse.Action):
 
 
 class LongHelpArgumentParser(argparse.ArgumentParser):
-    def __init__(self, *args, formatter_class=LongHelpFormatter, **kwargs):
+    def __init__(self, formatter_class=LongHelpFormatter, **kwargs):
         self._max_level = 0
         super(LongHelpArgumentParser, self).__init__(
-            *args, formatter_class=formatter_class, **kwargs
+            formatter_class=formatter_class, **kwargs
         )
 
     # Stop ArgumentParser __init__ adding the wrong help formatter

--- a/pylint/exceptions.py
+++ b/pylint/exceptions.py
@@ -16,3 +16,6 @@ class EmptyReportError(Exception):
 
 class InvalidReporterError(Exception):
     """raised when selected reporter is invalid (e.g. not found)"""
+
+class ConfigurationError(Exception):
+    """Raised when the configuration is invalid."""

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -1162,14 +1162,14 @@ group are mutually exclusive.'),
         linter.read_config_file()
         config_parser = linter.cfgfile_parser
         # run init hook, if present, before loading plugins
-        if config_parser.has_option('MASTER', 'init-hook'):
+        if config_parser._parser.has_option('MASTER', 'init-hook'):
             cb_init_hook('init-hook',
-                         utils._unquote(config_parser.get('MASTER',
+                         utils._unquote(config_parser._parser.get('MASTER',
                                                           'init-hook')))
         # is there some additional plugins in the file configuration, in
-        if config_parser.has_option('MASTER', 'load-plugins'):
+        if config_parser._parser.has_option('MASTER', 'load-plugins'):
             plugins = utils._splitstrip(
-                config_parser.get('MASTER', 'load-plugins'))
+                config_parser._parser.get('MASTER', 'load-plugins'))
             linter.load_plugin_modules(plugins)
         # now we can load file config and command line, plugins (which can
         # provide options) have been registered

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -268,13 +268,13 @@ class PyLinter(config.OptionsManagerMixIn,
     @staticmethod
     def make_options():
         return (('ignore',
-                 {'type' : 'csv', 'metavar' : '<file>[,<file>...]',
+                 {'type' : 'csv', 'metavar' : '<file>,...',
                   'dest' : 'black_list', 'default' : ('CVS',),
                   'help' : 'Add files or directories to the blacklist. '
                            'They should be base names, not paths.'}),
 
                 ('ignore-patterns',
-                 {'type' : 'regexp_csv', 'metavar' : '<pattern>[,<pattern>...]',
+                 {'type' : 'regexp_csv', 'metavar' : '<pattern>,...',
                   'dest' : 'black_list_re', 'default' : (),
                   'help' : 'Add files or directories matching the regex patterns to the'
                            ' blacklist. The regex matches against base names, not paths.'}),
@@ -385,7 +385,7 @@ class PyLinter(config.OptionsManagerMixIn,
                            ' may run arbitrary code.')}),
 
                 ('extension-pkg-whitelist',
-                 {'type': 'csv', 'metavar': '<pkg[,pkg]>', 'default': [],
+                 {'type': 'csv', 'metavar': '<pkg>,...', 'default': [],
                   'help': ('A comma-separated list of package or module names'
                            ' from where C extensions may be loaded. Extensions are'
                            ' loading into the active Python interpreter and may run'

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -1244,3 +1244,25 @@ def _rest_format_section(stream, section, options, encoding=None, doc=None):
             value = _encode(_format_option_value(optdict, value), encoding)
             print(file=stream)
             print('  Default: ``%s``' % value.replace("`` ", "```` ``"), file=stream)
+
+
+def walk_up(from_dir):
+    """Walk up a directory tree
+
+    :param from_dir: The directory to walk up from.
+        This directory is included in the output.
+    :type from_dir: str
+
+    :returns: Each parent directory
+    :rtype: generator(str)
+    """
+    cur_dir = None
+    new_dir = os.path.expanduser(from_dir)
+    new_dir = os.path.abspath(new_dir)
+
+    # The parent of the root directory is the root directory.
+    # Once we have reached it, we are done.
+    while cur_dir != new_dir:
+        cur_dir = new_dir
+        yield cur_dir
+        new_dir = os.path.abspath(os.path.join(cur_dir, os.pardir))

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
    astroid>=1.5.1
    isort
 
-commands = pylint -rn --rcfile={toxinidir}/pylintrc --load-plugins=pylint.extensions.docparams, pylint.extensions.mccabe {envsitepackagesdir}/pylint
+commands = pylint -rn --rcfile={toxinidir}/pylintrc --load-plugins=pylint.extensions.docparams,pylint.extensions.mccabe {envsitepackagesdir}/pylint
 
 [testenv]
 deps =


### PR DESCRIPTION
This is part of the per directory config work (#618) so this is being merged into `per_dir_config` and not master. It also isn't 100% production ready.
Fixing #972 and moving the command line parsing out of the PyLinter class is a huge change. So I'm splitting it up into smaller chunks. Although, this has still ended up being pretty big so I'll explain some of the changes here. Don't feel as though you can't make statements about the overall design, and feel free to be picky even though this is a big change.

This first chunk of work removes optparse in favour of argparse. I've also added the start of some classes that we'll eventually start using once we fully move the config parsing out of PyLinter:
* `Configuration`: This is an `argparse.Namespace` like object that will store all of the configuration values and be supplied to each checker through the `self.config` variable of the checker. At the moment is mostly provides an abstraction from argparse so that we aren't giving each checker an `argparse.Namespace`. Eventually it will also be useful for merging configs which we'll need to implement `include` directives in configs.
* `ConfigurationStore`: We don't use this at the moment but eventually it'll be used for keeping track of what config objects belong to what directory. Currently it's merging configs from parent directories just to give an example of how we can merge `Configuration` objects but eventually it will check the config for include directives and merge as appropriate (unless it ends up making more sense for the file parser to do it).
* `ConfigParser`: This is a base class for anything that reads a configuration from somewhere.  It was a bit undecided whether this needed to be a class because generally they're small, but I think keeping things inheriting from `ConfigParser` will make it easier for others to create a new `ConfigParser` classes to get a config from other sources (eg a gui, registry) without also having to write a whole `Runner` class.
* `CLIParser`: At the moment this is pretty much just a container for an `argparse.ArgumentParser` but eventually I'm hoping that we'll only need to call `preprocess` and `parse`. To make wedging this into optik a bit easier the optik code is using the `argparse.ArgumentParser` directly but the end goal is for outside users to need to interact with the class through `OptionDefinition` objects only.
* `IniFileParser`: Like `CLIParse` this is mostly a container for an `OptionParser` at the moment and will be more useful later.
* `LongHelpFormatter` and `LongHelpArgumentParser`: These are objects to implement `--long-help`, `--long-long-help`, etc in argparse. argparse doesn't let you do much to override it's help formatting behaviour so I'm having to do a bit of fudgery to get this to work. Mostly this is setting the level on the formatter class because there's too much argparse machinery to override the methods that call the formatter class to call the formatter class methods with a level. This was the least hacky way I could see of doing things without relying on argparse implementation details. Let me know if you can think of another way!

Breaking changes:
* csv type arguments can no longer have a space after the comma.
* Option callbacks are no longer called with optparse arguments, but with argparse type arguments instead. For example `value` is no longer an `optparse.Option` but an `argparse.Action`.
* For now I've broken manpage generation but I need to have a think about how we'll implement this in the future. I probably won't use a HelpFormatter like we did with optparse but instead convert the `OptionDefinition` objects to the manpage directly.

The next step for #972 is to remove option callbacks altogether. This will also mean we stop dispatching options to `OptionProvider` objects and instead set options on the `Configuration` objects directly.