### PR TITLE
Flush output buffer after each line

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -247,3 +247,5 @@ contributors:
 * Lucas Cimon: contributor
 
 * Mike Miller: contributor
+
+* Daniel King: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -172,6 +172,8 @@ Release date: TBA
      Close #2019
 
    * Add a new check 'implicit-str-concat-in-sequence' to spot string concatenation inside lists, sets & tuples.
+   
+   * Flush output after each report line
 
 What's New in Pylint 2.1.1?
 ===========================

--- a/pylint/reporters/__init__.py
+++ b/pylint/reporters/__init__.py
@@ -69,7 +69,7 @@ class BaseReporter:
 
     def writeln(self, string=""):
         """write a line in the output buffer"""
-        print(string, file=self.out)
+        print(string, file=self.out, flush=True)
 
     def display_reports(self, layout):
         """display results encapsulated in the layout tree"""


### PR DESCRIPTION
Hi!

I use pylint like this:

```bash
pylint my_project  --score=n | tee $PYLINT_OUTPUT_FILE
diff $PYLINT_OUTPUT_FILE ignored-pylint-errors
```

So that I can ignore individual instances of errors. I use `tee` because I want to see the output in real-time on `stdout` in addition to storing the output in a file for later `diff`'ing. Unfortunately, `pylint` does not flush after printing each line, so the pipe gets buffered and I don't see any output until the pipe buffer is full (I think it defaults to 4KB?). This small change allows me to see output in real-time. I've tested this by modifying pylint with this patch, installing it, and using it as described above.

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description


## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |