### PR TITLE
Enable pylint checks

### DIFF
--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -798,11 +798,9 @@ a metaclass class method.'}
         other implementation to take precedence.
         '''
 
-        if not function.is_method():
-            return
-
-        if function.decorators:
-            # With decorators is a change of use
+        if (not function.is_method()
+                # With decorators is a change of use
+                or function.decorators):
             return
 
         body = function.body
@@ -817,10 +815,9 @@ a metaclass class method.'}
             return
 
         call = statement.value
-        if not isinstance(call, astroid.Call):
-            return
-        if not isinstance(call.func, astroid.Attribute):
-            # Not a super() attribute access.
+        if (not isinstance(call, astroid.Call)
+                # Not a super() attribute access.
+                or not isinstance(call.func, astroid.Attribute)):
             return
 
         # Should be a super call.
@@ -836,14 +833,12 @@ a metaclass class method.'}
         if call.func.attrname != function.name:
             return
 
-        # Should be a super call with the MRO pointer being the current class
-        # and the type being the current instance.
+        # Should be a super call with the MRO pointer being the
+        # current class and the type being the current instance.
         current_scope = function.parent.scope()
-        if super_call.mro_pointer != current_scope:
-            return
-        if not isinstance(super_call.type, astroid.Instance):
-            return
-        if super_call.type.name != current_scope.name:
+        if (super_call.mro_pointer != current_scope
+                or not isinstance(super_call.type, astroid.Instance)
+                or super_call.type.name != current_scope.name):
             return
 
         # Check values of default args
@@ -857,11 +852,11 @@ a metaclass class method.'}
                 # dictionary.
                 # This may happen with astroid build from living objects
                 continue
-            if not isinstance(meth_node, astroid.FunctionDef):
-                # If the method have an ancestor which is not a function
-                # then it is legitimate to redefine it
-                return
-            if _has_different_parameters_default_value(meth_node.args, function.args):
+            if (not isinstance(meth_node, astroid.FunctionDef)
+                    # If the method have an ancestor which is not a
+                    # function then it is legitimate to redefine it
+                    or _has_different_parameters_default_value(
+                        meth_node.args, function.args)):
                 return
             else:
                 break

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -848,6 +848,7 @@ accessed. Python regular expressions are accepted.'}
                                      args=node.func.as_string())
                     break
 
+    # pylint: disable=too-many-branches
     @check_messages(*(list(MSGS.keys())))
     def visit_call(self, node):
         """check that called functions/methods are inferred to callable objects,

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1027,9 +1027,8 @@ accessed. Python regular expressions are accepted.'}
         # If the types can be determined, only allow indices to be int,
         # slice or instances with __index__.
         parent_type = safe_infer(node.parent.value)
-        if not isinstance(parent_type, (astroid.ClassDef, astroid.Instance)):
-            return None
-        if not has_known_bases(parent_type):
+        if (not isinstance(parent_type, (astroid.ClassDef, astroid.Instance))
+                or not has_known_bases(parent_type)):
             return None
 
         # Determine what method on the parent this index will use
@@ -1055,13 +1054,11 @@ accessed. Python regular expressions are accepted.'}
                 exceptions.AttributeInferenceError,
                 IndexError):
             return None
-        if not isinstance(itemmethod, astroid.FunctionDef):
-            return None
-        if itemmethod.root().name != BUILTINS:
-            return None
-        if not itemmethod.parent:
-            return None
-        if itemmethod.parent.name not in SEQUENCE_TYPES:
+
+        if (not isinstance(itemmethod, astroid.FunctionDef)
+                or itemmethod.root().name != BUILTINS
+                or not itemmethod.parent
+                or itemmethod.parent.name not in SEQUENCE_TYPES):
             return None
 
         # For ExtSlice objects coming from visit_extslice, no further

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -276,6 +276,7 @@ def _multiple_choices_validating_option(opt, name, value):
     return _multiple_choice_validator(opt.choices, name, value)
 
 
+# pylint: disable=no-member
 class Option(optparse.Option):
     TYPES = optparse.Option.TYPES + ('regexp', 'regexp_csv', 'csv', 'yn',
                                      'multiple_choice',

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -377,12 +377,12 @@ class _ManHelpFormatter(optparse.HelpFormatter):
             optstring = self.format_option_strings(option)
         if option.help:
             help_text = self.expand_default(option)
-            help = ' '.join([l.strip() for l in help_text.splitlines()])
+            help_string = ' '.join([l.strip() for l in help_text.splitlines()])
         else:
-            help = ''
+            help_string = ''
         return '''.IP "%s"
 %s
-''' % (optstring, help)
+''' % (optstring, help_string)
 
     def format_head(self, optparser, pkginfo, section=1):
         long_desc = ""

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -265,6 +265,7 @@ if multiprocessing is not None:
                     msgs, linter.stats, linter.msg_status)
 
 
+# pylint: disable=too-many-instance-attributes
 class PyLinter(config.OptionsManagerMixIn,
                utils.MessagesHandlerMixIn,
                utils.ReportsHandlerMixIn,

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -1186,7 +1186,7 @@ class Run(object):
 group are mutually exclusive.'),
         )
 
-    def __init__(self, args, reporter=None, exit=True):
+    def __init__(self, args, reporter=None, do_exit=True):
         self._rcfile = None
         self._plugins = []
         try:
@@ -1349,7 +1349,7 @@ group are mutually exclusive.'),
         with fix_import_path(args):
             linter.check(args)
             linter.generate_reports()
-        if exit:
+        if do_exit:
             sys.exit(self.linter.msg_status)
 
     def cb_set_rcfile(self, name, value):

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -944,6 +944,7 @@ class PyLinter(config.OptionsManagerMixIn,
         try:
             return MANAGER.ast_from_file(filepath, modname, source=True)
         except astroid.AstroidSyntaxError as ex:
+            # pylint: disable=no-member
             self.add_message('syntax-error',
                              line=getattr(ex.error, 'lineno', 0),
                              args=str(ex.error))

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -33,6 +33,8 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
+# pylint: disable=broad-except
+
 """ %prog [options] modules_or_packages
 
   Check that module(s) satisfy a coding standard (and more !).
@@ -946,7 +948,7 @@ class PyLinter(config.OptionsManagerMixIn,
                              args=str(ex.error))
         except astroid.AstroidBuildingException as ex:
             self.add_message('parse-error', args=ex)
-        except Exception as ex: # pylint: disable=broad-except
+        except Exception as ex:
             import traceback
             traceback.print_exc()
             self.add_message('astroid-error', args=(ex.__class__, ex))
@@ -1032,7 +1034,7 @@ class PyLinter(config.OptionsManagerMixIn,
         evaluation = self.config.evaluation
         try:
             note = eval(evaluation, {}, self.stats) # pylint: disable=eval-used
-        except Exception as ex: # pylint: disable=broad-except
+        except Exception as ex:
             msg = 'An exception occurred while rating: %s' % ex
         else:
             self.stats['global_note'] = note

--- a/pylint/reporters/text.py
+++ b/pylint/reporters/text.py
@@ -197,6 +197,7 @@ class ColorizedTextReporter(TextReporter):
         ansi_terms = ['xterm-16color', 'xterm-256color']
         if os.environ.get('TERM') not in ansi_terms:
             if sys.platform == 'win32':
+                # pylint: disable=import-error
                 import colorama
                 self.out = colorama.AnsiToWin32(self.out)
 

--- a/pylint/reporters/ureports/nodes.py
+++ b/pylint/reporters/ureports/nodes.py
@@ -39,6 +39,7 @@ class VNode(object):
         visitor
         """
         try:
+            # pylint: disable=no-member
             return self.TYPE.replace('-', '_')
         # pylint: disable=broad-except
         except Exception:

--- a/pylint/reporters/ureports/nodes.py
+++ b/pylint/reporters/ureports/nodes.py
@@ -40,6 +40,7 @@ class VNode(object):
         """
         try:
             return self.TYPE.replace('-', '_')
+        # pylint: disable=broad-except
         except Exception:
             return self.__class__.__name__.lower()
 

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -1188,11 +1188,11 @@ def _ini_format(stream, options, encoding):
     """format options using the INI format"""
     for optname, optdict, value in options:
         value = _format_option_value(optdict, value)
-        help = optdict.get('help')
-        if help:
-            help = _normalize_text(help, line_len=79, indent='# ')
+        help_opt = optdict.get('help')
+        if help_opt:
+            help_opt = _normalize_text(help_opt, line_len=79, indent='# ')
             print(file=stream)
-            print(_encode(help, encoding), file=stream)
+            print(_encode(help_opt, encoding), file=stream)
         else:
             print(file=stream)
         if value is None:
@@ -1219,11 +1219,11 @@ def _rest_format_section(stream, section, options, encoding=None, doc=None):
         print(_encode(_normalize_text(doc, line_len=79, indent=''), encoding), file=stream)
         print(file=stream)
     for optname, optdict, value in options:
-        help = optdict.get('help')
+        help_opt = optdict.get('help')
         print(':%s:' % optname, file=stream)
-        if help:
-            help = _normalize_text(help, line_len=79, indent='  ')
-            print(_encode(help, encoding), file=stream)
+        if help_opt:
+            help_opt = _normalize_text(help_opt, line_len=79, indent='  ')
+            print(_encode(help_opt, encoding), file=stream)
         if value:
             value = _encode(_format_option_value(optdict, value), encoding)
             print(file=stream)

--- a/pylintrc
+++ b/pylintrc
@@ -56,7 +56,6 @@ disable=
     attribute-defined-outside-init,
     duplicate-code,
     fixme,
-    import-error,
     invalid-name,
     missing-docstring,
     no-member,

--- a/pylintrc
+++ b/pylintrc
@@ -70,7 +70,6 @@ disable=
     too-many-statements,
     too-few-public-methods,
     too-many-public-methods,
-    too-many-return-statements,
     too-many-instance-attributes,
 
 
@@ -321,7 +320,7 @@ ignored-argument-names=_.*
 max-locals=15
 
 # Maximum number of return / yield for function / method body
-max-returns=6
+max-returns=11
 
 # Maximum number of branch for function / method body
 max-branches=12

--- a/pylintrc
+++ b/pylintrc
@@ -62,7 +62,6 @@ disable=
     no-member,
     redefined-builtin,
     protected-access,
-    too-many-locals,
     too-many-arguments,
     too-many-statements,
     too-few-public-methods,
@@ -313,7 +312,7 @@ max-args=5
 ignored-argument-names=_.*
 
 # Maximum number of locals for function / method body
-max-locals=15
+max-locals=25
 
 # Maximum number of return / yield for function / method body
 max-returns=11

--- a/pylintrc
+++ b/pylintrc
@@ -69,7 +69,6 @@ disable=
     too-many-arguments,
     too-many-statements,
     too-few-public-methods,
-    too-many-public-methods,
     too-many-instance-attributes,
 
 
@@ -338,7 +337,7 @@ max-attributes=7
 min-public-methods=2
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods=20
+max-public-methods=25
 
 
 [CLASSES]

--- a/pylintrc
+++ b/pylintrc
@@ -59,7 +59,6 @@ disable=
     invalid-name,
     missing-docstring,
     no-member,
-    redefined-builtin,
     protected-access,
     too-many-arguments,
     too-many-statements,

--- a/pylintrc
+++ b/pylintrc
@@ -60,7 +60,6 @@ disable=
     missing-docstring,
     no-member,
     protected-access,
-    too-many-statements,
     too-few-public-methods,
 
 
@@ -317,7 +316,7 @@ max-returns=11
 max-branches=26
 
 # Maximum number of statements in function / method body
-max-statements=50
+max-statements=100
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7

--- a/pylintrc
+++ b/pylintrc
@@ -60,7 +60,6 @@ disable=
     missing-docstring,
     no-member,
     protected-access,
-    too-many-arguments,
     too-many-statements,
     too-few-public-methods,
 
@@ -302,7 +301,7 @@ spelling-store-unknown-words=no
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=5
+max-args=10
 
 # Argument names that match this expression will be ignored. Default to name
 # with leading underscore

--- a/pylintrc
+++ b/pylintrc
@@ -58,7 +58,6 @@ disable=
     fixme,
     invalid-name,
     missing-docstring,
-    no-member,
     protected-access,
     too-few-public-methods,
 

--- a/pylintrc
+++ b/pylintrc
@@ -65,7 +65,6 @@ disable=
     too-many-arguments,
     too-many-statements,
     too-few-public-methods,
-    too-many-instance-attributes,
 
 
 [REPORTS]
@@ -327,7 +326,7 @@ max-statements=50
 max-parents=7
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=11
 
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=2

--- a/pylintrc
+++ b/pylintrc
@@ -52,13 +52,26 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 
-disable=invalid-name,protected-access,fixme,too-many-branches,
-        attribute-defined-outside-init,too-many-locals,
-        too-many-arguments,too-many-statements,
-        too-many-return-statements,too-few-public-methods,
-        import-error,too-many-lines,too-many-instance-attributes,
-        too-many-public-methods,duplicate-code,broad-except,
-        redefined-builtin,missing-docstring,no-member,
+disable=
+    attribute-defined-outside-init,
+    broad-except,
+    duplicate-code,
+    fixme,
+    import-error,
+    invalid-name,
+    missing-docstring,
+    no-member,
+    redefined-builtin,
+    protected-access,
+    too-many-lines,
+    too-many-locals,
+    too-many-branches,
+    too-many-arguments,
+    too-many-statements,
+    too-few-public-methods,
+    too-many-public-methods,
+    too-many-return-statements,
+    too-many-instance-attributes,
 
 
 [REPORTS]

--- a/pylintrc
+++ b/pylintrc
@@ -59,8 +59,6 @@ disable=invalid-name,protected-access,fixme,too-many-branches,
         import-error,too-many-lines,too-many-instance-attributes,
         too-many-public-methods,duplicate-code,broad-except,
         redefined-builtin,missing-docstring,no-member,
-        # Crashes, see #743.
-        redefined-variable-type
 
 
 [REPORTS]

--- a/pylintrc
+++ b/pylintrc
@@ -54,7 +54,6 @@ confidence=
 
 disable=
     attribute-defined-outside-init,
-    broad-except,
     duplicate-code,
     fixme,
     import-error,

--- a/pylintrc
+++ b/pylintrc
@@ -63,7 +63,6 @@ disable=
     no-member,
     redefined-builtin,
     protected-access,
-    too-many-lines,
     too-many-locals,
     too-many-branches,
     too-many-arguments,
@@ -161,7 +160,7 @@ single-line-if-stmt=no
 no-space-check=trailing-comma,dict-separator
 
 # Maximum number of lines in a module
-max-module-lines=1000
+max-module-lines=2000
 
 # String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
 # tab).

--- a/pylintrc
+++ b/pylintrc
@@ -63,7 +63,6 @@ disable=
     redefined-builtin,
     protected-access,
     too-many-locals,
-    too-many-branches,
     too-many-arguments,
     too-many-statements,
     too-few-public-methods,
@@ -320,7 +319,7 @@ max-locals=15
 max-returns=11
 
 # Maximum number of branch for function / method body
-max-branches=12
+max-branches=26
 
 # Maximum number of statements in function / method body
 max-statements=50


### PR DESCRIPTION
### Fixes / new features
Ironically, Pylint's own `pylintrc` has many checks disabled. This PR enables most them. Enabling the checks globally was offset by liberalizing configurable variables (`max-lines` et al) and disabling locally.

The commits are small and independent, so it should be easy to remove them if some of the changes aren't welcome. They can be squashed later.