### PR TITLE
Fix superfluous-parens false positive for logical statements involving `in` operator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -87,6 +87,11 @@ What's New in Pylint 1.8?
 
       Close #1336
 
+    * Fix ``superfluous-parens`` false positive related to handling logical statements
+      involving ``in`` operator.
+
+      Close #574
+
 What's New in Pylint 1.7.1?
 =========================
 

--- a/doc/whatsnew/1.8.rst
+++ b/doc/whatsnew/1.8.rst
@@ -241,14 +241,15 @@ Other Changes
   With this change, it is now more clear what should be improved for a name to be accepted according to
   its corresponding template.
 
-  .. code-block:: python
-
-    $ cat a.py
-    var = 24
-    $ pylint a.py
-    C:  1, 0: Constant name "var" doesn't conform to 'const-name-hint' template (invalid-name)
-
-
 * New configuration flag, ``suggestion-mode`` was introduced. When enabled, pylint would
   attempt to emit user-friendly suggestions instead of spurious errors for some known
   false-positive scenarios. Flag is enabled by default.
+
+* ``superfluous-parens`` is no longer wrongly emitted for logical statements involving ``in`` operator
+  (see example below for what used to be false-postive).
+
+  .. code-block:: python
+
+    foo = None
+    if 'bar' in (foo or {}):
+      pass

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -126,7 +126,6 @@ def _loop_exits_early(loop):
     for child in loop.body:
         if isinstance(child, loop_nodes):
             # break statement may be in orelse of child loop.
-            # pylint: disable=superfluous-parens
             for orelse in (child.orelse or ()):
                 for _ in orelse.nodes_of_class(astroid.Break, skip_klass=loop_nodes):
                     return True

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -564,7 +564,7 @@ class FormatChecker(BaseTokenChecker):
                         self.add_message('superfluous-parens', line=line_num,
                                          args=keyword_token)
                     elif keyword_token not in self._keywords_with_parens:
-                        if not (tokens[i+1][1] == 'in' and found_and_or):
+                        if not found_and_or:
                             self.add_message('superfluous-parens', line=line_num,
                                              args=keyword_token)
                 return

--- a/pylint/test/unittest_checker_format.py
+++ b/pylint/test/unittest_checker_format.py
@@ -129,6 +129,10 @@ class TestSuperfluousParentheses(CheckerTestCase):
              'if (not (foo)):', 0),
             (Message('superfluous-parens', line=1, args='not'),
              'if (not (foo)):', 2),
+            (Message('superfluous-parens', line=1, args='for'),
+             'for (x) in (1, 2, 3):', 0),
+            (Message('superfluous-parens', line=1, args='if'),
+             'if (1) in (1, 2, 3):', 0),
             ]
         for msg, code, offset in cases:
             with self.assertAddsMessages(msg):
@@ -142,6 +146,12 @@ print('Hello world!')
         with self.assertNoMessages():
             self.checker.process_module(tree)
             self.checker.process_tokens(_tokenize_str(code))
+
+    def testKeywordParensFalsePositive(self):
+        self.checker._keywords_with_parens = set()
+        code = "if 'bar' in (DICT or {}):"
+        with self.assertNoMessages():
+            self.checker._check_keyword_parentheses(_tokenize_str(code), start=2)
 
 
 class TestCheckSpace(CheckerTestCase):


### PR DESCRIPTION
Closes #574

I honestly have no idea why this extra condition was introduced in first place. A the end of the day we have no regressions and correct no-emit for reported case.