### PR TITLE
Allow simple xrefs for types in docstrings

### DIFF
--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -396,9 +396,9 @@ class GoogleDocstring(Docstring):
     """.format(type=re_type, xref=re_xref)
 
     re_multiple_type = r"""
-        (?:{container_type}|{type})
-        (?:\s+or\s+(?:{container_type}|{type}))*
-    """.format(type=re_type, container_type=re_container_type)
+        (?:{container_type}|{type}|{xref})
+        (?:\s+or\s+(?:{container_type}|{type}|{xref}))*
+    """.format(type=re_type, xref=re_xref, container_type=re_container_type)
 
     _re_section_template = r"""
         ^([ ]*)   {0} \s*:   \s*$     # Google parameter header

--- a/pylint/test/extensions/test_check_docs.py
+++ b/pylint/test/extensions/test_check_docs.py
@@ -1228,6 +1228,29 @@ class TestParamDocChecker(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
+    def test_finds_args_with_xref_type_numpy(self):
+        node = astroid.extract_node('''
+        def my_func(named_arg, *args):
+            """The docstring
+
+            Args
+            ----
+            named_arg : `example.value`
+                Returned
+            args :
+                Optional Arguments
+
+            Returns
+            -------
+                `example.value`
+                    Maybe named_arg
+            """
+            if args:
+                return named_arg
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
+
     def test_finds_kwargs_without_type_numpy(self):
         node = astroid.extract_node('''
         def my_func(named_arg, **kwargs):

--- a/pylint/test/extensions/test_check_docs.py
+++ b/pylint/test/extensions/test_check_docs.py
@@ -1228,6 +1228,24 @@ class TestParamDocChecker(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
+    def test_finds_args_with_xref_type_google(self):
+        node = astroid.extract_node('''
+        def my_func(named_arg, **kwargs):
+            """The docstring
+
+            Args:
+                named_arg (`example.value`): Returned
+                **kwargs: Keyword arguments
+
+            Returns:
+                `example.value`: Maybe named_arg
+            """
+            if kwargs:
+                return named_arg
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
+
     def test_finds_args_with_xref_type_numpy(self):
         node = astroid.extract_node('''
         def my_func(named_arg, *args):


### PR DESCRIPTION
Currently xref is allowed only for a container type, but not for a basic type.

This pull requests extends the basic type with xref as well.