### PR TITLE
Fix py3k issues

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,14 @@ Pylint's ChangeLog
 What's New in Pylint 1.8?
 =========================
 
+    * Fix py3k checks related to absolute imports.
+
+      Do not display no-absolute-import warning multiple times per file.
+
+      Respect disabled no-absolute-import.
+
+      Respect disable=... in config file when running with --py3k.
+
     * Fixing u'' string in superfluous-parens message 
 
       Close #1420

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -661,8 +661,9 @@ class Python3Checker(checkers.BaseChecker):
 
     def visit_import(self, node):
         if not self._future_absolute_import:
-            self.add_message('no-absolute-import', node=node)
-            self._future_absolute_import = True
+            if self.linter.is_message_enabled('no-absolute-import'):
+                self.add_message('no-absolute-import', node=node)
+                self._future_absolute_import = True
         if not _is_conditional_import(node):
             for name, _ in node.names:
                 self._warn_if_deprecated(node, name, None)

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -650,6 +650,7 @@ class Python3Checker(checkers.BaseChecker):
             if not self._future_absolute_import:
                 if self.linter.is_message_enabled('no-absolute-import'):
                     self.add_message('no-absolute-import', node=node)
+                    self._future_absolute_import = True
             if not _is_conditional_import(node) and not node.level:
                 self._warn_if_deprecated(node, node.modname, {x[0] for x in node.names})
 
@@ -661,6 +662,7 @@ class Python3Checker(checkers.BaseChecker):
     def visit_import(self, node):
         if not self._future_absolute_import:
             self.add_message('no-absolute-import', node=node)
+            self._future_absolute_import = True
         if not _is_conditional_import(node):
             for name, _ in node.names:
                 self._warn_if_deprecated(node, name, None)

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -595,9 +595,9 @@ class PyLinter(config.OptionsManagerMixIn,
             for msg_id in self._checker_messages('python3'):
                 if msg_id.startswith('E'):
                     self.enable(msg_id)
-            config = self.cfgfile_parser
-            if config.has_option('MESSAGES CONTROL', 'disable'):
-                value = config.get('MESSAGES CONTROL', 'disable')
+            config_parser = self.cfgfile_parser
+            if config_parser.has_option('MESSAGES CONTROL', 'disable'):
+                value = config_parser.get('MESSAGES CONTROL', 'disable')
                 self.global_set_option('disable', value)
         else:
             self.disable('python3')
@@ -618,9 +618,9 @@ class PyLinter(config.OptionsManagerMixIn,
                     self.enable(msg_id)
                 else:
                     self.disable(msg_id)
-        config = self.cfgfile_parser
-        if config.has_option('MESSAGES CONTROL', 'disable'):
-            value = config.get('MESSAGES CONTROL', 'disable')
+        config_parser = self.cfgfile_parser
+        if config_parser.has_option('MESSAGES CONTROL', 'disable'):
+            value = config_parser.get('MESSAGES CONTROL', 'disable')
             self.global_set_option('disable', value)
         self._python3_porting_mode = True
 

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -595,6 +595,10 @@ class PyLinter(config.OptionsManagerMixIn,
             for msg_id in self._checker_messages('python3'):
                 if msg_id.startswith('E'):
                     self.enable(msg_id)
+            config = self.cfgfile_parser
+            if config.has_option('MESSAGES CONTROL', 'disable'):
+                value = config.get('MESSAGES CONTROL', 'disable')
+                self.global_set_option('disable', value)
         else:
             self.disable('python3')
         self.set_option('reports', False)
@@ -614,6 +618,10 @@ class PyLinter(config.OptionsManagerMixIn,
                     self.enable(msg_id)
                 else:
                     self.disable(msg_id)
+        config = self.cfgfile_parser
+        if config.has_option('MESSAGES CONTROL', 'disable'):
+            value = config.get('MESSAGES CONTROL', 'disable')
+            self.global_set_option('disable', value)
         self._python3_porting_mode = True
 
     # block level option handling #############################################

--- a/pylint/test/regrtest_data/py3k-disabled.rc
+++ b/pylint/test/regrtest_data/py3k-disabled.rc
@@ -1,0 +1,2 @@
+[MESSAGES CONTROL]
+disable=no-absolute-import

--- a/pylint/test/regrtest_data/py3k_errors_and_warnings.py
+++ b/pylint/test/regrtest_data/py3k_errors_and_warnings.py
@@ -1,0 +1,16 @@
+"""Contains both normal error messages and Python3 porting error messages."""
+# pylint: disable=too-few-public-methods
+
+# error: import missing `from __future__ import absolute_import`
+import sys
+
+# error: Use raise ErrorClass(args) instead of raise ErrorClass, args.
+raise Exception, 1
+
+class Test(object):
+    """dummy"""
+
+    def __init__(self):
+        # warning: Calling a dict.iter*() method
+        {1: 2}.iteritems()
+        return 42

--- a/pylint/test/test_self.py
+++ b/pylint/test/test_self.py
@@ -237,6 +237,37 @@ class TestRunTC(object):
         self._test_output([module, "--py3k", "-E", "--msg-template='{msg}'"],
                           expected_output=expected)
 
+    @pytest.mark.skipif(sys.version_info[0] > 2, reason="Requires the --py3k flag.")
+    def test_py3k_commutative_with_config_disable(self):
+        module = join(HERE, 'regrtest_data', 'py3k_errors_and_warnings.py')
+        rcfile = join(HERE, 'regrtest_data', 'py3k-disabled.rc')
+        cmd = [module, "--msg-template='{msg}'", "--reports=n"]
+
+        expected = textwrap.dedent("""
+        import missing `from __future__ import absolute_import`
+        Use raise ErrorClass(args) instead of raise ErrorClass, args.
+        Calling a dict.iter*() method
+        """)
+        self._test_output(cmd + ["--py3k"], expected_output=expected)
+
+        expected = textwrap.dedent("""
+        ************* Module py3k_errors_and_warnings
+        Use raise ErrorClass(args) instead of raise ErrorClass, args.
+        Calling a dict.iter*() method
+        """)
+        self._test_output(cmd + ["--py3k", "--rcfile", rcfile],
+                          expected_output=expected)
+
+        expected = textwrap.dedent("""
+        ************* Module py3k_errors_and_warnings
+        Use raise ErrorClass(args) instead of raise ErrorClass, args.
+        """)
+        self._test_output(cmd + ["--py3k", "-E", "--rcfile", rcfile],
+                          expected_output=expected)
+
+        self._test_output(cmd + ["-E", "--py3k", "--rcfile", rcfile],
+                          expected_output=expected)
+
     def test_abbreviations_are_not_supported(self):
         expected = "no such option: --load-plugin"
         self._test_output([".", "--load-plugin"], expected_output=expected)

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -313,12 +313,18 @@ class TestPython3Checker(testutils.CheckerTestCase):
         message = testutils.Message('no-absolute-import', node=node)
         with self.assertAddsMessages(message):
             self.checker.visit_import(node)
+        with self.assertNoMessages():
+            # message should only be added once
+            self.checker.visit_import(node)
 
     def test_relative_from_import(self):
         node = astroid.extract_node('from os import path  #@')
         message = testutils.Message('no-absolute-import', node=node)
         with self.assertAddsMessages(message):
-            self.checker.visit_import(node)
+            self.checker.visit_importfrom(node)
+        with self.assertNoMessages():
+            # message should only be added once
+            self.checker.visit_importfrom(node)
 
     def test_absolute_import(self):
         module_import = astroid.parse(

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -606,6 +606,7 @@ class TestPython3Checker(testutils.CheckerTestCase):
             absolute_import_message = testutils.Message('no-absolute-import', node=node)
             with self.assertAddsMessages(absolute_import_message):
                 self.checker.visit_importfrom(node)
+            self.checker._future_absolute_import = False
 
     @python2_only
     def test_bad_import_conditional(self):

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # Copyright (c) 2014-2015 Brett Cannon <brett@python.org>
 # Copyright (c) 2014-2016 Claudiu Popa <pcmanticore@gmail.com>
 


### PR DESCRIPTION
### Fixes
- Do not display `no-absolute-import` warning multiple times per file.
- Respect disabled `no-absolute-import`.
- Respect `disable=...` in config file when running with `--py3k`.
