### PR TITLE
Fix false positive unused-variable in lambda default arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -343,6 +343,13 @@ Release date: |TBA|
 
       Close #638
 
+    * Fix false positive unused-variable in lambda default arguments
+
+      Close #1921
+      Close #1552
+      Close #1099
+      Close #210
+
     * Updated the default report format to include paths that can be clicked on in some terminals (e.g. iTerm).
 
     * Fix inline def behavior with ``too-many-statements`` checker

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -318,6 +318,8 @@ Other Changes
   When modules are imported under ``typing.TYPE_CHECKING`` guard, **pylint**
   will no longer emit *unused-import*.
 
+* Fix false positive ``unused-variable`` in lambda default arguments
+
 * ``assignment-from-no-return`` considers methods as well as functions.
 
   If you have a method that doesn't return a value, but later on you assign

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -243,17 +243,18 @@ def is_defined_before(var_node):
         _node = _node.previous_sibling()
     return False
 
-def is_func_default(node):
-    """return true if the given Name node is used in function default argument's
-    value
+def is_default_argument(node):
+    """return true if the given Name node is used in function or lambda
+    default argument's value
     """
     parent = node.scope()
-    if isinstance(parent, astroid.FunctionDef):
+    if isinstance(parent, (astroid.FunctionDef, astroid.Lambda)):
         for default_node in parent.args.defaults:
             for default_name_node in default_node.nodes_of_class(astroid.Name):
                 if default_name_node is node:
                     return True
     return False
+
 
 def is_func_decorator(node):
     """return true if the name is used in function decorator"""

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1173,7 +1173,7 @@ class VariablesChecker(BaseChecker):
         # if the name node is used as a function default argument's value or as
         # a decorator, then start from the parent frame of the function instead
         # of the function frame - and thus open an inner class scope
-        if (utils.is_func_default(node) or utils.is_func_decorator(node)
+        if (utils.is_default_argument(node) or utils.is_func_decorator(node)
                 or utils.is_ancestor_name(frame, node)):
             start_index = len(self._to_consume) - 2
         else:

--- a/pylint/test/functional/cellvar_escaping_loop.py
+++ b/pylint/test/functional/cellvar_escaping_loop.py
@@ -17,7 +17,7 @@ def good_case2():
 def good_case3():
     """No problems here."""
     lst = []
-    for i in range(10):  # [unused-variable]
+    for i in range(10):
         lst.append(lambda i=i: i)
 
 

--- a/pylint/test/functional/cellvar_escaping_loop.txt
+++ b/pylint/test/functional/cellvar_escaping_loop.txt
@@ -1,4 +1,3 @@
-unused-variable:20:good_case3:Unused variable 'i'
 undefined-loop-variable:44:good_case6.<lambda>:Using possibly undefined loop variable 'i'
 cell-var-from-loop:77:bad_case.<lambda>:Cell variable i defined in loop
 cell-var-from-loop:82:bad_case2.<lambda>:Cell variable i defined in loop


### PR DESCRIPTION
The NameConsumer to_consume frame needed to be backed out by one so that
for lambda bound default argument variables (closure) could consume the
name in a higher scope (just like function default arguments)

Close #1921
Close #1552
Close #1099
Close #210