### PR TITLE
fix typo

### DIFF
--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -203,7 +203,7 @@ MSGS = {
               'no-member',
               'Used when a variable is accessed for an unexistent member.',
               {'old_names': [('E1103', 'maybe-no-member')]}),
-    'I1101': ('%s %r has not %r member%s, but source is unavailable. Consider '
+    'I1101': ('%s %r has no %r member%s, but source is unavailable. Consider '
               'adding this module to extension-pkg-whitelist if you want '
               'to perform analysis based on run-time introspection of living objects.',
               'c-extension-no-member',


### PR DESCRIPTION
### Fixes / new features
- Fix typo in I1101 message ("has not 'foo' member" should be "has no 'foo' member")