### PR TITLE
Can ignore arguments that cause redefined-outer-name

### DIFF
--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -722,8 +722,7 @@ class VariablesChecker(BaseChecker):
                     continue
 
                 line = definition.fromlineno
-                dummy_rgx = self.config.dummy_variables_rgx
-                if not dummy_rgx.match(name):
+                if not self._is_name_ignored(stmt, name):
                     self.add_message('redefined-outer-name',
                                      args=(name, line), node=stmt)
 


### PR DESCRIPTION
Just like unused-argument, redefined-outer-name now also uses ignored-argument-names.

Technically this is a new feature but it should be easy to backport to 1.8 anyway.

### Fixes / new features
- Fixes #1535