### PR TITLE
`len-as-condition` recognize more cases

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -201,3 +201,5 @@ contributors:
 
 * Wolfgang Grafen, Axel Muller, Fabio Zadrozny, Pierre Rouleau,
   Maarten ter Huurne, Mirko Friedenhagen and all the Logilab's team (among others).
+
+* Matej Marusak: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in Pylint 2.0?
 
 Release date: |TBA|
 
+    * Make `len-as-condition` test more cases, such as `len() < 1` or `len <= 0'
+
     * Fix false-positive ``line-too-long`` message emission for
       commented line at the end of a module
 

--- a/pylint/test/functional/len_checks.py
+++ b/pylint/test/functional/len_checks.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-few-public-methods,import-error, no-absolute-import,missing-docstring
+# pylint: disable=too-few-public-methods,import-error, no-absolute-import,missing-docstring, misplaced-comparison-constant
 # pylint: disable=useless-super-delegation,wrong-import-position,invalid-name, wrong-import-order
 
 if len('TEST'): # [len-as-condition]
@@ -63,3 +63,15 @@ def github_issue_1331_v2(*args):
 
 def github_issue_1331_v3(*args):
     assert len(args) or z, args  # [len-as-condition]
+
+if len('TEST') < 1: # [len-as-condition]
+    pass
+
+if len('TEST') <= 0: # [len-as-condition]
+    pass
+
+if 1 > len('TEST'): # [len-as-condition]
+    pass
+
+if 0 >= len('TEST'): # [len-as-condition]
+    pass

--- a/pylint/test/functional/len_checks.txt
+++ b/pylint/test/functional/len_checks.txt
@@ -10,3 +10,7 @@ len-as-condition:30::Do not use `len(SEQUENCE)` to determine if a sequence is em
 len-as-condition:43::Do not use `len(SEQUENCE)` to determine if a sequence is empty
 len-as-condition:61:github_issue_1331_v2:Do not use `len(SEQUENCE)` to determine if a sequence is empty
 len-as-condition:65:github_issue_1331_v3:Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:67::Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:70::Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:73::Do not use `len(SEQUENCE)` to determine if a sequence is empty
+len-as-condition:76::Do not use `len(SEQUENCE)` to determine if a sequence is empty


### PR DESCRIPTION
This patch adds lints for two more cases:
1) `if len(X) < 1:`
2) `if len(X) <= 0:`

Meaning of the both is same as `if not X`.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>

### Fixes / new features
- 
