### PR TITLE
Use codecs.getreader.

### DIFF
--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -15,7 +15,7 @@ from collections import defaultdict
 import six
 from six.moves import zip
 
-from pylint.utils import safe_decode
+from pylint.utils import decoding_stream
 from pylint.interfaces import IRawChecker
 from pylint.checkers import BaseChecker, table_lines_from_stats
 from pylint.reporters.ureports.nodes import Table
@@ -37,7 +37,7 @@ class Similar(object):
         if encoding is None:
             readlines = stream.readlines
         else:
-            readlines = lambda: [safe_decode(line, encoding) for line in stream]
+            readlines = decoding_stream(stream, encoding).readlines
         try:
             self.linesets.append(LineSet(streamid,
                                          readlines(),

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -15,6 +15,7 @@ main pylint class
 """
 from __future__ import print_function
 
+import codecs
 import collections
 from inspect import cleandoc
 import os
@@ -125,9 +126,17 @@ def safe_decode(line, encoding, *args, **kwargs):
     except LookupError:
         return line.decode(sys.getdefaultencoding(), *args, **kwargs)
 
+def decoding_stream(stream, encoding, errors='strict'):
+    try:
+        reader_cls = codecs.getreader(encoding or sys.getdefaultencoding())
+    except LookupError:
+        reader_cls = codecs.getreader(sys.getdefaultencoding())
+    return reader_cls(stream, errors)
+
+
 def _decoding_readline(stream, encoding):
     '''return lambda function for tokenize with safe decode'''
-    return lambda: safe_decode(stream.readline(), encoding, 'replace')
+    return decoding_stream(stream, encoding, errors='replace').readline
 
 
 def tokenize_module(module):


### PR DESCRIPTION
This is part of a patch from https://github.com/asottile/future-fstrings/issues/7#issuecomment-329305973

I think this is the less controversial half of that patch, I'd be willing to write tests if this seems like a _good_ idea (don't really want to invest time otherwise!).

The tl;dr rationale is I've written a terrible hacky encoding that does some (really cool?) source rewriting -- the source it produces *is* valid and the codec produces correct results for `full_file_contents.decode(...)` and properly decodes in a simulated linewise fashion by the implemented `codecs.StreamReader`.

The codec interface requires an implementation of `StreamReader`, the `StreamReader` is designed to wrap a binary stream and give you file-like operations (`readline`, `readlines`, etc.), this makes pylint use it!

There's still an additional issue with pylint (as seen by the other part of the patch I haven't included in this PR) where it does linewise decoding but I've (intentionally? intelligently?) split that more-controversial bit out of this PR!