### PR TITLE
Ignore 'optional' type specifier for google docstring

### DIFF
--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -428,6 +428,7 @@ class GoogleDocstring(Docstring):
         \s*  \*{{0,2}}(\w+)             # identifier potentially with asterisks
         \s*  ( [(]
             {type}
+            (?:,\s+optional)?
             [)] )? \s* :                # optional type declaration
         \s*  (.*)                       # beginning of optional description
     """.format(

--- a/pylint/test/extensions/test_check_docs.py
+++ b/pylint/test/extensions/test_check_docs.py
@@ -1464,6 +1464,27 @@ class TestParamDocChecker(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
+    def test_ignores_optional_specifier_google(self):
+        node = astroid.extract_node('''
+        def do_something(param1, param2, param3=(), param4=[], param5=[], param6=True):
+            """Do something.
+
+            Args:
+                param1 (str): Description.
+                param2 (dict(str, int)): Description.
+                param3 (tuple(str), optional): Defaults to empty. Description.
+                param4 (List[str], optional): Defaults to empty. Description.
+                param5 (list[tuple(str)], optional): Defaults to empty. Description.
+                param6 (bool, optional): Defaults to True. Description.
+
+            Returns:
+                int: Description.
+            """
+            return param1, param2, param3, param4, param5, param6
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
+
     def test_ignores_optional_specifier_numpy(self):
         node = astroid.extract_node('''
         def do_something(param, param2='all'):


### PR DESCRIPTION
Fixes #1844 

### Fixes / new features
- Adding ", optional" to the end of the type of a parameter in a google docstring no longer makes docparams throw a missing-type-doc warning.
