### PR TITLE
Warn when using subprocess.Popen preexec_fn kwarg - resolves: #1195

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -170,3 +170,5 @@ Order doesn't matter (not that much, at least ;)
 * Thomas Snowden: fix missing-docstring for inner functions
 
 * Mitchell Young: minor adjustment to docparams
+
+* Benjamin Freeman: contributor

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -91,7 +91,8 @@ New checkers
   when creating subprocess.Popen instances which may be unsafe when used in
   the presence of threads.
 
-  See https://docs.python.org/3/library/subprocess.html#popen-constructor for details
+  See `subprocess.Popen <https://docs.python.org/3/library/subprocess.html#popen-constructor>`_
+  for full warning details.
 
 * New ``try-except-raise`` message when an except handler block has a bare
   `raise` statement as its first operator or the exception type being raised

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -85,6 +85,14 @@ New checkers
   functions uses a different type than strings, while the latter is emitted whenever
   the said functions are using a default variable of different type than expected.
 
+* A new check was added, `subprocess-popen-preexec-fn`,
+
+  This refactoring message is emitted when using the keyword argument preexec_fn
+  when creating subprocess.Popen instances which may be unsafe when used in
+  the presence of threads.
+
+  See https://docs.python.org/3/library/subprocess.html#popen-constructor for details
+
 * New ``try-except-raise`` message when an except handler block has a bare
   `raise` statement as its first operator or the exception type being raised
   is the same as the one being handled.

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -230,7 +230,8 @@ class StdlibChecker(BaseChecker):
                           'bad-thread-instantiation',
                           'shallow-copy-environ',
                           'invalid-envvar-value',
-                          'invalid-envvar-default')
+                          'invalid-envvar-default',
+                          'subprocess-popen-preexec-fn')
     def visit_call(self, node):
         """Visit a Call node."""
         try:

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -123,7 +123,7 @@ class StdlibChecker(BaseChecker):
                   'See https://docs.python.org/3/library/os.html#os.getenv. '),
         'W1509': ('Using preexec_fn keyword which may be unsafe in the presence '
                   'of threads',
-                  'subprocess-popen-preexec-fc',
+                  'subprocess-popen-preexec-fn',
                   'The preexec_fn parameter is not safe to use in the presence '
                   'of threads in your application. The child process could '
                   'deadlock before exec is called. If you must use it, keep it '
@@ -211,10 +211,10 @@ class StdlibChecker(BaseChecker):
         if not node.kwargs and not node.keywords and len(node.args) <= 1:
             self.add_message('bad-thread-instantiation', node=node)
 
-    def _check_for_preexec_fc_in_Popen(self, node):
+    def _check_for_preexec_fn_in_Popen(self, node):
         for keyword in node.keywords:
             if keyword.arg == 'preexec_fn':
-                self.add_message('subprocess-popen-preexec_fc', node=node)
+                self.add_message('subprocess-popen-preexec-fn', node=node)
 
     def _check_shallow_copy_environ(self, node):
         arg = utils.get_argument_from_call(node, position=0)
@@ -245,7 +245,7 @@ class StdlibChecker(BaseChecker):
                     if inferred.qname() == THREADING_THREAD:
                         self._check_bad_thread_instantiation(node)
                     elif inferred.qname() == SUBPROCESS_POPEN:
-                        self._check_for_preexec_fc_in_Popen(node)
+                        self._check_for_preexec_fn_in_Popen(node)
                 elif isinstance(inferred, astroid.FunctionDef):
                     name = inferred.qname()
                     if name == COPY_COPY:

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -223,8 +223,6 @@ class StdlibChecker(BaseChecker):
                 self.add_message('shallow-copy-environ', node=node)
                 break
 
-
-
     @utils.check_messages('bad-open-mode',
                           'redundant-unittest-assert',
                           'deprecated-method',

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -34,6 +34,7 @@ THREADING_THREAD = 'threading.Thread'
 COPY_COPY = 'copy.copy'
 OS_ENVIRON = 'os._Environ'
 ENV_GETTERS = {'os.getenv'}
+SUBPROCESS_POPEN = 'subprocess.Popen'
 
 if sys.version_info >= (3, 0):
     OPEN_MODULE = '_io'
@@ -120,6 +121,14 @@ class StdlibChecker(BaseChecker):
                   'Env manipulation functions return None or str values. '
                   'Supplying anything different as a default may cause bugs. '
                   'See https://docs.python.org/3/library/os.html#os.getenv. '),
+        'W1509': ('Using preexec_fn keyword which may be unsafe in the presence '
+                  'of threads',
+                  'subprocess-popen-preexec-fc',
+                  'The preexec_fn parameter is not safe to use in the presence '
+                  'of threads in your application. The child process could '
+                  'deadlock before exec is called. If you must use it, keep it '
+                  'trivial! Minimize the number of libraries you call into.'
+                  'https://docs.python.org/3/library/subprocess.html#popen-constructor'),
 
     }
 
@@ -202,12 +211,19 @@ class StdlibChecker(BaseChecker):
         if not node.kwargs and not node.keywords and len(node.args) <= 1:
             self.add_message('bad-thread-instantiation', node=node)
 
+    def _check_for_preexec_fc_in_Popen(self, node):
+        for keyword in node.keywords:
+            if keyword.arg == 'preexec_fn':
+                self.add_message('subprocess-popen-preexec_fc', node=node)
+
     def _check_shallow_copy_environ(self, node):
         arg = utils.get_argument_from_call(node, position=0)
         for inferred in arg.inferred():
             if inferred.qname() == OS_ENVIRON:
                 self.add_message('shallow-copy-environ', node=node)
                 break
+
+
 
     @utils.check_messages('bad-open-mode',
                           'redundant-unittest-assert',
@@ -227,9 +243,11 @@ class StdlibChecker(BaseChecker):
                         self._check_open_mode(node)
                 elif inferred.root().name == UNITTEST_CASE:
                     self._check_redundant_assert(node, inferred)
-                elif (isinstance(inferred, astroid.ClassDef)
-                      and inferred.qname() == THREADING_THREAD):
-                    self._check_bad_thread_instantiation(node)
+                elif isinstance(inferred, astroid.ClassDef):
+                    if inferred.qname() == THREADING_THREAD:
+                        self._check_bad_thread_instantiation(node)
+                    elif inferred.qname() == SUBPROCESS_POPEN:
+                        self._check_for_preexec_fc_in_Popen(node)
                 elif isinstance(inferred, astroid.FunctionDef):
                     name = inferred.qname()
                     if name == COPY_COPY:

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -212,9 +212,10 @@ class StdlibChecker(BaseChecker):
             self.add_message('bad-thread-instantiation', node=node)
 
     def _check_for_preexec_fn_in_Popen(self, node):
-        for keyword in node.keywords:
-            if keyword.arg == 'preexec_fn':
-                self.add_message('subprocess-popen-preexec-fn', node=node)
+        if node.keywords:
+            for keyword in node.keywords:
+                if keyword.arg == 'preexec_fn':
+                    self.add_message('subprocess-popen-preexec-fn', node=node)
 
     def _check_shallow_copy_environ(self, node):
         arg = utils.get_argument_from_call(node, position=0)

--- a/pylint/test/functional/subprocess_popen_preexec_fn.py
+++ b/pylint/test/functional/subprocess_popen_preexec_fn.py
@@ -1,0 +1,11 @@
+# pylint: disable=blacklisted-name,no-value-for-parameter,missing-docstring
+
+import subprocess
+
+def foo():
+    pass
+
+
+subprocess.Popen(preexec_fn=foo) # [subprocess-popen-preexec-fn]
+
+subprocess.Popen()

--- a/pylint/test/functional/subprocess_popen_preexec_fn.txt
+++ b/pylint/test/functional/subprocess_popen_preexec_fn.txt
@@ -1,0 +1,1 @@
+subprocess-popen-preexec-fn:9::Using preexec_fn keyword which may be unsafe in the presence of threads

--- a/pylint/test/unittest_checker_stdlib.py
+++ b/pylint/test/unittest_checker_stdlib.py
@@ -105,28 +105,3 @@ class TestStdlibChecker(CheckerTestCase):
         """)
         with self.assertNoMessages():
             self.checker.visit_call(node)
-
-    def test_preexec_fn_warning(self):
-        # preexec_fn parameter is not safe to use in the presence of threads
-        node = astroid.extract_node("""
-        import subprocess
-        def foo():
-            pass
-        subprocess.Popen(preexec_fn=foo)
-        """)
-        with self.assertAddsMessages(
-            Message(
-                msg_id='subprocess-popen-preexec-fn', node=node, confidence=UNDEFINED)
-        ):
-            self.checker.visit_call(node)
-
-    def test_no_preexec_fn_warning(self):
-        # env and start_new_session are preferred over preexec_fn
-        node = astroid.extract_node("""
-        import subprocess
-        def foo():
-            pass
-        subprocess.Popen(env=None, start_new_session=False)
-        """)
-        with self.assertNoMessages():
-            self.checker.visit_call(node)

--- a/pylint/test/unittest_checker_stdlib.py
+++ b/pylint/test/unittest_checker_stdlib.py
@@ -105,3 +105,28 @@ class TestStdlibChecker(CheckerTestCase):
         """)
         with self.assertNoMessages():
             self.checker.visit_call(node)
+
+    def test_preexec_fn_warning(self):
+        # preexec_fn parameter is not safe to use in the presence of threads
+        node = astroid.extract_node("""
+        import subprocess
+        def foo():
+            pass
+        subprocess.Popen(preexec_fn=foo)
+        """)
+        with self.assertAddsMessages(
+            Message(
+                msg_id='subprocess-popen-preexec_fc', node=node, confidence=UNDEFINED)
+        ):
+            self.checker.visit_call(node)
+
+    def test_no_preexec_fn_warning(self):
+        # env and start_new_session are preferred over preexec_fn
+        node = astroid.extract_node("""
+        import subprocess
+        def foo():
+            pass
+        subprocess.Popen(env=None, start_new_session=False)
+        """)
+        with self.assertNoMessages():
+            self.checker.visit_call(node)

--- a/pylint/test/unittest_checker_stdlib.py
+++ b/pylint/test/unittest_checker_stdlib.py
@@ -116,7 +116,7 @@ class TestStdlibChecker(CheckerTestCase):
         """)
         with self.assertAddsMessages(
             Message(
-                msg_id='subprocess-popen-preexec_fc', node=node, confidence=UNDEFINED)
+                msg_id='subprocess-popen-preexec-fn', node=node, confidence=UNDEFINED)
         ):
             self.checker.visit_call(node)
 


### PR DESCRIPTION
### Fixes / new features
- Adds a warning when using the preexc_fn keyword argument with the subprocess.Popen constructor. 
