### PR TITLE
Exposequietmode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,11 @@ What's New in Pylint 2.0?
 
        Close #1793
 
+    * New quiet mode option, enabled with `--quiet` command line flag, to
+      suppress display of extra non-checker-related output.
+
+      Close #1863
+
 
 What's New in Pylint 1.9?
 =========================

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -137,6 +137,7 @@ New checkers
          def foo(self, bar):
              self = bar
 
+* New quiet mode option `--quiet` to suppress display of extra non-checker-related output.
 
 Other Changes
 =============

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -460,7 +460,7 @@ Please report bugs on the project\'s mailing list:
 class OptionsManagerMixIn(object):
     """Handle configuration from both a configuration file and command line options"""
 
-    def __init__(self, usage, config_file=None, version=None, quiet=0):
+    def __init__(self, usage, config_file=None, version=None):
         self.config_file = config_file
         self.reset_parsers(usage, version=version)
         # list of registered options providers

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -655,7 +655,7 @@ class OptionsManagerMixIn(object):
             for sect, values in list(parser._sections.items()):
                 if not sect.isupper() and values:
                     parser._sections[sect.upper()] = values
-        
+
         if quiet:
             return
 

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -471,7 +471,6 @@ class OptionsManagerMixIn(object):
         self._nocallback_options = {}
         self._mygroups = {}
         # verbosity
-        self.quiet = quiet
         self._maxlevel = 0
 
     def reset_parsers(self, usage='', version=None):
@@ -617,7 +616,7 @@ class OptionsManagerMixIn(object):
         for provider in self.options_providers:
             provider.load_defaults()
 
-    def read_config_file(self, config_file=None):
+    def read_config_file(self, config_file=None, quiet=None):
         """read the configuration file but do not load it (i.e. dispatching
         values to each options provider)
         """
@@ -656,8 +655,8 @@ class OptionsManagerMixIn(object):
             for sect, values in list(parser._sections.items()):
                 if not sect.isupper() and values:
                     parser._sections[sect.upper()] = values
-
-        if self.quiet:
+        
+        if quiet:
             return
 
         if use_config_file:

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -1278,7 +1278,7 @@ group are mutually exclusive.'),
             ('quiet',
              {'action' : 'callback', 'callback' : self.cb_quiet_mode,
               'help' : 'In quiet mode, extra non-checker-related info '
-                       'will be disabled, like the config file path' })
+                       'will not be displayed' })
 
             ), option_groups=self.option_groups, pylintrc=self._rcfile)
         # register standard checkers

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -1198,12 +1198,14 @@ group are mutually exclusive.'),
     def __init__(self, args, reporter=None, do_exit=True):
         self._rcfile = None
         self._plugins = []
+        self.quiet = None
         try:
             preprocess_options(args, {
                 # option: (callback, takearg)
                 'init-hook':   (cb_init_hook, True),
                 'rcfile':       (self.cb_set_rcfile, True),
                 'load-plugins': (self.cb_add_plugins, True),
+                'quiet': (self.cb_quiet_mode, False)
                 })
         except ArgumentPreprocessingError as ex:
             print(ex, file=sys.stderr)
@@ -1273,6 +1275,11 @@ group are mutually exclusive.'),
                        'disabled and only messages emitted by the porting '
                        'checker will be displayed'}),
 
+            ('quiet',
+             {'action' : 'callback', 'callback' : self.cb_quiet_mode,
+              'help' : 'In quiet mode, extra non-checker-related info '
+                       'will be disabled, like the config file path' })
+
             ), option_groups=self.option_groups, pylintrc=self._rcfile)
         # register standard checkers
         linter.load_default_plugins()
@@ -1310,7 +1317,7 @@ group are mutually exclusive.'),
         # read configuration
         linter.disable('I')
         linter.enable('c-extension-no-member')
-        linter.read_config_file()
+        linter.read_config_file(quiet=self.quiet)
         config_parser = linter.cfgfile_parser
         # run init hook, if present, before loading plugins
         if config_parser.has_option('MASTER', 'init-hook'):
@@ -1409,6 +1416,8 @@ group are mutually exclusive.'),
         """Activate only the python3 porting checker."""
         self.linter.python3_porting_mode()
 
+    def cb_quiet_mode(self, name, value):
+        self.quiet = True
 
 def cb_list_confidence_levels(option, optname, value, parser):
     for level in interfaces.CONFIDENCE_LEVELS:


### PR DESCRIPTION
### Fixes / new features
- Expose quiet mode to command line options with --quiet flag
- closes #1863

The quiet option is parsed in Run.preprocess_options. This was necessary due to the call order in the Run class constructor. I also moved the quiet keyword argument from OptionsManagerMixIn.__init__() to OptionsManagerMixin.read_config_file() because it wasn't used anywhere else in the class. Currently, quiet mode only manipulates the display of the config file path ("Using config file <path>").
