### PR TITLE
CLI fixes

### DIFF
--- a/pylint/__init__.py
+++ b/pylint/__init__.py
@@ -10,11 +10,14 @@ import sys
 
 from .__pkginfo__ import version as __version__
 
+
 def run_pylint():
     """run pylint"""
     from pylint.lint import Run
-    Run(sys.argv[1:])
-
+    try:
+        Run(sys.argv[1:])
+    except KeyboardInterrupt:
+        sys.exit(1)
 
 def run_epylint():
     """run pylint"""

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -453,7 +453,7 @@ class PyLinter(config.OptionsManagerMixIn,
             'disable': self.disable}
         self._bw_options_methods = {'disable-msg': self.disable,
                                     'enable-msg': self.enable}
-        full_version = '%%prog %s, \nastroid %s\nPython %s' % (
+        full_version = '%%prog %s\nastroid %s\nPython %s' % (
             version, astroid_version, sys.version)
         utils.MessagesHandlerMixIn.__init__(self)
         utils.ReportsHandlerMixIn.__init__(self)


### PR DESCRIPTION
### Fixes / new features
Fixes to CLI stuff that has been bothering me:
- Don't print config file info for `pylint --version`
- Don't print stacktrace on keyboard interrupt
