### PR TITLE
keep support for python3 by pinning isort to version 4.2.15

### DIFF
--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -29,7 +29,7 @@ version = '.'.join([str(num) for num in numversion])
 install_requires = [
     'astroid<2.0',
     'six',
-    'isort >= 4.2.5',
+    'isort == 4.2.15',
     'mccabe',
 ]
 


### PR DESCRIPTION
### Fixes / new features
- https://github.com/PyCQA/pylint/issues/1960 makes pylint installable on python 3.3.0 again
