### PR TITLE
fix compatibility with unreleased changes to stdlib tokenizer

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -239,3 +239,5 @@ contributors:
 * Benjamin Drung: contributing Debian Developer
 
 * Scott Worley: contributor
+
+* Michael Hudson-Doyle

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in Pylint 2.2?
 
 Release date: TBA
 
+   * Fix compatibility with changes to stdlib tokenizer.
+
    * ``pylint`` is less eager to consume the whole line for pragmas
 
      Close #2485

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -1074,7 +1074,10 @@ class FormatChecker(BaseTokenChecker):
     def _check_line_ending(self, line_ending, line_num):
         # check if line endings are mixed
         if self._last_line_ending is not None:
-            if line_ending != self._last_line_ending:
+            # line_ending == "" indicates a synthetic newline added at
+            # the end of a file that does not, in fact, end with a
+            # newline.
+            if line_ending and line_ending != self._last_line_ending:
                 self.add_message("mixed-line-endings", line=line_num)
 
         self._last_line_ending = line_ending


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

https://github.com/python/cpython/commit/c4ef4896eac86a6759901c8546e26de4695a1389
(not yet in any released version, but it's been backported to all
versions of Python in git, even 2.7!) changed the behaviour in the
stdlib's tokenize module to emit a synthetic NEWLINE token even if the
file does not end with a newline. This was causing a spurious
"mixed-line-endings" warning to be emitted, but luckily the synthetic
token is easy to test for (the token text is "").

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
