### PR TITLE
Fix "Incorrect column number for whitespace conventions"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,11 @@ What's New in Pylint 1.8?
 
     * Do not display no-absolute-import warning multiple times per file.
 
+	* Correct column number for whitespace conventions. Previously the column
+	was stuck at 0
+
+	Close #1649
+
     * `trailing-comma-tuple` refactor check now extends to assignment with
        more than one element (such as lists)
 

--- a/pylint/checkers/__init__.py
+++ b/pylint/checkers/__init__.py
@@ -88,9 +88,10 @@ class BaseChecker(OptionsProviderMixIn):
         OptionsProviderMixIn.__init__(self)
         self.linter = linter
 
-    def add_message(self, msg_id, line=None, node=None, args=None, confidence=UNDEFINED):
+    def add_message(self, msg_id, line=None, node=None, args=None, confidence=UNDEFINED,
+                    col_offset=None):
         """add a message of a given type"""
-        self.linter.add_message(msg_id, line, node, args, confidence)
+        self.linter.add_message(msg_id, line, node, args, confidence, col_offset)
 
     # dummy methods implementing the IChecker interface
 

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -725,7 +725,7 @@ class FormatChecker(BaseTokenChecker):
             count, state = _policy_string(policy)
             self.add_message('bad-whitespace', line=token[2][0],
                              args=(count, state, position, construct,
-                                   _underline_token(token)))
+                                   _underline_token(token)), col_offset=token[2][1]+1)
 
     def _inside_brackets(self, left):
         return self._bracket_stack[-1] == left

--- a/pylint/testutils.py
+++ b/pylint/testutils.py
@@ -165,7 +165,9 @@ class UnittestLinter(object):
         finally:
             self._messages = []
 
-    def add_message(self, msg_id, line=None, node=None, args=None, confidence=None):
+    def add_message(self, msg_id, line=None, node=None, args=None, confidence=None,
+                    col_offset=None):
+        # Do not test col_offset for now since changing Message breaks everything
         self._messages.append(Message(msg_id, line, node, args, confidence))
 
     def is_message_enabled(self, *unused_args, **unused_kwargs):

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -354,7 +354,8 @@ class MessagesHandlerMixIn(object):
         except KeyError:
             return self._msgs_state.get(msgid, True)
 
-    def add_message(self, msg_descr, line=None, node=None, args=None, confidence=UNDEFINED):
+    def add_message(self, msg_descr, line=None, node=None, args=None, confidence=UNDEFINED,
+                    col_offset=None):
         """Adds a message given by ID or name.
 
         If provided, the message string is expanded using args
@@ -386,10 +387,9 @@ class MessagesHandlerMixIn(object):
 
         if line is None and node is not None:
             line = node.fromlineno
-        if hasattr(node, 'col_offset'):
+        if col_offset is None and hasattr(node, 'col_offset'):
             col_offset = node.col_offset # XXX measured in bytes for utf-8, divide by two for chars?
-        else:
-            col_offset = None
+
         # should this message be displayed
         if not self.is_message_enabled(msgid, line, confidence):
             self.file_state.handle_ignored_message(


### PR DESCRIPTION
Fixes #1649 

I needed to modify add_message to accommodate column offsets that do not have nodes (since bad-whitespace uses tokens).