### PR TITLE
Add new check py3k invalid-unicode-literal.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -152,3 +152,6 @@ Order doesn't matter (not that much, at least ;)
 * Jacques Kvam: contributor
 
 * Brian Shaginaw: prevent error on exception check for functions
+
+* Sushobhit (sushobhit27): contributor
+  Added new py3k check invalid-unicode-literal.

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in Pylint 1.8.4?
 
 Release date: 2018-04-05
 
+    * Fix invalid string literal like a = ur'xxx' with --py3k.
+
+    Close #1938
+
     * Stop early when we already detected a disable for a line too long
 
     Close #1974

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -944,6 +944,11 @@ class Python3TokenChecker(checkers.BaseTokenChecker):
                   'Used when non-ascii bytes literals are found in a program. '
                   'They are no longer supported in Python 3.',
                   {'maxversion': (3, 0)}),
+        'E1611': ('unicode raw string literals not supported in 3.x',
+                  'invalid-unicode-literal',
+                  'Used when raw unicode literals are found in a program. '
+                  'They are no longer supported in Python 3.',
+                  {'maxversion': (3, 0)}),
     }
 
     def process_tokens(self, tokens):
@@ -959,6 +964,8 @@ class Python3TokenChecker(checkers.BaseTokenChecker):
             if tok_type == tokenize.STRING and token.startswith('b'):
                 if any(elem for elem in token if ord(elem) > 127):
                     self.add_message('non-ascii-bytes-literal', line=start[0])
+            if tok_type == tokenize.STRING and token.startswith('ur'):
+                self.add_message('invalid-unicode-literal', line=start[0])
 
 
 def register(linter):

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -933,6 +933,9 @@ class TestPython3TokenChecker(testutils.CheckerTestCase):
     def test_old_ne_operator(self):
         self._test_token_message("1 <> 2", "old-ne-operator")
 
+    def test_invalid_string_literal(self):
+        self._test_token_message("a = ur'aaa'", 'invalid-unicode-literal')
+
     def test_old_octal_literal(self):
         for octal in ("045", "055", "075", "077", "076543"):
             self._test_token_message(octal, "old-octal-literal")


### PR DESCRIPTION
Add new check py3k invalid-unicode-literal for below strings.
a = ur'foobar'
### Fixes / new features
- Close #1938

