### PR TITLE
emit unused-import instead of unused-variable if the import in is function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ What's New in Pylint 2.2?
 =========================
 
 Release date: TBA
+   * ``pylint`` used to emit a ``unused-variable`` error if unused import was found in the function. Now instead of
+     ``unused-variable``, ``unused-import`` is emitted.
+
+     Close #2421
 
    * Handle asyncio.coroutine when looking for ``not-an-iterable`` check.
 

--- a/doc/whatsnew/2.2.rst
+++ b/doc/whatsnew/2.2.rst
@@ -36,3 +36,8 @@ Other Changes
   with ``asyncio.coroutine``. This is no longer the case as we handle coroutines explicitly.
 
   Close #996
+
+* ``pylint`` used to emit a ``unused-variable`` error if unused import was found in the function. Now instead of
+  ``unused-variable``, ``unused-import`` is emitted.
+
+  Close #2421

--- a/pylint/test/functional/unused_variable.py
+++ b/pylint/test/functional/unused_variable.py
@@ -1,11 +1,11 @@
 # pylint: disable=missing-docstring, invalid-name, too-few-public-methods, no-self-use, useless-object-inheritance
 
 def test_regression_737():
-    import xml # [unused-variable]
+    import xml # [unused-import]
 
 def test_regression_923():
-    import unittest.case  # [unused-variable]
-    import xml as sql # [unused-variable]
+    import unittest.case  # [unused-import]
+    import xml as sql # [unused-import]
 
 def test_unused_with_prepended_underscore():
     _foo = 42
@@ -48,3 +48,8 @@ def locals_does_not_account_for_subscopes():
     def some_other_scope():
         return locals()
     return some_other_scope
+
+
+def unused_import_from():
+    from functools import wraps as abc # [unused-import]
+    from collections import namedtuple # [unused-import]

--- a/pylint/test/functional/unused_variable.txt
+++ b/pylint/test/functional/unused_variable.txt
@@ -1,6 +1,6 @@
-unused-variable:4:test_regression_737:Unused variable 'xml'
-unused-variable:7:test_regression_923:Unused variable 'unittest.case'
-unused-variable:8:test_regression_923:Unused variable 'sql'
+unused-import:4:test_regression_737:Unused import xml
+unused-import:7:test_regression_923:Unused import unittest.case
+unused-import:8:test_regression_923:Unused xml imported as sql
 unused-variable:15:test_unused_with_prepended_underscore:Unused variable '_a_'
 unused-variable:16:test_unused_with_prepended_underscore:Unused variable '__a__'
 unused-variable:20:test_local_field_prefixed_with_unused_or_ignored:Unused variable 'flagged_local_field'
@@ -8,3 +8,5 @@ unused-variable:28:HasUnusedDunderClass.test:Unused variable '__class__'
 possibly-unused-variable:35:locals_example_defined_before:Possibly unused variable 'value'
 unused-variable:41:locals_example_defined_after:Unused variable 'value'
 unused-variable:46:locals_does_not_account_for_subscopes:Unused variable 'value'
+unused-import:54:unused_import_from:Unused wraps imported from functools as abc
+unused-import:55:unused_import_from:Unused namedtuple imported from collections

--- a/pylint/test/messages/func_w0612.txt
+++ b/pylint/test/messages/func_w0612.txt
@@ -1,6 +1,6 @@
 W:  9:function: Unused variable 'aaaa'
 W: 28:test_global: Using the global statement
-W: 34:test_global: Unused variable 'platform'
-W: 35:test_global: Unused variable 'VERSION'
-W: 36:test_global: Unused variable 'this'
-W: 37:test_global: Unused variable 'RE'
+W: 34:test_global: Unused platform imported from sys
+W: 35:test_global: Unused version imported from sys as VERSION
+W: 36:test_global: Unused import this
+W: 37:test_global: Unused re imported as RE


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ x ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ x ] Add a ChangeLog entry describing what your PR does.
- [ x ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ x ] Write a good description on what the PR does.

## Description
``pylint`` used to emit a ``unused-variable`` error if unused import was found in the function. Now instead of
  ``unused-variable``, ``unused-import`` is emitted.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #2421 
-->
