### PR TITLE
Fix: pylint: Symbol’s function definition is void: tramp-tramp-file-p

### DIFF
--- a/elisp/pylint.el
+++ b/elisp/pylint.el
@@ -202,8 +202,9 @@ output buffer, to go to the lines where pylint found matches.
 
   (save-some-buffers (not pylint-ask-about-save) nil)
   (let* ((filename (buffer-file-name))
-         (filename (or (and (tramp-tramp-file-p filename)
-                         (aref (tramp-dissect-file-name filename) 3))
+         (filename (or  (and (fboundp 'tramp-tramp-file-p)
+                             (and (tramp-tramp-file-p filename)
+                                  (aref (tramp-dissect-file-name filename) 3)))
                       filename))
          (filename (shell-quote-argument filename))
          (pylint-command (if arg


### PR DESCRIPTION
### Fixes / new features
- Fix: pylint: Symbol’s function definition is void: tramp-tramp-file-p
  which occured with emacs 25.3.1 and tramp 2.2.13.25.2