### PR TITLE
Add back accidentally removed changelog entry

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,19 @@ What's New in Pylint 1.8?
 
     * Respect disable=... in config file when running with --py3k.
 
+    * New warning `shallow-copy-environ` added
+
+      Shallow copy of os.environ doesn't work as people may expect. os.environ
+      is not a dict object but rather a proxy object, so any changes made
+      on copy may have unexpected effects on os.environ
+
+      Instead of copy.copy(os.environ) method os.environ.copy() should be
+      used.
+
+      See https://bugs.python.org/issue15373 for details.
+
+      Close #1301
+
     * Do not display no-absolute-import warning multiple times per file.
 
     * `trailing-comma-tuple` refactor check now extends to assignment with


### PR DESCRIPTION
Change log entry added in #1733 was accidentally removed in commit
996b3fb51597379ad6170056ce445f9f52da52e6 in PR #1726

Adding changelog entry back.

Fixes: #1301
