### PR TITLE
Add support for numpydoc return value names

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -168,3 +168,5 @@ Order doesn't matter (not that much, at least ;)
 * Renat Galimov: contributor
 
 * Thomas Snowden: fix missing-docstring for inner functions
+
+* Mitchell Young: minor adjustment to docparams

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@ Pylint's ChangeLog
 ------------------
 What's New in Pylint 2.0?
 =========================
+	* Add support for nupmydoc optional return value names.
+
+	  Close #2030
 
     * Add a check `consider-using-in` for comparisons of a variable against
       multiple values with "==" and "or"s instead of checking if the variable

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -693,8 +693,9 @@ class NumpyDocstring(GoogleDocstring):
     )
 
     re_returns_line = re.compile(r"""
-        \s* ({type})$ # type declaration
-        \s* (.*)                       # optional description
+        \s* (?:\w+\s+:\s+)? # optional name
+        ({type})$                         # type declaration
+        \s* (.*)                          # optional description
     """.format(
         type=GoogleDocstring.re_multiple_type,
     ), re.X | re.S | re.M)


### PR DESCRIPTION
Numpydoc specification allows for optional return value name in the form
of:
```
Returns
-------
name : type
    Some description
```
These were not being honored by the current regex for return lines. This
adds an optional, non-capturing group to the regex which accounts for
the `name : ` bit.

Fixes #2030