### PR TITLE
Stop newlines in function parameters from raising a false positive bad-whitespace from annotations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,11 @@ Pylint's ChangeLog
 What's New in Pylint 2.0?
 =========================
 
+	* Fix false positive bad-whitespace from function arguments with default
+	values and annotations
+
+	  Close #1831
+
 	* Fix stop-iteration-return false positive when next builtin has a
 	default value in a generator
 

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -632,6 +632,9 @@ class FormatChecker(BaseTokenChecker):
         """Extended check of PEP-484 type hint presence"""
         if not self._inside_brackets('('):
             return False
+        # token_info
+        # type string start end line
+        #  0      1     2    3    4
         bracket_level = 0
         for token in tokens[i-1::-1]:
             if token[1] == ':':
@@ -647,7 +650,7 @@ class FormatChecker(BaseTokenChecker):
                     return False
             elif token[1] == '.':
                 continue
-            elif token[0] not in (tokenize.NAME, tokenize.STRING):
+            elif token[0] not in (tokenize.NAME, tokenize.STRING, tokenize.NL):
                 return False
         return False
 

--- a/pylint/test/unittest_checker_format.py
+++ b/pylint/test/unittest_checker_format.py
@@ -296,6 +296,9 @@ class TestCheckSpace(CheckerTestCase):
                     args=('Exactly one', 'required', 'around', 'keyword argument assignment',
                           '(foo: List[int]=bar)\n               ^'))):
             self.checker.process_tokens(_tokenize_str('(foo: List[int]=bar)\n'))
+        # Regression test for #1831
+        with self.assertNoMessages():
+            self.checker.process_tokens(_tokenize_str("(arg: Tuple[\n    int, str] = None):\n"))
 
     def testOperatorSpacingGood(self):
         good_cases = [


### PR DESCRIPTION
Fixes #1831 