### PR TITLE
Fix error on 'raise from function'.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -150,3 +150,5 @@ Order doesn't matter (not that much, at least ;)
   Added new check for shallow copy of os.environ
 
 * Jacques Kvam: contributor
+
+* Brian Shaginaw: prevent error on exception check for functions

--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,8 @@ What's New in Pylint 2.0?
 
       Close #1771
 
+    * Fix error when checking if function is exception, as in ``bad-exception-context``.
+
 What's New in Pylint 1.8.1?
 =========================
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -467,6 +467,8 @@ def inherit_from_std_ex(node):
     if node.name in ('Exception', 'BaseException') \
             and node.root().name == EXCEPTIONS_MODULE:
         return True
+    if not hasattr(node, 'ancestors'):
+        return False
     return any(inherit_from_std_ex(parent)
                for parent in node.ancestors(recurs=True))
 

--- a/pylint/test/unittest_checker_exceptions.py
+++ b/pylint/test/unittest_checker_exceptions.py
@@ -60,3 +60,19 @@ class TestExceptionsChecker(CheckerTestCase):
         message = Message('raising-bad-type', node=nodes[3], args='tuple')
         with self.assertAddsMessages(message):
             self.checker.visit_raise(nodes[3])
+
+    @pytest.mark.skipif(sys.version_info[0] != 3,
+                        reason="The test is valid only on Python 3.")
+    def test_bad_exception_context_function(self):
+        node = astroid.extract_node("""
+        def function():
+            pass
+
+        try:
+            pass
+        except function as exc:
+            raise Exception from exc  #@
+        """)
+        message = Message('bad-exception-context', node=node)
+        with self.assertAddsMessages(message):
+            self.checker.visit_raise(node)


### PR DESCRIPTION
### Fixes / new features
 Currently when pylint checks if a function is an exception, it causes an error:

```python
Traceback (most recent call last):
  File "/project/.tox/py36/bin/pylint", line 11, in <module>
    sys.exit(run_pylint())
  File "/project/.tox/py36/lib/python3.6/site-packages/pylint/__init__.py", line 16, in run_pylint
    Run(sys.argv[1:])
  File "/project/.tox/py36/lib/python3.6/site-packages/pylint/lint.py", line 1347, in __init__
    linter.check(args)
  File "/project/.tox/py36/lib/python3.6/site-packages/pylint/lint.py", line 768, in check
    self._do_check(files_or_modules)
  File "/project/.tox/py36/lib/python3.6/site-packages/pylint/lint.py", line 901, in _do_check
    self.check_astroid_module(ast_node, walker, rawcheckers, tokencheckers)
  File "/project/.tox/py36/lib/python3.6/site-packages/pylint/lint.py", line 980, in check_astroid_module
    walker.walk(ast_node)
  File "/project/.tox/py36/lib/python3.6/site-packages/pylint/utils.py", line 1014, in walk
    self.walk(child)
  File "/project/.tox/py36/lib/python3.6/site-packages/pylint/utils.py", line 1014, in walk
    self.walk(child)
  File "/project/.tox/py36/lib/python3.6/site-packages/pylint/utils.py", line 1014, in walk
    self.walk(child)
  [Previous line repeated 1 more times]
  File "/project/.tox/py36/lib/python3.6/site-packages/pylint/utils.py", line 1011, in walk
    cb(astroid)
  File "/project/.tox/py36/lib/python3.6/site-packages/pylint/checkers/exceptions.py", line 262, in visit_raise
    self._check_bad_exception_context(node)
  File "/project/.tox/py36/lib/python3.6/site-packages/pylint/checkers/exceptions.py", line 308, in _check_bad_exception_context
    not utils.inherit_from_std_ex(cause)):
  File "/project/.tox/py36/lib/python3.6/site-packages/pylint/checkers/utils.py", line 471, in inherit_from_std_ex
    for parent in node.ancestors(recurs=True))
  File "/project/.tox/py36/lib/python3.6/site-packages/astroid/bases.py", line 71, in __getattr__
    return getattr(self._proxied, name)
AttributeError: 'FunctionDef' object has no attribute 'ancestors'
```

This change just declares nodes without `ancestors` to be not exceptions.
