### PR TITLE
Add a new check: `logging-fstring-interpolation`.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -183,3 +183,7 @@ Order doesn't matter (not that much, at least ;)
 
 * Sushobhit (sushobhit27): contributor
   Added new check 'comparison-with-itself'.
+
+* Mariatta Wijaya: contributor
+  Added new check `logging-fstring-interpolation`
+  Documentation typo fixes

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,11 @@ What's New in Pylint 2.0?
 
       Close #2051
 
+    * Add a new warning, 'logging-fstring-interpolation', emitted when f-string
+      is used within logging function calls.
+
+      Close #1998
+
     * Don't show 'useless-super-delegation' if the subclass method has different type annotations.
 
       Close #1923
@@ -14,7 +19,7 @@ What's New in Pylint 2.0?
     * Add `unhashable-dict-key` check.
 
       Closes #586
-    
+
     * Don't warn that a global variable is unused if it is defined by an import
 
       Close #1453

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -46,6 +46,17 @@ MSGS = {
               '. Such calls should use % formatting instead, but leave '
               'interpolation to the logging function by passing the parameters '
               'as arguments.'),
+    'W1203': ('Use % formatting in logging functions and pass the % '
+              'parameters as arguments',
+              'logging-fstring-interpolation',
+              'Used when a logging statement has a call form of '
+              '"logging.<logging method>(format_string.format(format_args...))"'
+              '. Such calls should use % formatting instead, but leave '
+              'interpolation to the logging function by passing the parameters '
+              'as arguments.'
+              'This message is emitted if f-string was used, and it can be '
+              'disabled if you like'
+              ),
     'E1200': ('Unsupported logging format character %r (%#02x) at index %d',
               'logging-unsupported-format',
               'Used when an unsupported format character is used in a logging\
@@ -191,7 +202,7 @@ class LoggingChecker(checkers.BaseChecker):
         elif isinstance(node.args[format_pos], astroid.Const):
             self._check_format_string(node, format_pos)
         elif isinstance(node.args[format_pos], astroid.JoinedStr):
-            self.add_message('logging-format-interpolation', node=node)
+            self.add_message('logging-fstring-interpolation', node=node)
 
     @staticmethod
     def _is_operand_literal_str(operand):

--- a/pylint/test/functional/logging_format_interpolation_py36.py
+++ b/pylint/test/functional/logging_format_interpolation_py36.py
@@ -2,4 +2,4 @@
 import logging as renamed_logging
 
 
-renamed_logging.info(f'Read {renamed_logging} from globals')  # [logging-format-interpolation]
+renamed_logging.info(f'Read {renamed_logging} from globals')  # [logging-fstring-interpolation]

--- a/pylint/test/functional/logging_format_interpolation_py36.txt
+++ b/pylint/test/functional/logging_format_interpolation_py36.txt
@@ -1,1 +1,1 @@
-logging-format-interpolation:5::Use % formatting in logging functions and pass the % parameters as arguments
+logging-fstring-interpolation:5::Use % formatting in logging functions and pass the % parameters as arguments

--- a/pylint/test/functional/logging_fstring_interpolation_py36.py
+++ b/pylint/test/functional/logging_fstring_interpolation_py36.py
@@ -1,0 +1,21 @@
+# pylint: disable=invalid-name,trailing-newlines
+
+"""Test logging-fstring-interpolation for Python 3.6"""
+from datetime import datetime
+
+import logging as renamed_logging
+
+
+local_var_1 = 4
+local_var_2 = "run!"
+
+pi = 3.14159265
+
+may_14 = datetime(year=2018, month=5, day=14)
+
+# Statements that should be flagged:
+renamed_logging.debug(f'{local_var_1} {local_var_2}') # [logging-fstring-interpolation]
+renamed_logging.log(renamed_logging.DEBUG, f'msg: {local_var_2}') # [logging-fstring-interpolation]
+renamed_logging.log(renamed_logging.DEBUG, f'pi: {pi:.3f}') # [logging-fstring-interpolation]
+renamed_logging.info(f"{local_var_2.upper()}") # [logging-fstring-interpolation]
+renamed_logging.info(f"{may_14:'%b %d: %Y'}") # [logging-fstring-interpolation]

--- a/pylint/test/functional/logging_fstring_interpolation_py36.rc
+++ b/pylint/test/functional/logging_fstring_interpolation_py36.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.6

--- a/pylint/test/functional/logging_fstring_interpolation_py36.txt
+++ b/pylint/test/functional/logging_fstring_interpolation_py36.txt
@@ -1,0 +1,5 @@
+logging-fstring-interpolation:17::Use % formatting in logging functions and pass the % parameters as arguments
+logging-fstring-interpolation:18::Use % formatting in logging functions and pass the % parameters as arguments
+logging-fstring-interpolation:19::Use % formatting in logging functions and pass the % parameters as arguments
+logging-fstring-interpolation:20::Use % formatting in logging functions and pass the % parameters as arguments
+logging-fstring-interpolation:21::Use % formatting in logging functions and pass the % parameters as arguments


### PR DESCRIPTION
A new check `logging-fstring-interpolation` is added.
It emits a warning when f-string is used within logging
function calls.

### New feature

Closes https://github.com/PyCQA/pylint/issues/1998
