### PR TITLE
Don't report docstrings on inner functions.

### DIFF
--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -717,7 +717,7 @@ class BasicChecker(_BasicChecker):
     """checks for :
     * doc strings
     * number of arguments, local variables, branches, returns and statements in
-functions, methods
+    functions, methods
     * required module attributes
     * dangerous default values as arguments
     * redefinition of function / method / class
@@ -1594,8 +1594,10 @@ class DocStringChecker(_BasicChecker):
                 self._check_docstring(ftype, node,
                                       report_missing=not overridden,
                                       confidence=confidence)
-            else:
+            elif isinstance(node.parent.frame(), astroid.Module):
                 self._check_docstring(ftype, node)
+            else:
+                return
 
     visit_asyncfunctiondef = visit_functiondef
 

--- a/pylint/test/unittest_checker_base.py
+++ b/pylint/test/unittest_checker_base.py
@@ -100,6 +100,17 @@ class TestDocstring(CheckerTestCase):
         with self.assertAddsMessages(message):
             self.checker.visit_classdef(klass)
 
+    def test_inner_function_no_docstring(self):
+        func = astroid.extract_node("""
+        def func(tion):
+            \"""Documented\"""
+            def inner(fun):
+                # Not documented
+                pass
+        """)
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(func)
+
 
 class TestNameChecker(CheckerTestCase):
     CHECKER_CLASS = base.NameChecker


### PR DESCRIPTION
I said I'd fix it myself if need be!

### Fixes / new features
- Fixes `missing-docstring` errors for inner (and thus unreachable) functions
