### PR TITLE
False positive snake case waring

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -209,3 +209,5 @@ contributors:
 * Matej Marusak: contributor
 
 * Nick Drozd: contributor, performance improvements to astroid
+
+* Kosarchuk Sergey: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,15 @@
 Pylint's ChangeLog
 ------------------
 
+What's New in Pylint 2.1?
+=========================
+
+Release date: |TBA|
+
+   * Fix a false positive `invalid name` message when method or attribute name is longer then 30 characters.
+
+       Close #2047
+
 What's New in Pylint 2.0?
 =========================
 

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -91,8 +91,8 @@ class SnakeCaseStyle(NamingStyle):
     MOD_NAME_RGX = re.compile('([a-z_][a-z0-9_]*)$')
     CONST_NAME_RGX = re.compile('(([a-z_][a-z0-9_]*)|(__.*__))$')
     COMP_VAR_RGX = re.compile('[a-z_][a-z0-9_]*$')
-    DEFAULT_NAME_RGX = re.compile('(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$')
-    CLASS_ATTRIBUTE_RGX = re.compile(r'(([a-z_][a-z0-9_]{2,30}|(__.*__)))$')
+    DEFAULT_NAME_RGX = re.compile('(([a-z_][a-z0-9_]{2,})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$')
+    CLASS_ATTRIBUTE_RGX = re.compile(r'(([a-z_][a-z0-9_]{2,}|(__.*__)))$')
 
 
 class CamelCaseStyle(NamingStyle):
@@ -101,8 +101,8 @@ class CamelCaseStyle(NamingStyle):
     MOD_NAME_RGX = re.compile('([a-z_][a-zA-Z0-9]*)$')
     CONST_NAME_RGX = re.compile('(([a-z_][A-Za-z0-9]*)|(__.*__))$')
     COMP_VAR_RGX = re.compile('[a-z_][A-Za-z0-9]*$')
-    DEFAULT_NAME_RGX = re.compile('(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$')
-    CLASS_ATTRIBUTE_RGX = re.compile(r'([a-z_][A-Za-z0-9]{2,30}|(__.*__))$')
+    DEFAULT_NAME_RGX = re.compile('(([a-z_][a-zA-Z0-9]{2,})|(__[a-z][a-zA-Z0-9_]+__))$')
+    CLASS_ATTRIBUTE_RGX = re.compile(r'([a-z_][A-Za-z0-9]{2,}|(__.*__))$')
 
 
 class PascalCaseStyle(NamingStyle):
@@ -111,8 +111,8 @@ class PascalCaseStyle(NamingStyle):
     MOD_NAME_RGX = re.compile('[A-Z_][a-zA-Z0-9]+$')
     CONST_NAME_RGX = re.compile('(([A-Z_][A-Za-z0-9]*)|(__.*__))$')
     COMP_VAR_RGX = re.compile('[A-Z_][a-zA-Z0-9]+$')
-    DEFAULT_NAME_RGX = re.compile('[A-Z_][a-zA-Z0-9]{2,30}$|(__[a-z][a-zA-Z0-9_]+__)$')
-    CLASS_ATTRIBUTE_RGX = re.compile('[A-Z_][a-zA-Z0-9]{2,30}$')
+    DEFAULT_NAME_RGX = re.compile('[A-Z_][a-zA-Z0-9]{2,}$|(__[a-z][a-zA-Z0-9_]+__)$')
+    CLASS_ATTRIBUTE_RGX = re.compile('[A-Z_][a-zA-Z0-9]{2,}$')
 
 
 class UpperCaseStyle(NamingStyle):
@@ -121,8 +121,8 @@ class UpperCaseStyle(NamingStyle):
     MOD_NAME_RGX = re.compile('[A-Z_][A-Z0-9_]+$')
     CONST_NAME_RGX = re.compile('(([A-Z_][A-Z0-9_]*)|(__.*__))$')
     COMP_VAR_RGX = re.compile('[A-Z_][A-Z0-9_]+$')
-    DEFAULT_NAME_RGX = re.compile('([A-Z_][A-Z0-9_]{2,30})|(__[a-z][a-zA-Z0-9_]+__)$')
-    CLASS_ATTRIBUTE_RGX = re.compile('[A-Z_][A-Z0-9_]{2,30}$')
+    DEFAULT_NAME_RGX = re.compile('([A-Z_][A-Z0-9_]{2,})|(__[a-z][a-zA-Z0-9_]+__)$')
+    CLASS_ATTRIBUTE_RGX = re.compile('[A-Z_][A-Z0-9_]{2,}$')
 
 
 class AnyStyle(NamingStyle):

--- a/pylint/test/functional/namePresetCamelCase.txt
+++ b/pylint/test/functional/namePresetCamelCase.txt
@@ -1,3 +1,3 @@
 invalid-name:3::"Constant name ""SOME_CONSTANT"" doesn't conform to camelCase naming style ('(([a-z_][A-Za-z0-9]*)|(__.*__))$' pattern)"
 invalid-name:10:MyClass:"Class name ""MyClass"" doesn't conform to camelCase naming style ('[a-z_][a-zA-Z0-9]+$' pattern)"
-invalid-name:22:say_hello:"Function name ""say_hello"" doesn't conform to camelCase naming style ('(([a-z_][a-zA-Z0-9]{2,30})|(__[a-z][a-zA-Z0-9_]+__))$' pattern)"
+invalid-name:22:say_hello:"Function name ""say_hello"" doesn't conform to camelCase naming style ('(([a-z_][a-zA-Z0-9]{2,})|(__[a-z][a-zA-Z0-9_]+__))$' pattern)"

--- a/pylint/test/functional/name_preset_snake_case.txt
+++ b/pylint/test/functional/name_preset_snake_case.txt
@@ -1,3 +1,3 @@
 invalid-name:3::"Constant name ""SOME_CONSTANT"" doesn't conform to snake_case naming style ('(([a-z_][a-z0-9_]*)|(__.*__))$' pattern)"
 invalid-name:10:MyClass:"Class name ""MyClass"" doesn't conform to snake_case naming style ('[a-z_][a-z0-9_]+$' pattern)"
-invalid-name:22:sayHello:"Function name ""sayHello"" doesn't conform to snake_case naming style ('(([a-z_][a-z0-9_]{2,30})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$' pattern)"
+invalid-name:22:sayHello:"Function name ""sayHello"" doesn't conform to snake_case naming style ('(([a-z_][a-z0-9_]{2,})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$' pattern)"

--- a/pylint/test/functional/name_styles.py
+++ b/pylint/test/functional/name_styles.py
@@ -129,10 +129,6 @@ def good_public_function_name(good_arg_name):
     return good_variable_name + good_arg_name
 
 
-def too_long_function_name_in_public_scope():  # [invalid-name]
-    """Public scope function with a too long name"""
-    return 12
-
 def _private_scope_function_with_long_descriptive_name():
     """Private scope function are cool with long descriptive names"""
     return 12

--- a/pylint/test/functional/name_styles.txt
+++ b/pylint/test/functional/name_styles.txt
@@ -14,4 +14,3 @@ invalid-name:94:test_globals:"Constant name ""AlsoCorrect"" doesn't conform to U
 invalid-name:107:FooClass.PROPERTY_NAME:"Attribute name ""PROPERTY_NAME"" doesn't conform to snake_case naming style":INFERENCE
 invalid-name:112:FooClass.ABSTRACT_PROPERTY_NAME:"Attribute name ""ABSTRACT_PROPERTY_NAME"" doesn't conform to snake_case naming style":INFERENCE
 invalid-name:117:FooClass.PROPERTY_NAME_SETTER:"Attribute name ""PROPERTY_NAME_SETTER"" doesn't conform to snake_case naming style":INFERENCE
-invalid-name:132:too_long_function_name_in_public_scope:"Function name ""too_long_function_name_in_public_scope"" doesn't conform to snake_case naming style"

--- a/pylintrc
+++ b/pylintrc
@@ -201,10 +201,10 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
 # Regular expression matching correct attribute names
-attr-rgx=[a-z_][a-z0-9_]{2,30}$
+attr-rgx=[a-z_][a-z0-9_]{2,}$
 
 # Naming hint for attribute names
-attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+attr-name-hint=[a-z_][a-z0-9_]{2,}$
 
 # Regular expression matching correct argument names
 argument-rgx=[a-z_][a-z0-9_]{2,30}$
@@ -237,10 +237,10 @@ module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
 # Regular expression matching correct method names
-method-rgx=[a-z_][a-z0-9_]{2,30}$
+method-rgx=[a-z_][a-z0-9_]{2,}$
 
 # Naming hint for method names
-method-name-hint=[a-z_][a-z0-9_]{2,30}$
+method-name-hint=[a-z_][a-z0-9_]{2,}$
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.


### PR DESCRIPTION
### Fixes / new features
- Fixed false positive check for invalid name "doesn't conform to snake_case naming style" for class methods and attributes. 

Removed max length in regex for class method and attribute. Tests and docs updated according to [this PR](https://github.com/PyCQA/pylint/pull/2149)

See [#2047](https://github.com/PyCQA/pylint/issues/2047)
