### PR TITLE
Add `--exit-zero` option

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -187,3 +187,5 @@ Order doesn't matter (not that much, at least ;)
 * Mariatta Wijaya: contributor
   Added new check `logging-fstring-interpolation`
   Documentation typo fixes
+
+* Jason Owen: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,12 @@ What's New in Pylint 2.0?
 
 Release date: |TBA|
 
+    * Add `--exit-zero` option for continuous integration scripts to more
+      easily call Pylint in environments that abort when a program returns a
+      non-zero (error) status code.
+
+      Close #2042
+
     * Warn if the first argument of an instance/ class method gets assigned
 
       Close #977

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -420,6 +420,12 @@ class PyLinter(config.OptionsManagerMixIn,
                   'help': ('When enabled, pylint would attempt to guess common '
                            'misconfiguration and emit user-friendly hints instead '
                            'of false-positive error messages')}),
+
+                ('exit-zero',
+                 {'action': 'store_true',
+                  'help': ('Always return a 0 (non-error) status code, even if '
+                           'lint errors are found. This is primarily useful in '
+                           'continuous integration scripts.')}),
                )
 
     option_groups = (
@@ -1359,7 +1365,10 @@ group are mutually exclusive.'),
             linter.check(args)
             linter.generate_reports()
         if do_exit:
-            sys.exit(self.linter.msg_status)
+            if linter.config.exit_zero:
+                sys.exit(0)
+            else:
+                sys.exit(self.linter.msg_status)
 
     def cb_set_rcfile(self, name, value):
         """callback for option preprocessing (i.e. before option parsing)"""

--- a/pylint/test/test_self.py
+++ b/pylint/test/test_self.py
@@ -149,6 +149,12 @@ class TestRunTC(object):
     def test_w0704_ignored(self):
         self._runtest([join(HERE, 'input', 'ignore_except_pass_by_default.py')], code=0)
 
+    def test_exit_zero(self):
+        self._runtest([
+            '--exit-zero',
+            join(HERE, 'regrtest_data', 'syntax_error.py')
+        ], code=0)
+
     def test_generate_config_option(self):
         self._runtest(['--generate-rcfile'], code=0)
 


### PR DESCRIPTION
Add a new command-line option for the use of continuous integration scripts which abort if a command returns a non-zero status code.  If the option is specified, and Pylint runs successfully, it will exit with 0 regardless of the number of lint issues detected.

Configuration errors, parse errors, and calling Pylint with invalid command-line options all still return a non-zero error code, even if `--exit-zero` is specified.

Thanks for hosting a sprint at PyCon 2018!

Resolves #2042 Provide ability to disable exit code for lint errors