### PR TITLE
Do not warn no-absolute-import multiple times

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -141,3 +141,5 @@ Order doesn't matter (not that much, at least ;)
 * Ahirnish Pareek, 'keyword-arg-before-var-arg' check
 
 * Guillaume Peillex: contributor.
+
+* Daniel Miller: contributor.

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@ Pylint's ChangeLog
 What's New in Pylint 1.8?
 =========================
 
+    * Do not display no-absolute-import warning multiple times per file.
+
     * Fixing u'' string in superfluous-parens message 
 
       Close #1420

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -650,6 +650,7 @@ class Python3Checker(checkers.BaseChecker):
             if not self._future_absolute_import:
                 if self.linter.is_message_enabled('no-absolute-import'):
                     self.add_message('no-absolute-import', node=node)
+                    self._future_absolute_import = True
             if not _is_conditional_import(node) and not node.level:
                 self._warn_if_deprecated(node, node.modname, {x[0] for x in node.names})
 
@@ -660,7 +661,9 @@ class Python3Checker(checkers.BaseChecker):
 
     def visit_import(self, node):
         if not self._future_absolute_import:
-            self.add_message('no-absolute-import', node=node)
+            if self.linter.is_message_enabled('no-absolute-import'):
+                self.add_message('no-absolute-import', node=node)
+                self._future_absolute_import = True
         if not _is_conditional_import(node):
             for name, _ in node.names:
                 self._warn_if_deprecated(node, name, None)

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # Copyright (c) 2014-2015 Brett Cannon <brett@python.org>
 # Copyright (c) 2014-2016 Claudiu Popa <pcmanticore@gmail.com>
 
@@ -313,12 +314,18 @@ class TestPython3Checker(testutils.CheckerTestCase):
         message = testutils.Message('no-absolute-import', node=node)
         with self.assertAddsMessages(message):
             self.checker.visit_import(node)
+        with self.assertNoMessages():
+            # message should only be added once
+            self.checker.visit_import(node)
 
     def test_relative_from_import(self):
         node = astroid.extract_node('from os import path  #@')
         message = testutils.Message('no-absolute-import', node=node)
         with self.assertAddsMessages(message):
-            self.checker.visit_import(node)
+            self.checker.visit_importfrom(node)
+        with self.assertNoMessages():
+            # message should only be added once
+            self.checker.visit_importfrom(node)
 
     def test_absolute_import(self):
         module_import = astroid.parse(
@@ -600,6 +607,7 @@ class TestPython3Checker(testutils.CheckerTestCase):
             absolute_import_message = testutils.Message('no-absolute-import', node=node)
             with self.assertAddsMessages(absolute_import_message):
                 self.checker.visit_importfrom(node)
+            self.checker._future_absolute_import = False
 
     @python2_only
     def test_bad_import_conditional(self):


### PR DESCRIPTION
### Fixes / new features
- Do not display no-absolute-import warning multiple times per file.
