### PR TITLE
consider bare except also for try-except-raise

### DIFF
--- a/pylint/test/functional/try_except_raise.py
+++ b/pylint/test/functional/try_except_raise.py
@@ -1,4 +1,4 @@
-# pylint:disable=missing-docstring, unreachable
+# pylint:disable=missing-docstring, unreachable, bad-except-order, bare-except
 
 try:
     int("9a")
@@ -41,3 +41,35 @@ def ccc():
         raise
     except AAAException:
         raise BBBException("raised from AAAException")
+
+
+def ddd():
+    """try-except-raise test function"""
+
+    try:
+        raise BBBException("asdf")
+    except AAAException:
+        raise BBBException("raised from AAAException")
+    except:  # [try-except-raise]
+        raise
+
+try:
+    pass
+except RuntimeError:
+    raise
+except:
+    print("a failure")
+
+try:
+    pass
+except:
+    print("a failure")
+except RuntimeError:  # [try-except-raise]
+    raise
+
+try:
+    pass
+except:  # [try-except-raise]
+    raise
+except RuntimeError:
+    print("a failure")

--- a/pylint/test/functional/try_except_raise.txt
+++ b/pylint/test/functional/try_except_raise.txt
@@ -1,2 +1,5 @@
 try-except-raise:5::The except handler raises immediately
 try-except-raise:16::The except handler raises immediately
+try-except-raise:53:ddd:The except handler raises immediately
+try-except-raise:67::The except handler raises immediately
+try-except-raise:72::The except handler raises immediately


### PR DESCRIPTION
pylint crashes due to safe_infer, in case of bare except.

### Fixes / new features
- #2352
