### PR TITLE
Suppress false-positive not-callable messages from class descriptors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -97,6 +97,11 @@ What's New in Pylint 2.0?
 
       Close #1599
 
+    * Suppress false-positive ``not-callable`` messages from certain
+        staticmethod descriptors
+
+      Close #1699
+
 What's New in Pylint 1.8.1?
 =========================
 

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -45,3 +45,6 @@ Other Changes
 
 * Fix false positive ``undefined-variable`` for lambda argument in
     class definitions
+
+* Suppress false-positive ``not-callable`` messages from certain
+    staticmethod descriptors

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -875,8 +875,13 @@ accessed. Python regular expressions are accepted.'}
 
         called = safe_infer(node.func)
         # only function, generator and object defining __call__ are allowed
+        # Ignore instances of descriptors since astroid cannot properly handle them
+        # yet
         if called and not called.callable():
-            if isinstance(called, astroid.Instance) and not has_known_bases(called):
+            if isinstance(called, astroid.Instance) and (
+                    not has_known_bases(called)
+                    or (isinstance(called.scope(), astroid.ClassDef)
+                        and '__get__' in called.locals)):
                 # Don't emit if we can't make sure this object is callable.
                 pass
             else:

--- a/pylint/test/unittest_checker_typecheck.py
+++ b/pylint/test/unittest_checker_typecheck.py
@@ -229,3 +229,36 @@ class TestTypeChecker(CheckerTestCase):
         subscript = module.body[-1].value
         with self.assertNoMessages():
             self.checker.visit_subscript(subscript)
+
+    def test_staticmethod_multiprocessing_call(self):
+        """Make sure not-callable isn't raised for descriptors
+
+        astroid can't process descriptors correctly so
+        pylint needs to ignore not-callable for them
+        right now
+
+        Test for https://github.com/PyCQA/pylint/issues/1699
+        """
+        call = astroid.extract_node("""
+        import multiprocessing
+        multiprocessing.current_process() #@
+        """)
+        with self.assertNoMessages():
+            self.checker.visit_call(call)
+
+    def test_descriptor_call(self):
+        call = astroid.extract_node("""
+        def func():
+            pass
+
+        class ADescriptor:
+            def __get__(self, instance, owner):
+                return func
+
+        class AggregateCls:
+            a = ADescriptor()
+
+        AggregateCls().a() #@
+        """)
+        with self.assertNoMessages():
+            self.checker.visit_call(call)


### PR DESCRIPTION
This is a holdover until astroid can be fixed. Astroid needs to
understand descriptors or at least raise Uninferable instead
of allowing the descriptor instance through

Close #1699
