### PR TITLE
No extra space

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -215,3 +215,5 @@ contributors:
 * Kosarchuk Sergey: contributor
 
 * Carey Metcalfe: demoted `try-except-raise` from error to warning
+
+* Marcus Näslund (naslundx): contributor 

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -295,7 +295,7 @@ expected-line-ending-format=
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 
-# Number of spaces of indent required inside a hanging  or continued line.
+# Number of spaces of indent required inside a hanging or continued line.
 indent-after-paren=4
 
 # String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1

--- a/man/pylint.1
+++ b/man/pylint.1
@@ -205,7 +205,7 @@ Maximum number of lines in a module [default: 1000]
 .IP "--indent-string=<string>"
 String used as indentation unit. This is usually "    " (4 spaces) or "\\t" (1 tab). [default: '    ']
 .IP "--indent-after-paren=<int>"
-Number of spaces of indent required inside a hanging  or continued line. [default: 4]
+Number of spaces of indent required inside a hanging or continued line. [default: 4]
 .IP "--expected-line-ending-format=<empty or LF or CRLF>"
 Expected format of line ending, e.g. empty (any line ending), LF or CRLF. [default: none]
 

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -541,7 +541,7 @@ class FormatChecker(BaseTokenChecker):
                ('indent-after-paren',
                 {'type': 'int', 'metavar': '<int>', 'default': 4,
                  'help': 'Number of spaces of indent required inside a hanging '
-                         ' or continued line.'}),
+                         'or continued line.'}),
                ('expected-line-ending-format',
                 {'type': 'choice', 'metavar': '<empty or LF or CRLF>', 'default': '',
                  'choices': ['', 'LF', 'CRLF'],


### PR DESCRIPTION
### Fixes / new features
- Removed a double space that was generated in "Number of spaces of indent required inside a hanging  or continued line" and updated man page and pylintrc example accordingly.

This bothered me unreasonably much.

( Not sure if this really warrants a contributor entry but the guidelines told me to, so. :) )