### PR TITLE
fixes zip-builtin-not-iterating false positive when used as reversed function argument

### DIFF
--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -71,7 +71,7 @@ def _is_builtin(node):
 
 
 _ACCEPTS_ITERATOR = {'iter', 'list', 'tuple', 'sorted', 'set', 'sum', 'any',
-                     'all', 'enumerate', 'dict', 'filter'}
+                     'all', 'enumerate', 'dict', 'filter', 'reversed'}
 DICT_METHODS = {'items', 'keys', 'values'}
 
 


### PR DESCRIPTION
### Fixes #1803
