### PR TITLE
Bug 1643

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,15 @@
 ------------------
 Pylint's ChangeLog
 ------------------
+What's New in Pylint 2.0?
+=========================
+
+Release date: ????
+
+    * Fix emission of false positive ``no-member`` message for class with 
+      "private" attributes whose name is mangled.
+      Close #1643
+
 What's New in Pylint 1.8?
 =========================
 

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -1,0 +1,21 @@
+**************************
+  What's New In Pylint 2.0
+**************************
+
+:Release: 2.0
+:Date: ????
+
+
+Summary -- Release highlights
+=============================
+
+* None so far
+
+New checkers
+============
+
+Other Changes
+=============
+
+* Fix emission of false positive ``no-member`` message for class with 
+  "private" attributes whose name is mangled.

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -338,8 +338,11 @@ def _emit_no_member(node, owner, owner_name, ignored_mixins):
     if node.attrname.startswith('_' + owner_name):
         # Test if an attribute has been mangled ('private' attribute)
         unmangled_name = node.attrname.split('_' + owner_name)[-1]
-        if owner.getattr(unmangled_name, None) is not None:
-            return False
+        try:
+            if owner.getattr(unmangled_name, context=None) is not None:
+                return False
+        except astroid.NotFoundError:
+            return True
     return True
 
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -335,6 +335,11 @@ def _emit_no_member(node, owner, owner_name, ignored_mixins):
             return False
         if not all(map(has_known_bases, owner.type.mro())):
             return False
+    if node.attrname.startswith('_' + owner_name):
+        # Test if an attribute has been mangled ('private' attribute)
+        unmangled_name = node.attrname.split('_' + owner_name)[-1]
+        if owner.getattr(unmangled_name, None) is not None:
+            return False
     return True
 
 

--- a/pylint/test/functional/member_checks.py
+++ b/pylint/test/functional/member_checks.py
@@ -189,3 +189,11 @@ class SomeClass(object):
 
 
 SomeClass.does_not_exist
+
+class ClassWithMangledAttribute(object):
+    def __init__(self):
+        self.name = 'Bug1643'
+    def __bar(self):
+        print(self.name + "xD")
+
+ClassWithMangledAttribute()._ClassWithMangledAttribute__bar()  # pylint: disable=protected-access


### PR DESCRIPTION
This PR fixes the issue #1643.
I simply added a test to deal with mangled names in the ``_emit_no_member_method``.
I also added a unit test to ensure pylint doesn't emit ``no-member`` message when accessing a mangled attribute.
