### PR TITLE
Add new checker useless-return

### DIFF
--- a/pylint/test/unittest_checker_base.py
+++ b/pylint/test/unittest_checker_base.py
@@ -24,6 +24,30 @@ from pylint.checkers import base
 from pylint.testutils import CheckerTestCase, Message, set_config
 
 
+class TestBasicErrorChecker(CheckerTestCase):
+    CHECKER_CLASS = base.BasicErrorChecker
+
+    def test_useless_return(self):
+        func = astroid.extract_node("""
+        def myfunc():
+            print('---- testing ---')
+            return
+        """)
+        message = Message('useless-return', node=func)
+        with self.assertAddsMessages(message):
+            self.checker.visit_functiondef(func)
+
+    def test_useless_return_none(self):
+        func = astroid.extract_node("""
+        def myfunc():
+            print('---- testing ---')
+            return None
+        """)
+        message = Message('useless-return', node=func)
+        with self.assertAddsMessages(message):
+            self.checker.visit_functiondef(func)
+
+
 class TestDocstring(CheckerTestCase):
     CHECKER_CLASS = base.DocStringChecker
 


### PR DESCRIPTION
warns about "return" and "return None" statements at the end of functions/methods. These statements are useless because None is the default return type if they are missing.

Please comment on this feature because there are 20+ existing test cases that break with it. I'd like to know how to "fix" the failing tests before updating documentation, etc.