### PR TITLE
Added checker for format string type mismatches.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -225,3 +225,5 @@ contributors:
 * Roberto Leinardi: PyCharm plugin maintainer
 
 * Hornwitser: fix import graph
+
+* Yuri Gribov: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in Pylint 2.2?
 
 Release date: TBA
 
+   * Report format string type mismatches.
+
    * Handle ``AstroidSyntaxError`` when trying to import a module.
 
      Close #2313

--- a/doc/whatsnew/2.2.rst
+++ b/doc/whatsnew/2.2.rst
@@ -12,6 +12,7 @@ Summary -- Release highlights
 New checkers
 ============
 
+* String checker now reports format string type mismatches.
 
 Other Changes
 =============

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -248,7 +248,7 @@ class LoggingChecker(checkers.BaseChecker):
             required_num_args = 0
         else:
             try:
-                keyword_args, required_num_args = \
+                keyword_args, required_num_args, _, _ = \
                     utils.parse_format_string(format_string)
                 if keyword_args:
                     # Keyword checking on logging strings is complicated by

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -352,13 +352,16 @@ class UnsupportedFormatCharacter(Exception):
         Exception.__init__(self, index)
         self.index = index
 
-def parse_format_string(format_string: str) -> Tuple[Set[str], int]:
+def parse_format_string(format_string: str) -> \
+        Tuple[Set[str], int, Dict[str, str], List[str]]:
     """Parses a format string, returning a tuple of (keys, num_args), where keys
     is the set of mapping keys in the format string, and num_args is the number
     of arguments required by the format string.  Raises
     IncompleteFormatString or UnsupportedFormatCharacter if a
     parse error occurs."""
     keys = set()
+    key_types = dict()
+    pos_types = []
     num_args = 0
     def next_char(i):
         i += 1
@@ -416,10 +419,12 @@ def parse_format_string(format_string: str) -> Tuple[Set[str], int]:
                 raise UnsupportedFormatCharacter(i)
             if key:
                 keys.add(key)
+                key_types[key] = char
             elif char != '%':
                 num_args += 1
+                pos_types.append(char)
         i += 1
-    return keys, num_args
+    return keys, num_args, key_types, pos_types
 
 
 def is_attr_protected(attrname: str) -> bool:

--- a/pylint/test/unittest_checker_strings.py
+++ b/pylint/test/unittest_checker_strings.py
@@ -7,7 +7,7 @@
 import astroid
 
 from pylint.checkers import strings
-from pylint.testutils import CheckerTestCase
+from pylint.testutils import CheckerTestCase, Message
 
 
 class TestStringChecker(CheckerTestCase):
@@ -18,3 +18,38 @@ class TestStringChecker(CheckerTestCase):
         node = astroid.extract_node(code)
         with self.assertNoMessages():
             self.checker.visit_call(node)
+
+    def test_format_types(self):
+        for code in ("'%s' % 1", "'%d' % 1", "'%f' % 1"):
+            with self.assertNoMessages():
+                node = astroid.extract_node(code)
+            self.checker.visit_binop(node)
+
+        for code in ("'%s' % 1",
+                     "'%(key)s' % {'key' : 1}",
+                     "'%d' % 1",
+                     "'%(key)d' % {'key' : 1}",
+                     "'%f' % 1",
+                     "'%(key)f' % {'key' : 1}",
+                     "'%d' % 1.1",
+                     "'%(key)d' % {'key' : 1.1}",
+                     "'%s' % []",
+                     "'%(key)s' % {'key' : []}",
+                     "'%s' % None",
+                     "'%(key)s' % {'key' : None}"):
+            with self.assertNoMessages():
+                node = astroid.extract_node(code)
+                self.checker.visit_binop(node)
+
+        for code, arg_type, format_type in [("'%d' % '1'",                'builtins.str',   'd'),
+                                            ("'%(key)d' % {'key' : '1'}", 'builtins.str',   'd'),
+                                            ("'%x' % 1.1",                'builtins.float', 'x'),
+                                            ("'%(key)x' % {'key' : 1.1}", 'builtins.float', 'x'),
+                                            ("'%d' % []",                 'builtins.list',  'd'),
+                                            ("'%(key)d' % {'key' : []}",  'builtins.list',  'd')]:
+            node = astroid.extract_node(code)
+            with self.assertAddsMessages(
+                    Message('bad-string-format-type',
+                            node=node,
+                            args=(arg_type, format_type))):
+                self.checker.visit_binop(node)


### PR DESCRIPTION
## Steps

- [X] Add yourself to CONTRIBUTORS if you are a new contributor.
- [X] Add a ChangeLog entry describing what your PR does.
- [X] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [X] Write a good description on what the PR does.

## Description

This commit detects situations when string format specifier does not match argument type as e.g. in
```
"%d" % '1'
```
I've been personally bitten by this several times so decided that this check deserves some attention.

I'll be happy to update/fix the patch if needed.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |