### PR TITLE
Bug 1774: fix redefining functions that were imported

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -148,3 +148,5 @@ Order doesn't matter (not that much, at least ;)
 
 * Martin Bašti: contributor
   Added new check for shallow copy of os.environ
+
+* Jacques Kvam: contributor

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -714,7 +714,7 @@ class BasicErrorChecker(_BasicChecker):
         if defined_self is not node and not astroid.are_exclusive(node, defined_self):
             dummy_variables_rgx = lint_utils.get_global_option(
                 self, 'dummy-variables-rgx', default=None)
-            if dummy_variables_rgx and dummy_variables_rgx.match(defined_self.name):
+            if dummy_variables_rgx and dummy_variables_rgx.match(node.name):
                 return
             self.add_message('function-redefined', node=node,
                              args=(redeftype, defined_self.fromlineno))

--- a/pylint/test/functional/function_redefined.py
+++ b/pylint/test/functional/function_redefined.py
@@ -1,5 +1,4 @@
-# pylint: disable=R0201,missing-docstring,using-constant-test
-# pylint: disable=unused-import,wrong-import-position,reimported
+# pylint: disable=R0201,missing-docstring,using-constant-test,unused-import,wrong-import-position,reimported
 from __future__ import division
 __revision__ = ''
 

--- a/pylint/test/functional/function_redefined.py
+++ b/pylint/test/functional/function_redefined.py
@@ -1,5 +1,5 @@
 # pylint: disable=R0201,missing-docstring,using-constant-test
-# pylint: disable=unused-import,wrong-import-position
+# pylint: disable=unused-import,wrong-import-position,reimported
 from __future__ import division
 __revision__ = ''
 

--- a/pylint/test/functional/function_redefined.py
+++ b/pylint/test/functional/function_redefined.py
@@ -1,4 +1,5 @@
 # pylint: disable=R0201,missing-docstring,using-constant-test
+# pylint: disable=unused-import,wrong-import-position
 from __future__ import division
 __revision__ = ''
 
@@ -80,4 +81,16 @@ def dummy_func():
 def dummy_func():
     """Second dummy function, don't emit function-redefined message
     because of the dummy name"""
+    pass
+
+from math import ceil
+def ceil(): # [function-redefined]
+    pass
+
+import math
+def math(): # [function-redefined]
+    pass
+
+import math as _
+def _():
     pass

--- a/pylint/test/functional/function_redefined.txt
+++ b/pylint/test/functional/function_redefined.txt
@@ -3,3 +3,5 @@ function-redefined:18:AAAA:class already defined line 5
 function-redefined:32:func2:function already defined line 29
 redefined-outer-name:34:func2:Redefining name '__revision__' from outer scope (line 3)
 function-redefined:51:exclusive_func2:function already defined line 45
+function-redefined:86:ceil:function already defined line 85
+function-redefined:90:math:function already defined line 89


### PR DESCRIPTION
### Fixes / new features
- Fixed #1774 
- Adds more regression tests to make redefined testing more robust.

Maybe this can be backported to 1.8 branch as well?