### PR TITLE
Fix false positive Non-iterable value with async comprehensions

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -252,3 +252,6 @@ contributors:
 * Sergei Lebedev: contributor
 
 * Sasha Bagan
+
+* Pablo Galindo Salgado: contributor
+  Fix false positive 'Non-iterable value' with async comprehensions.

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1614,17 +1614,17 @@ class IterableChecker(BaseChecker):
     @check_messages("not-an-iterable")
     def visit_dictcomp(self, node):
         for gen in node.generators:
-            self._check_iterable(gen.iter)
+            self._check_iterable(gen.iter, check_async=gen.is_async)
 
     @check_messages("not-an-iterable")
     def visit_setcomp(self, node):
         for gen in node.generators:
-            self._check_iterable(gen.iter)
+            self._check_iterable(gen.iter, check_async=gen.is_async)
 
     @check_messages("not-an-iterable")
     def visit_generatorexp(self, node):
         for gen in node.generators:
-            self._check_iterable(gen.iter)
+            self._check_iterable(gen.iter, check_async=gen.is_async)
 
 
 def register(linter):

--- a/pylint/test/functional/iterable_context_py36.py
+++ b/pylint/test/functional/iterable_context_py36.py
@@ -26,3 +26,16 @@ async def count_to(number):
     """ counts to n in async manner"""
     async for i in some_iter_func(number):
         print(i)
+
+
+async def gen_values(num_values):
+    for value in range(num_values):
+        yield value
+
+
+async def do_some_comprehensions():
+    sets = {elem async for elem in gen_values(10)}
+    lists = [elem async for elem in gen_values(10)]
+    dicts = {elem: elem async for elem in gen_values(10)}
+    gen = (elem async for elem in gen_values(10))
+    return sets, lists, dicts, gen


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

This PR fixes #2637 by adding a missing a `check_async` parameter when checking async comprehensions. It also adds a new test for all the async comprehensions.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #2637 

