### PR TITLE
Correct sentence in FAQ around Python version support

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -42,8 +42,8 @@ Pylint from the repository, simply invoke ::
 -----------------------------------
 
 Pylint depends on astroid_ and a couple of other packages.
-It should be compatible with any Python version greater than 2.7.0 and
-it is also working on PyPy.
+See the following section for details on what versions of Python are
+supported.
 
 .. _`astroid`: https://github.com/PyCQA/astroid
 


### PR DESCRIPTION
### Fixes / new features
- Corrects a sentence in the FAQ which seemed to imply that Pylint works with any version of Python 2.7 or greater.  With Pylint 2.0+ being 3.4+ only, this was misleading & confusing.
