### PR TITLE
Check classes have both __eq__ and __ne__

### DIFF
--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -416,6 +416,10 @@ MSGS = {
               'Used whenever we can detect that an overridden method is useless, '
               'relying on super() delegation to do the same thing as another method '
               'from the MRO.'),
+    'W0236': ('Class defines only one of __eq__ and __ne__',
+              'both-equality-methods',
+              'Used when a class defines only of __eq__ and __ne__, which can '
+              'result in asymmetric equality/inequality comparisons.'),
     'E0236': ('Invalid object %r in __slots__, must contain '
               'only non empty strings',
               'invalid-slots-object',
@@ -553,6 +557,7 @@ a metaclass class method.'}
         self._check_slots(node)
         self._check_proper_bases(node)
         self._check_consistent_mro(node)
+        self._check_equality_methods(node)
 
     def _check_consistent_mro(self, node):
         """Detect that a class has a consistent mro or duplicate bases."""
@@ -565,6 +570,12 @@ a metaclass class method.'}
         except NotImplementedError:
             # Old style class, there's no mro so don't do anything.
             pass
+
+    def _check_equality_methods(self, node):
+        """ Check that a class defines both or neither of __eq__ and __ne__. """
+        method_names = set(m.name for m in node.mymethods())
+        if ('__eq__' in method_names) != ('__ne__' in method_names):
+            self.add_message('both-equality-methods', node=node)
 
     def _check_proper_bases(self, node):
         """

--- a/pylint/test/functional/both_equality_methods.py
+++ b/pylint/test/functional/both_equality_methods.py
@@ -1,0 +1,26 @@
+# pylint: disable=too-few-public-methods,missing-docstring
+"""
+Check that a class defines both or neither of __eq__ and __ne__.
+"""
+
+
+class MissingNe(object): # [both-equality-methods]
+    def __eq__(self, other):
+        pass
+
+
+class MissingEq(object): # [both-equality-methods]
+    def __ne__(self, other):
+        pass
+
+
+class HasBoth(object):
+    def __eq__(self, other):
+        pass
+
+    def __ne__(self, other):
+        pass
+
+
+class HasNeither(object):
+    pass

--- a/pylint/test/functional/both_equality_methods.txt
+++ b/pylint/test/functional/both_equality_methods.txt
@@ -1,0 +1,2 @@
+both-equality-methods:7:MissingNe:Class defines only one of __eq__ and __ne__
+both-equality-methods:12:MissingEq:Class defines only one of __eq__ and __ne__

--- a/pylint/test/functional/unneeded_not.py
+++ b/pylint/test/functional/unneeded_not.py
@@ -1,7 +1,7 @@
 """Check exceeding negations in boolean expressions trigger warnings"""
 
 # pylint: disable=singleton-comparison,too-many-branches,too-few-public-methods,undefined-variable
-# pylint: disable=literal-comparison
+# pylint: disable=literal-comparison,both-equality-methods
 def unneeded_not():
     """This is not ok
     """


### PR DESCRIPTION
Adds a new check to ClassChecker that warns when a class defines one, but not both, of `__eq__` and `__ne__`.

Rationale: if a Python 2 class defines `__eq__`, but not `__ne__`, comparing instances of that class might not work as expected.

E.g.:
```python
class Widget(object):
    def __init__(self, uuid):
        self.uuid = uuid

    def __eq__(self, other):
        return self.uuid == other.uuid

w1 = Widget('abcd')
w2 = Widget('abcd')

print(w1 == w2)  # -> True
print(w1 != w2)  # -> True
```

## Note

 - this isn't a problem in Python 3, so perhaps it shouldn't apply there.
 - this check doesn't detect `__eq__` and `__ne__` defined in different levels of a class hierarchy. This might be desirable (if you override one you should override both) — but I don't have a strong opinion.

### Fixes / new features
- new class checker for mismatched `__eq__` / `__ne__` methods