### PR TITLE
Ignore import-error in deprecated_module_py36.py test

### DIFF
--- a/pylint/test/functional/deprecated_module_py36.py
+++ b/pylint/test/functional/deprecated_module_py36.py
@@ -1,5 +1,5 @@
 """Test deprecated modules from Python 3.6."""
-# pylint: disable=unused-import
+# pylint: disable=unused-import,import-error
 
 import optparse # [deprecated-module]
 import tkinter.tix # [deprecated-module]


### PR DESCRIPTION
tkinter can be unavailable in python distributions compiled without it.

Without this ignore, `pytest pylint/test/test_functional.py::test_functional` gives:

```
E           Failed: Wrong results for file "deprecated_module_py36":
E           
E           Unexpected in testdata:
E              5: import-error
```