### PR TITLE
Fix typo in base checker unit test

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -174,3 +174,5 @@ Order doesn't matter (not that much, at least ;)
 * Marianna Polatoglou: minor contribution for wildcard import check
 
 * Benjamin Freeman: contributor
+
+* Fureigh: contributor

--- a/pylint/test/unittest_checker_base.py
+++ b/pylint/test/unittest_checker_base.py
@@ -121,7 +121,7 @@ class TestNameChecker(CheckerTestCase):
     @set_config(attr_rgx=re.compile('[A-Z]+'),
                 property_classes=('abc.abstractproperty', '.custom_prop'))
     def test_property_names(self):
-        # If a method is annotated with @property, it's name should
+        # If a method is annotated with @property, its name should
         # match the attr regex. Since by default the attribute regex is the same
         # as the method regex, we override it here.
         methods = astroid.extract_node("""


### PR DESCRIPTION
This PR does two things:
 * Change `it's name should` to `its name should`
 * Update CONTRIBUTORS.txt

Thanks for holding a sprint at PyCon!