### PR TITLE
Fix false-postive undefined-variable in nested lambda. (#2274)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,10 @@ Release date: |TBA|
 
       Close #1169
 
+   * Fix false-postive undefined-variable in nested lambda
+
+      Close #760
+
 
 What's New in Pylint 1.9.3?
 ===========================

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -239,7 +239,6 @@ def is_defined_before(var_node):
                 return True
             if getattr(_node, 'name', None) == varname:
                 return True
-            break
         elif isinstance(_node, astroid.ExceptHandler):
             if isinstance(_node.name, astroid.AssignName):
                 ass_node = _node.name

--- a/pylint/test/unittest_checker_variables.py
+++ b/pylint/test/unittest_checker_variables.py
@@ -180,6 +180,7 @@ class TestVariablesCheckerWithTearDown(CheckerTestCase):
         with self.assertNoMessages():
             self.walk(node)
 
+
     def test_scope_in_defaults(self):
         # Should not emit undefined variable
         node = astroid.extract_node('''
@@ -197,6 +198,18 @@ class TestVariablesCheckerWithTearDown(CheckerTestCase):
         node = astroid.extract_node('''
         def foof(x=lambda zoo: zoo):
             return x
+        ''')
+        with self.assertNoMessages():
+            self.walk(node)
+
+    def test_nested_lambda(self):
+        """Make sure variables from parent lambdas
+        aren't noted as undefined
+
+        https://github.com/PyCQA/pylint/issues/760
+        """
+        node = astroid.parse('''
+        lambda x: lambda: x + 1
         ''')
         with self.assertNoMessages():
             self.walk(node)


### PR DESCRIPTION
Remove unnecessary break in checker utils for lambdas causing parent lambdas to be ignored.

Close #760

## Description

Bugfix backport

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Backport of #760 fix, issue reported as #2595 