### PR TITLE
Disable no-init and old-style-class for enchant helper mocks

### DIFF
--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -22,6 +22,7 @@ try:
                                   WikiWordFilter)
 except ImportError:
     enchant = None
+    # pylint: disable=old-style-class,no-init
     class Filter:
         def _skip(self, word):
             raise NotImplementedError


### PR DESCRIPTION
`tox -e pylint` failed on my machine due to those warnings.