### PR TITLE
The right way was wrong, os.environ is not a dict

### DIFF
--- a/doc/whatsnew/1.8.rst
+++ b/doc/whatsnew/1.8.rst
@@ -33,7 +33,7 @@ New checkers
      wrong_env_copy['ENV_VAR'] = 'new_value'  # changes os.environ
      assert os.environ['ENV_VAR'] == 'new_value'
 
-     good_env_copy = os.environ.copy()  # the right way
+     good_env_copy = dict(os.environ)  # the right way
      good_env_copy['ENV_VAR'] = 'different_value'  # doesn't change os.environ
      assert os.environ['ENV_VAR'] == 'new_value'
 


### PR DESCRIPTION
The documentation specify that os.environ is a mapping object, so we should
not assume the undocumented copy() method. The recommended and simple
way to copy the os.environ is with a dict.
