### PR TITLE
[per_dir_config] Moved reporting from PyLinter

### DIFF
--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -75,23 +75,6 @@ from pylint.reporters.ureports import nodes as report_nodes
 MANAGER = astroid.MANAGER
 
 
-def _get_new_args(message):
-    location = (
-        message.abspath,
-        message.path,
-        message.module,
-        message.obj,
-        message.line,
-        message.column,
-    )
-    return (
-        message.msg_id,
-        message.symbol,
-        location,
-        message.msg,
-        message.confidence,
-    )
-
 def _get_python_path(filepath):
     dirname = os.path.realpath(os.path.expanduser(filepath))
     if not os.path.isdir(dirname):
@@ -104,26 +87,6 @@ def _get_python_path(filepath):
         if old_dirname == dirname:
             return os.getcwd()
     return None
-
-
-def _merge_stats(stats):
-    merged = {}
-    by_msg = collections.Counter()
-    for stat in stats:
-        message_stats = stat.pop('by_msg', {})
-        by_msg.update(message_stats)
-
-        for key, item in six.iteritems(stat):
-            if key not in merged:
-                merged[key] = item
-            else:
-                if isinstance(item, dict):
-                    merged[key].update(item)
-                else:
-                    merged[key] = merged[key] + item
-
-    merged['by_msg'] = by_msg
-    return merged
 
 
 @contextlib.contextmanager
@@ -142,6 +105,67 @@ def _patch_sysmodules():
     finally:
         if mock_main:
             sys.modules.pop('__main__')
+
+
+# some reporting functions ####################################################
+
+def report_total_messages_stats(sect, stats, previous_stats):
+    """make total errors / warnings report"""
+    lines = ['type', 'number', 'previous', 'difference']
+    lines += checkers.table_lines_from_stats(stats, previous_stats,
+                                             ('convention', 'refactor',
+                                              'warning', 'error'))
+    sect.append(report_nodes.Table(children=lines, cols=4, rheaders=1))
+
+def report_messages_stats(sect, stats, _):
+    """make messages type report"""
+    if not stats['by_msg']:
+        # don't print this report when we didn't detected any errors
+        raise exceptions.EmptyReportError()
+    in_order = sorted([(value, msg_id)
+                       for msg_id, value in six.iteritems(stats['by_msg'])
+                       if not msg_id.startswith('I')])
+    in_order.reverse()
+    lines = ('message id', 'occurrences')
+    for value, msg_id in in_order:
+        lines += (msg_id, str(value))
+    sect.append(report_nodes.Table(children=lines, cols=2, rheaders=1))
+
+def report_messages_by_module_stats(sect, stats, _):
+    """make errors / warnings by modules report"""
+    if len(stats['by_module']) == 1:
+        # don't print this report when we are analysing a single module
+        raise exceptions.EmptyReportError()
+    by_mod = collections.defaultdict(dict)
+    for m_type in ('fatal', 'error', 'warning', 'refactor', 'convention'):
+        total = stats[m_type]
+        for module in six.iterkeys(stats['by_module']):
+            mod_total = stats['by_module'][module][m_type]
+            if total == 0:
+                percent = 0
+            else:
+                percent = float((mod_total)*100) / total
+            by_mod[module][m_type] = percent
+    sorted_result = []
+    for module, mod_info in six.iteritems(by_mod):
+        sorted_result.append((mod_info['error'],
+                              mod_info['warning'],
+                              mod_info['refactor'],
+                              mod_info['convention'],
+                              module))
+    sorted_result.sort()
+    sorted_result.reverse()
+    lines = ['module', 'error', 'warning', 'refactor', 'convention']
+    for line in sorted_result:
+        # Don't report clean modules.
+        if all(entry == 0 for entry in line[:-1]):
+            continue
+        lines.append(line[-1])
+        for val in line[:-1]:
+            lines.append('%.2f' % val)
+    if len(lines) == 5:
+        raise exceptions.EmptyReportError()
+    sect.append(report_nodes.Table(children=lines, cols=5, rheaders=1))
 
 
 # Python Linter class #########################################################
@@ -372,19 +396,24 @@ class PyLinter(utils.MessagesHandlerMixIn,
         ('Reports', 'Options related to output formatting and reporting'),
         )
 
+    reports = (
+        ('RP0001', 'Messages by category',
+         report_total_messages_stats),
+        ('RP0002', '% errors / warnings by module',
+         report_messages_by_module_stats),
+        ('RP0003', 'Messages',
+         report_messages_stats),
+    )
+
     def __init__(self, config=None):
         # some stuff has to be done before ancestors initialization...
         #
         # messages store / checkers / reporter / astroid manager
         self.config = config
-        self.msgs_store = utils.MessagesStore()
-        self.reporter = None
-        self._reporters = {}
         self._checkers = collections.defaultdict(list)
         self._pragma_lineno = {}
         self._ignore_file = False
         # visit variables
-        self.file_state = utils.FileState()
         self.current_name = None
         self.current_file = None
         self.stats = None
@@ -392,17 +421,8 @@ class PyLinter(utils.MessagesHandlerMixIn,
         # TODO: Runner needs to give this to parser?
         full_version = '%%prog %s\nastroid %s\nPython %s' % (
             version, astroid_version, sys.version)
-        utils.MessagesHandlerMixIn.__init__(self)
-        utils.ReportsHandlerMixIn.__init__(self)
-        checkers.BaseTokenChecker.__init__(self)
+        super().__init__()
         # provided reports
-        self.reports = (('RP0001', 'Messages by category',
-                         report_total_messages_stats),
-                        ('RP0002', '% errors / warnings by module',
-                         report_messages_by_module_stats),
-                        ('RP0003', 'Messages',
-                         report_messages_stats),
-                       )
         self._dynamic_plugins = set()
         self._python3_porting_mode = False
         self._error_mode = False
@@ -809,67 +829,6 @@ class PyLinter(utils.MessagesHandlerMixIn,
         if self.config.score:
             sect = report_nodes.EvaluationSection(msg)
             self.reporter.display_reports(sect)
-
-# some reporting functions ####################################################
-
-def report_total_messages_stats(sect, stats, previous_stats):
-    """make total errors / warnings report"""
-    lines = ['type', 'number', 'previous', 'difference']
-    lines += checkers.table_lines_from_stats(stats, previous_stats,
-                                             ('convention', 'refactor',
-                                              'warning', 'error'))
-    sect.append(report_nodes.Table(children=lines, cols=4, rheaders=1))
-
-def report_messages_stats(sect, stats, _):
-    """make messages type report"""
-    if not stats['by_msg']:
-        # don't print this report when we didn't detected any errors
-        raise exceptions.EmptyReportError()
-    in_order = sorted([(value, msg_id)
-                       for msg_id, value in six.iteritems(stats['by_msg'])
-                       if not msg_id.startswith('I')])
-    in_order.reverse()
-    lines = ('message id', 'occurrences')
-    for value, msg_id in in_order:
-        lines += (msg_id, str(value))
-    sect.append(report_nodes.Table(children=lines, cols=2, rheaders=1))
-
-def report_messages_by_module_stats(sect, stats, _):
-    """make errors / warnings by modules report"""
-    if len(stats['by_module']) == 1:
-        # don't print this report when we are analysing a single module
-        raise exceptions.EmptyReportError()
-    by_mod = collections.defaultdict(dict)
-    for m_type in ('fatal', 'error', 'warning', 'refactor', 'convention'):
-        total = stats[m_type]
-        for module in six.iterkeys(stats['by_module']):
-            mod_total = stats['by_module'][module][m_type]
-            if total == 0:
-                percent = 0
-            else:
-                percent = float((mod_total)*100) / total
-            by_mod[module][m_type] = percent
-    sorted_result = []
-    for module, mod_info in six.iteritems(by_mod):
-        sorted_result.append((mod_info['error'],
-                              mod_info['warning'],
-                              mod_info['refactor'],
-                              mod_info['convention'],
-                              module))
-    sorted_result.sort()
-    sorted_result.reverse()
-    lines = ['module', 'error', 'warning', 'refactor', 'convention']
-    for line in sorted_result:
-        # Don't report clean modules.
-        if all(entry == 0 for entry in line[:-1]):
-            continue
-        lines.append(line[-1])
-        for val in line[:-1]:
-            lines.append('%.2f' % val)
-    if len(lines) == 5:
-        raise exceptions.EmptyReportError()
-    sect.append(report_nodes.Table(children=lines, cols=5, rheaders=1))
-
 
 # utilities ###################################################################
 

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -461,9 +461,6 @@ class PyLinter(utils.MessagesHandlerMixIn,
                 self.global_set_option('disable', value)
         else:
             self.disable('python3')
-        self.set_option('reports', False)
-        self.set_option('persistent', False)
-        self.set_option('score', False)
 
     def python3_porting_mode(self):
         """Disable all other checkers and enable Python 3 warnings."""
@@ -1050,7 +1047,10 @@ group are mutually exclusive.'),
         # TODO: if global_config.generate_man
 
         if self._global_config.errors_only:
-            self._linter.errors_mode()
+            self._linter.error_mode()
+            self._global_config.reports = False
+            self._global_config.persistent = False
+            self._global_config.score = False
 
         if self._global_config.py3k:
             self._linter.python3_porting_mode()

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -818,13 +818,6 @@ class PluginRegistry(object):
 
         :raises ValueError: If the priority of the checker is invalid.
         """
-        if checker.name in self._checkers:
-            # TODO: Raise if classes are the same
-            for duplicate in self._checkers[checker.name]:
-                msg = 'A checker called {} has already been registered ({}).'
-                msg = msg.format(checker.name, duplicate.__class__)
-                warnings.warn(msg)
-
         if checker.priority > 0:
             # TODO: Use a custom exception
              msg = '{}.priority must be <= 0'.format(checker.__class__)

--- a/pylint/reporters/text.py
+++ b/pylint/reporters/text.py
@@ -129,7 +129,7 @@ class TextReporter(BaseReporter):
     def __init__(self, output=None):
         BaseReporter.__init__(self, output)
         self._modules = set()
-        self._template = None
+        self._template = self.line_format
 
     def on_set_current_module(self, module, filepath):
         self._template = six.text_type(self.linter.config.msg_template or self.line_format)

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -251,8 +251,12 @@ class MessagesHandlerMixIn(object):
     """
 
     def __init__(self):
+        self.file_state = FileState()
         self._msgs_state = {}
         self.msg_status = 0
+        self.msgs_store = MessagesStore()
+        self.reporter = None
+        super().__init__()
 
     def _checker_messages(self, checker):
         for known_checker in self._checkers[checker.lower()]:
@@ -786,6 +790,7 @@ class ReportsHandlerMixIn(object):
     def __init__(self):
         self._reports = collections.defaultdict(list)
         self._reports_state = {}
+        super().__init__()
 
     def report_order(self):
         """ Return a list of reports, sorted in the order

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -787,27 +787,55 @@ class ReportsHandlerMixIn(object):
     """a mix-in class containing all the reports and stats manipulation
     related methods for the main lint class
     """
+
+    _POST_CHECKER = object()
+
     def __init__(self):
         self._reports = collections.defaultdict(list)
         self._reports_state = {}
         super().__init__()
 
     def report_order(self):
-        """ Return a list of reports, sorted in the order
-        in which they must be called.
+        """A list of reports, sorted in the order in which they must be called.
+
+        :returns: The list of reports.
+        :rtype: list(BaseChecker or object)
         """
-        return list(self._reports)
+        reports = sorted(self._reports, key=lambda x: getattr(x, 'name', ''))
+        try:
+            reports.remove(self._POST_CHECKER)
+        except ValueError:
+            pass
+        else:
+            reports.append(self._POST_CHECKER)
+        return reports
 
     def register_report(self, reportid, r_title, r_cb, checker):
         """register a report
 
-        reportid is the unique identifier for the report
-        r_title the report's title
-        r_cb the method to call to make the report
-        checker is the checker defining the report
+        :param reportid: The unique identifier for the report.
+        :type reportid: str
+        :param r_title: The report's title.
+        :type r_title: str
+        :param r_cb: The method to call to make the report.
+        :type r_cb: callable
+        :param checker: The checker defining the report.
+        :type checker: BaseChecker
         """
         reportid = reportid.upper()
         self._reports[checker].append((reportid, r_title, r_cb))
+
+    def register_post_report(self, reportid, r_title, r_cb):
+        """Register a report to run last.
+
+        :param reportid: The unique identifier for the report.
+        :type reportid: str
+        :param r_title: The report's title.
+        :type r_title: str
+        :param r_cb: The method to call to make the report.
+        :type r_cb: callable
+        """
+        self.register_report(reportid, r_title, r_cb, self._POST_CHECKER)
 
     def enable_report(self, reportid):
         """disable the report of the given id"""


### PR DESCRIPTION
Setting a reporter is something that's global. With PyLinters being created per file/directory in the future, it makes sense for the reporting to move elsewhere.

New tasks:
- Split up the ReportsHandlerMixin methods. The PluginRegistry needs to handle the registering of reporters, and the Runner should handle setting the runner and doing the reporting.

Closes #1899 