### PR TITLE
New checker dunder-class-attribute

### DIFF
--- a/pylint/test/functional/class_with_dunder_attributes.py
+++ b/pylint/test/functional/class_with_dunder_attributes.py
@@ -1,0 +1,22 @@
+""" Tests for class with dunder attributes. """
+# pylint: disable=too-few-public-methods,missing-docstring
+
+class MyClass(object):
+    __all__ = ('one', 'two', 'three')  # [dunder-class-attribute]
+
+    regular_attribute = __dunder__ = True  # [dunder-class-attribute]
+
+    __this_is_fine = True
+
+    so_is_this__ = True
+
+    perfectly_fine = 10
+
+    # assigning to predefined attributes is also fine, e.g.
+    __doc__ = 'My testing class'
+
+    def __init__(self):
+        pass
+
+    def test(self):
+        pass

--- a/pylint/test/functional/class_with_dunder_attributes.txt
+++ b/pylint/test/functional/class_with_dunder_attributes.txt
@@ -1,0 +1,2 @@
+dunder-class-attribute:5:MyClass:Class attributes should not contain double underscores
+dunder-class-attribute:7:MyClass:Class attributes should not contain double underscores


### PR DESCRIPTION
### Fixes / new features
- New checker to warn the developer when they have class attributes starting and ending in double underscores since these are reserved for Python, see:
https://mail.python.org/pipermail/code-quality/2018-March/000996.html


I'm trying my best to exclude magic method names and known attributes that are defined by the language. As a shortcut to listing all of these as strings I grab the list from the list class.


Please review and comment.