### PR TITLE
Tests are no longer installed with package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,11 @@
 include ChangeLog
 include COPYING
 include DEPENDS
-include README README.Python3
+include README.rst
 include bin/*
 include examples/*.py examples/pylintrc examples/pylintrc_camelcase
 include elisp/startup elisp/*.el
 include man/*.1
-recursive-include doc *.rst *.jpeg Makefile *.html *.py *.bat
+include pytest.ini
+recursive-include doc *.rst Makefile *.py *.bat
 graft pylint/test

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -87,5 +87,3 @@ long_desc = """\
 scripts = [join('bin', filename)
            for filename in ('pylint', "symilar", "epylint",
                             "pyreverse")]
-
-include_dirs = [join('pylint', 'test')]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,9 @@ universal = 1
 [bdist_rpm]
 packager = Sylvain Thenault  <sylvain.thenault@logilab.fr>
 provides = pylint 
+
+[aliases]
+test = pytest
+
+[tool:pytest]
+testpaths = pylint/test/


### PR DESCRIPTION
Tests can also be run from the source distribution with `python setup.py test`.
We should be able to move the tests directory out of the astroid source and put it at the root level of the repository. But I think it makes more sense to do this when we have less pull requests about to be merged.