### PR TITLE
pin tox version to prevent CI error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - sudo apt-get install -y enchant
 install:
   - pip install -U setuptools
-  - pip install tox coverage coveralls
+  - pip install tox==3.1.2 coverage coveralls
   - virtualenv --version
   - easy_install --version
   - pip --version


### PR DESCRIPTION
This was the only obvious change between the passing and failing pypy tests