### PR TITLE
Update Spyder links and short description in IDE integration doc

### DIFF
--- a/doc/user_guide/ide-integration.rst
+++ b/doc/user_guide/ide-integration.rst
@@ -21,10 +21,11 @@ Pylint is integrated in:
 
  - `Visual Studio`_, see the `Python > Run PyLint` command on a project's context menu.
  - Eric_ IDE, see the `Project > Check` menu,
- - Spyder_, see http://packages.python.org/spyder/pylint.html,
+ - Spyder_, see the `View -> Panes -> Static code analysis` pane and
+   its `corresponding documentation <https://docs.spyder-ide.org/pylint.html>`_.
  - pyscripter_, see the `Tool -> Tools` menu.
  - `Visual Studio Code`_, see the `Preferences -> Settings` menu.
- 
+
 .. _Emacs: http://www.gnu.org/software/emacs/
 .. _Vim: http://www.vim.org/
 .. _Visual Studio: https://www.visualstudio.com/
@@ -35,7 +36,7 @@ Pylint is integrated in:
 .. _Komodo: http://www.activestate.com/Products/Komodo/
 .. _gedit: https://wiki.gnome.org/Apps/Gedit
 .. _WingIDE: http://www.wingware.com/
-.. _spyder: http://code.google.com/p/spyderlib/
+.. _spyder: https://www.spyder-ide.org/
 .. _PyCharm: http://www.jetbrains.com/pycharm/
 .. _TextMate: http://macromates.com
 .. _Visual Studio Code: https://code.visualstudio.com/


### PR DESCRIPTION
Does just what it says on the tin; the links to both the Spyder IDE site and docs are many years out of date, so as part of spyder-ide/spyder-docs#39 this updates them as well as adding a brief line about how to actually access Pylint (as the other IDEs have). I made this off ``master`` like most other PRs, but if there's any chance this could get backported to at least the 2.0.1 docs if not older that would be great since the links are so out of date (but if not, I understand).

As a minor note, the relevant sentence is a pretty clear comma splice as is, but I didn't fix that here (i.e. by changing ``,`` to ``;``) for consistancy's sake with the other list entries that also all have the same problem.

I didn't create an issue or changelog entry since this was such a trivial and ephemeral change.  I didn't see any Contributing guide so hopefully this is conformant with your project standards; let me know if you want me to change something. Thanks!