### PR TITLE
Includes file paths in the default report format

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -172,3 +172,5 @@ Order doesn't matter (not that much, at least ;)
 * Mitchell Young: minor adjustment to docparams
 
 * Marianna Polatoglou: minor contribution for wildcard import check
+
+* Jace Browning: updated default report format with clickable paths

--- a/ChangeLog
+++ b/ChangeLog
@@ -226,6 +226,8 @@ What's New in Pylint 2.0?
 
       Close #638
 
+    * Updated the default report format to include paths that can be clicked on in some terminals (e.g. iTerm).
+
 
 What's New in Pylint 1.8.1?
 =========================

--- a/doc/user_guide/output.rst
+++ b/doc/user_guide/output.rst
@@ -39,9 +39,9 @@ For example, the former (pre 1.0) default format can be obtained with::
 
 A few other examples:
 
-* the new default format::
+* the default format::
 
-    {C}:{line:3d},{column:2d}: {msg} ({symbol})
+    {path}:{line}:{column}: {msg_id}: {msg} ({symbol})
 
 * Visual Studio compatible format (former 'msvs' output format)::
 

--- a/pylint/reporters/text.py
+++ b/pylint/reporters/text.py
@@ -124,7 +124,7 @@ class TextReporter(BaseReporter):
     __implements__ = IReporter
     name = 'text'
     extension = 'txt'
-    line_format = '{C}:{line:3d},{column:2d}: {msg} ({symbol})'
+    line_format = '{path}:{line}:{column}: {msg_id}: {msg} ({symbol})'
 
     def __init__(self, output=None):
         BaseReporter.__init__(self, output)

--- a/pylint/test/test_self.py
+++ b/pylint/test/test_self.py
@@ -118,10 +118,14 @@ class TestRunTC(object):
                     Run(args, reporter=reporter)
             return cm.value.code
 
+    def _clean_paths(self, output):
+        """Remove version-specific tox parent directories from paths."""
+        return re.sub(r'py\d\d/.+/site-packages/', '', output)
+
     def _test_output(self, args, expected_output):
         out = six.StringIO()
         self._run_pylint(args, out=out)
-        actual_output = out.getvalue()
+        actual_output = self._clean_paths(out.getvalue())
         assert expected_output.strip() in actual_output.strip()
 
     def test_pkginfo(self):
@@ -297,9 +301,9 @@ class TestRunTC(object):
         module = join(HERE, 'data', 'clientmodule_test.py')
         expected = textwrap.dedent("""
         ************* Module data.clientmodule_test
-        W: 10, 8: Unused variable 'local_variable' (unused-variable)
-        C: 18, 4: Missing method docstring (missing-docstring)
-        C: 22, 0: Missing class docstring (missing-docstring)
+        pylint/test/data/clientmodule_test.py:10:8: W0612: Unused variable 'local_variable' (unused-variable)
+        pylint/test/data/clientmodule_test.py:18:4: C0111: Missing method docstring (missing-docstring)
+        pylint/test/data/clientmodule_test.py:22:0: C0111: Missing class docstring (missing-docstring)
         """)
         self._test_output([module, "--disable=all", "--enable=all", "-rn"],
                           expected_output=expected)
@@ -307,7 +311,7 @@ class TestRunTC(object):
     def test_wrong_import_position_when_others_disabled(self):
         expected_output = textwrap.dedent('''
         ************* Module wrong_import_position
-        C: 11, 0: Import "import os" should be placed at the top of the module (wrong-import-position)
+        pylint/test/regrtest_data/wrong_import_position.py:11:0: C0413: Import "import os" should be placed at the top of the module (wrong-import-position)
         ''')
         module1 = join(HERE, 'regrtest_data', 'import_something.py')
         module2 = join(HERE, 'regrtest_data', 'wrong_import_position.py')
@@ -316,7 +320,7 @@ class TestRunTC(object):
                 "-rn", "-sn"]
         out = six.StringIO()
         self._run_pylint(args, out=out)
-        actual_output = out.getvalue().strip()
+        actual_output = self._clean_paths(out.getvalue().strip())
 
         to_remove = "No config file found, using default configuration"
         if to_remove in actual_output:
@@ -391,7 +395,7 @@ class TestRunTC(object):
     def test_error_mode_shows_no_score(self):
         expected_output = textwrap.dedent('''
         ************* Module application_crash
-        E:  1, 6: Undefined variable 'something_undefined' (undefined-variable)
+        pylint/test/regrtest_data/application_crash.py:1:6: E0602: Undefined variable 'something_undefined' (undefined-variable)
         ''')
         module = join(HERE, 'regrtest_data', 'application_crash.py')
         self._test_output([module, "-E"], expected_output=expected_output)
@@ -439,9 +443,9 @@ class TestRunTC(object):
         config_path = join(HERE, 'regrtest_data', 'comments_pylintrc')
         expected = textwrap.dedent('''
         ************* Module test_pylintrc_comments
-        W:  2, 0: Bad indentation. Found 1 spaces, expected 4 (bad-indentation)
-        C:  1, 0: Missing module docstring (missing-docstring)
-        C:  1, 0: Missing function docstring (missing-docstring)
+        pylint/test/regrtest_data/test_pylintrc_comments.py:2:0: W0311: Bad indentation. Found 1 spaces, expected 4 (bad-indentation)
+        pylint/test/regrtest_data/test_pylintrc_comments.py:1:0: C0111: Missing module docstring (missing-docstring)
+        pylint/test/regrtest_data/test_pylintrc_comments.py:1:0: C0111: Missing function docstring (missing-docstring)
         ''')
         self._test_output([path, "--rcfile=%s" % config_path, "-rn"],
                           expected_output=expected)
@@ -453,7 +457,7 @@ class TestRunTC(object):
     def test_getdefaultencoding_crashes_with_lc_ctype_utf8(self):
         expected_output = textwrap.dedent('''
         ************* Module application_crash
-        E:  1, 6: Undefined variable 'something_undefined' (undefined-variable)
+        pylint/test/regrtest_data/application_crash.py:1:6: E0602: Undefined variable 'something_undefined' (undefined-variable)
         ''')
         module = join(HERE, 'regrtest_data', 'application_crash.py')
         with _configure_lc_ctype('UTF-8'):

--- a/pylint/test/test_self.py
+++ b/pylint/test/test_self.py
@@ -120,7 +120,7 @@ class TestRunTC(object):
 
     def _clean_paths(self, output):
         """Remove version-specific tox parent directories from paths."""
-        return re.sub(r'py\d\d/.+/site-packages/', '', output)
+        return re.sub('^py.+/site-packages/', '', output.replace('\\', '/'), flags=re.MULTILINE)
 
     def _test_output(self, args, expected_output):
         out = six.StringIO()


### PR DESCRIPTION
The default report format in `mypy`, `pydocstyle`, and other tools includes the file path so that the user of certain terminals (e.g. iTerm) can click on each warning to open that line in their editor.

For example, here is what the default `mypy` output looks like:
> framework/views/billing.py:92: error: Incompatible return value type (got "View", expected "DashboardTab")

With this new format, `pylint`output looks like:
> framework/views/dashboards.py:21:8: W0612: Unused variable 'x' (unused-variable)

Note that some editors (e.g. Sublime Text) index columns from 1, so this will place the cursor one column to the left of the warning.

cc @PCManticore 