### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,12 +56,15 @@ Pylint can be simply installed by running::
 
     pip install pylint
 
+If you are using Python 3.6+, upgrade to get full support for your version::
+
+    pip install pylint --upgrade
 
 If you want to install from a source distribution, extract the tarball and run
 the following command ::
 
     python setup.py install
-
+    
 
 Do make sure to do the same for astroid, which is used internally by pylint.
 


### PR DESCRIPTION
## ChangeLog
Adds an entry to the installation instructions, instructing Python 3.6+ users to upgrade after installing via pip.

## Description
As given, the install instructions gather a version of PyLint which does not support all the features of Python 3.6.  For example, as of 11/3/2018, f-strings are not supported, and pyreverse3 will fail reporting a syntax error.  After running upgrade as prescribed in the new instructions, this problem is solved.

## Type of Changes
:scroll: Docs
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x ] Add a ChangeLog entry describing what your PR does.
- [x ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x ] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
