### PR TITLE
Enhancement/consider using in

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,17 +4,23 @@ Pylint's ChangeLog
 What's New in Pylint 2.0?
 =========================
 
+    * Add a check `consider-using-in` for comparisons of a variable against
+      multiple values with "==" and "or"s instead of checking if the variable
+      is contained "in" a tuple of those values.
+
+      Close #1977
+
     * Added a new Python 2/3 check for accessing `operator.div`, which is removed in Python 3
 
-     Close #1936
+      Close #1936
 
-   * Added a new Python 2/3 check for accessing removed urllib functions
+    * Added a new Python 2/3 check for accessing removed urllib functions
 
-     Close #1997
+      Close #1997
 
     * `logging-format-interpolation` also emits when f-strings are used instead of % syntax.
 
-       Close #1788
+      Close #1788
 
     * Don't trigger misplaced-bare-raise when the raise is in a finally clause
 

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -16,6 +16,19 @@ Summary -- Release highlights
 New checkers
 ============
 
+* A new check was added, ``consider-using-in``.
+
+  This refactoring message is emitted when a variable is compared against multiple
+  values concatenated by ors instead of using the faster, more idiomatic "in" check.
+
+  .. code-block:: python
+
+    if variable == 1 or variable == 2 or variable == 3:  # bad
+        pass
+
+    if variable in (1, 2, 3):  # good
+        pass
+
 * A new check was added, ``consider-using-join``.
 
   This refactoring message is emitted when using a for loop over a iterable to join strings

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -113,7 +113,7 @@ def _is_owner_ignored(owner, name, ignored_classes, ignored_modules):
         qname = owner.qname()
     else:
         qname = ''
-    return any(name == ignore or qname == ignore for ignore in ignored_classes)
+    return any(ignore in (name, qname) for ignore in ignored_classes)
 
 
 @singledispatch

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -115,7 +115,7 @@ def find_pylintrc():
         pylintrc = os.environ['PYLINTRC']
     else:
         user_home = os.path.expanduser('~')
-        if user_home == '~' or user_home == '/root':
+        if user_home in ('~', '/root'):
             pylintrc = ".pylintrc"
         else:
             pylintrc = os.path.join(user_home, '.pylintrc')

--- a/pylint/test/functional/consider_using_in.py
+++ b/pylint/test/functional/consider_using_in.py
@@ -1,0 +1,44 @@
+# pylint: disable=missing-docstring, invalid-name, pointless-statement, misplaced-comparison-constant, undefined-variable, literal-comparison
+
+value = value1 = 1
+value2 = 2
+a_set = {1, 2, 3}
+a_list = [1, 2, 3]
+a_str = '1'
+
+# Positive
+value == 1 or value == 1  # [consider-using-in]
+value == 1 or value == 2  # [consider-using-in]
+value == 1 or value == undef_value  # [consider-using-in]
+value == 1 or value == 2 or value == 3  # [consider-using-in]
+value == '1' or value == '2'  # [consider-using-in]
+1 == value or 2 == value  # [consider-using-in]
+1 == value or value == 2  # [consider-using-in]
+value == 1 or value == a_list  # [consider-using-in]
+value == a_set or value == a_list or value == a_str  # [consider-using-in]
+value != 1 and value != 2  # [consider-using-in]
+value in (1, 2) or value in (3, 4)  # [consider-using-in]
+value == 1 or value in (2, 3)  # [consider-using-in]
+value != 1 and value not in (2, 3)  # [consider-using-in]
+value1 == value2 or value2 == value1  # [consider-using-in]
+(value1 == 1 or value1 == 2) and (value2 != 1 and value2 != 2)  # [consider-using-in]
+
+# Negative
+value != 1 or value != 2  # not a "not in"-case because of "or"
+value == 1 and value == 2  # not a "in"-case because of "and"
+value == 1 and value == 2 or value == 3  # not only 'or's
+value == 1 or value == 2 or 3 < value < 4  # not only '=='
+value == 1  # value not checked against multiple values
+value == 1 and value in (2, 3)  # unjoinable "and" and "in"
+value == 1 or value == 2 or value == 3 and value == 4  # not all checks are concatenated with 'or'
+value == 1 or value in (2, 3) and value == 4  # not all checks are concatenated with 'or'
+value == 1 or 2 < value < 3  # length of 'ops' != 1 for second check
+value == 1 or (value == 2 or value == 3)  # could be considered in the future, but too complex for now
+value is 1 or value is 2  # 'in' compares using '==' not 'is' and therefore not considered
+not value == 1 and not value == 2
+value1 == 1 or value2 == 2  # different variables and only one comparison for each
+value1 == value2 == 1 or value1 == 2  # not checking multi-compares for '=='
+value1 != 1 == value2 and value2 != value1 != 2  # not checking multi-compares for '!='
+value1 == 1 or value2 in (2, 3)  # unjoinable 'value1' != 'value2'
+value1 == 1 or value1 == value2 or value2 == 3  # value1 or value2 do not occur in every check
+value1 == 1 or value1 == 2 or value2 == 1 or value2 == 2  # value1 or value2 do not occur in every check

--- a/pylint/test/functional/consider_using_in.py
+++ b/pylint/test/functional/consider_using_in.py
@@ -9,18 +9,19 @@ a_str = '1'
 # Positive
 value == 1 or value == 1  # [consider-using-in]
 value == 1 or value == 2  # [consider-using-in]
+'value' == value or 'value' == value  # [consider-using-in]
 value == 1 or value == undef_value  # [consider-using-in]
 value == 1 or value == 2 or value == 3  # [consider-using-in]
-value == '1' or value == '2'  # [consider-using-in]
+value == '2' or value == 1  # [consider-using-in]
 1 == value or 2 == value  # [consider-using-in]
 1 == value or value == 2  # [consider-using-in]
 value == 1 or value == a_list  # [consider-using-in]
 value == a_set or value == a_list or value == a_str  # [consider-using-in]
-value in (1, 2) or value in (3, 4)  # [consider-using-in]
-value == 1 or value in (2, 3)  # [consider-using-in]
 value != 1 and value != 2  # [consider-using-in]
-value != 1 and value not in (2, 3)  # [consider-using-in]
 value1 == value2 or value2 == value1  # [consider-using-in]
+
+# Undecided
+'value' == 1 or 'value' == 2  # no variables
 
 # Negative
 value != 1 or value != 2  # not a "not in"-case because of "or"
@@ -28,15 +29,12 @@ value == 1 and value == 2  # not a "in"-case because of "and"
 value == 1 and value == 2 or value == 3  # not only 'or's
 value == 1 or value == 2 or 3 < value < 4  # not only '=='
 value == 1  # value not checked against multiple values
-value == 1 and value in (2, 3)  # unjoinable "and" and "in"
 value == 1 or value == 2 or value == 3 and value == 4  # not all checks are concatenated with 'or'
-value == 1 or value in (2, 3) and value == 4  # not all checks are concatenated with 'or'
 value == 1 or 2 < value < 3  # length of 'ops' != 1 for second check
 value is 1 or value is 2  # 'in' compares using '==' not 'is' and therefore not considered
 not value == 1 and not value == 2
 value1 == 1 or value2 == 2  # different variables and only one comparison for each
 value1 == value2 == 1 or value1 == 2  # not checking multi-compares for '=='
 value1 != 1 == value2 and value2 != value1 != 2  # not checking multi-compares for '!='
-value1 == 1 or value2 in (2, 3)  # unjoinable 'value1' != 'value2'
 value1 == 1 or value1 == value2 or value2 == 3  # value1 or value2 do not occur in every check
 value1 == 1 or value1 == 2 or value2 == 1 or value2 == 2  # value1 or value2 do not occur in every check

--- a/pylint/test/functional/consider_using_in.py
+++ b/pylint/test/functional/consider_using_in.py
@@ -19,6 +19,7 @@ value == 1 or value == a_list  # [consider-using-in]
 value == a_set or value == a_list or value == a_str  # [consider-using-in]
 value != 1 and value != 2  # [consider-using-in]
 value1 == value2 or value2 == value1  # [consider-using-in]
+a_list == [1, 2, 3] or a_list == []  # [consider-using-in]
 
 # Undecided
 'value' == 1 or 'value' == 2  # no variables

--- a/pylint/test/functional/consider_using_in.py
+++ b/pylint/test/functional/consider_using_in.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, invalid-name, pointless-statement, misplaced-comparison-constant, undefined-variable, literal-comparison
+# pylint: disable=missing-docstring, invalid-name, pointless-statement, misplaced-comparison-constant, undefined-variable, literal-comparison, line-too-long, unneeded-not
 
 value = value1 = 1
 value2 = 2
@@ -16,12 +16,11 @@ value == '1' or value == '2'  # [consider-using-in]
 1 == value or value == 2  # [consider-using-in]
 value == 1 or value == a_list  # [consider-using-in]
 value == a_set or value == a_list or value == a_str  # [consider-using-in]
-value != 1 and value != 2  # [consider-using-in]
 value in (1, 2) or value in (3, 4)  # [consider-using-in]
 value == 1 or value in (2, 3)  # [consider-using-in]
+value != 1 and value != 2  # [consider-using-in]
 value != 1 and value not in (2, 3)  # [consider-using-in]
 value1 == value2 or value2 == value1  # [consider-using-in]
-(value1 == 1 or value1 == 2) and (value2 != 1 and value2 != 2)  # [consider-using-in]
 
 # Negative
 value != 1 or value != 2  # not a "not in"-case because of "or"
@@ -33,7 +32,6 @@ value == 1 and value in (2, 3)  # unjoinable "and" and "in"
 value == 1 or value == 2 or value == 3 and value == 4  # not all checks are concatenated with 'or'
 value == 1 or value in (2, 3) and value == 4  # not all checks are concatenated with 'or'
 value == 1 or 2 < value < 3  # length of 'ops' != 1 for second check
-value == 1 or (value == 2 or value == 3)  # could be considered in the future, but too complex for now
 value is 1 or value is 2  # 'in' compares using '==' not 'is' and therefore not considered
 not value == 1 and not value == 2
 value1 == 1 or value2 == 2  # different variables and only one comparison for each

--- a/pylint/test/functional/consider_using_in.py
+++ b/pylint/test/functional/consider_using_in.py
@@ -21,9 +21,6 @@ value != 1 and value != 2  # [consider-using-in]
 value1 == value2 or value2 == value1  # [consider-using-in]
 a_list == [1, 2, 3] or a_list == []  # [consider-using-in]
 
-# Undecided
-'value' == 1 or 'value' == 2  # no variables
-
 # Negative
 value != 1 or value != 2  # not a "not in"-case because of "or"
 value == 1 and value == 2  # not a "in"-case because of "and"
@@ -39,3 +36,4 @@ value1 == value2 == 1 or value1 == 2  # not checking multi-compares for '=='
 value1 != 1 == value2 and value2 != value1 != 2  # not checking multi-compares for '!='
 value1 == 1 or value1 == value2 or value2 == 3  # value1 or value2 do not occur in every check
 value1 == 1 or value1 == 2 or value2 == 1 or value2 == 2  # value1 or value2 do not occur in every check
+'value' == 1 or 'value' == 2  # only detect variables for now

--- a/pylint/test/functional/consider_using_in.txt
+++ b/pylint/test/functional/consider_using_in.txt
@@ -12,4 +12,3 @@ consider-using-in:20::Consider using "in" to compare a variable with multiple va
 consider-using-in:21::Consider using "in" to compare a variable with multiple values
 consider-using-in:22::Consider using "in" to compare a variable with multiple values
 consider-using-in:23::Consider using "in" to compare a variable with multiple values
-consider-using-in:24::Consider using "in" to compare a variable with multiple values

--- a/pylint/test/functional/consider_using_in.txt
+++ b/pylint/test/functional/consider_using_in.txt
@@ -1,14 +1,12 @@
-consider-using-in:10::Consider using "in" to compare a variable with multiple values
-consider-using-in:11::Consider using "in" to compare a variable with multiple values
-consider-using-in:12::Consider using "in" to compare a variable with multiple values
-consider-using-in:13::Consider using "in" to compare a variable with multiple values
-consider-using-in:14::Consider using "in" to compare a variable with multiple values
-consider-using-in:15::Consider using "in" to compare a variable with multiple values
-consider-using-in:16::Consider using "in" to compare a variable with multiple values
-consider-using-in:17::Consider using "in" to compare a variable with multiple values
-consider-using-in:18::Consider using "in" to compare a variable with multiple values
-consider-using-in:19::Consider using "in" to compare a variable with multiple values
-consider-using-in:20::Consider using "in" to compare a variable with multiple values
-consider-using-in:21::Consider using "in" to compare a variable with multiple values
-consider-using-in:22::Consider using "in" to compare a variable with multiple values
-consider-using-in:23::Consider using "in" to compare a variable with multiple values
+consider-using-in:10::Consider merging these comparisons with "in" to value in (1,)
+consider-using-in:11::Consider merging these comparisons with "in" to value in (1, 2)
+consider-using-in:12::Consider merging these comparisons with "in" to value in ('value',)
+consider-using-in:13::Consider merging these comparisons with "in" to value in (1, undef_value)
+consider-using-in:14::Consider merging these comparisons with "in" to value in (1, 2, 3)
+consider-using-in:15::Consider merging these comparisons with "in" to value in ('2', 1)
+consider-using-in:16::Consider merging these comparisons with "in" to value in (1, 2)
+consider-using-in:17::Consider merging these comparisons with "in" to value in (1, 2)
+consider-using-in:18::Consider merging these comparisons with "in" to value in (1, a_list)
+consider-using-in:19::Consider merging these comparisons with "in" to value in (a_set, a_list, a_str)
+consider-using-in:20::Consider merging these comparisons with "in" to value not in (1, 2)
+consider-using-in:21::Consider merging these comparisons with "in" to value1 in (value2,)

--- a/pylint/test/functional/consider_using_in.txt
+++ b/pylint/test/functional/consider_using_in.txt
@@ -1,0 +1,15 @@
+consider-using-in:10::Consider using "in" to compare a variable with multiple values
+consider-using-in:11::Consider using "in" to compare a variable with multiple values
+consider-using-in:12::Consider using "in" to compare a variable with multiple values
+consider-using-in:13::Consider using "in" to compare a variable with multiple values
+consider-using-in:14::Consider using "in" to compare a variable with multiple values
+consider-using-in:15::Consider using "in" to compare a variable with multiple values
+consider-using-in:16::Consider using "in" to compare a variable with multiple values
+consider-using-in:17::Consider using "in" to compare a variable with multiple values
+consider-using-in:18::Consider using "in" to compare a variable with multiple values
+consider-using-in:19::Consider using "in" to compare a variable with multiple values
+consider-using-in:20::Consider using "in" to compare a variable with multiple values
+consider-using-in:21::Consider using "in" to compare a variable with multiple values
+consider-using-in:22::Consider using "in" to compare a variable with multiple values
+consider-using-in:23::Consider using "in" to compare a variable with multiple values
+consider-using-in:24::Consider using "in" to compare a variable with multiple values

--- a/pylint/test/functional/consider_using_in.txt
+++ b/pylint/test/functional/consider_using_in.txt
@@ -10,3 +10,4 @@ consider-using-in:18::Consider merging these comparisons with "in" to value in (
 consider-using-in:19::Consider merging these comparisons with "in" to value in (a_set, a_list, a_str)
 consider-using-in:20::Consider merging these comparisons with "in" to value not in (1, 2)
 consider-using-in:21::Consider merging these comparisons with "in" to value1 in (value2,)
+consider-using-in:22::Consider merging these comparisons with "in" to a_list in ([1, 2, 3], [])

--- a/pylint/test/functional/consider_using_in.txt
+++ b/pylint/test/functional/consider_using_in.txt
@@ -1,13 +1,13 @@
-consider-using-in:10::Consider merging these comparisons with "in" to value in (1,)
-consider-using-in:11::Consider merging these comparisons with "in" to value in (1, 2)
-consider-using-in:12::Consider merging these comparisons with "in" to value in ('value',)
-consider-using-in:13::Consider merging these comparisons with "in" to value in (1, undef_value)
-consider-using-in:14::Consider merging these comparisons with "in" to value in (1, 2, 3)
-consider-using-in:15::Consider merging these comparisons with "in" to value in ('2', 1)
-consider-using-in:16::Consider merging these comparisons with "in" to value in (1, 2)
-consider-using-in:17::Consider merging these comparisons with "in" to value in (1, 2)
-consider-using-in:18::Consider merging these comparisons with "in" to value in (1, a_list)
-consider-using-in:19::Consider merging these comparisons with "in" to value in (a_set, a_list, a_str)
-consider-using-in:20::Consider merging these comparisons with "in" to value not in (1, 2)
-consider-using-in:21::Consider merging these comparisons with "in" to value1 in (value2,)
-consider-using-in:22::Consider merging these comparisons with "in" to a_list in ([1, 2, 3], [])
+consider-using-in:10::Consider merging these comparisons with "in" to 'value in (1,)'
+consider-using-in:11::Consider merging these comparisons with "in" to 'value in (1, 2)'
+consider-using-in:12::Consider merging these comparisons with "in" to "value in ('value',)"
+consider-using-in:13::Consider merging these comparisons with "in" to 'value in (1, undef_value)'
+consider-using-in:14::Consider merging these comparisons with "in" to 'value in (1, 2, 3)'
+consider-using-in:15::Consider merging these comparisons with "in" to "value in ('2', 1)"
+consider-using-in:16::Consider merging these comparisons with "in" to 'value in (1, 2)'
+consider-using-in:17::Consider merging these comparisons with "in" to 'value in (1, 2)'
+consider-using-in:18::Consider merging these comparisons with "in" to 'value in (1, a_list)'
+consider-using-in:19::Consider merging these comparisons with "in" to 'value in (a_set, a_list, a_str)'
+consider-using-in:20::Consider merging these comparisons with "in" to 'value not in (1, 2)'
+consider-using-in:21::Consider merging these comparisons with "in" to 'value1 in (value2,)'
+consider-using-in:22::Consider merging these comparisons with "in" to 'a_list in ([1, 2, 3], [])'


### PR DESCRIPTION
PR [do not merge yet] for #1977 
I did some work and I'd like some feedback before I continue.
I am especially interested in feedback to the following points:
* We can now also detect "not in" cases.
(See line 20 in [pylint/test/functional/consider_using_in.py](https://github.com/PyCQA/pylint/compare/master...pheanex:enhancement/consider-using-in#diff-72d92d1a1366fbd15845f30babb82d2d)).
I thought this was a valuable addition, but if there good arguments why not to include it, I'd remove it.
* Currently this version detects only "in/not in"-cases if comparisons are made against variables.
I am unsure why we should not generalize it to also being able to detect cases without variables
(See line 25 "Undecided" in [pylint/test/functional/consider_using_in.py](https://github.com/PyCQA/pylint/compare/master...pheanex:enhancement/consider-using-in#diff-72d92d1a1366fbd15845f30babb82d2d)). 
For example: `'value' == 1 or 'value' == 2` should be `'value' in (1, 2)`
* Suggesting the fix "costs" 10 lines of code. I am unsure if it's worth it.

Things to do after review/before merge:
* Add Documentation/Changelog
* Squash these commits to one clean commit