### PR TITLE
Enum classes no longer trigger too-few-methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,17 +4,24 @@ Pylint's ChangeLog
 What's New in Pylint 2.0?
 =========================
 
+    * Special methods do not count towards `too-few-methods`,
+      and are considered part of the public API.
+
+    * Enum classes do not trigger `too-few-methods`
+
+      Close #605
+
     * `undefined-loop-variable` takes in consideration non-empty iterred objects before emitting
 
-       Close #2039
+      Close #2039
 
-	* Add support for nupmydoc optional return value names.
+    * Add support for nupmydoc optional return value names.
 
-	  Close #2030
+      Close #2030
 
     * `singleton-comparison` accounts for negative checks
 
-       Close #2037
+      Close #2037
 
     * Add a check `consider-using-in` for comparisons of a variable against
       multiple values with "==" and "or"s instead of checking if the variable
@@ -22,9 +29,9 @@ What's New in Pylint 2.0?
 
       Close #1977
 
-   * defaultdict and subclasses of dict are now handled for dict-iter-* checks
+    * defaultdict and subclasses of dict are now handled for dict-iter-* checks
 
-     Close #2005
+      Close #2005
 
     * Added a new Python 2/3 check for accessing `operator.div`, which is removed in Python 3
 

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -130,4 +130,9 @@ Other Changes
 
   For instance, if the loop iterable is not empty, this check will no longer be emitted.
 
+* Enum classes no longer trigger `too-few-methods`
 
+* Special methods now count towards `too-few-methods`,
+  and are considered part of the public API.
+  They are still not counted towards the number of methods for
+  `too-many-methods`.

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -914,3 +914,28 @@ def get_node_last_lineno(node):
         return get_node_last_lineno(node.body[-1])
     # Not a compound statement
     return node.lineno
+
+
+def is_enum_class(node):
+    """Check if a class definition defines an Enum class.
+
+    :param node: The class node to check.
+    :type node: astroid.ClassDef
+
+    :returns: True if the given node represents an Enum class. False otherwise.
+    :rtype: bool
+    """
+    for base in node.bases:
+        try:
+            inferred_bases = base.inferred()
+        except astroid.InferenceError:
+            continue
+
+        for ancestor in inferred_bases:
+            if not isinstance(ancestor, astroid.ClassDef):
+                continue
+
+            if ancestor.name == 'Enum' and ancestor.root().name == 'enum':
+                return True
+
+    return False

--- a/pylint/test/functional/too_few_public_methods.py
+++ b/pylint/test/functional/too_few_public_methods.py
@@ -1,6 +1,10 @@
 # pylint: disable=missing-docstring
 from __future__ import print_function
 
+import collections
+from enum import Enum
+
+
 class Aaaa(object): # [too-few-public-methods]
 
     def __init__(self):
@@ -26,3 +30,21 @@ class Klass(object):
 
 class EnoughPublicMethods(Klass):
     """We shouldn't emit too-few-public-methods for this."""
+
+
+class BossMonster(Enum):
+    """An enum does not need methods to be useful."""
+    megashark = 1
+    octopus = 2
+
+
+class DumbList(collections.Sequence):
+    """A class can define only special methods."""
+    def __init__(self, iterable):
+        self._list = list(iterable)
+
+    def __len__(self):
+        return len(self._list)
+
+    def __getitem__(self, index):
+        return self._list[index]

--- a/pylint/test/functional/too_few_public_methods.txt
+++ b/pylint/test/functional/too_few_public_methods.txt
@@ -1,1 +1,1 @@
-too-few-public-methods:4:Aaaa:Too few public methods (1/2)
+too-few-public-methods:8:Aaaa:Too few public methods (1/2)


### PR DESCRIPTION
### Fixes / new features
- Enum classes do not trigger too-few-methods
- Special methods are counted as part of the public API when counting methods for too-few-methods. They are not counted towards the number of methods for too-many-methods though.

Needs backporting to 1.8

Fixes #605