### PR TITLE
enhancement: add new checker 'consider-using-dict-comprehension'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,9 @@ What's New in Pylint 2.0?
 
 Release date: |TBA|
 
+    * Add a check `consider-using-dict-comprehension` which is emitted if for dict initialization
+      the old style with list comprehensions is used.
+
     * `logging-not-lazy` is emitted whenever pylint infers that a string is built with addition
 
       Close #2193

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -160,10 +160,12 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                   'This message is emitted when pylint encounters boolean operation like'
                   '"a < b and b < c", suggesting instead to refactor it to "a < b < c"',
                  ),
-        'R1717': ('Consider using new dict initialization syntax',
+        'R1717': ('Consider using a dictionary comprehension',
                   'consider-using-dict-comprehension',
                   'Although there is nothing syntactically wrong with this code, '
-                  'it is hard to read and can be simplified to a dict comprehension',
+                  'it is hard to read and can be simplified to a dict comprehension.'
+                  'Also it is faster since you don\'t need to create another '
+                  'transient list',
                  ),
     }
     options = (('max-nested-blocks',
@@ -440,10 +442,9 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         return any(_class.qname() == stopiteration_qname for _class in exc.mro())
 
     def _check_consider_using_dict_comprehension(self, node):
-        if (hasattr(node, 'func') and
-                hasattr(node.func, 'name') and
+        if (isinstance(node.func, astroid.Name) and
                 node.func.name == 'dict' and
-                len(node.args) and
+                node.args and
                 isinstance(node.args[0], astroid.ListComp)):
             self.add_message('consider-using-dict-comprehension', node=node)
 

--- a/pylint/test/functional/consider_using_dict_comprehension.py
+++ b/pylint/test/functional/consider_using_dict_comprehension.py
@@ -1,0 +1,9 @@
+# pylint: disable=missing-docstring, invalid-name
+
+numbers = [1, 2, 3, 4, 5, 6]
+
+dict()
+
+dict([])
+
+dict([(number, number*2) for number in numbers])  # [consider-using-dict-comprehension]

--- a/pylint/test/functional/consider_using_dict_comprehension.txt
+++ b/pylint/test/functional/consider_using_dict_comprehension.txt
@@ -1,0 +1,1 @@
+consider-using-dict-comprehension:9::Consider using new dict initialization syntax

--- a/pylint/test/functional/consider_using_dict_comprehension.txt
+++ b/pylint/test/functional/consider_using_dict_comprehension.txt
@@ -1,1 +1,1 @@
-consider-using-dict-comprehension:9::Consider using new dict initialization syntax
+consider-using-dict-comprehension:9::Consider using a dictionary comprehension


### PR DESCRIPTION
As discussed in #2194 this adds the new checker for using old style dict initializations with list comprehensions instead of dict-comprehensions.
How is this for a first version?
I think it could use some more tests, but could not think of any more at the moment :smile: 
Anyone see any edge-cases?