### PR TITLE
Added missin Info type to doc

### DIFF
--- a/doc/user_guide/output.rst
+++ b/doc/user_guide/output.rst
@@ -69,6 +69,7 @@ option.
 
 The message type can be:
 
+  * [I]nformational messages that Pylint emits (do not contribute to your analysis score)
   * [R]efactor for a "good practice" metric violation
   * [C]onvention for coding standard violation
   * [W]arning for stylistic problems, or minor programming issues


### PR DESCRIPTION
## Description
Added missing `info` type to the output documentation.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

## Related Issue
Closes #2466
