### PR TITLE
standardize help strings a bit

### DIFF
--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1262,11 +1262,11 @@ def _create_naming_options():
             '%s-naming-style' % (name_type,),
             {'default': default_style,
              'type': 'choice', 'choices': list(NAMING_STYLES.keys()), 'metavar': '<style>',
-             'help': 'Naming style matching correct %s names' % (human_readable_name,)}),)
+             'help': 'Naming style matching correct %s names.' % (human_readable_name,)}),)
         name_options.append((
             '%s-rgx' % (name_type,),
             {'default': None, 'type': 'regexp', 'metavar': '<regexp>',
-             'help': 'Regular expression matching correct %s names. Overrides %s-naming-style'
+             'help': 'Regular expression matching correct %s names. Overrides %s-naming-style.'
                      % (human_readable_name, name_type,)}))
     return tuple(name_options)
 
@@ -1285,20 +1285,20 @@ class NameChecker(_BasicChecker):
         'W0111': ('Name %s will become a keyword in Python %s',
                   'assign-to-new-keyword',
                   'Used when assignment will become invalid in future '
-                  'Python release due to introducing new keyword'),
+                  'Python release due to introducing new keyword.'),
     }
 
     options = (('good-names',
                 {'default' : ('i', 'j', 'k', 'ex', 'Run', '_'),
                  'type' :'csv', 'metavar' : '<names>',
                  'help' : 'Good variable names which should always be accepted,'
-                          ' separated by a comma'}
+                          ' separated by a comma.'}
                ),
                ('bad-names',
                 {'default' : ('foo', 'bar', 'baz', 'toto', 'tutu', 'tata'),
                  'type' :'csv', 'metavar' : '<names>',
                  'help' : 'Bad variable names which should always be refused, '
-                          'separated by a comma'}
+                          'separated by a comma.'}
                ),
                ('name-group',
                 {'default' : (),
@@ -1309,7 +1309,7 @@ class NameChecker(_BasicChecker):
                ),
                ('include-naming-hint',
                 {'default': False, 'type': 'yn', 'metavar': '<y_or_n>',
-                 'help': 'Include a hint for the correct naming format with invalid-name'}
+                 'help': 'Include a hint for the correct naming format with invalid-name.'}
                ),
                ('property-classes',
                 {'default': ('abc.abstractproperty',),

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -28,29 +28,29 @@ from pylint import utils
 MSGS = {
     'R0901': ('Too many ancestors (%s/%s)',
               'too-many-ancestors',
-              'Used when class has too many parent classes, try to reduce \
-              this to get a simpler (and so easier to use) class.'),
+              'Used when class has too many parent classes, try to reduce '
+              'this to get a simpler (and so easier to use) class.'),
     'R0902': ('Too many instance attributes (%s/%s)',
               'too-many-instance-attributes',
-              'Used when class has too many instance attributes, try to reduce \
-              this to get a simpler (and so easier to use) class.'),
+              'Used when class has too many instance attributes, try to reduce '
+              'this to get a simpler (and so easier to use) class.'),
     'R0903': ('Too few public methods (%s/%s)',
               'too-few-public-methods',
-              'Used when class has too few public methods, so be sure it\'s \
-              really worth it.'),
+              'Used when class has too few public methods, so be sure it\'s '
+              'really worth it.'),
     'R0904': ('Too many public methods (%s/%s)',
               'too-many-public-methods',
-              'Used when class has too many public methods, try to reduce \
-              this to get a simpler (and so easier to use) class.'),
+              'Used when class has too many public methods, try to reduce '
+              'this to get a simpler (and so easier to use) class.'),
 
     'R0911': ('Too many return statements (%s/%s)',
               'too-many-return-statements',
-              'Used when a function or method has too many return statement, \
-              making it hard to follow.'),
+              'Used when a function or method has too many return statement, '
+              'making it hard to follow.'),
     'R0912': ('Too many branches (%s/%s)',
               'too-many-branches',
-              'Used when a function or method has too many branches, \
-              making it hard to follow.'),
+              'Used when a function or method has too many branches, '
+              'making it hard to follow.'),
     'R0913': ('Too many arguments (%s/%s)',
               'too-many-arguments',
               'Used when a function or method takes too many arguments.'),
@@ -59,12 +59,12 @@ MSGS = {
               'Used when a function or method has too many local variables.'),
     'R0915': ('Too many statements (%s/%s)',
               'too-many-statements',
-              'Used when a function or method has too many statements. You \
-              should then split it in smaller functions / methods.'),
+              'Used when a function or method has too many statements. You '
+              'should then split it in smaller functions / methods.'),
     'R0916': ('Too many boolean expressions in if statement (%s/%s)',
               'too-many-boolean-expressions',
               'Used when an if statement contains too many boolean '
-              'expressions'),
+              'expressions.'),
     }
 SPECIAL_OBJ = re.compile('^_{2}[a-z]+_{2}$')
 
@@ -110,25 +110,25 @@ class MisdesignChecker(BaseChecker):
     # configuration options
     options = (('max-args',
                 {'default' : 5, 'type' : 'int', 'metavar' : '<int>',
-                 'help': 'Maximum number of arguments for function / method'}
+                 'help': 'Maximum number of arguments for function / method.'}
                ),
                ('max-locals',
                 {'default' : 15, 'type' : 'int', 'metavar' : '<int>',
-                 'help': 'Maximum number of locals for function / method body'}
+                 'help': 'Maximum number of locals for function / method body.'}
                ),
                ('max-returns',
                 {'default' : 6, 'type' : 'int', 'metavar' : '<int>',
                  'help': 'Maximum number of return / yield for function / '
-                         'method body'}
+                         'method body.'}
                ),
                ('max-branches',
                 {'default' : 12, 'type' : 'int', 'metavar' : '<int>',
-                 'help': 'Maximum number of branch for function / method body'}
+                 'help': 'Maximum number of branch for function / method body.'}
                ),
                ('max-statements',
                 {'default' : 50, 'type' : 'int', 'metavar' : '<int>',
                  'help': 'Maximum number of statements in function / method '
-                         'body'}
+                         'body.'}
                ),
                ('max-parents',
                 {'default' : 7,
@@ -162,7 +162,7 @@ class MisdesignChecker(BaseChecker):
                  'type': 'int',
                  'metavar': '<num>',
                  'help': 'Maximum number of boolean expressions in an if '
-                         'statement'}
+                         'statement.'}
                ),
               )
 

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -243,7 +243,7 @@ class ExceptionsChecker(checkers.BaseChecker):
                 {'default' : OVERGENERAL_EXCEPTIONS,
                  'type' : 'csv', 'metavar' : '<comma-separated class names>',
                  'help' : 'Exceptions that will emit a warning '
-                          'when being caught. Defaults to "%s"' % (
+                          'when being caught. Defaults to "%s".' % (
                               ', '.join(OVERGENERAL_EXCEPTIONS),)}
                ),
               )

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -514,7 +514,7 @@ class FormatChecker(BaseTokenChecker):
                           '`'+ _EMPTY_LINE + '` allows space-only lines.')}),
                ('max-module-lines',
                 {'default': 1000, 'type': 'int', 'metavar': '<int>',
-                 'help': 'Maximum number of lines in a module'}
+                 'help': 'Maximum number of lines in a module.'}
                ),
                ('indent-string',
                 {'default': '    ', 'type': "non_empty_string", 'metavar': '<string>',

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -272,7 +272,7 @@ class ImportsChecker(BaseChecker):
                  'type' : 'csv',
                  'metavar' : '<modules>',
                  'help' : 'Deprecated modules which should not be used,'
-                          ' separated by a comma'}
+                          ' separated by a comma.'}
                ),
                ('import-graph',
                 {'default' : '',
@@ -280,21 +280,21 @@ class ImportsChecker(BaseChecker):
                  'metavar' : '<file.dot>',
                  'help' : 'Create a graph of every (i.e. internal and'
                           ' external) dependencies in the given file'
-                          ' (report RP0402 must not be disabled)'}
+                          ' (report RP0402 must not be disabled).'}
                ),
                ('ext-import-graph',
                 {'default' : '',
                  'type' : 'string',
                  'metavar' : '<file.dot>',
                  'help' : 'Create a graph of external dependencies in the'
-                          ' given file (report RP0402 must not be disabled)'}
+                          ' given file (report RP0402 must not be disabled).'}
                ),
                ('int-import-graph',
                 {'default' : '',
                  'type' : 'string',
                  'metavar' : '<file.dot>',
                  'help' : 'Create a graph of internal dependencies in the'
-                          ' given file (report RP0402 must not be disabled)'}
+                          ' given file (report RP0402 must not be disabled).'}
                ),
                ('known-standard-library',
                 {'default': DEFAULT_STANDARD_LIBRARY,

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -55,16 +55,16 @@ MSGS = {
               'interpolation to the logging function by passing the parameters '
               'as arguments.'
               'This message is emitted if f-string was used, and it can be '
-              'disabled if you like'
+              'disabled if you like.'
               ),
     'E1200': ('Unsupported logging format character %r (%#02x) at index %d',
               'logging-unsupported-format',
-              'Used when an unsupported format character is used in a logging\
-              statement format string.'),
+              'Used when an unsupported format character is used in a logging '
+              'statement format string.'),
     'E1201': ('Logging format string ends in middle of conversion specifier',
               'logging-format-truncated',
-              'Used when a logging statement format string terminates before\
-              the end of a conversion specifier.'),
+              'Used when a logging statement format string terminates before '
+              'the end of a conversion specifier.'),
     'E1205': ('Too many arguments for logging format string',
               'logging-too-many-args',
               'Used when a logging format string is given too many arguments.'),
@@ -109,7 +109,7 @@ class LoggingChecker(checkers.BaseChecker):
                  'type': 'csv',
                  'metavar': '<comma separated list>',
                  'help': 'Logging modules to check that the string format '
-                         'arguments are in logging function parameter format'}
+                         'arguments are in logging function parameter format.'}
                ),
               )
 

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -161,7 +161,7 @@ class SpellingChecker(BaseTokenChecker):
                 {'default' : '', 'type' : 'choice', 'metavar' : '<dict name>',
                  'choices': dict_choices,
                  'help' : 'Spelling dictionary name. '
-                          'Available dictionaries: %s.%s' % (dicts, instr)}),
+                          'Available dictionaries: %s.%s.' % (dicts, instr)}),
                ('spelling-ignore-words',
                 {'default' : '',
                  'type' : 'string',
@@ -183,7 +183,7 @@ class SpellingChecker(BaseTokenChecker):
                ('max-spelling-suggestions',
                 {'default': 4, 'type': 'int', 'metavar': 'N',
                  'help': 'Limits count of emitted suggestions for '
-                         'spelling mistakes'}),
+                         'spelling mistakes.'}),
               )
 
     def open(self):

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -212,28 +212,28 @@ MSGS = {
               'but it may be performed by introspecting living objects in run-time.'),
     'E1102': ('%s is not callable',
               'not-callable',
-              'Used when an object being called has been inferred to a non \
-              callable object'),
+              'Used when an object being called has been inferred to a non '
+              'callable object.'),
     'E1111': ('Assigning to function call which doesn\'t return',
               'assignment-from-no-return',
-              'Used when an assignment is done on a function call but the \
-              inferred function doesn\'t return anything.'),
+              'Used when an assignment is done on a function call but the '
+              'inferred function doesn\'t return anything.'),
     'E1120': ('No value for argument %s in %s call',
               'no-value-for-parameter',
               'Used when a function call passes too few arguments.'),
     'E1121': ('Too many positional arguments for %s call',
               'too-many-function-args',
-              'Used when a function call passes too many positional \
-              arguments.'),
+              'Used when a function call passes too many positional '
+              'arguments.'),
     'E1123': ('Unexpected keyword argument %r in %s call',
               'unexpected-keyword-arg',
-              'Used when a function call passes a keyword argument that \
-              doesn\'t correspond to one of the function\'s parameter names.'),
+              'Used when a function call passes a keyword argument that '
+              'doesn\'t correspond to one of the function\'s parameter names.'),
     'E1124': ('Argument %r passed by position and keyword in %s call',
               'redundant-keyword-arg',
-              'Used when a function call would result in assigning multiple \
-              values to a function parameter, one value from a positional \
-              argument and one from a keyword argument.'),
+              'Used when a function call would result in assigning multiple '
+              'values to a function parameter, one value from a positional '
+              'argument and one from a keyword argument.'),
     'E1125': ('Missing mandatory keyword argument %r in %s call',
               'missing-kwoa',
               ('Used when a function call does not pass a mandatory'
@@ -245,8 +245,8 @@ MSGS = {
               'method.'),
     'E1127': ('Slice index is not an int, None, or instance with __index__',
               'invalid-slice-index',
-              'Used when a slice index is not an integer, None, or an object \
-               with an __index__ method.'),
+              'Used when a slice index is not an integer, None, or an object '
+              'with an __index__ method.'),
     'E1128': ('Assigning to function call which only returns None',
               'assignment-from-none',
               'Used when an assignment is done on a function call but the '
@@ -259,7 +259,7 @@ MSGS = {
     'E1130': ('%s',
               'invalid-unary-operand-type',
               'Emitted when a unary operand is used on an object which does not '
-              'support this type of operation'),
+              'support this type of operation.'),
     'E1131': ('%s',
               'unsupported-binary-operation',
               'Emitted when a binary arithmetic operation between two '
@@ -270,19 +270,19 @@ MSGS = {
     'E1135': ("Value '%s' doesn't support membership test",
               'unsupported-membership-test',
               'Emitted when an instance in membership test expression doesn\'t '
-              'implement membership protocol (__contains__/__iter__/__getitem__)'),
+              'implement membership protocol (__contains__/__iter__/__getitem__).'),
     'E1136': ("Value '%s' is unsubscriptable",
               'unsubscriptable-object',
-              "Emitted when a subscripted value doesn't support subscription"
-              "(i.e. doesn't define __getitem__ method)"),
+              "Emitted when a subscripted value doesn't support subscription "
+              "(i.e. doesn't define __getitem__ method)."),
     'E1137': ("%r does not support item assignment",
               'unsupported-assignment-operation',
               "Emitted when an object does not support item assignment "
-              "(i.e. doesn't define __setitem__ method)"),
+              "(i.e. doesn't define __setitem__ method)."),
     'E1138': ("%r does not support item deletion",
               'unsupported-delete-operation',
               "Emitted when an object does not support item deletion "
-              "(i.e. doesn't define __delitem__ method)"),
+              "(i.e. doesn't define __delitem__ method)."),
     'E1139': ('Invalid metaclass %r used',
               'invalid-metaclass',
               'Emitted whenever we can detect that a class is using, '
@@ -290,8 +290,8 @@ MSGS = {
               'a metaclass.'),
     'E1140': ("Dict key is unhashable",
               'unhashable-dict-key',
-              "Emitted when a dict key is not hashable"
-              "(i.e. doesn't define __hash__ method)"),
+              'Emitted when a dict key is not hashable '
+              "(i.e. doesn't define __hash__ method)."),
     'W1113': ('Keyword argument before variable positional arguments list '
               'in the definition of %s function',
               'keyword-arg-before-vararg',
@@ -567,7 +567,7 @@ class should be ignored. A mixin class is detected if its name ends with \
                ('ignore-none',
                 {'default': True, 'type': 'yn', 'metavar': '<y_or_n>',
                  'help': 'Tells whether to warn about missing members when the owner '
-                         'of the attribute is inferred to be None'
+                         'of the attribute is inferred to be None.'
                 }
                 ),
                ('ignored-modules',

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -434,7 +434,7 @@ class VariablesChecker(BaseChecker):
                 {'default': '_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_',
                  'type' :'regexp', 'metavar' : '<regexp>',
                  'help' : 'A regular expression matching the name of dummy '
-                          'variables (i.e. expectedly not used).'}),
+                          'variables (i.e. expected to not be used).'}),
                ("additional-builtins",
                 {'default': (), 'type' : 'csv',
                  'metavar' : '<comma separated list>',
@@ -460,7 +460,7 @@ class VariablesChecker(BaseChecker):
                 {'default' : IGNORED_ARGUMENT_NAMES,
                  'type' :'regexp', 'metavar' : '<regexp>',
                  'help' : 'Argument names that match this expression will be '
-                          'ignored. Default to name with leading underscore'}
+                          'ignored. Default to name with leading underscore.'}
                ),
                ('allow-global-unused-variables',
                 {'default': True,

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -328,7 +328,7 @@ class PyLinter(config.OptionsManagerMixIn,
                   'short': 'r',
                   'group': 'Reports',
                   'help' : 'Tells whether to display a full report or only the '
-                           'messages'}),
+                           'messages.'}),
 
                 ('evaluation',
                  {'type' : 'string', 'metavar' : '<python_expression>',
@@ -354,7 +354,7 @@ class PyLinter(config.OptionsManagerMixIn,
                   'choices': [c.name for c in interfaces.CONFIDENCE_LEVELS],
                   'group': 'Messages control',
                   'help' : 'Only show warnings with the listed confidence levels.'
-                           ' Leave empty to show all. Valid levels: %s' % (
+                           ' Leave empty to show all. Valid levels: %s.' % (
                                ', '.join(c.name for c in interfaces.CONFIDENCE_LEVELS),)}),
 
                 ('enable',
@@ -366,24 +366,24 @@ class PyLinter(config.OptionsManagerMixIn,
                            'separated by comma (,) or put this option multiple time '
                            '(only on the command line, not in the configuration file '
                            'where it should appear only once). '
-                           'See also the "--disable" option for examples. '}),
+                           'See also the "--disable" option for examples.'}),
 
                 ('disable',
                  {'type' : 'csv', 'metavar': '<msg ids>',
                   'short': 'd',
                   'group': 'Messages control',
                   'help' : 'Disable the message, report, category or checker '
-                           'with the given id(s). You can either give multiple identifiers'
-                           ' separated by comma (,) or put this option multiple times '
+                           'with the given id(s). You can either give multiple identifiers '
+                           'separated by comma (,) or put this option multiple times '
                            '(only on the command line, not in the configuration file '
-                           'where it should appear only once).'
+                           'where it should appear only once). '
                            'You can also use "--disable=all" to disable everything first '
                            'and then reenable specific checks. For example, if you want '
                            'to run only the similarities checker, you can use '
                            '"--disable=all --enable=similarities". '
                            'If you want to run only the classes checker, but have no '
-                           'Warning level messages displayed, use'
-                           '"--disable=all --enable=classes --disable=W"'}),
+                           'Warning level messages displayed, use '
+                           '"--disable=all --enable=classes --disable=W".'}),
 
                 ('msg-template',
                  {'type' : 'string', 'metavar': '<template>',
@@ -391,7 +391,7 @@ class PyLinter(config.OptionsManagerMixIn,
                   'help' : ('Template used to display messages. '
                             'This is a python new-style format string '
                             'used to format the message information. '
-                            'See doc for all details')
+                            'See doc for all details.')
                  }),
 
                 ('jobs',
@@ -413,12 +413,12 @@ class PyLinter(config.OptionsManagerMixIn,
                   'help': ('A comma-separated list of package or module names'
                            ' from where C extensions may be loaded. Extensions are'
                            ' loading into the active Python interpreter and may run'
-                           ' arbitrary code')}),
+                           ' arbitrary code.')}),
                 ('suggestion-mode',
                  {'type': 'yn', 'metavar': '<yn>', 'default': True,
                   'help': ('When enabled, pylint would attempt to guess common '
                            'misconfiguration and emit user-friendly hints instead '
-                           'of false-positive error messages')}),
+                           'of false-positive error messages.')}),
 
                 ('exit-zero',
                  {'action': 'store_true',
@@ -1272,19 +1272,19 @@ group are mutually exclusive.'),
               'short': 'E',
               'help' : 'In error mode, checkers without error messages are '
                        'disabled and for others, only the ERROR messages are '
-                       'displayed, and no reports are done by default'''}),
+                       'displayed, and no reports are done by default.'}),
 
             ('py3k',
              {'action' : 'callback', 'callback' : self.cb_python3_porting_mode,
               'help' : 'In Python 3 porting mode, all checkers will be '
                        'disabled and only messages emitted by the porting '
-                       'checker will be displayed'}),
+                       'checker will be displayed.'}),
 
             ('verbose',
              {'action' : 'callback', 'callback' : self.cb_verbose_mode,
               'short': 'v',
               'help' : 'In verbose mode, extra non-checker-related info '
-                       'will be displayed'})
+                       'will be displayed.'})
 
             ), option_groups=self.option_groups, pylintrc=self._rcfile)
         # register standard checkers


### PR DESCRIPTION
A number of help strings are inconsistent in trailing periods, or
spaces after them in the middle of text, or add a large amount of
whitespace by using \ to continue the string.  Standardize a lot
of these so all help messages end in a period and there is normal
whitespace in the middle.

The tests don't show any regressions, and pylint is clean.
I think I'm supposed to regenerate the pylintrc & man pages, but
I haven't been able to figure out how to do that.