### PR TITLE
Filter with should_analyze_file in parallel mode

### DIFF
--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -812,7 +812,11 @@ class PyLinter(config.OptionsManagerMixIn,
         results_queue = manager.Queue()
 
         # Send files to child linters.
-        expanded_files = self.expand_files(files_or_modules)
+        expanded_files = []
+        for descr in self.expand_files(files_or_modules):
+            modname, filepath, is_arg = descr['name'], descr['path'], descr['isarg']
+            if self.should_analyze_file(modname, filepath, is_argument=is_arg):
+                expanded_files.append(descr)
 
         # do not start more jobs than needed
         for _ in range(min(self.config.jobs, len(expanded_files))):

--- a/pylint/test/unittest_lint.py
+++ b/pylint/test/unittest_lint.py
@@ -741,21 +741,24 @@ def test_custom_should_analyze_file():
 
     package_dir = os.path.join(HERE, 'regrtest_data', 'bad_package')
     wrong_file = os.path.join(package_dir, 'wrong.py')
-    reporter = testutils.TestReporter()
-    linter = CustomPyLinter()
-    linter.config.persistent = 0
-    linter.open()
-    linter.set_reporter(reporter)
 
-    try:
-        sys.path.append(os.path.dirname(package_dir))
-        linter.check([package_dir, wrong_file])
-    finally:
-        sys.path.pop()
+    for jobs in [1, 2]:
+        reporter = testutils.TestReporter()
+        linter = CustomPyLinter()
+        linter.config.jobs = jobs
+        linter.config.persistent = 0
+        linter.open()
+        linter.set_reporter(reporter)
 
-    messages = reporter.messages
-    assert len(messages) == 1
-    assert 'invalid syntax' in messages[0]
+        try:
+            sys.path.append(os.path.dirname(package_dir))
+            linter.check([package_dir, wrong_file])
+        finally:
+            sys.path.pop()
+
+        messages = reporter.messages
+        assert len(messages) == 1
+        assert 'invalid syntax' in messages[0]
 
 
 def test_filename_with__init__(init_linter):


### PR DESCRIPTION
Each ChildLinter receives a file path and instantiates a linter to check
that file. As such, all files are arguments to child linters in parallel
mode. Therefore, the check for should_analyze_file must happen in the
parent linter, where knowledge of the original arguments is available.

Expand the custom should_analyze_file test to exercise parallel mode.

Close #1885