### PR TITLE
Change refactoring nodes_of_class call to use skip_klass

### DIFF
--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -808,10 +808,8 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         return condition, true_value, false_value
 
     def visit_functiondef(self, node):
-        self._return_nodes[node.name] = []
-        return_nodes = node.nodes_of_class(astroid.Return)
-        self._return_nodes[node.name] = [_rnode for _rnode in return_nodes
-                                         if _rnode.frame() == node.frame()]
+        self._return_nodes[node.name] = list(
+            node.nodes_of_class(astroid.Return, skip_klass=astroid.FunctionDef))
 
     def _check_consistent_returns(self, node):
         """Check that all return statements inside a function are consistent.


### PR DESCRIPTION
Calling nodes_of_class without a skip_klass and then filtering
afterwards is slightly inefficient, but more importantly it's an
unusual use of the function (this is the only example in Pylint where
Return nodes are extracted without skipping FunctionDef).