### PR TITLE
Pylint doesn't take anymore the default rcfile if the rcfile specified on the command line doesn't exist

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -173,6 +173,10 @@ What's New in Pylint 1.8?
       of ``line-too-long`` message for long commented lines.
       Close #1741
 
+    * If the rcfile specified on the command line doesn't exist, then an
+      IOError exception is raised.
+      Close #1747
+
 What's New in Pylint 1.7.1?
 =========================
 

--- a/doc/whatsnew/1.8.rst
+++ b/doc/whatsnew/1.8.rst
@@ -364,3 +364,6 @@ Other Changes
 * Fix ``line-too-long`` message deactivated by wrong disable directive.
   The directive ``disable=fixme`` doesn't deactivate anymore the emission 
   of ``line-too-long`` message for long commented lines.
+
+* If the rcfile specified on the command line doesn't exist, then an
+  IOError exception is raised.

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -626,6 +626,8 @@ class OptionsManagerMixIn(object):
             config_file = self.config_file
         if config_file is not None:
             config_file = os.path.expanduser(config_file)
+            if not os.path.exists(config_file):
+                raise IOError("The config file {:s} doesn't exist!".format(config_file))
 
         use_config_file = config_file and os.path.exists(config_file)
         if use_config_file:
@@ -645,10 +647,9 @@ class OptionsManagerMixIn(object):
 
         if use_config_file:
             msg = 'Using config file {0}'.format(os.path.abspath(config_file))
-            print(msg, file=sys.stderr)
         else:
-            msg = 'Config file {0} not found!'.format(os.path.abspath(config_file))
-            raise IOError(msg)
+            msg = 'No config file found, using default configuration'
+        print(msg, file=sys.stderr)
 
     def load_config_file(self):
         """dispatch values previously read from a configuration file to each

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -645,9 +645,10 @@ class OptionsManagerMixIn(object):
 
         if use_config_file:
             msg = 'Using config file {0}'.format(os.path.abspath(config_file))
+            print(msg, file=sys.stderr)
         else:
-            msg = 'No config file found, using default configuration'
-        print(msg, file=sys.stderr)
+            msg = 'Config file {0} not found!'.format(os.path.abspath(config_file))
+            raise IOError(msg)
 
     def load_config_file(self):
         """dispatch values previously read from a configuration file to each

--- a/pylint/test/test_self.py
+++ b/pylint/test/test_self.py
@@ -169,6 +169,12 @@ class TestRunTC(object):
         output = out.getvalue()
         assert "profile" not in output
 
+    def test_inexisting_rcfile(self):
+        out = six.StringIO()
+        with pytest.raises(IOError) as excinfo:
+            self._run_pylint(["--rcfile=/tmp/norcfile.txt"], out=out)
+        assert "The config file /tmp/norcfile.txt doesn't exist!" == str(excinfo.value)
+
     def test_help_message_option(self):
         self._runtest(['--help-msg', 'W0101'], code=0)
 


### PR DESCRIPTION
@thish has shown (#1747) that pylint takes the default rcfile even if the rcfile specified on the command line doesn't exist. It may be problematic.
This PR is a proposal to fix this.
If the rcfile specified on the command line does't exist then an IOError exception is raised.
We only check the existence of the rcfile and not is type (file or directory) because it is already taken into account in `read_config_file` method in `config.py`.