### PR TITLE
check for annotation in missing-type-doc and missing-return-type-doc

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -183,7 +183,8 @@ Order doesn't matter (not that much, at least ;)
 
 * Sushobhit (sushobhit27): contributor
   Added new check 'comparison-with-itself'.
-
+  Added support of annotations in missing-type-doc and missing-return-type-doc.
+  
 * Mariatta Wijaya: contributor
   Added new check `logging-fstring-interpolation`
   Documentation typo fixes

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@ Pylint's ChangeLog
 ------------------
 What's New in Pylint 2.0?
 =========================
+    * Don't warn for ``missing-type-doc`` and/or ``missing-return-type-doc``, if type
+      annotations exist on the function signature for a parameter and/or return type.
+      Close #2083
 
 Release date: |TBA|
 

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -141,6 +141,8 @@ New checkers
 
 Other Changes
 =============
+* Don't warn for ``missing-type-doc`` and/or ``missing-return-type-doc``, if type annotations
+  exist on the function signature for a parameter and/or return type.
 
 * Fix a false positive ``inconsistent-return-statements`` message when if
   statement is inside try/except.

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -237,6 +237,9 @@ class DocstringParameterChecker(BaseChecker):
                 node=func_node
             )
 
+        if func_node.returns:
+            return
+
         if not (doc.has_rtype() or
                 (doc.has_property_type() and is_property)):
             self.add_message(
@@ -388,6 +391,11 @@ class DocstringParameterChecker(BaseChecker):
 
         _compare_missing_args(params_with_doc, 'missing-param-doc',
                               self.not_needed_param_in_docstring)
+
+        for index, arg_name in enumerate(arguments_node.args):
+            if arguments_node.annotations[index]:
+                params_with_type.add(arg_name.name)
+
         _compare_missing_args(params_with_type, 'missing-type-doc',
                               not_needed_type_in_docstring)
 

--- a/pylint/test/extensions/test_check_return_docs.py
+++ b/pylint/test/extensions/test_check_return_docs.py
@@ -66,6 +66,33 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 Message(msg_id='missing-return-type-doc', node=node)):
             self.checker.visit_return(return_node)
 
+    def test_sphinx_returns_annotations(self):
+        node = astroid.extract_node('''
+        def my_func(self) -> bool:
+            """This is a docstring.
+
+            :returns: Always False
+            """
+            return False
+        ''')
+        return_node = node.body[0]
+        with self.assertNoMessages():
+            self.checker.visit_return(return_node)
+
+    def test_sphinx_missing_return_type_with_annotations(self):
+        node = astroid.extract_node('''
+           def my_func(self) -> bool:
+               """This is a docstring.
+
+               :returns: Always False
+               """
+               return False
+           ''')
+        return_node = node.body[0]
+        with self.assertNoMessages():
+            self.checker.visit_return(return_node)
+
+
     def test_warn_partial_sphinx_returns_type(self):
         node = astroid.extract_node('''
         def my_func(self):


### PR DESCRIPTION
If type annotations exists on the function signature for a parameter and/or

return type then don't raise missing-type-doc and/or missing-return-type-doc.


### Fixes / new features
- #2083 
