### PR TITLE
Extend trailing-comma-tuple check to more complex assignments

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -141,3 +141,5 @@ Order doesn't matter (not that much, at least ;)
 * Ahirnish Pareek, 'keyword-arg-before-var-arg' check
 
 * Guillaume Peillex: contributor.
+
+* Bryce Guinta: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,11 @@ Pylint's ChangeLog
 What's New in Pylint 1.8?
 =========================
 
+    * `trailing-comma-tuple` refactor check now extends to assignment with
+       more than one element (such as lists)
+
+      Close #1713
+
     * Fixing u'' string in superfluous-parens message 
 
       Close #1420

--- a/pylint/test/functional/trailing_comma_tuple.py
+++ b/pylint/test/functional/trailing_comma_tuple.py
@@ -3,6 +3,7 @@
 AAA = 1, # [trailing-comma-tuple]
 BBB = "aaaa", # [trailing-comma-tuple]
 CCC="aaa", # [trailing-comma-tuple]
+FFF=['f'], # [trailing-comma-tuple]
 
 BBB = 1, 2
 CCC = (1, 2, 3)

--- a/pylint/test/functional/trailing_comma_tuple.txt
+++ b/pylint/test/functional/trailing_comma_tuple.txt
@@ -1,3 +1,4 @@
 trailing-comma-tuple:3::Disallow trailing comma tuple
 trailing-comma-tuple:4::Disallow trailing comma tuple
 trailing-comma-tuple:5::Disallow trailing comma tuple
+trailing-comma-tuple:6::Disallow trailing comma tuple


### PR DESCRIPTION
The prevous implementation was too conservative with looking for
previous tokens associated with assignment: It looked only
at the immediately previous token, causing 'a = (5),' to not be
caught.

Now The current implementation backtracks to the start of the line
to find an assignment substring.

Fixes issue #1713 