### PR TITLE
Bug 1770

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,13 @@
 ------------------
 Pylint's ChangeLog
 ------------------
+What's New in Pylint 2.0?
+=========================
+
+    * Fix a false positive ``inconsistent-return-statements`` message when if
+      statement is inside try/except.
+			Close #1770
+
 What's New in Pylint 1.8?
 =========================
 

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -1,0 +1,21 @@
+**************************
+  What's New In Pylint 2.0
+**************************
+
+:Release: 2.0
+:Date: ????
+
+
+Summary -- Release highlights
+=============================
+
+* None so far
+
+New checkers
+============
+
+Other Changes
+=============
+
+* Fix a false positive ``inconsistent-return-statements`` message when if
+  statement is inside try/except.

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -57,7 +57,7 @@ def _is_node_return_ended(node):
             return False
         exc_name = exc.pytype().split('.')[-1]
         handlers = utils.get_exception_handlers(node, exc_name)
-        handlers = list(handlers) if handlers is not None else list()
+        handlers = list(handlers) if handlers is not None else []
         if handlers:
             # among all the handlers handling the exception at least one
             # must end with a return statement

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -57,6 +57,7 @@ def _is_node_return_ended(node):
             return False
         exc_name = exc.pytype().split('.')[-1]
         handlers = utils.get_exception_handlers(node, exc_name)
+        handlers = list(handlers) if handlers is not None else list()
         if handlers:
             # among all the handlers handling the exception at least one
             # must end with a return statement

--- a/pylint/test/functional/inconsistent_returns.py
+++ b/pylint/test/functional/inconsistent_returns.py
@@ -32,6 +32,17 @@ def returns_and_exceptions(var):
     else:
         raise ValueError("Incorrect value")
 
+def returns_and_exceptions_issue1770(var):
+    try:
+        if var == 1:
+            return 'a'
+        elif var == 2:
+            return 'b'
+        else:
+            raise ValueError
+    except AssertionError:
+        return None
+
 def explicit_returns3(arg):
     if arg:
         return False

--- a/pylint/test/functional/inconsistent_returns.txt
+++ b/pylint/test/functional/inconsistent_returns.txt
@@ -1,7 +1,7 @@
-inconsistent-return-statements:91:explicit_implicit_returns:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:95:empty_explicit_returns:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:100:explicit_implicit_returns2:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:108:explicit_implicit_returns3:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:116:returns_missing_in_catched_exceptions:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:126:complex_func:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:134:inconsistent_returns_in_nested_function.not_consistent_returns_inner:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:102:explicit_implicit_returns:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:106:empty_explicit_returns:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:111:explicit_implicit_returns2:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:119:explicit_implicit_returns3:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:127:returns_missing_in_catched_exceptions:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:137:complex_func:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:145:inconsistent_returns_in_nested_function.not_consistent_returns_inner:Either all return statements in a function should return an expression, or none of them should.


### PR DESCRIPTION
This PR fixes the bug #1770.
The bug was due to the fact that the test to determine if there are handlers able to deal with the exception was done on a generator and thus returns True even if there was no handlers.
Turning the generator into a list solves the problem.
Thanks @The-Compiler !
