### PR TITLE
Fixed literal-comparison for the case of 0 and 1

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -247,3 +247,5 @@ contributors:
 * Lucas Cimon: contributor
 
 * Mike Miller: contributor
+
+* Sergei Lebedev: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -173,6 +173,8 @@ Release date: TBA
 
    * Add a new check 'implicit-str-concat-in-sequence' to spot string concatenation inside lists, sets & tuples.
 
+   * ``literal-comparison`` is now emitted for 0 and 1 literals.
+
 What's New in Pylint 2.1.1?
 ===========================
 

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -2080,7 +2080,7 @@ class ComparisonChecker(_BasicChecker):
         is_other_literal = isinstance(literal, nodes)
         is_const = False
         if isinstance(literal, astroid.Const):
-            if literal.value in (True, False, None):
+            if isinstance(literal.value, bool) or literal.value is None:
                 # Not interested in this values.
                 return
             is_const = isinstance(literal.value, (bytes, str, int, float))

--- a/pylint/test/functional/literal_comparison.py
+++ b/pylint/test/functional/literal_comparison.py
@@ -32,8 +32,19 @@ if () is not {1, 2, 3}: # [literal-comparison]
     pass
 
 
+CONST = 24
+
+
+if CONST is 0: # [literal-comparison]
+    pass
+
+if CONST is 1: # [literal-comparison]
+    pass
+
+if CONST is 42: # [literal-comparison]
+    pass
+
 # We do not do inference for this check, since the comparing
 # object might be used as a sentinel.
-CONST = 24
 if () is CONST:
     pass

--- a/pylint/test/functional/literal_comparison.txt
+++ b/pylint/test/functional/literal_comparison.txt
@@ -8,3 +8,6 @@ literal-comparison:22::Comparison to literal
 literal-comparison:25::Comparison to literal
 literal-comparison:28::Comparison to literal
 literal-comparison:31::Comparison to literal
+literal-comparison:38::Comparison to literal
+literal-comparison:41::Comparison to literal
+literal-comparison:44::Comparison to literal


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Fixed literal-comparison for the case of 0 and 1

Prior to this commit literal-comparison did not fire for the following
comparisons

    x is 0
    x is 1

due to a subtle bug in the checker implementation. The skip condition
in the ``ComparisonChecker._check_literal_comparison`` was

    literal.value in (True, False, None)

which holds for True/False/None _as well as_ 0 and 1, since 0 == False
and 1 == True.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|  | :sparkles: New feature |
|   | :hammer: Refactoring  |
|  | :scroll: Docs |

## Related Issue

N/A
