### PR TITLE
Revert "Proposal of a fix for bug #1950"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -170,11 +170,6 @@ What's New in Pylint 2.0?
 
       Close #638
 
-    * Fix false-positive ``line-too-long`` message emission for
-      commented line at the end of a module
-
-      Close #1950
-
 
 What's New in Pylint 1.8.1?
 =========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -110,5 +110,3 @@ Other Changes
     class definitions
 
 * Suppress false-positive ``not-callable`` messages from certain staticmethod descriptors
-
-* Fix false positive ``line-too-long`` for commented lines at the end of module

--- a/pylint/test/functional/line_too_long_end_of_module.py
+++ b/pylint/test/functional/line_too_long_end_of_module.py
@@ -1,7 +1,0 @@
-#pylint: disable=missing-docstring, line-too-long
-
-# Hey this is a very long commented line just to trigger pylint's line-too-long message. It is just above a dummy function with a very long code line.
-def dummy_function():
-    print("What a beautiful dummy function with such a very long line inside that it should trigger pylint's line-too-long message ")
-
-# Hey this is a very long commented line at the end of the module. It is just here to trigger pylint's line-too-long message.

--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -394,13 +394,6 @@ class MessagesHandlerMixIn(object):
         try:
             return self.file_state._module_msgs_state[msgid][line]
         except KeyError:
-            # Check if the message's line is after the maximum line existing in ast tree.
-            # This line won't appear in the ast tree and won't be referred in
-            # self.file_state._module_msgs_state
-            # This happens for example with a commented line at the end of a module.
-            max_line_number = self.file_state.get_effective_max_line_number()
-            if (max_line_number and line > max_line_number):
-                return msgid not in self.file_state._raw_module_msgs_state
             return self._msgs_state.get(msgid, True)
 
     def add_message(self, msg_descr, line=None, node=None, args=None, confidence=UNDEFINED,
@@ -690,12 +683,6 @@ class FileState(object):
             for line in lines:
                 yield 'suppressed-message', line, \
                     (msgs_store.get_msg_display_string(warning), from_)
-
-    def get_effective_max_line_number(self):
-        """Return the maximum line number present in _module_msgs_state."""
-        if self._module_msgs_state:
-            return max((max(d.keys()) for d in self._module_msgs_state.values()))
-        return None
 
 
 class MessagesStore(object):


### PR DESCRIPTION
This seems to break the message control from the configuration file. That's the reason the linting suddenly started to fail.

CC @hippo91 Didn't have time to check why this is happening, if you can take a look when you get a chance, that would be great.
Reverts PyCQA/pylint#2004