### PR TITLE
Remove Python 2 specific checks from checks. Close #1896

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,6 +3,8 @@
 
 Order doesn't matter (not that much, at least ;)
 
+* Natalie Serebryakova: contributor
+
 * Sylvain Thenault (Logilab): main author / maintainer
 
 * Torsten Marek (Google): comitter / contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,10 @@ Pylint's ChangeLog
 What's New in Pylint 2.0?
 =========================
 
+    * Remove Python 2 specific checks
+
+      Close   #1896
+
     * Warn if the first argument of an instance/ class method gets assigned
 
       Close #977

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -399,12 +399,6 @@ class BasicErrorChecker(_BasicChecker):
                   'yield-outside-function',
                   'Used when a "yield" statement is found outside a function or '
                   'method.'),
-        'E0106': ('Return with argument inside generator',
-                  'return-arg-in-generator',
-                  'Used when a "return" statement with an argument is found '
-                  'outside in a generator function or method (e.g. with some '
-                  '"yield" statements).',
-                  {'maxversion': (3, 3)}),
         'E0107': ("Use of the non-existent %s operator",
                   'nonexistent-operator',
                   "Used when you attempt to use the C-style pre-increment or "
@@ -1651,37 +1645,6 @@ class PassChecker(_BasicChecker):
     def visit_pass(self, node):
         if len(node.parent.child_sequence(node)) > 1:
             self.add_message('unnecessary-pass', node=node)
-
-
-class LambdaForComprehensionChecker(_BasicChecker):
-    """check for using a lambda where a comprehension would do.
-
-    See <http://www.artima.com/weblogs/viewpost.jsp?thread=98196>
-    where GvR says comprehensions would be clearer.
-    """
-
-    msgs = {'W0110': ('map/filter on lambda could be replaced by comprehension',
-                      'deprecated-lambda',
-                      'Used when a lambda is the first argument to "map" or '
-                      '"filter". It could be clearer as a list '
-                      'comprehension or generator expression.',
-                      {'maxversion': (3, 0)}),
-           }
-
-    @utils.check_messages('deprecated-lambda')
-    def visit_call(self, node):
-        """visit a Call node, check if map or filter are called with a
-        lambda
-        """
-        if not node.args:
-            return
-        if not isinstance(node.args[0], astroid.Lambda):
-            return
-        infered = utils.safe_infer(node.func)
-        if (utils.is_builtin_object(infered)
-                and infered.name in ['map', 'filter']):
-            self.add_message('deprecated-lambda', node=node)
-
 
 def _is_one_arg_pos_call(call):
     """Is this a call with exactly 1 argument,

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -114,11 +114,6 @@ MSGS = {
               'duplicate-except',
               'Used when an except catches a type that was already caught by '
               'a previous handler.'),
-    'W0710': ('Exception doesn\'t inherit from standard "Exception" class',
-              'nonstandard-exception',
-              'Used when a custom exception class is raised but doesn\'t \
-              inherit from the builtin "Exception" class.',
-              {'maxversion': (3, 0)}),
     'W0711': ('Exception to catch is the result of a binary "%s" operation',
               'binary-op-exception',
               'Used when the exception to catch is of the form \

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -82,7 +82,7 @@ MSGS = {
     'C0302': ('Too many lines in module (%s/%s)',  # was W0302
               'too-many-lines',
               'Used when a module has too many lines, reducing its readability.'
-             ),
+              ),
     'C0303': ('Trailing whitespace',
               'trailing-whitespace',
               'Used when there is whitespace between the end of a line and the '
@@ -122,12 +122,6 @@ MSGS = {
               {'old_names': [('C0323', 'no-space-after-operator'),
                              ('C0324', 'no-space-after-comma'),
                              ('C0322', 'no-space-before-operator')]}),
-    'W0332': ('Use of "l" as long integer identifier',
-              'lowercase-l-suffix',
-              'Used when a lower case "l" is used to mark a long integer. You '
-              'should use an upper case "L" since the letter "l" looks too much '
-              'like the digit "1"',
-              {'maxversion': (3, 0)}),
     'C0327': ('Mixed line endings LF and CRLF',
               'mixed-line-endings',
               'Used when there are mixed (LF and CRLF) newline signs in a file.'),
@@ -515,7 +509,7 @@ class FormatChecker(BaseTokenChecker):
                ('max-module-lines',
                 {'default': 1000, 'type': 'int', 'metavar': '<int>',
                  'help': 'Maximum number of lines in a module'}
-               ),
+                ),
                ('indent-string',
                 {'default': '    ', 'type': "non_empty_string", 'metavar': '<string>',
                  'help': 'String used as indentation unit. This is usually '
@@ -529,7 +523,7 @@ class FormatChecker(BaseTokenChecker):
                  'choices': ['', 'LF', 'CRLF'],
                  'help': ('Expected format of line ending, '
                           'e.g. empty (any line ending), LF or CRLF.')}),
-              )
+               )
 
     def __init__(self, linter=None):
         BaseTokenChecker.__init__(self, linter)
@@ -888,7 +882,7 @@ class FormatChecker(BaseTokenChecker):
             else:
                 handler(tokens, idx)
 
-        line_num -= 1 # to be ok with "wc -l"
+        line_num -= 1  # to be ok with "wc -l"
         if line_num > self.config.max_module_lines:
             # Get the line where the too-many-lines (or its message id)
             # was disabled or default to 1.
@@ -976,7 +970,7 @@ class FormatChecker(BaseTokenChecker):
         if not node.is_statement:
             return
         if not node.root().pure_python:
-            return # XXX block visit of child nodes
+            return  # XXX block visit of child nodes
         prev_sibl = node.previous_sibling()
         if prev_sibl is not None:
             prev_line = prev_sibl.fromlineno
@@ -1097,7 +1091,7 @@ class FormatChecker(BaseTokenChecker):
         """return the indent level of the string
         """
         indent = self.config.indent_string
-        if indent == '\\t': # \t is not interpreted in the configuration file
+        if indent == '\\t':  # \t is not interpreted in the configuration file
             indent = '\t'
         level = 0
         unit_size = len(indent)

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -120,6 +120,7 @@ def _ignore_import_failure(node, modname, ignored_modules):
 
 # utilities to represents import dependencies as tree and dot graph ###########
 
+
 def _make_tree_defs(mod_files_list):
     """get a list of 2-uple (module, list_of_files_which_import_this_module),
     it will return a dictionary to represent this as a tree
@@ -206,11 +207,6 @@ MSGS = {
     'W0402': ('Uses of a deprecated module %r',
               'deprecated-module',
               'Used a module marked as deprecated is imported.'),
-    'W0403': ('Relative import %r, should be %r',
-              'relative-import',
-              'Used when an import relative to the package directory is '
-              'detected.',
-              {'maxversion': (3, 0)}),
     'W0404': ('Reimport %r (imported line %s)',
               'reimported',
               'Used when a module is reimported multiple times.'),
@@ -264,48 +260,48 @@ class ImportsChecker(BaseChecker):
     else:
         deprecated_modules = ('optparse', 'tkinter.tix')
     options = (('deprecated-modules',
-                {'default' : deprecated_modules,
-                 'type' : 'csv',
-                 'metavar' : '<modules>',
-                 'help' : 'Deprecated modules which should not be used,'
-                          ' separated by a comma'}
-               ),
+                {'default': deprecated_modules,
+                 'type': 'csv',
+                 'metavar': '<modules>',
+                 'help': 'Deprecated modules which should not be used,'
+                         'separated by a comma'}
+                ),
                ('import-graph',
-                {'default' : '',
-                 'type' : 'string',
-                 'metavar' : '<file.dot>',
-                 'help' : 'Create a graph of every (i.e. internal and'
-                          ' external) dependencies in the given file'
-                          ' (report RP0402 must not be disabled)'}
-               ),
+                {'default': '',
+                 'type': 'string',
+                 'metavar': '<file.dot>',
+                 'help': 'Create a graph of every (i.e. internal and'
+                         ' external) dependencies in the given file'
+                         '(report RP0402 must not be disabled)'}
+                ),
                ('ext-import-graph',
-                {'default' : '',
-                 'type' : 'string',
-                 'metavar' : '<file.dot>',
-                 'help' : 'Create a graph of external dependencies in the'
-                          ' given file (report RP0402 must not be disabled)'}
-               ),
+                {'default': '',
+                 'type': 'string',
+                 'metavar': '<file.dot>',
+                 'help': 'Create a graph of external dependencies in the'
+                         ' given file (report RP0402 must not be disabled)'}
+                ),
                ('int-import-graph',
-                {'default' : '',
-                 'type' : 'string',
-                 'metavar' : '<file.dot>',
-                 'help' : 'Create a graph of internal dependencies in the'
-                          ' given file (report RP0402 must not be disabled)'}
-               ),
+                {'default': '',
+                 'type': 'string',
+                 'metavar': '<file.dot>',
+                 'help': 'Create a graph of internal dependencies in the'
+                         'given file (report RP0402 must not be disabled)'}
+                ),
                ('known-standard-library',
                 {'default': DEFAULT_STANDARD_LIBRARY,
                  'type': 'csv',
                  'metavar': '<modules>',
                  'help': 'Force import order to recognize a module as part of'
                          ' the standard compatibility libraries.'}
-               ),
+                ),
                ('known-third-party',
                 {'default': DEFAULT_KNOWN_THIRD_PARTY,
                  'type': 'csv',
                  'metavar': '<modules>',
                  'help': 'Force import order to recognize a module as part of'
                          ' a third party library.'}
-               ),
+                ),
                ('analyse-fallback-blocks',
                 {'default': False,
                  'type': 'yn',
@@ -314,13 +310,13 @@ class ImportsChecker(BaseChecker):
                          'support both Python 2 and 3 compatible code, which means that '
                          'the block might have code that exists only in one or another '
                          'interpreter, leading to false positives when analysed.'},
-               ),
+                ),
                ('allow-wildcard-with-all',
                 {'default': False,
                  'type': 'yn',
                  'metavar': '<y_or_n>',
                  'help': 'Allow wildcard imports from modules that define __all__.'}),
-              )
+               )
 
     def __init__(self, linter=None):
         BaseChecker.__init__(self, linter)
@@ -333,7 +329,7 @@ class ImportsChecker(BaseChecker):
                          self._report_external_dependencies),
                         ('RP0402', 'Modules dependencies graph',
                          self._report_dependencies_graph),
-                       )
+                        )
 
         self._site_packages = self._compute_site_packages()
 
@@ -575,7 +571,7 @@ class ImportsChecker(BaseChecker):
         std_imports = []
         third_party_imports = []
         first_party_imports = []
-        # need of a list that holds third or first party ordered import
+        # need of a list that holds third or first party ordered import
         external_imports = []
         local_imports = []
         third_party_not_ignored = []
@@ -660,9 +656,9 @@ class ImportsChecker(BaseChecker):
         if not self.linter.is_message_enabled('relative-import'):
             return None
         if importedmodnode.file is None:
-            return False # built-in module
+            return False  # built-in module
         if modnode is importedmodnode:
-            return False # module importing itself
+            return False  # module importing itself
         if modnode.absolute_import_activated() or getattr(importnode, 'level', None):
             return False
         if importedmodnode.name != importedasname:

--- a/pylint/checkers/newstyle.py
+++ b/pylint/checkers/newstyle.py
@@ -26,34 +26,10 @@ from pylint.checkers.utils import (
 )
 
 MSGS = {
-    'E1001': ('Use of __slots__ on an old style class',
-              'slots-on-old-class',
-              'Used when an old style class uses the __slots__ attribute.',
-              {'maxversion': (3, 0)}),
-    'E1002': ('Use of super on an old style class',
-              'super-on-old-class',
-              'Used when an old style class uses the super builtin.',
-              {'maxversion': (3, 0)}),
     'E1003': ('Bad first argument %r given to super()',
               'bad-super-call',
               'Used when another argument than the current class is given as \
               first argument of the super builtin.'),
-    'E1004': ('Missing argument to super()',
-              'missing-super-argument',
-              'Used when the super builtin didn\'t receive an \
-               argument.',
-              {'maxversion': (3, 0)}),
-    'W1001': ('Use of "property" on an old style class',
-              'property-on-old-class',
-              'Used when Pylint detect the use of the builtin "property" \
-              on an old style class while this is relying on new style \
-              classes features.',
-              {'maxversion': (3, 0)}),
-    'C1001': ('Old-style class defined.',
-              'old-style-class',
-              'Used when a class is defined that does not inherit from another '
-              'class and does not inherit explicitly from "object".',
-              {'maxversion': (3, 0)})
     }
 
 


### PR DESCRIPTION
Duplicate for closed https://github.com/PyCQA/pylint/pull/2003 seems like appveyour was broken not sure how to fix it.

### Fixes / new features
 1. deleted python2 checks from the files:

 - pylint/checkers/base.py
- pylint/checkers/format.py
- pylint/checkers/imports.py
- pylint/checkers/newstyle.py
- pylint/checkers/exceptions.py

2. small Pep8 fixes