### PR TITLE
Fix stop-iteration-return false positive

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,11 @@ Pylint's ChangeLog
 What's New in Pylint 2.0?
 =========================
 
+	* Fix stop-iteration-return false positive when next builtin has a
+	default value in a generator
+
+	  Close #1830
+
     * Fix emission of false positive ``no-member`` message for class with  "private" attributes whose name is mangled.
 
       Close #1643

--- a/pylint/test/functional/stop_iteration_inside_generator.py
+++ b/pylint/test/functional/stop_iteration_inside_generator.py
@@ -94,3 +94,8 @@ def gen_dont_crash_on_uninferable():
     # https://github.com/PyCQA/pylint/issues/1779
     yield from iter()
     raise asyncio.TimeoutError()
+
+
+# https://github.com/PyCQA/pylint/issues/1830
+def gen_next_with_sentinel():
+    yield next([], 42) # No bad return


### PR DESCRIPTION
Fix stop-iteration-return false positive when next builtin has a default
value in a generator.

Fixes #1830 