### PR TITLE
`try-except-raise` should consider parent class handlers.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,9 @@ What's New in Pylint 2.0?
 =========================
 
 Release date: 2018-07-15
+    * `try-except-raise` should not be emitted if there are any parent exception class handlers.
+
+       Close #2284
 
     * `trailing-comma-tuple` can be emitted for `return` statements as well.
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -973,3 +973,22 @@ def is_postponed_evaluation_enabled(node):
     module = node.root()
     stmt = module.locals.get(name)
     return stmt and isinstance(stmt[0], astroid.ImportFrom) and stmt[0].modname == '__future__'
+
+
+def is_subclass_of(node_a, node_b):
+    """
+    Check if first node is a subclass of second node.
+    :param node_a: Node to check for subclass.
+    :type node_a: astroid.ClassDef
+    :param node_b: Node to check for superclass.
+    :type node_b: astroid.ClassDef
+    :returns: True if node_a is derived from node_b. False otherwise.
+    :rtype: bool
+    """
+    if not any(isinstance(node, astroid.ClassDef) for node in (node_a, node_b)):
+        return False
+
+    bases = [base.name for base in node_a.bases]
+    if node_b.name in bases:
+        return True
+    return False

--- a/pylint/test/functional/try_except_raise.py
+++ b/pylint/test/functional/try_except_raise.py
@@ -1,4 +1,4 @@
-# pylint:disable=missing-docstring
+# pylint:disable=missing-docstring, unreachable
 
 try:
     int("9a")
@@ -9,3 +9,35 @@ try:
     int("9a")
 except:
     raise ValueError('Invalid integer')
+
+
+try:
+    int("9a")
+except:  # [try-except-raise]
+    raise
+    print('caught exception')
+
+try:
+    int("9a")
+except:
+    print('caught exception')
+    raise
+
+
+class AAAException(Exception):
+    """AAAException"""
+    pass
+
+class BBBException(AAAException):
+    """BBBException"""
+    pass
+
+def ccc():
+    """try-except-raise test function"""
+
+    try:
+        raise BBBException("asdf")
+    except BBBException:
+        raise
+    except AAAException:
+        raise BBBException("raised from AAAException")

--- a/pylint/test/functional/try_except_raise.txt
+++ b/pylint/test/functional/try_except_raise.txt
@@ -1,2 +1,2 @@
 try-except-raise:5::The except handler raises immediately
-try-except-raise:15::The except handler raises immediately
+try-except-raise:16::The except handler raises immediately


### PR DESCRIPTION
`try-except-raise` should not be emitted if there are any parent exception class handlers.

### Fixes / new features
- #2284 
