### PR TITLE
Add check to not register same linter type twice

### DIFF
--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -787,6 +787,21 @@ class PluginRegistry(utils.ReportsHandlerMixIn):
         :raises InvalidCheckerError: If the priority of the checker is
             invalid.
         """
+        existing_checker_types = set(
+            type(existing_checker)
+            for name_checkers in self._checkers.values()
+            for existing_checker in name_checkers
+        )
+        checker_type = type(checker)
+        if checker_type in existing_checker_types:
+            msg_fmt = (
+                'Not registering checker {}. A checker of type {} has '
+                'already been registered.'
+            )
+            msg = msg_fmt.format(checker.name, checker_type.__name__)
+            warnings.warn(msg)
+            return
+
         if checker.priority > 0:
              msg = '{}.priority must be <= 0'.format(checker.__class__)
              raise exceptions.InvalidCheckerError(msg)

--- a/pylint/test/unittest_lint.py
+++ b/pylint/test/unittest_lint.py
@@ -247,6 +247,20 @@ def test_register_checker_invalid_priority():
         plugin_registry.register_checker(CustomChecker(linter))
 
 
+def test_register_checker_type_once():
+    class CustomChecker(checkers.BaseChecker):
+        name = 'custom'
+
+    linter = PyLinter()
+    plugin_registry = PluginRegistry(linter)
+    checker1 = CustomChecker()
+    checker2 = CustomChecker()
+    plugin_registry.register_checker(checker1)
+    plugin_registry.register_checker(checker2)
+
+    assert list(plugin_registry.for_all_checkers()) == [checker1]
+
+
 def test_pylint_visit_method_taken_in_account(linter):
     class CustomChecker(checkers.BaseChecker):
         __implements__ = interfaces.IAstroidChecker

--- a/pylint/testutils.py
+++ b/pylint/testutils.py
@@ -256,7 +256,6 @@ class CheckerTestCase(object):
 # Init
 test_reporter = TestReporter()
 linter = PyLinter(pylint.config.Configuration())
-linter.set_reporter(test_reporter)
 linter.config.persistent = 0
 checkers.initialize(PluginRegistry(linter))
 


### PR DESCRIPTION
Skipping register with no error based on type as per #1892.