### PR TITLE
Json reporter improvment

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,4 +1,4 @@
-﻿Contributors
+Contributors
 ------------
 
 Current team:
@@ -233,3 +233,6 @@ contributors:
 * Drew Risinger: committer (docs)
 
 * Tomer Chachamu, Richard Goodman: simplifiable-if-expression
+
+* Alexandre GALODE (deusyss): contributor
+  Improve JSON reporter by adding score & reports output

--- a/ChangeLog
+++ b/ChangeLog
@@ -117,6 +117,8 @@ Release date: TBA
    * Fix wildcard import check not skipping `__init__.py`
 
      Close #2430
+     
+   * Improve JSON reporter by adding score & reports output
 
 
 What's New in Pylint 2.1.1?

--- a/doc/whatsnew/2.2.rst
+++ b/doc/whatsnew/2.2.rst
@@ -45,3 +45,5 @@ Other Changes
   ``unused-variable``, ``unused-import`` is emitted.
 
   Close #2421
+  
+* Improve JSON reporter by adding score & reports output

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -1563,6 +1563,7 @@ group are mutually exclusive.",
             linter.set_reporter(reporter)
         try:
             args = linter.load_command_line_configuration(args)
+            linter.reporter.cfg = linter.config
         except SystemExit as exc:
             if exc.code == 2:  # bad options
                 exc.code = 32

--- a/pylint/reporters/__init__.py
+++ b/pylint/reporters/__init__.py
@@ -54,6 +54,7 @@ class BaseReporter:
     def __init__(self, output=None):
         self.linter = None
         self.section = 0
+        self.cfg = None
         self.out = None
         self.out_encoding = None
         self.set_output(output)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ✓] Add yourself to CONTRIBUTORS if you are a new contributor.
- [✓ ] Add a ChangeLog entry describing what your PR does.
- [✓ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [✓ ] Write a good description on what the PR does.

## Description
Hi,

The aim of this PR is to allow to get reports and score outputs in JSON, by limiting code impact. Impacted files are:
  * lint.py (one more line)
  * reporters.\_\_init\_\_.py (one more line)
  * reporters.json.py (only update existing methods)

In json.py, i used `display_reports` to display score & reports in JSON.

To get a valid JSON, i also modified `display_messages` and add a `self.cfg` variable in `BaseReporter` class to get the possibility to know, in reporter object, what user asked in command line. To pass this information, a line was added in `lint.py`.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| x  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| x  | :hammer: Refactoring  |
| x  | :scroll: Docs |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
