### PR TITLE
New error condition try-except-raise

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -127,7 +127,8 @@ Order doesn't matter (not that much, at least ;)
   Added new check for incorrect len(SEQUENCE) usage,
   Added new extension for comparison against empty string constants,
   Added new extension which detects comparing integers to zero,
-  Added new useless-return checker
+  Added new useless-return checker,
+  Added new try-except-raise checker
 
 * Erik Eriksson - Added overlapping-except error check.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,11 @@ What's New in Pylint 2.0?
 
       Close #1922
 
+    * Add new checker `try-except-raise` that warns the user if an except handler block
+      has a ``raise`` statement as its first operator. The warning is shown when there is
+      a bare raise statement, effectively re-raising the exception that was caught or the
+      type of the exception being raised is the same as the one being handled.
+
     * Don't crash on invalid strings when checking for `logging-format-interpolation`
 
       Close #1944
@@ -123,6 +128,7 @@ What's New in Pylint 2.0?
     * Fix false-positive ``bad-continuation`` error
 
       Close #638
+
 
 What's New in Pylint 1.8.1?
 =========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -49,6 +49,10 @@ New checkers
   functions uses a different type than strings, while the latter is emitted whenever
   the said functions are using a default variable of different type than expected.
 
+* New ``try-except-raise`` message when an except handler block has a bare
+  `raise` statement as its first operator or the exception type being raised
+  is the same as the one being handled.
+
 Other Changes
 =============
 

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -84,6 +84,12 @@ MSGS = {
               'a bare raise inside a finally clause, which might work, as long '
               'as an exception is raised inside the try block, but it is '
               'nevertheless a code smell that must not be relied upon.'),
+    'E0705': ('The except handler raises immediately',
+              'try-except-raise',
+              'Used when an except handler uses raise as its first or only '
+              'operator. This is useless because it raises back the exception '
+              'immediately. Remove the raise operator or the entire '
+              'try-except-raise block!'),
     'E0710': ('Raising a new style class which doesn\'t inherit from BaseException',
               'raising-non-exception',
               'Used when a new style class which doesn\'t inherit from \
@@ -347,7 +353,7 @@ class ExceptionsChecker(checkers.BaseChecker):
                                  node=handler.type,
                                  args=(exc.name, ))
 
-    @utils.check_messages('bare-except', 'broad-except',
+    @utils.check_messages('bare-except', 'broad-except', 'try-except-raise',
                           'binary-op-exception', 'bad-except-order',
                           'catching-non-exception', 'duplicate-except')
     def visit_tryexcept(self, node):
@@ -355,9 +361,32 @@ class ExceptionsChecker(checkers.BaseChecker):
         exceptions_classes = []
         nb_handlers = len(node.handlers)
         for index, handler in enumerate(node.handlers):
+            # `raise` as the first operator inside the except handler
+            if utils.is_raising([handler.body[0]]):
+                # flags when there is a bare raise
+                if handler.body[0].exc is None:
+                    self.add_message('try-except-raise', node=handler)
+                else:
+                    # not a bare raise
+                    raise_type = None
+                    if isinstance(handler.body[0].exc, astroid.Call):
+                        raise_type = handler.body[0].exc.func
+
+                    # flags only when the exception types of the handler
+                    # and the raise statement match b/c we're raising the same
+                    # type of exception that we're trying to handle. Example:
+                    #
+                    # except ValueError:
+                    #   raise ValueError('some user friendly message')
+                    if (isinstance(handler.type, astroid.Name)
+                            and isinstance(raise_type, astroid.Name)
+                            and raise_type.name == handler.type.name):
+                        self.add_message('try-except-raise', node=handler)
+
             if handler.type is None:
                 if not utils.is_raising(handler.body):
                     self.add_message('bare-except', node=handler)
+
                 # check if an "except:" is followed by some other
                 # except
                 if index < (nb_handlers - 1):

--- a/pylint/test/functional/inconsistent_returns.py
+++ b/pylint/test/functional/inconsistent_returns.py
@@ -1,4 +1,4 @@
-#pylint: disable=missing-docstring, no-else-return, invalid-name, unused-variable, superfluous-parens
+#pylint: disable=missing-docstring, no-else-return, invalid-name, unused-variable, superfluous-parens, try-except-raise
 """Testing inconsistent returns"""
 import math
 import sys

--- a/pylint/test/functional/misplaced_bare_raise.py
+++ b/pylint/test/functional/misplaced_bare_raise.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, broad-except, unreachable
+# pylint: disable=missing-docstring, broad-except, unreachable, try-except-raise
 # pylint: disable=unused-variable, too-few-public-methods, invalid-name
 
 try:

--- a/pylint/test/functional/stop_iteration_inside_generator.py
+++ b/pylint/test/functional/stop_iteration_inside_generator.py
@@ -1,7 +1,7 @@
 """
 Test that no StopIteration is raised inside a generator
 """
-# pylint: disable=missing-docstring,invalid-name,import-error
+# pylint: disable=missing-docstring,invalid-name,import-error, try-except-raise
 import asyncio
 
 class RebornStopIteration(StopIteration):

--- a/pylint/test/functional/try_except_raise.py
+++ b/pylint/test/functional/try_except_raise.py
@@ -1,0 +1,16 @@
+# pylint:disable=missing-docstring
+
+try:
+    int("9a")
+except:  # [try-except-raise]
+    raise
+
+try:
+    int("9a")
+except:
+    raise ValueError('Invalid integer')
+
+try:
+    int("9a")
+except ValueError:  # [try-except-raise]
+    raise ValueError('Invalid integer')

--- a/pylint/test/functional/try_except_raise.txt
+++ b/pylint/test/functional/try_except_raise.txt
@@ -1,0 +1,2 @@
+try-except-raise:5::The except handler raises immediately
+try-except-raise:15::The except handler raises immediately


### PR DESCRIPTION
reports on except handlers where raise is the first operator in the handler body.

There are some failures from existing code which need to be examined. I'm not sure how do we want to handle some scenarios. 

The motivation behind this checker comes from a legacy code base which has a lot of
```
try:
    do_something
except:
    raise
```

which obviously doesn't do anything useful. 

There's also the use case where `raise` is followed by some other nodes which is also detected by unreachable. 

Then there's the scenario where we `raise ExcType()` and the edge case where we raise the same exception type as the one that has been caught in the except clause. 

Let me know how do you like this PR to evolve.