### PR TITLE
Add ``no-else-raise`` warning (R1720)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,13 +7,18 @@ What's New in Pylint 2.3.0?
 
 Release date: TBA
 
-* Fix incorrect generation of ``no-else-raise`` warnings (R1705)
+* Add ``no-else-raise`` warning (R1720)
+
+  Close #2558
+
+* Fix incorrect generation of ``no-else-return`` warnings (R1705)
 
   Fixed issue where ``if`` statements with nested ``if`` statements
-  were incorrectly being flagged as ``no-else-raise`` in some cases and
-  not being flagged as ``no-else-raise`` in other cases.  Added tests
+  were incorrectly being flagged as ``no-else-return`` in some cases and
+  not being flagged as ``no-else-return`` in other cases.  Added tests
   for verification and updated pylint source files to eliminate newly
   exposed warnings.
+
 * Fix false positive with `not-async-context-manager` caused by not understanding `contextlib.asynccontextmanager`
 
   Close #2440

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -327,7 +327,7 @@ class Option(optparse.Option):
                 raise optparse.OptionError(
                     "must supply a list of choices for type 'choice'", self
                 )
-            elif not isinstance(self.choices, (tuple, list)):
+            if not isinstance(self.choices, (tuple, list)):
                 raise optparse.OptionError(
                     "choices must be a list of strings ('%s' supplied)"
                     % str(type(self.choices)).split("'")[1],

--- a/pylint/test/functional/no_else_raise.py
+++ b/pylint/test/functional/no_else_raise.py
@@ -1,0 +1,110 @@
+""" Test that superfluous else return are detected. """
+
+# pylint:disable=invalid-name,missing-docstring,unused-variable
+
+def foo1(x, y, z):
+    if x:  # [no-else-raise]
+        a = 1
+        raise Exception(y)
+    else:
+        b = 2
+        raise Exception(z)
+
+
+def foo2(x, y, w, z):
+    if x:  # [no-else-raise]
+        a = 1
+        raise Exception(y)
+    elif z:
+        b = 2
+        raise Exception(w)
+    else:
+        c = 3
+        raise Exception(z)
+
+
+def foo3(x, y, z):
+    if x:
+        a = 1
+        if y:  # [no-else-raise]
+            b = 2
+            raise Exception(y)
+        else:
+            c = 3
+            raise Exception(x)
+    else:
+        d = 4
+        raise Exception(z)
+
+
+def foo4(x, y):
+    if x: # [no-else-raise]
+        if y:
+            a = 4
+        else:
+            b = 2
+        raise Exception(x)
+    else:
+        c = 3
+    raise Exception(y)
+
+
+def foo5(x, y, z):
+    if x: # [no-else-raise]
+        if y:
+            a = 4
+        else:
+            b = 2
+        raise Exception(x)
+    elif z:
+        raise Exception(y)
+    else:
+        c = 3
+    raise Exception(z)
+
+
+def foo6(x, y):
+    if x:
+        if y:   # [no-else-raise]
+            a = 4
+            raise Exception(x)
+        else:
+            b = 2
+    else:
+        c = 3
+    raise Exception(y)
+
+
+def bar1(x, y, z):
+    if x:
+        raise Exception(y)
+    raise Exception(z)
+
+
+def bar2(w, x, y, z):
+    if x:
+        raise Exception(y)
+    if z:
+        a = 1
+    else:
+        raise Exception(w)
+    raise Exception(None)
+
+
+def bar3(x, y, z):
+    if x:
+        if z:
+            raise Exception(y)
+    else:
+        raise Exception(z)
+    raise Exception(None)
+
+
+def bar4(x):
+    if x:  # [no-else-raise]
+        raise Exception(True)
+    else:
+        try:
+            raise Exception(False)
+        except ValueError:
+            raise Exception(None)

--- a/pylint/test/functional/no_else_raise.txt
+++ b/pylint/test/functional/no_else_raise.txt
@@ -1,0 +1,7 @@
+no-else-raise:6:foo1:Unnecessary "else" after "raise"
+no-else-raise:15:foo2:Unnecessary "elif" after "raise"
+no-else-raise:29:foo3:Unnecessary "else" after "raise"
+no-else-raise:41:foo4:Unnecessary "else" after "raise"
+no-else-raise:53:foo5:Unnecessary "elif" after "raise"
+no-else-raise:68:foo6:Unnecessary "else" after "raise"
+no-else-raise:104:bar4:Unnecessary "else" after "raise"


### PR DESCRIPTION
## Steps

- [X] Add yourself to CONTRIBUTORS if you are a new contributor.
- [X] Add a ChangeLog entry describing what your PR does.
- [X] Write a good description on what the PR does.

## Description
Add ``no-else-raise`` warning for else statements that are unnecessary due to a raise statement within the previous if statement.  Added as R1720.

Fixed up ChangeLog comments from previous submit; that submit was for 'return', not 'raise'.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

Closes #2558
