### PR TITLE
Fix --list-msgs

### DIFF
--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -988,8 +988,8 @@ class CLIRunner(Runner):
           'exit. The value may be a comma separated list of message ids.'}),
 
         ('list-msgs',
-         {'metavar': '<msg-id>',
-          'group': 'Commands', 'level': 1, 'default': None,
+         {'group': 'Commands', 'level': 1,
+          'action': 'store_true', 'default': False,
           'help' : "Generate pylint's messages."}),
 
         ('list-conf-levels',

--- a/pylint/test/test_self.py
+++ b/pylint/test/test_self.py
@@ -150,6 +150,9 @@ class TestRunTC(object):
     def test_w0704_ignored(self):
         self._runtest([join(HERE, 'input', 'ignore_except_pass_by_default.py')], code=0)
 
+    def test_list_msgs(self):
+        self._runtest(['--list-msgs'], code=0)
+
     def test_generate_config_option(self):
         self._runtest(['--generate-rcfile'], code=0)
 


### PR DESCRIPTION
### Fixes / new features
- `--list-msgs` works again with 0 arguments.