### PR TITLE
add new case for `unnecessary-pass`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,13 @@ What's New in Pylint 2.1?
 =========================
 
 Release date: 2018-08-01
+   * `unnecessary-pass` is now also emitted when a function or class contains only docstring and pass statement.
+
+      In Python, stubbed functions often have a body that contains just a single `pass` statement, 
+      indicating that the function doesn't do anything. However, a stubbed function can also have just a
+      docstring, and function with a docstring and no body also does nothing.
+
+      Close #2208
 
    * `trailing-comma-tuple` gets emitted for ``yield`` statements as well.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,15 @@ What's New in Pylint 2.2?
 
 Release date: TBA
 
-  * Stop ``protected-access`` exception for missing class attributes
+   * Stop ``protected-access`` exception for missing class attributes
+
+   * `unnecessary-pass` is now also emitted when a function or class contains only docstring and pass statement.
+
+      In Python, stubbed functions often have a body that contains just a single `pass` statement, 
+      indicating that the function doesn't do anything. However, a stubbed function can also have just a
+      docstring, and function with a docstring and no body also does nothing.
+
+      Close #2208
 
 
 What's New in Pylint 2.1.1?
@@ -28,14 +36,6 @@ What's New in Pylint 2.1?
 =========================
 
 Release date: 2018-08-01
-   * `unnecessary-pass` is now also emitted when a function or class contains only docstring and pass statement.
-
-      In Python, stubbed functions often have a body that contains just a single `pass` statement, 
-      indicating that the function doesn't do anything. However, a stubbed function can also have just a
-      docstring, and function with a docstring and no body also does nothing.
-
-      Close #2208
-
    * `trailing-comma-tuple` gets emitted for ``yield`` statements as well.
 
       Close #2363

--- a/doc/whatsnew/2.1.rst
+++ b/doc/whatsnew/2.1.rst
@@ -28,6 +28,9 @@ New checkers
 Other Changes
 =============
 
+* `unnecessary-pass` is now also emitted when a function or class contains only docstring and pass statement, 
+  in which case, docstring is enough for empty definition.
+
 * `try-except-raise` check was demoted from an error to a warning, as part of issue #2323.
 
 * Correctly handle the new name of the Python implementation of the `abc` module.

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1710,7 +1710,8 @@ class PassChecker(_BasicChecker):
 
     @utils.check_messages('unnecessary-pass')
     def visit_pass(self, node):
-        if len(node.parent.child_sequence(node)) > 1:
+        if (len(node.parent.child_sequence(node)) > 1 or 
+                node.parent.doc is not None):
             self.add_message('unnecessary-pass', node=node)
 
 

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1710,8 +1710,9 @@ class PassChecker(_BasicChecker):
 
     @utils.check_messages('unnecessary-pass')
     def visit_pass(self, node):
-        if (len(node.parent.child_sequence(node)) > 1 or 
-                node.parent.doc is not None):
+        if (len(node.parent.child_sequence(node)) > 1 or
+                (isinstance(node.parent, (astroid.ClassDef, astroid.FunctionDef)) and
+                 (node.parent.doc is not None))):
             self.add_message('unnecessary-pass', node=node)
 
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -325,7 +325,6 @@ def check_messages(*messages):
 
 class IncompleteFormatString(Exception):
     """A format string ended in the middle of a format specifier."""
-    pass
 
 class UnsupportedFormatCharacter(Exception):
     """A format character in a format string is not one of the supported

--- a/pylint/test/extensions/data/docstring.py
+++ b/pylint/test/extensions/data/docstring.py
@@ -8,7 +8,6 @@ def check_messages(*messages):
 
 def function2():
     """Test Ok"""
-    pass
 
 class FFFF:
     """
@@ -19,30 +18,23 @@ class FFFF:
         '''
         Test Triple Single Quotes docstring
         '''
-        pass
 
     def method2(self):
         "bad docstring 1"
-        pass
 
     def method3(self):
         'bad docstring 2'
-        pass
 
     def method4(self):
         ' """bad docstring 3 '
-        pass
 
     @check_messages('bad-open-mode', 'redundant-unittest-assert',
                     'deprecated-module')
     def method5(self):
         """Test OK 1 with decorators"""
-        pass
 
     def method6(self):
         r"""Test OK 2 with raw string"""
-        pass
 
     def method7(self):
         u"""Test OK 3 with unicode string"""
-        pass

--- a/pylint/test/functional/docstrings.py
+++ b/pylint/test/functional/docstrings.py
@@ -1,4 +1,4 @@
-# pylint: disable=R0201, useless-object-inheritance
+# pylint: disable=R0201, useless-object-inheritance, unnecessary-pass
 # -1: [missing-docstring]
 from __future__ import print_function
 

--- a/pylint/test/functional/function_redefined.py
+++ b/pylint/test/functional/function_redefined.py
@@ -1,4 +1,4 @@
-# pylint: disable=R0201,missing-docstring,using-constant-test,unused-import,wrong-import-position,reimported, useless-object-inheritance
+# pylint: disable=R0201,missing-docstring,using-constant-test,unused-import,wrong-import-position,reimported, useless-object-inheritance, unnecessary-pass
 from __future__ import division
 __revision__ = ''
 

--- a/pylint/test/functional/init_not_called.py
+++ b/pylint/test/functional/init_not_called.py
@@ -1,4 +1,4 @@
-# pylint: disable=R0903,import-error,missing-docstring,wrong-import-position,useless-super-delegation, useless-object-inheritance
+# pylint: disable=R0903,import-error,missing-docstring,wrong-import-position,useless-super-delegation, useless-object-inheritance, unnecessary-pass
 """test for __init__ not called
 """
 from __future__ import print_function

--- a/pylint/test/functional/invalid_sequence_index.py
+++ b/pylint/test/functional/invalid_sequence_index.py
@@ -1,5 +1,5 @@
 """Errors for invalid sequence indices"""
-# pylint: disable=too-few-public-methods, no-self-use, import-error, missing-docstring, useless-object-inheritance
+# pylint: disable=too-few-public-methods, no-self-use, import-error, missing-docstring, useless-object-inheritance, unnecessary-pass
 import six
 from unknown import Unknown
 

--- a/pylint/test/functional/invalid_slice_index.py
+++ b/pylint/test/functional/invalid_slice_index.py
@@ -1,5 +1,5 @@
 """Errors for invalid slice indices"""
-# pylint: disable=too-few-public-methods, no-self-use,missing-docstring,expression-not-assigned, useless-object-inheritance
+# pylint: disable=too-few-public-methods, no-self-use,missing-docstring,expression-not-assigned, useless-object-inheritance, unnecessary-pass
 
 
 TESTLIST = [1, 2, 3]

--- a/pylint/test/functional/keyword_arg_before_vararg.py
+++ b/pylint/test/functional/keyword_arg_before_vararg.py
@@ -1,7 +1,7 @@
 """Unittests for W1125 (kw args before *args)"""
 from __future__ import absolute_import, print_function
 
-# pylint: disable=unused-argument, useless-object-inheritance
+# pylint: disable=unused-argument, useless-object-inheritance, unnecessary-pass
 def check_kwargs_before_args(param1, param2=2, *args): # [keyword-arg-before-vararg]
     """docstring"""
     pass

--- a/pylint/test/functional/line_too_long.py
+++ b/pylint/test/functional/line_too_long.py
@@ -1,4 +1,4 @@
-# pylint: disable=invalid-encoded-data, fixme
+# pylint: disable=invalid-encoded-data, fixme, unnecessary-pass
 # +1: [line-too-long]
 #####################################################################################################
 # +1: [line-too-long]

--- a/pylint/test/functional/name_styles.py
+++ b/pylint/test/functional/name_styles.py
@@ -1,5 +1,5 @@
 """Test for the invalid-name warning."""
-# pylint: disable=no-absolute-import, useless-object-inheritance
+# pylint: disable=no-absolute-import, useless-object-inheritance, unnecessary-pass
 from __future__ import print_function
 import abc
 import collections

--- a/pylint/test/functional/names_in__all__.py
+++ b/pylint/test/functional/names_in__all__.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-few-public-methods,no-self-use, no-absolute-import,import-error, useless-object-inheritance
+# pylint: disable=too-few-public-methods,no-self-use, no-absolute-import,import-error, useless-object-inheritance, unnecessary-pass
 """Test Pylint's use of __all__.
 
 * NonExistant is not defined in this module, and it is listed in

--- a/pylint/test/functional/try_except_raise.py
+++ b/pylint/test/functional/try_except_raise.py
@@ -1,4 +1,4 @@
-# pylint:disable=missing-docstring, unreachable, bad-except-order, bare-except
+# pylint:disable=missing-docstring, unreachable, bad-except-order, bare-except, unnecessary-pass
 
 try:
     int("9a")

--- a/pylint/test/functional/unnecessary_pass.py
+++ b/pylint/test/functional/unnecessary_pass.py
@@ -1,7 +1,49 @@
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring, too-few-public-methods
 
 try:
     A = 2
 except ValueError:
     A = 24
+    pass # [unnecessary-pass]
+
+def docstring_only():
+    '''In Python, stubbed functions often have a body that contains just a
+    single `pass` statement, indicating that the function doesn't do
+    anything. However, a stubbed function can also have just a
+    docstring, and function with a docstring and no body also does
+    nothing.
+    '''
+
+
+# This function has no docstring, so it needs a `pass` statement.
+def pass_only():
+    pass
+
+
+def docstring_and_pass():
+    '''This function doesn't do anything, but it has a docstring, so its
+    `pass` statement is useless clutter.
+
+    NEW CHECK: useless-pass
+
+    This would check for stubs with both docstrings and `pass`
+    statements, suggesting the removal of the useless `pass`
+    statements
+    '''
+    pass # [unnecessary-pass]
+
+
+class DocstringOnly:
+    '''The same goes for class stubs: docstring, or `pass`, but not both.
+    '''
+
+
+# No problem
+class PassOnly:
+    pass
+
+
+class DocstringAndPass:
+    '''Whoops! Mark this one as bad too.
+    '''
     pass # [unnecessary-pass]

--- a/pylint/test/functional/unnecessary_pass.txt
+++ b/pylint/test/functional/unnecessary_pass.txt
@@ -1,1 +1,3 @@
 unnecessary-pass:7::Unnecessary pass statement
+unnecessary-pass:33:docstring_and_pass:Unnecessary pass statement
+unnecessary-pass:49:DocstringAndPass:Unnecessary pass statement

--- a/pylint/test/input/func_bug113231.py
+++ b/pylint/test/input/func_bug113231.py
@@ -1,6 +1,6 @@
 # pylint: disable=E1101
 # pylint: disable=C0103
-# pylint: disable=R0903, useless-object-inheritance
+# pylint: disable=R0903, useless-object-inheritance, unnecessary-pass
 """test bugfix for #113231 in logging checker
 """
 from __future__ import absolute_import

--- a/pylint/test/input/func_noerror_inner_classes.py
+++ b/pylint/test/input/func_noerror_inner_classes.py
@@ -1,4 +1,4 @@
-# pylint: disable=R0903, useless-object-inheritance
+# pylint: disable=R0903, useless-object-inheritance, unnecessary-pass
 """Backend Base Classes for the schwelm user DB"""
 
 __revision__ = "alpha"

--- a/pylint/test/input/func_w0623_py30.py
+++ b/pylint/test/input/func_w0623_py30.py
@@ -1,4 +1,5 @@
 """Test for W0623, overwriting names in exception handlers."""
+# pylint: disable=unnecessary-pass
 
 __revision__ = ''
 

--- a/pylint/test/messages/func_w0623_py30.txt
+++ b/pylint/test/messages/func_w0623_py30.txt
@@ -1,2 +1,2 @@
-W: 15:some_function: Redefining name 'some_function' from outer scope (line 10) in exception handler
-W: 15:some_function: Unused variable 'some_function'
+W: 16:some_function: Redefining name 'some_function' from outer scope (line 11) in exception handler
+W: 16:some_function: Unused variable 'some_function'


### PR DESCRIPTION
`unnecessary-pass` is now also emitted when a function or class contains
only docstring and pass statement, in which case, docstring is enough for
empty definition.

### Fixes / new features
- #2208 
