### PR TITLE
Linters are created per file

### DIFF
--- a/pylint/utils.py
+++ b/pylint/utils.py
@@ -180,13 +180,12 @@ def build_message_def(checker, msgid, msg_tuple):
                       "a symbolic name" % msgid, DeprecationWarning)
         symbol = None
     options.setdefault('scope', default_scope)
-    return MessageDefinition(checker, msgid, msg, descr, symbol, **options)
+    return MessageDefinition(msgid, msg, descr, symbol, **options)
 
 
 class MessageDefinition:
-    def __init__(self, checker, msgid, msg, descr, symbol, scope,
+    def __init__(self, msgid, msg, descr, symbol, scope,
                  minversion=None, maxversion=None, old_names=None):
-        self.checker = checker
         if len(msgid) != 5:
             raise InvalidMessageError('Invalid message id %r' % msgid)
         if not msgid[0] in MSG_TYPES:
@@ -257,6 +256,7 @@ class MessagesHandlerMixIn:
         self.stats = {
             'by_module': {},
             'by_msg': {},
+            'statement': 0,
         }
         super().__init__()
 
@@ -371,10 +371,13 @@ class MessagesHandlerMixIn:
                 for msgid in msgids:
                     self.disable(msgid)
 
-    def init_msg_states(self):
+    def _init_msg_states(self):
         for msg in self.msgs_store.messages:
             if not msg.may_be_emitted():
                 self._msgs_state[msg.msgid] = False
+
+        for msg_cat in MSG_TYPES.values():
+            self.stats[msg_cat] = 0
 
     def get_message_state_scope(self, msgid, line=None, confidence=UNDEFINED):
         """Returns the scope at which a message was enabled/disabled."""


### PR DESCRIPTION
As the title says, PyLinter objects are now created on a per file basis. There's possibly some optimisation to be done here. Really linters need to be created only once per directory because a configuration file will affect a directory and not individual files.