### PR TITLE
Fix weird indentation in contributing guide

### DIFF
--- a/doc/development_guide/contribute.rst
+++ b/doc/development_guide/contribute.rst
@@ -89,7 +89,7 @@ your patch gets accepted.
 
 - Relate your change to an issue in the tracker if such an issue exists (see
   `Closing issues via commit messages`_ of the GitHub documentation for more
-   information on this)
+  information on this)
 
 - Document your change, if it is a non-trivial one.
 


### PR DESCRIPTION
Current markup looks a little strange...

see screenshot

<img width="797" alt="screen shot 2018-05-14 at 5 25 54 pm" src="https://user-images.githubusercontent.com/5844587/40024396-282be8b8-579c-11e8-83ba-6dfe92d849d7.png">

This should fix it.
