### PR TITLE
Make the documentation build reproducibly.

### DIFF
--- a/doc/exts/pylint_extensions.py
+++ b/doc/exts/pylint_extensions.py
@@ -42,6 +42,7 @@ def builder_inited(app):
         elif ext == '.rst':
             doc_files['pylint.extensions.' + name] = os.path.join(ext_path,
                                                                   filename)
+    modules.sort()
     if not modules:
         sys.exit("No Pylint extensions found?")
 

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -471,7 +471,7 @@ class MessagesHandlerMixIn(object):
         print("Below is a list of all checkers and their features.", file=stream)
         print("", file=stream)
 
-        for checker, info in six.iteritems(by_checker):
+        for checker, info in sorted(six.iteritems(by_checker)):
             self._print_checker_doc(checker, info, stream=stream)
 
     @staticmethod


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that pylint could not be built reproducibly.

This is due to the documentation generator iterating over the filesystem
in a nondeterminstic order and then iterating over an internal,
nondeterminstic, data structure.

This was originally filed in Debian as #883913.

 [0] https://reproducible-builds.org/
 [1] https://bugs.debian.org/883913

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>
