### PR TITLE
Use final 3.7 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,9 @@ jobs:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    - python: 3.7-dev
+    - python: 3.7
       env: TOXENV=py37
+      dist: xenial
     - stage: tests-pypy
       python: pypy3.5-5.8.0
       env: TOXENV=pypy


### PR DESCRIPTION
Tests fail, but I don't think it's the fault of this PR, but just maybe a real issue this change has revealed with 3.7.0.