### PR TITLE
Demote 'try-except-raise' from an error to a warning

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -211,3 +211,5 @@ contributors:
 * Nick Drozd: contributor, performance improvements to astroid
 
 * Kosarchuk Sergey: contributor
+
+* Carey Metcalfe: demoted `try-except-raise` from error to warning

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in Pylint 2.1?
 
 Release date: |TBA|
 
+   * Demote the `try-except-raise` message from an error to a warning (E0705 -> W0706)
+
+      Close #2323
+
    * Fix a false positive `invalid name` message when method or attribute name is longer then 30 characters.
 
       Close #2047

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -88,12 +88,6 @@ MSGS = {
               'a bare raise inside a finally clause, which might work, as long '
               'as an exception is raised inside the try block, but it is '
               'nevertheless a code smell that must not be relied upon.'),
-    'E0705': ('The except handler raises immediately',
-              'try-except-raise',
-              'Used when an except handler uses raise as its first or only '
-              'operator. This is useless because it raises back the exception '
-              'immediately. Remove the raise operator or the entire '
-              'try-except-raise block!'),
     'E0710': ('Raising a new style class which doesn\'t inherit from BaseException',
               'raising-non-exception',
               'Used when a new style class which doesn\'t inherit from \
@@ -118,6 +112,12 @@ MSGS = {
               'duplicate-except',
               'Used when an except catches a type that was already caught by '
               'a previous handler.'),
+    'W0706': ('The except handler raises immediately',
+              'try-except-raise',
+              'Used when an except handler uses raise as its first or only '
+              'operator. This is useless because it raises back the exception '
+              'immediately. Remove the raise operator or the entire '
+              'try-except-raise block!'),
     'W0710': ('Exception doesn\'t inherit from standard "Exception" class',
               'nonstandard-exception',
               'Used when a custom exception class is raised but doesn\'t \


### PR DESCRIPTION
This changes the `try-accept-raise` message from `E0705` to `W0706` to be more in line with the way the rest of the messages are organized.

Fixes #2323
