### PR TITLE
Use contextlib.redirect_stdout instead of sys.stdout = StringIO()

### DIFF
--- a/pylint/test/unittest_checker_similar.py
+++ b/pylint/test/unittest_checker_similar.py
@@ -11,6 +11,7 @@
 
 import sys
 from os.path import join, dirname, abspath
+from contextlib import redirect_stdout
 
 from io import StringIO
 import pytest
@@ -22,13 +23,11 @@ SIMILAR2 = join(dirname(abspath(__file__)), 'input', 'similar2')
 
 
 def test_ignore_comments():
-    sys.stdout = StringIO()
-    with pytest.raises(SystemExit) as ex:
+    output = StringIO()
+    with redirect_stdout(output), pytest.raises(SystemExit) as ex:
         similar.Run(['--ignore-comments', SIMILAR1, SIMILAR2])
     assert ex.value.code == 0
-    output = sys.stdout.getvalue()
-    sys.stdout = sys.__stdout__
-    assert output.strip() == ("""
+    assert output.getvalue().strip() == ("""
 10 similar lines in 2 files
 ==%s:0
 ==%s:0
@@ -47,13 +46,11 @@ TOTAL lines=44 duplicates=10 percent=22.73
 
 
 def test_ignore_docsrings():
-    sys.stdout = StringIO()
-    with pytest.raises(SystemExit) as ex:
+    output = StringIO()
+    with redirect_stdout(output), pytest.raises(SystemExit) as ex:
         similar.Run(['--ignore-docstrings', SIMILAR1, SIMILAR2])
     assert ex.value.code == 0
-    output = sys.stdout.getvalue()
-    sys.stdout = sys.__stdout__
-    assert output.strip() == ("""
+    assert output.getvalue().strip() == ("""
 8 similar lines in 2 files
 ==%s:6
 ==%s:6
@@ -79,25 +76,21 @@ TOTAL lines=44 duplicates=13 percent=29.55
 
 
 def test_ignore_imports():
-    sys.stdout = StringIO()
-    with pytest.raises(SystemExit) as ex:
+    output = StringIO()
+    with redirect_stdout(output), pytest.raises(SystemExit) as ex:
         similar.Run(['--ignore-imports', SIMILAR1, SIMILAR2])
     assert ex.value.code == 0
-    output = sys.stdout.getvalue()
-    sys.stdout = sys.__stdout__
-    assert output.strip() == """
+    assert output.getvalue().strip() == """
 TOTAL lines=44 duplicates=0 percent=0.00
 """.strip()
 
 
 def test_ignore_nothing():
-    sys.stdout = StringIO()
-    with pytest.raises(SystemExit) as ex:
+    output = StringIO()
+    with redirect_stdout(output), pytest.raises(SystemExit) as ex:
         similar.Run([SIMILAR1, SIMILAR2])
     assert ex.value.code == 0
-    output = sys.stdout.getvalue()
-    sys.stdout = sys.__stdout__
-    assert output.strip() == ("""
+    assert output.getvalue().strip() == ("""
 5 similar lines in 2 files
 ==%s:0
 ==%s:0
@@ -111,24 +104,22 @@ TOTAL lines=44 duplicates=5 percent=11.36
 
 
 def test_help():
-    sys.stdout = StringIO()
-    try:
-        similar.Run(['--help'])
-    except SystemExit as ex:
-        assert ex.code == 0
-    else:
-        pytest.fail('not system exit')
-    finally:
-        sys.stdout = sys.__stdout__
+    output = StringIO()
+    with redirect_stdout(output):
+        try:
+            similar.Run(['--help'])
+        except SystemExit as ex:
+            assert ex.code == 0
+        else:
+            pytest.fail('not system exit')
 
 
 def test_no_args():
-    sys.stdout = StringIO()
-    try:
-        similar.Run([])
-    except SystemExit as ex:
-        assert ex.code == 1
-    else:
-        pytest.fail('not system exit')
-    finally:
-        sys.stdout = sys.__stdout__
+    output = StringIO()
+    with redirect_stdout(output):
+        try:
+            similar.Run([])
+        except SystemExit as ex:
+            assert ex.code == 1
+        else:
+            pytest.fail('not system exit')

--- a/pylint/test/unittest_lint.py
+++ b/pylint/test/unittest_lint.py
@@ -26,7 +26,7 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stdout
 import sys
 import os
 import re
@@ -702,14 +702,11 @@ class TestMessagesStore(object):
             msg, checkerref=False)
 
     def test_list_messages(self, store):
-        sys.stdout = StringIO()
-        try:
+        output = StringIO()
+        with redirect_stdout(output):
             store.list_messages()
-            output = sys.stdout.getvalue()
-        finally:
-            sys.stdout = sys.__stdout__
         # cursory examination of the output: we're mostly testing it completes
-        assert ':msg-symbol (W1234): *message*' in output
+        assert ':msg-symbol (W1234): *message*' in output.getvalue()
 
     def test_add_renamed_message(self, store):
         store.add_renamed_message('W1234', 'old-bad-name', 'msg-symbol')


### PR DESCRIPTION
In https://github.com/PyCQA/pylint/pull/2424 , PCManticore suggested that this `sys.stdout = StringIO()` idiom be replaced with `contextlib.redirect_stdout`.

I did not change the similar `stderr` idiom to use `contextlib.redirect_stderr` because `redirect_stderr` was introduced in python 3.5 and `setup.py` specifies `python_requires='>=3.4.*'`.