### PR TITLE
Add of test determining if the function/method name is a dummy one in…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -108,7 +108,7 @@ What's New in Pylint 1.8?
       Close #574
 
     * ``function-redefined`` message is no longer emitted for functions and
-      methods wich names matches dummy variable name regular expression.
+      methods which names matches dummy variable name regular expression.
       Close #1369
 
     * Fix ``missing-param-doc`` and ``missing-type-doc`` false positives when

--- a/ChangeLog
+++ b/ChangeLog
@@ -102,8 +102,8 @@ What's New in Pylint 1.8?
 
       Close #574
 
-    * Disabling ``function-redefined```message for function or method with
-      dummy names.
+    * ``function-redefined`` message is no longer emitted for functions and
+      methods wich names matches dummy variable name regular expression.
       Close #1369
 
 What's New in Pylint 1.7.1?

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,11 +4,15 @@ Pylint's ChangeLog
 What's New in Pylint 1.8?
 =========================
 
-    * Added a new check, ``keyword-arg-before-vararg``, to raise warning for function definitions
-      in which keyword arguments are placed before variable positional arguments (*args).
+    * Added a new check, ``keyword-arg-before-vararg``
 
-      This may lead to args list getting modified if keyword argument's value is not provided in
-      the function call assuming it will take default value provided in the definition.
+      This is emitted for function definitions
+      in which keyword arguments are placed before variable
+      positional arguments (*args).
+
+      This may lead to args list getting modified if keyword argument's value
+      is not provided in the function call assuming it will take default value
+      provided in the definition.
 	
     * The `invalid-name` check contains the name of the template that caused the failure
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -102,6 +102,10 @@ What's New in Pylint 1.8?
 
       Close #574
 
+    * Disabling ``function-redefined```message for function or method with
+      dummy names.
+      Close #1369
+
 What's New in Pylint 1.7.1?
 =========================
 

--- a/doc/whatsnew/1.8.rst
+++ b/doc/whatsnew/1.8.rst
@@ -275,3 +275,6 @@ Other Changes
     foo = None
     if 'bar' in (foo or {}):
       pass
+
+* Redefinition of dummy function is now possible. No ``function-redefined`` message will be emitted anymore if
+  dummy functions are redefined.

--- a/doc/whatsnew/1.8.rst
+++ b/doc/whatsnew/1.8.rst
@@ -16,7 +16,7 @@ New checkers
 
 * A new check was added, ``keyword-arg-before-vararg``.
 
-  This warning message is emmitted when a function is defined with a keyword
+  This warning message is emitted when a function is defined with a keyword
   argument appearing before variable-length positional arguments (*args).
   This may lead to args list getting modified if keyword argument's value is
   not provided in the function call assuming it will take default value provided
@@ -25,7 +25,7 @@ New checkers
   .. code-block:: python
 
      def foo(a, b=3, *args):
-     	 print(a, b, args)
+         print(a, b, args)
 
      # Case1: a=0, b=2, args=(4,5)
      foo(0,2,4,5) # 0 2 (4,5) ==> Observed values are same as expected values

--- a/doc/whatsnew/1.8.rst
+++ b/doc/whatsnew/1.8.rst
@@ -282,7 +282,7 @@ Other Changes
     if 'bar' in (foo or {}):
       pass
 
-* Redefinition of dummy function is now possible. No ``function-redefined`` message will be emitted anymore if
+* Redefinition of dummy function is now possible. ``function-redefined`` message won't be emitted anymore when
   dummy functions are redefined.
 
 * ``missing-param-doc`` and ``missing-type-doc`` are no longer emitted when

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -610,9 +610,10 @@ class BasicErrorChecker(_BasicChecker):
             # correspond to dummy names.
             dummy_variables_rgx = lint_utils.get_global_option(
                 self, 'dummy-variables-rgx', default=None)
-            if dummy_variables_rgx.match(defined_self.name) is None:
-                self.add_message('function-redefined', node=node,
-                                 args=(redeftype, defined_self.fromlineno))
+            if dummy_variables_rgx and dummy_variables_rgx.match(defined_self.name):
+                return
+            self.add_message('function-redefined', node=node,
+                             args=(redeftype, defined_self.fromlineno))
 
 
 class BasicChecker(_BasicChecker):

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -673,8 +673,6 @@ class BasicErrorChecker(_BasicChecker):
         """check for redefinition of a function / method / class name"""
         defined_self = node.parent.frame()[node.name]
         if defined_self is not node and not astroid.are_exclusive(node, defined_self):
-            # before emitting a message check that function/method name doesn't not
-            # correspond to dummy names.
             dummy_variables_rgx = lint_utils.get_global_option(
                 self, 'dummy-variables-rgx', default=None)
             if dummy_variables_rgx and dummy_variables_rgx.match(defined_self.name):

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -36,6 +36,7 @@ from pylint import interfaces
 from pylint.checkers import utils
 from pylint import reporters
 from pylint.reporters.ureports import nodes as reporter_nodes
+import pylint.utils as lint_utils
 
 
 # regex for class/function/variable/constant name
@@ -605,8 +606,13 @@ class BasicErrorChecker(_BasicChecker):
         """check for redefinition of a function / method / class name"""
         defined_self = node.parent.frame()[node.name]
         if defined_self is not node and not astroid.are_exclusive(node, defined_self):
-            self.add_message('function-redefined', node=node,
-                             args=(redeftype, defined_self.fromlineno))
+            # before emitting a message check that function/method name doesn't not
+            # correspond to dummy names.
+            dummy_variables_rgx = lint_utils.get_global_option(
+                self, 'dummy-variables-rgx', default=None)
+            if dummy_variables_rgx.match(defined_self.name) is None:
+                self.add_message('function-redefined', node=node,
+                                 args=(redeftype, defined_self.fromlineno))
 
 
 class BasicChecker(_BasicChecker):

--- a/pylint/test/functional/function_redefined.py
+++ b/pylint/test/functional/function_redefined.py
@@ -72,3 +72,12 @@ def some_func():
     """
     division = 2
     return division
+
+def dummy_func():
+    """First dummy function"""
+    pass
+
+def dummy_func():
+    """Second dummy function, don't emit function-redefined message
+    because of the dummy name"""
+    pass


### PR DESCRIPTION
…side _check_redefinition method. If it is, then do not emit function-redefined message. Add of corresponding test, ChangeLog and whatsnew entries.
Fixes #1369
