### PR TITLE
Report each duplicated argument

### DIFF
--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -512,13 +512,29 @@ class BasicErrorChecker(_BasicChecker):
                            retnode.value.value is not None:
                         self.add_message('return-arg-in-generator', node=node,
                                          line=retnode.fromlineno)
-        # Check for duplicate names
-        args = set()
-        for name in node.argnames():
-            if name in args:
-                self.add_message('duplicate-argument-name', node=node, args=(name,))
+        # Check for duplicate names by clustering args with same name for detailed report
+        args = node.args
+        arg_clusters = collections.defaultdict(list)
+        for arg in itertools.chain.from_iterable(pack for pack in
+                                                 [args.args, [args.vararg],
+                                                  args.kwonlyargs, [args.kwarg]]
+                                                 if pack is not None and all(pack)):
+            if isinstance(arg, str):
+                # sadly, asteroid doesn't expose variadic and kw-variadic arg nodes
+                arg_clusters[arg].append(arg)
             else:
-                args.add(name)
+                arg_clusters[arg.name].append(arg)
+
+        # provide detailed report about each repeated argument
+        for arg in itertools.chain.from_iterable(args for args in arg_clusters.values()
+                                                 if len(args) > 1):
+            if isinstance(arg, str):
+                # fallback on previous behavior
+                add_message_args = node.lineno, node, (arg,)
+            else:
+                add_message_args = arg.lineno, arg, (arg.name,)
+
+            self.add_message('duplicate-argument-name', *add_message_args)
 
     visit_asyncfunctiondef = visit_functiondef
 

--- a/pylint/test/functional/async_functions.py
+++ b/pylint/test/functional/async_functions.py
@@ -53,7 +53,7 @@ async def complex_function(this, function, has, more, arguments, than,
         pass
 
 
-# +1: [duplicate-argument-name,dangerous-default-value]
+# +1: [duplicate-argument-name, duplicate-argument-name, dangerous-default-value]
 async def func(a, a, b=[]):
     return a, b
 

--- a/pylint/test/functional/async_functions.txt
+++ b/pylint/test/functional/async_functions.txt
@@ -6,5 +6,6 @@ too-many-branches:26:complex_function:Too many branches (13/12)
 too-many-return-statements:26:complex_function:Too many return statements (10/6)
 dangerous-default-value:57:func:Dangerous default value [] as argument
 duplicate-argument-name:57:func:Duplicate argument name a in function definition
+duplicate-argument-name:57:func:Duplicate argument name a in function definition
 blacklisted-name:62:foo:Black listed name "foo"
 empty-docstring:62:foo:Empty function docstring

--- a/pylint/test/functional/duplicate_argument_name.py
+++ b/pylint/test/functional/duplicate_argument_name.py
@@ -1,11 +1,14 @@
 """Check for duplicate function arguments."""
 
 
-def foo1(_, _): # [duplicate-argument-name]
+def foo1(_, _): # [duplicate-argument-name, duplicate-argument-name]
     """Function with duplicate argument name."""
 
-def foo2(_, *_): # [duplicate-argument-name]
+def foo2(_, *_): # [duplicate-argument-name, duplicate-argument-name]
     """Function with duplicate argument name."""
 
-def foo3(_, _=3): # [duplicate-argument-name]
+def foo3(_, _=3): # [duplicate-argument-name, duplicate-argument-name]
+    """Function with duplicate argument name."""
+
+def foo4(_, **_): # [duplicate-argument-name, duplicate-argument-name]
     """Function with duplicate argument name."""

--- a/pylint/test/functional/duplicate_argument_name.txt
+++ b/pylint/test/functional/duplicate_argument_name.txt
@@ -1,3 +1,8 @@
 duplicate-argument-name:4:foo1:Duplicate argument name _ in function definition
+duplicate-argument-name:4:foo1:Duplicate argument name _ in function definition
+duplicate-argument-name:7:foo2:Duplicate argument name _ in function definition
 duplicate-argument-name:7:foo2:Duplicate argument name _ in function definition
 duplicate-argument-name:10:foo3:Duplicate argument name _ in function definition
+duplicate-argument-name:10:foo3:Duplicate argument name _ in function definition
+duplicate-argument-name:13:foo4:Duplicate argument name _ in function definition
+duplicate-argument-name:13:foo4:Duplicate argument name _ in function definition

--- a/pylint/test/functional/duplicate_argument_name_py3.py
+++ b/pylint/test/functional/duplicate_argument_name_py3.py
@@ -1,0 +1,5 @@
+"""Check for duplicate function keywordonly arguments."""
+
+
+def foo1(_, *_, _=3): # [duplicate-argument-name, duplicate-argument-name, duplicate-argument-name]
+    """Function with duplicate argument name."""

--- a/pylint/test/functional/duplicate_argument_name_py3.rc
+++ b/pylint/test/functional/duplicate_argument_name_py3.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.0

--- a/pylint/test/functional/duplicate_argument_name_py3.txt
+++ b/pylint/test/functional/duplicate_argument_name_py3.txt
@@ -1,0 +1,3 @@
+duplicate-argument-name:4:foo1:Duplicate argument name _ in function definition
+duplicate-argument-name:4:foo1:Duplicate argument name _ in function definition
+duplicate-argument-name:4:foo1:Duplicate argument name _ in function definition


### PR DESCRIPTION
### New features
- Added detailed reporting on each duplicated argument in function signature
Fixes issue #1712
### Motivation
Current behavior doesn't allow to provide informative highlighting of errors in such cases (like PyCharm does), because it points to begin of function node and loses any information about count of this errors, positions etc
Example:
* Current behavior 
```python
def func(arg, arg):
    pass
▲ [duplicate-argument-name]
```
* Proposed behavior
```python
def func(arg, arg):
    pass
              ▲ [duplicate-argument-name]
         ▲ [duplicate-argument-name]
```
### Issues
- `*args` and `**kwargs` arguments are counted, but it isn't trivial to find their positions, because Astroid doesn't hold nodes of such arguments, only names
