### PR TITLE
Fix `AttributeError` when `None` is passed to `safe_infer`

### DIFF
--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -802,6 +802,8 @@ def safe_infer(node, context=None):
     Return None if inference failed or if there is some ambiguity (more than
     one node has been inferred).
     """
+    if not node:
+        return None
     try:
         inferit = node.infer(context=context)
         value = next(inferit)


### PR DESCRIPTION
### Fixes
- Exception:
`AttributeError: 'NoneType' object has no attribute 'infer'`
can occur when `None` is passed to `safe_infer` function
of  `pylint.checkers.utils`.
This may happen because of code in `pylint.checkers.refactoring._is_node_return_ended`:
```python
        exc = utils.safe_infer(node.exc)
        if exc is None or exc is astroid.Uninferable:
            return False
```
