### PR TITLE
(WIP) Remove max length for snake_case method names

### DIFF
--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -81,7 +81,7 @@ class SnakeCaseStyle(NamingStyle):
     MOD_NAME_RGX = re.compile('([a-z_][a-z0-9_]*)$')
     CONST_NAME_RGX = re.compile('(([a-z_][a-z0-9_]*)|(__.*__))$')
     COMP_VAR_RGX = re.compile('[a-z_][a-z0-9_]*$')
-    DEFAULT_NAME_RGX = re.compile('(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$')
+    DEFAULT_NAME_RGX = re.compile('(([a-z_][a-z0-9_]{2,})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$')
     CLASS_ATTRIBUTE_RGX = re.compile(r'(([a-z_][a-z0-9_]{2,30}|(__.*__)))$')
 
 


### PR DESCRIPTION
Resolves #2047

### Fixes / new features
- Prevents lengthy method names from raising a snake_case warning.

### TODO:

- [X] Remove max length check for `snake_case` methods
- [ ] Update Regex references in documentation
- [ ] Remove max length check from other case styles

### Discussion

- Should the max length check be re-implemented using a different warning?
- Should this check be removed for other case styles? (camelCaseStyle, PascalCaseStyle, etc)