### PR TITLE
Fix unhandled exception when node without a name is used as exception class

### DIFF
--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -110,7 +110,7 @@ MSGS = {
               'Used when the exception to catch is of the form \
               "except A or B:".  If intending to catch multiple, \
               rewrite as "except (A, B):"'),
-    'W0715': ('Arguments to %s suggest string formatting might be intended',
+    'W0715': ('Exception arguments suggest string formatting might be intended',
               'raising-format-tuple',
               'Used when passing multiple arguments to an exception \
               constructor, the first of them a string literal containing what \
@@ -157,8 +157,7 @@ class ExceptionRaiseRefVisitor(BaseVisitor):
                     ('{' in msg and '}' in msg)):
                 self._checker.add_message(
                     'raising-format-tuple',
-                    node=self._node,
-                    args=call.func.name)
+                    node=self._node)
 
 
 class ExceptionRaiseLeafVisitor(BaseVisitor):

--- a/pylint/test/functional/raising_format_tuple.py
+++ b/pylint/test/functional/raising_format_tuple.py
@@ -44,3 +44,7 @@ def bad_triplequote(arg):
 def bad_unicode(arg):
     '''Unicode string literal'''
     raise ValueError(u'Bad %s', arg)  # [raising-format-tuple]
+
+def raise_something_without_name(arg):
+   import standard_exceptions  # pylint: disable=import-error
+   raise standard_exceptions.MyException(u'An %s', arg)  # [raising-format-tuple]

--- a/pylint/test/functional/raising_format_tuple.py
+++ b/pylint/test/functional/raising_format_tuple.py
@@ -46,5 +46,6 @@ def bad_unicode(arg):
     raise ValueError(u'Bad %s', arg)  # [raising-format-tuple]
 
 def raise_something_without_name(arg):
-   import standard_exceptions  # pylint: disable=import-error
-   raise standard_exceptions.MyException(u'An %s', arg)  # [raising-format-tuple]
+    '''Regression test for nodes without .node attribute'''
+    import standard_exceptions  # pylint: disable=import-error
+    raise standard_exceptions.MyException(u'An %s', arg)  # [raising-format-tuple]

--- a/pylint/test/functional/raising_format_tuple.txt
+++ b/pylint/test/functional/raising_format_tuple.txt
@@ -4,3 +4,4 @@ raising-format-tuple:26:bad_braces:Exception arguments suggest string formatting
 raising-format-tuple:34:bad_multistring:Exception arguments suggest string formatting might be intended
 raising-format-tuple:40:bad_triplequote:Exception arguments suggest string formatting might be intended
 raising-format-tuple:46:bad_unicode:Exception arguments suggest string formatting might be intended
+raising-format-tuple:51:raise_something_without_name:Exception arguments suggest string formatting might be intended

--- a/pylint/test/functional/raising_format_tuple.txt
+++ b/pylint/test/functional/raising_format_tuple.txt
@@ -1,6 +1,6 @@
-raising-format-tuple:10:bad_percent:Arguments to KeyError suggest string formatting might be intended
-raising-format-tuple:18:bad_multiarg:Arguments to ValueError suggest string formatting might be intended
-raising-format-tuple:26:bad_braces:Arguments to KeyError suggest string formatting might be intended
-raising-format-tuple:34:bad_multistring:Arguments to AssertionError suggest string formatting might be intended
-raising-format-tuple:40:bad_triplequote:Arguments to AssertionError suggest string formatting might be intended
-raising-format-tuple:46:bad_unicode:Arguments to ValueError suggest string formatting might be intended
+raising-format-tuple:10:bad_percent:Exception arguments suggest string formatting might be intended
+raising-format-tuple:18:bad_multiarg:Exception arguments suggest string formatting might be intended
+raising-format-tuple:26:bad_braces:Exception arguments suggest string formatting might be intended
+raising-format-tuple:34:bad_multistring:Exception arguments suggest string formatting might be intended
+raising-format-tuple:40:bad_triplequote:Exception arguments suggest string formatting might be intended
+raising-format-tuple:46:bad_unicode:Exception arguments suggest string formatting might be intended


### PR DESCRIPTION
First part of #1677

Cannot reproduce another issue on current master branch.