### PR TITLE
Fix zip-builtin-not-iterating false positive with OrderedDict

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -249,3 +249,5 @@ contributors:
 * Mike Miller: contributor
 
 * Sergei Lebedev: contributor
+
+* Sasha Bagan

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -83,6 +83,7 @@ _ACCEPTS_ITERATOR = {
     "max",
     "min",
     "frozenset",
+    "OrderedDict",
 }
 ATTRIBUTES_ACCEPTS_ITERATOR = {"join", "from_iterable"}
 _BUILTIN_METHOD_ACCEPTS_ITERATOR = {

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -214,6 +214,7 @@ class TestPython3Checker(testutils.CheckerTestCase):
             "all",
             "enumerate",
             "dict",
+            "OrderedDict",
         ):
             self.as_argument_to_callable_constructor_test(fxn, func)
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Currently pylint gets false-positive error (zip-builtin-not-iterating) on a line containing `OrderedDict(zip(...))`, even though OrderedDict is in `collections` and accepts iterator passed to it. This is very similar to following resolved issue https://github.com/PyCQA/pylint/issues/1803 with `reversed`, so the fix is the same, add `OrderedDict` to `_ACCEPTS_ITERATOR`

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
