### PR TITLE
Bug1409

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -102,6 +102,10 @@ What's New in Pylint 1.8?
 
       Close #574
 
+    * Fix ``missing-param-doc`` and ``missing-type-doc`` false positives when
+      mixing ``Args`` and ``Keyword Args`` in Google docstring.
+      Close #1409
+
 What's New in Pylint 1.7.1?
 =========================
 

--- a/doc/whatsnew/1.8.rst
+++ b/doc/whatsnew/1.8.rst
@@ -275,3 +275,6 @@ Other Changes
     foo = None
     if 'bar' in (foo or {}):
       pass
+
+* ``missing-param-doc`` and ``missing-type-doc`` are no longer emitted when
+  ``Args`` and ``Keyword Args`` are mixed in Google docstring.

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -410,6 +410,11 @@ class GoogleDocstring(Docstring):
         re.X | re.S | re.M
     )
 
+    re_keyword_param_section = re.compile(
+        _re_section_template.format(r"Keyword\s(?:Args|Arguments|Parameters)"),
+        re.X | re.S | re.M
+    )
+
     re_param_line = re.compile(r"""
         \s*  \*{{0,2}}(\w+)             # identifier potentially with asterisks
         \s*  ( [(]
@@ -571,6 +576,7 @@ class GoogleDocstring(Docstring):
         params_with_type = set()
 
         entries = self._parse_section(self.re_param_section)
+        entries.extend(self._parse_section(self.re_keyword_param_section))
         for entry in entries:
             match = self.re_param_line.match(entry)
             if not match:


### PR DESCRIPTION
``missing-param-doc`` and ``missing-type-doc`` are no longer emitted when mixing ``Args`` and ``Keyword Args`` inside function googlestyle docstring.
Fixes #1409 
