### PR TITLE
bad-whitespace checking around dotted type hint in pylint 1.7 (#1525, #1543)

### DIFF
--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -631,6 +631,8 @@ class FormatChecker(BaseTokenChecker):
             elif token[1] == ',':
                 if not bracket_level:
                     return False
+            elif token[1] == '.':
+                continue
             elif token[0] not in (tokenize.NAME, tokenize.STRING):
                 return False
         return False

--- a/pylint/test/unittest_checker_format.py
+++ b/pylint/test/unittest_checker_format.py
@@ -217,6 +217,7 @@ class TestCheckSpace(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.process_tokens(tokenize_str('foo(foo=bar)\n'))
             self.checker.process_tokens(tokenize_str('foo(foo: int = bar)\n'))
+            self.checker.process_tokens(tokenize_str('foo(foo: module.classname = bar)\n'))
             self.checker.process_tokens(tokenize_str('foo(foo: Dict[int, str] = bar)\n'))
             self.checker.process_tokens(tokenize_str('foo(foo: \'int\' = bar)\n'))
             self.checker.process_tokens(tokenize_str('foo(foo: Dict[int, \'str\'] = bar)\n'))


### PR DESCRIPTION
### Fixes / new features

- #1525
- #1543

Many issues and pull requests have been opened. And this is one of them.

With type hints becoming more and more popular, and 1.8 not released yet, more and more people are hitting upon the issue of bad-whitespace checking around dotted type hint.

Past issues:

pull #1229 Omit convention warnings on assignment with type hints
issue #1430 Incorrect checking of whitespace with dotted type hint
pull #1429 bad-whitespace checking around dotted type hint

Currently open issues:

issue #1525 Pylint not allowing whitespace after type hint
issue #1543 False positive "No space allowed around keyword argument assignment" when using non-trivial annotations

This PR doesn't include any new code, it simply cherry-picks a commit 2561f53 that's on master since April, into 1.7 branch.

I'm sure I'm not the only one who would like to see this merged into 1.7, unless the 1.8 release is coming up shortly.