### PR TITLE
Grammar fixes to docs

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -109,9 +109,9 @@ contributors:
 * Mike Frysinger: contributor.
 
 * Moisés López (Vauxoo): Support for deprecated-modules in modules not installed,
-  Refactory wrong-import-order to integrate it with `isort` library
+  Refactor wrong-import-order to integrate it with `isort` library
   Add check too-complex with mccabe for cyclomatic complexity
-  Refactory wrong-import-position to skip try-import and nested cases
+  Refactor wrong-import-position to skip try-import and nested cases
   Add consider-merging-isinstance, superfluous-else-return
   Fix consider-using-ternary for 'True and True and True or True' case
 
@@ -229,3 +229,5 @@ contributors:
 * Hornwitser: fix import graph
 
 * Yuri Gribov: contributor
+
+* Drew Risinger: committer (docs)

--- a/ChangeLog
+++ b/ChangeLog
@@ -3602,7 +3602,7 @@ What's New in Pylint 0.5.0?
 
 Release date: 2004-10-19
 
-    * avoid to import analyzed modules !
+    * avoid importing analyzed modules !
 
     * new Refactor and Convention message categories. Some Warnings have been
       remaped into those new categories

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -428,7 +428,7 @@ missing-member-max-choices=1
 [VARIABLES]
 
 # List of additional names supposed to be defined in builtins. Remember that
-# you should avoid to define new builtins when possible.
+# you should avoid defining new builtins when possible.
 additional-builtins=
 
 # Tells whether unused global variables should be treated as a violation.

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -453,7 +453,7 @@ class VariablesChecker(BaseChecker):
                 {'default': (), 'type' : 'csv',
                  'metavar' : '<comma separated list>',
                  'help' : 'List of additional names supposed to be defined in '
-                          'builtins. Remember that you should avoid to define new builtins '
+                          'builtins. Remember that you should avoid defining new builtins '
                           'when possible.'
                 }),
                ("callbacks",

--- a/pylintrc
+++ b/pylintrc
@@ -127,7 +127,7 @@ init-import=no
 dummy-variables-rgx=_$|dummy
 
 # List of additional names supposed to be defined in builtins. Remember that
-# you should avoid to define new builtins when possible.
+# you should avoid defining new builtins when possible.
 additional-builtins=
 
 # List of strings which can identify a callback function by name. A callback


### PR DESCRIPTION
## Description

Fix grammar errors in pylintrc files and CONTRIBUTORS.txt.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

## Related Issue

NONE
