### PR TITLE
Let function parameters implicitly defined as **kwargs be explicitly described in documentation string.

### DIFF
--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -381,6 +381,10 @@ class DocstringParameterChecker(BaseChecker):
 
             :param not_needed_names: names that may be omitted
             :type not_needed_names: set of str
+
+            :param bool accept_expanded_kwargs:
+                Allow explicit documentation for implicitly declared
+                (by **kwargs) parameters.
             """
             differing_argument_names = (
                 (expected_argument_names ^ found_argument_names)

--- a/pylint/test/extensions/test_docparams_expaned_kwargs.py
+++ b/pylint/test/extensions/test_docparams_expaned_kwargs.py
@@ -22,7 +22,7 @@ class TestExpandedKwargsChecker(CheckerTestCase):
 
     @set_config(accept_expanded_kwargs=False)
     def test_reject_expanded_kwargs(self):
-        """Checks whetrer the checkers works properly with accept_expanded_kwargs=False"""
+        """Checks whether the checkers works properly with accept_expanded_kwargs=False"""
         node = astroid.extract_node("""
         def doSomething(mandatory, **kwargs):
             '''
@@ -62,7 +62,7 @@ class TestExpandedKwargsChecker(CheckerTestCase):
 
     @set_config(accept_expanded_kwargs=True)
     def test_accept_expanded_kwargs(self):
-        """Checks whetrer the checkers works properly with accept_expanded_kwargs=True"""
+        """Checks whether the checkers works properly with accept_expanded_kwargs=True"""
         node = astroid.extract_node("""
         def doSomething(mandatory, **kwargs):
             '''
@@ -89,5 +89,45 @@ class TestExpandedKwargsChecker(CheckerTestCase):
             return mandatory * kwargs.get('alpha', 1) * kwargs.get('beta', 1)
         """)
         with self.assertAddsMessages(
+        ):
+            self.checker.visit_functiondef(node)
+
+    @set_config(accept_expanded_kwargs=True)
+    def test_real_warning(self):
+        """Checks whether the checker still detects differing-param-doc if there is no kwargs param"""
+        node = astroid.extract_node("""
+        def doSomething(mandatory):
+            '''
+            Does something
+
+            :param int mandatory:
+                The mandatory argument
+
+            :param dict kwargs:
+                Optional parameters, described below.
+
+            :param int alpha:
+                First optional argument
+
+            :param int beta:
+                Second optional argument
+
+            :returns:
+                mandatory argument
+
+            :rtype:
+                int
+            '''
+            return mandatory
+        """)
+        with self.assertAddsMessages(
+            Message(
+                msg_id='differing-param-doc',
+                node=node,
+                args=('alpha, beta',)),
+            Message(
+                msg_id='differing-type-doc',
+                node=node,
+                args=('alpha, beta',)),
         ):
             self.checker.visit_functiondef(node)

--- a/pylint/test/extensions/test_docparams_expaned_kwargs.py
+++ b/pylint/test/extensions/test_docparams_expaned_kwargs.py
@@ -103,9 +103,6 @@ class TestExpandedKwargsChecker(CheckerTestCase):
             :param int mandatory:
                 The mandatory argument
 
-            :param dict kwargs:
-                Optional parameters, described below.
-
             :param int alpha:
                 First optional argument
 

--- a/pylint/test/extensions/test_docparams_expaned_kwargs.py
+++ b/pylint/test/extensions/test_docparams_expaned_kwargs.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2018 Alex Itkes
+
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+"""Tests for the accept-expanded-kwargs option for DocstringParameterChecker
+"""
+
+import unittest
+
+import astroid
+from pylint.testutils import CheckerTestCase, Message, set_config
+
+from pylint.extensions.docparams import DocstringParameterChecker
+
+class TestExpandedKwargsChecker(CheckerTestCase):
+    """Tests the accept-expanded-kwargs option for DocstringParameterChecker"""
+    CHECKER_CLASS = DocstringParameterChecker
+    CONFIG = {
+        'accept_expanded_kwargs': True,
+    }
+
+    @set_config(accept_expanded_kwargs=False)
+    def test_reject_expanded_kwargs(self):
+        """Checks whetrer the checkers works properly with accept_expanded_kwargs=False"""
+        node = astroid.extract_node("""
+        def doSomething(mandatory, **kwargs):
+            '''
+            Does something
+
+            :param int mandatory:
+                The mandatory argument
+
+            :param dict kwargs:
+                Optional parameters, described below.
+
+            :param int alpha:
+                First optional argument
+
+            :param int beta:
+                Second optional argument
+
+            :returns:
+                mandatory * alpha * beta
+
+            :rtype:
+                int
+            '''
+            return mandatory * kwargs.get('alpha', 1) * kwargs.get('beta', 1)
+        """)
+        with self.assertAddsMessages(
+            Message(
+                msg_id='differing-param-doc',
+                node=node,
+                args=('alpha, beta',)),
+            Message(
+                msg_id='differing-type-doc',
+                node=node,
+                args=('alpha, beta',)),
+        ):
+            self.checker.visit_functiondef(node)
+
+    @set_config(accept_expanded_kwargs=True)
+    def test_accept_expanded_kwargs(self):
+        """Checks whetrer the checkers works properly with accept_expanded_kwargs=True"""
+        node = astroid.extract_node("""
+        def doSomething(mandatory, **kwargs):
+            '''
+            Does something
+
+            :param int mandatory:
+                The mandatory argument
+
+            :param dict kwargs:
+                Optional parameters, described below.
+
+            :param int alpha:
+                First optional argument
+
+            :param int beta:
+                Second optional argument
+
+            :returns:
+                mandatory * alpha * beta
+
+            :rtype:
+                int
+            '''
+            return mandatory * kwargs.get('alpha', 1) * kwargs.get('beta', 1)
+        """)
+        with self.assertAddsMessages(
+        ):
+            self.checker.visit_functiondef(node)


### PR DESCRIPTION
### Fixes / new features
- 
Hello everyone.

Pylint helps me greatly in Python software development, but nothing is perfect. In some cases it displays warnings I consider false positive. One of such cases appears within docparams extension when it scans the docstring for a function with large number of optional arguments. I mean somewhat like this.

```
def doSomething(mandatory, **kwargs):
    """
    Does something

    :param int mandatory:
        The mandatory argument

    :param dict kwargs:
        Optional parameters, described below.

    :param int alpha:
        First optional argument

    :param int beta:
        Second optional argument

    :returns:
        mandatory * alpha * beta

    :rtype:
        int
    """
    return mandatory * kwargs.get('alpha', 1) * kwargs.get('beta', 1)
```

For this function, Pylint displays differing-param-doc and differing-type-doc warnings because alpha and beta args are documented, but not accepted explicitly - they are both accepted as kwargs.

I use functions with large numbers of optional arguments quite often and that warnings annoy me. So, I would like to add a new option (let's name it accept-expanded-kwargs) to the docparams checker, used to ignore any documented, but not accepted explicitly parameters for a function having **kwargs parameter.

Here is a patch against 1.9 branch. Unfortunately, I still have some problems with deploying the master branch, so maybe later.

What do you think?

Sincerely,

Alex.