### PR TITLE
 Skip wildcard check if __init__.py, solves #2026

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -170,3 +170,5 @@ Order doesn't matter (not that much, at least ;)
 * Thomas Snowden: fix missing-docstring for inner functions
 
 * Mitchell Young: minor adjustment to docparams
+
+* Marianna Polatoglou: minor contribution for wildcard import check

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,10 @@ Pylint's ChangeLog
 What's New in Pylint 2.0?
 =========================
 
+    * Skip wildcard import check for `__init__.py`.
+
+      Close #2026
+
     * The Python 3 porting mode can now run with Python 3 as well.
 
     * `too-few-public-methods` is not emitted for dataclasses.

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -150,3 +150,5 @@ Other Changes
 * docparams allows abstract methods to document returns documentation even
   if the default implementation does not return something.
   They also no longer need to document raising a NotImplementedError.
+
+* Skip wildcard import check for `__init__.py`.

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -787,6 +787,11 @@ class ImportsChecker(BaseChecker):
         return self.__int_dep_info
 
     def _check_wildcard_imports(self, node, imported_module):
+        root = node.root()
+        if root.package and root.name == "__init__":
+            # Skip the check if in __init__.py issue #2026
+            return
+
         wildcard_import_is_allowed = (
             self._wildcard_import_is_allowed(imported_module)
         )

--- a/pylint/test/regrtest_data/awesome_module.py
+++ b/pylint/test/regrtest_data/awesome_module.py
@@ -1,0 +1,1 @@
+from other_awesome_module import *

--- a/pylint/test/regrtest_data/init_wildcard/__init__.py
+++ b/pylint/test/regrtest_data/init_wildcard/__init__.py
@@ -1,0 +1,1 @@
+from awesome_module import *

--- a/pylint/test/unittest_checker_imports.py
+++ b/pylint/test/unittest_checker_imports.py
@@ -13,6 +13,7 @@ import os
 import astroid
 from pylint.checkers import imports
 from pylint.testutils import CheckerTestCase, Message, set_config
+from pylint.interfaces import UNDEFINED
 
 
 class TestImportsChecker(CheckerTestCase):
@@ -96,3 +97,30 @@ class TestImportsChecker(CheckerTestCase):
             self.checker.visit_importfrom(module.body[1])
         with self.assertNoMessages():
             self.checker.visit_importfrom(module.body[2].body[0])
+
+    def test_wildcard_import_init(self):
+        here = os.path.abspath(os.path.dirname(__file__))
+        path = os.path.join(
+            here, 'regrtest_data', 'init_wildcard', '__init__.py')
+        with open(path) as stream:
+            data = stream.read()
+        module = astroid.parse(data, module_name='__init__', path=path)
+        import_from = module.body[0]
+
+        with self.assertNoMessages():
+            self.checker.visit_importfrom(import_from)
+
+    def test_wildcard_import_non_init(self):
+        here = os.path.abspath(os.path.dirname(__file__))
+        path = os.path.join(
+            here, 'regrtest_data', 'init_wildcard', '__init__.py')
+        with open(path) as stream:
+            data = stream.read()
+        module = astroid.parse(data, module_name='awesome_module', path=path)
+        import_from = module.body[0]
+
+        msg = Message(
+            msg_id='wildcard-import', node=import_from, args='awesome_module',
+            confidence=UNDEFINED)
+        with self.assertAddsMessages(msg):
+            self.checker.visit_importfrom(import_from)


### PR DESCRIPTION
### Fixes / new features
-  Skip wildcard check for `__init__.py`, since it is one of the best ways to populate packages in `__init__.py`
