### PR TITLE
WIP: New warning: shallow copy of os.environ

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -145,3 +145,6 @@ Order doesn't matter (not that much, at least ;)
 * Daniel Miller: contributor.
 
 * Bryce Guinta: contributor
+
+* Martin Bašti: contributor
+  Added new check for shallow copy of os.environ

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,19 @@ Pylint's ChangeLog
 What's New in Pylint 1.8?
 =========================
 
+    * New warning `shallow-copy-environ` added
+
+      Shallow copy of os.environ doesn't work as people may expect. os.environ
+      is not a dict object but rather a proxy object, so any changes made
+      on copy may have unexpected effects on os.environ
+
+      Instead of copy.copy(os.environ) method os.environ.copy() should be
+      used.
+
+      See https://bugs.python.org/issue15373 for details.
+
+      Close #1301
+
     * Do not display no-absolute-import warning multiple times per file.
 
     * `trailing-comma-tuple` refactor check now extends to assignment with

--- a/doc/whatsnew/1.8.rst
+++ b/doc/whatsnew/1.8.rst
@@ -14,6 +14,29 @@ Summary -- Release highlights
 New checkers
 ============
 
+* A new check was added, ``shallow-copy-environ``.
+
+  This warning message is emitted when shallow copy of os.environ is created.
+  Shallow copy of os.environ doesn't work as people may expect. os.environ
+  is not a dict object but rather a proxy object, so any changes made
+  on copy may have unexpected effects on os.environ
+
+  Instead of copy.copy(os.environ) method os.environ.copy() should be used.
+
+  See https://bugs.python.org/issue15373 for details.
+
+  .. code-block:: python
+
+     import copy
+     import os
+     wrong_env_copy = copy.copy(os.environ)  # will emit pylint warning
+     wrong_env_copy['ENV_VAR'] = 'new_value'  # changes os.environ
+     assert os.environ['ENV_VAR'] == 'new_value'
+
+     good_env_copy = os.environ.copy()  # the right way
+     good_env_copy['ENV_VAR'] = 'different_value'  # doesn't change os.environ
+     assert os.environ['ENV_VAR'] == 'new_value'
+
 * A new check was added, ``keyword-arg-before-vararg``.
 
   This warning message is emitted when a function is defined with a keyword


### PR DESCRIPTION
Shallow copy of os.environ doesn't work as people may expect. os.environ
is not a dict object but rather a proxy object, so any changes made
on the copy may have unexpected effects on os.environ

Instead of copy.copy(os.environ) method os.environ.copy() should be
used.

Message-id is: `shallow-copy-environ`

See https://bugs.python.org/issue15373 for details.

Resolves: #1301
