### PR TITLE
Fix format checker inconsistency for start of first line

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,10 @@ Release date: |TBA|
 
        Close #2295
 
+    * Fix inconsistent behavor for bad-continuation on first line of file
+
+      Close #2281
+
     * Don't emit `useless-return` when we have a single statement that is the return itself
 
       We still want to be explicit when a function is supposed to return

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -884,7 +884,7 @@ class FormatChecker(BaseTokenChecker):
                     last_blank_line_num = line_num
                 self._check_continued_indentation(TokenWrapper(tokens), idx+1)
                 self._current_line.next_physical_line()
-            elif tok_type != tokenize.COMMENT:
+            elif tok_type not in (tokenize.COMMENT, tokenize.ENCODING):
                 self._current_line.handle_line_start(idx)
                 # This is the first concrete token following a NEWLINE, so it
                 # must be the first token of the next program statement, or an

--- a/pylint/test/unittest_checker_format.py
+++ b/pylint/test/unittest_checker_format.py
@@ -24,6 +24,8 @@
 
 from __future__ import unicode_literals
 
+import tokenize
+
 import astroid
 
 from pylint.checkers.format import *
@@ -367,3 +369,15 @@ class TestCheckSpace(CheckerTestCase):
 
         with self.assertNoMessages():
             self.checker.process_tokens(_tokenize_str('a = 1\n\v\nb = 2\n'))
+
+
+    def test_encoding_token(self):
+        """Make sure the encoding token doesn't change the checker's behavior
+
+        _tokenize_str doesn't produce an encoding token, but
+        reading a file does
+        """
+        with self.assertNoMessages():
+            encoding_token = tokenize.TokenInfo(tokenize.ENCODING, "utf-8", (0, 0), (0, 0), '')
+            tokens = [encoding_token] + _tokenize_str('if (\n        None):\n    pass\n')
+            self.checker.process_tokens(tokens)


### PR DESCRIPTION
The format checker was ignoring block opener tokens on the first line
because the encoding token is the always the first value of the first line.

Close #2281