### PR TITLE
While loop are considered return ended for check of ``inconsistent-return-statements`` message

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,11 @@ Release date: |TBA|
 
       Close #1770
 
+    * Fix a false positive ``inconsistent-return-statements`` message when
+      while loop are used.
+
+      Close #1772
+
 What's New in Pylint 1.8.1?
 =========================
 

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -21,3 +21,6 @@ Other Changes
 
 * Fix a false positive ``inconsistent-return-statements`` message when if
   statement is inside try/except.
+
+* Fix a false positive ``inconsistent-return-statements`` message when
+  while loop are used.

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -48,6 +48,10 @@ def _is_node_return_ended(node):
     # Recursion base case
     if isinstance(node, astroid.Return):
         return True
+    # Avoid the check inside while loop as we don't know
+    # if they will be completed
+    if isinstance(node, astroid.While):
+        return True
     if isinstance(node, astroid.Raise):
         # a Raise statement doesn't need to end with a return statement
         # but if the exception raised is handled, then the handler has to

--- a/pylint/test/functional/inconsistent_returns.py
+++ b/pylint/test/functional/inconsistent_returns.py
@@ -170,3 +170,11 @@ def blarg(someval):
         return 5
     except BlargException:
         raise
+
+def bug_1772_counter_example(): # [inconsistent-return-statements]
+    counter = 1
+    if counter == 1:
+        while True:
+            counter += 1
+            if counter == 100:
+                return 7

--- a/pylint/test/functional/inconsistent_returns.py
+++ b/pylint/test/functional/inconsistent_returns.py
@@ -98,6 +98,14 @@ def explicit_returns7(arg):
         arg = 3 * arg
         return 'above 0'
 
+def bug_1772():
+    """Don't check inconsistent return statements inside while loop"""
+    counter = 1
+    while True:
+        counter += 1
+        if counter == 100:
+            return 7
+
 # Next ones are not consistent
 def explicit_implicit_returns(var): # [inconsistent-return-statements]
     if var >= 0:

--- a/pylint/test/functional/inconsistent_returns.txt
+++ b/pylint/test/functional/inconsistent_returns.txt
@@ -1,7 +1,7 @@
-inconsistent-return-statements:102:explicit_implicit_returns:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:106:empty_explicit_returns:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:111:explicit_implicit_returns2:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:119:explicit_implicit_returns3:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:127:returns_missing_in_catched_exceptions:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:137:complex_func:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:145:inconsistent_returns_in_nested_function.not_consistent_returns_inner:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:110:explicit_implicit_returns:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:114:empty_explicit_returns:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:119:explicit_implicit_returns2:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:127:explicit_implicit_returns3:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:135:returns_missing_in_catched_exceptions:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:145:complex_func:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:153:inconsistent_returns_in_nested_function.not_consistent_returns_inner:Either all return statements in a function should return an expression, or none of them should.

--- a/pylint/test/functional/inconsistent_returns.txt
+++ b/pylint/test/functional/inconsistent_returns.txt
@@ -5,3 +5,4 @@ inconsistent-return-statements:127:explicit_implicit_returns3:Either all return 
 inconsistent-return-statements:135:returns_missing_in_catched_exceptions:Either all return statements in a function should return an expression, or none of them should.
 inconsistent-return-statements:145:complex_func:Either all return statements in a function should return an expression, or none of them should.
 inconsistent-return-statements:153:inconsistent_returns_in_nested_function.not_consistent_returns_inner:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:174:bug_1772_counter_example:Either all return statements in a function should return an expression, or none of them should.


### PR DESCRIPTION
In the ``_is_node_return_ended`` method (in `refactoring.py`), if the node is a ``While`` then we consider the node as return ended.
I added two unit tests, one is directly the one of @jabdoa2 in bug #1772 and the other is a slight variation where the while loop is inside an if statement.
