### PR TITLE
Ignore import x.y.z as z cases for checker `useless-import-alias`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in Pylint 2.2?
 
 Release date: TBA
 
+   * Ignore import x.y.z as z cases for checker `useless-import-alias`.
+
+     Close #2309
+
    * Stop ``protected-access`` exception for missing class attributes
 
    * Don't emit `assignment-from-no-return` for decorated function nodes

--- a/doc/whatsnew/2.2.rst
+++ b/doc/whatsnew/2.2.rst
@@ -16,6 +16,8 @@ New checkers
 Other Changes
 =============
 
+* Ignore import x.y.z as z cases for checker `useless-import-alias`.
+
 * `unnecessary-pass` is now also emitted when a function or class contains only docstring and pass statement, 
   in which case, docstring is enough for empty definition.
 

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -732,10 +732,14 @@ class ImportsChecker(BaseChecker):
                 return
 
             real_name = name[0]
-            packages = real_name.rsplit('.', 1)
-            real_name = packages[1] if len(packages) == 2 else packages[0]
+            splitted_packages = real_name.rsplit('.')
+            real_name = splitted_packages[-1]
             imported_name = name[1]
-            if real_name == imported_name:
+            # consider only following cases
+            # import x as x
+            # and ignore following
+            # import x.y.z as z
+            if real_name == imported_name and len(splitted_packages) == 1:
                 self.add_message('useless-import-alias', node=node)
 
     def _check_reimport(self, node, basename=None, level=None):

--- a/pylint/test/functional/useless-import-alias.py
+++ b/pylint/test/functional/useless-import-alias.py
@@ -1,9 +1,9 @@
 # pylint: disable=unused-import, missing-docstring, invalid-name, reimported, import-error, wrong-import-order, no-name-in-module, relative-beyond-top-level
 from collections import OrderedDict as OrderedDict # [useless-import-alias]
 from collections import OrderedDict as o_dict
-import os.path as path # [useless-import-alias]
+import os.path as path
 import os.path as p
-import foo.bar.foobar as foobar # [useless-import-alias]
+import foo.bar.foobar as foobar
 import os
 import os as OS
 from sys import version
@@ -16,3 +16,6 @@ from ..foo.bar import foobar as anotherfoobar
 from . import foo as foo, foo2 as bar2  # [useless-import-alias]
 from . import foo as bar, foo2 as foo2  # [useless-import-alias]
 from . import foo as bar, foo2 as bar2
+from foo.bar import foobar as foobar  # [useless-import-alias]
+from foo.bar import foobar as foo
+from .foo.bar import f as foobar

--- a/pylint/test/functional/useless-import-alias.txt
+++ b/pylint/test/functional/useless-import-alias.txt
@@ -6,3 +6,4 @@ useless-import-alias:13::Import alias does not rename original package
 useless-import-alias:14::Import alias does not rename original package
 useless-import-alias:16::Import alias does not rename original package
 useless-import-alias:17::Import alias does not rename original package
+useless-import-alias:19::Import alias does not rename original package


### PR DESCRIPTION
### Fixes / new features
- #2309 
