### PR TITLE
Load plugin configuration hook

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -255,3 +255,5 @@ contributors:
 
 * Pablo Galindo Salgado: contributor
   Fix false positive 'Non-iterable value' with async comprehensions.
+
+* Matus Valo

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,16 @@ What's New in Pylint 2.3.0?
 
 Release date: TBA
 
+* Added ``load_configuration()`` hook for plugins
+
+  New optional hook for plugins is added: ``load_configuration()``.
+  This hook is executed after configuration is loaded to prevent
+  overwriting plugin specific configuration via user-based
+  configuration.
+
+  Close #2635
+
+
 * Add ``no-else-raise`` warning (R1720)
 
   Close #2558

--- a/doc/how_tos/plugins.rst
+++ b/doc/how_tos/plugins.rst
@@ -53,7 +53,7 @@ We can extend hello-world plugin to ignore some specific names using
     name_checker.config.good_names += ('Hello', 'World')
 
     # We ignore bin directory
-    linter.config.black_list += ('bin')
+    linter.config.black_list += ('bin',)
 
 Depending if we need a **transform plugin** or a **checker**, this might not
 be enough. For the former, this is enough to declare the module as a plugin,

--- a/doc/how_tos/plugins.rst
+++ b/doc/how_tos/plugins.rst
@@ -14,6 +14,12 @@ and tailored to a particular module, library of framework.
 In general, a plugin is a module which should have a function ``register``,
 which takes an instance of ``pylint.lint.PyLinter`` as input.
 
+A plugin can optionally define also function ``load_configuration``,
+which takes an instance of ``pylint.lint.PyLinter`` as input. This
+function is called after Pylint loads configuration from configuration
+file and command line interface. This function should load additional
+plugin specific configuration to Pylint.
+
 So a basic hello-world plugin can be implemented as:
 
 .. sourcecode:: python
@@ -22,6 +28,7 @@ So a basic hello-world plugin can be implemented as:
   def register(linter):
     print 'Hello world'
 
+
 We can run this plugin by placing this module in the PYTHONPATH and invoking
 **pylint** as:
 
@@ -29,6 +36,24 @@ We can run this plugin by placing this module in the PYTHONPATH and invoking
 
   $ pylint -E --load-plugins hello_plugin foo.py
   Hello world
+
+We can extend hello-world plugin to ignore some specific names using
+``load_configuration`` function:
+
+.. sourcecode:: python
+
+  # Inside hello_plugin.py
+  def register(linter):
+    print 'Hello world'
+
+  def load_configuration(linter):
+
+    name_checker = get_checker(linter, NameChecker)
+    # We consider as good names of variables Hello and World
+    name_checker.config.good_names += ('Hello', 'World')
+
+    # We ignore bin directory
+    linter.config.black_list += ('bin')
 
 Depending if we need a **transform plugin** or a **checker**, this might not
 be enough. For the former, this is enough to declare the module as a plugin,

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -661,7 +661,7 @@ class PyLinter(
         """
         for modname in self._dynamic_plugins:
             module = modutils.load_module_from_name(modname)
-            if hasattr(module, 'load_configuration'):
+            if hasattr(module, "load_configuration"):
                 module.load_configuration(self)
 
     def _load_reporter(self):

--- a/pylint/test/regrtest_data/dummy_plugin/dummy_conf_plugin.py
+++ b/pylint/test/regrtest_data/dummy_plugin/dummy_conf_plugin.py
@@ -1,0 +1,6 @@
+def register(linter):
+    pass
+
+
+def load_configuration(linter):
+    linter.config.black_list += ('bin',)

--- a/pylint/test/unittest_lint.py
+++ b/pylint/test/unittest_lint.py
@@ -511,6 +511,56 @@ def test_addmessage_invalid(linter):
     assert str(cm.value) == "Message C0321 must provide Node, got None"
 
 
+def test_load_plugin_command_line():
+    dummy_plugin_path = join(HERE, "regrtest_data", "dummy_plugin")
+    sys.path.append(dummy_plugin_path)
+
+    run = Run(
+        ["--load-plugins", "dummy_plugin", join(HERE, "regrtest_data", "empty.py")],
+        do_exit=False,
+    )
+    assert (
+        len([ch.name for ch in run.linter.get_checkers() if ch.name == "dummy_plugin"])
+        == 2
+    )
+
+    sys.path.remove(dummy_plugin_path)
+
+
+def test_load_plugin_config_file():
+    dummy_plugin_path = join(HERE, "regrtest_data", "dummy_plugin")
+    sys.path.append(dummy_plugin_path)
+    config_path = join(HERE, "regrtest_data", "dummy_plugin.rc")
+
+    run = Run(
+        ["--rcfile", config_path, join(HERE, "regrtest_data", "empty.py")],
+        do_exit=False,
+    )
+    assert (
+        len([ch.name for ch in run.linter.get_checkers() if ch.name == "dummy_plugin"])
+        == 2
+    )
+
+    sys.path.remove(dummy_plugin_path)
+
+
+def test_load_plugin_configuration():
+    dummy_plugin_path = join(HERE, "regrtest_data", "dummy_plugin")
+    sys.path.append(dummy_plugin_path)
+
+    run = Run(
+        [
+            "--load-plugins",
+            "dummy_conf_plugin",
+            "--ignore",
+            "foo,bar",
+            join(HERE, "regrtest_data", "empty.py"),
+        ],
+        do_exit=False,
+    )
+    assert run.linter.config.black_list == ["foo", "bar", "bin"]
+
+
 def test_init_hooks_called_before_load_plugins():
     with pytest.raises(RuntimeError):
         Run(["--load-plugins", "unexistant", "--init-hook", "raise RuntimeError"])


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [✓] Add yourself to CONTRIBUTORS if you are a new contributor.
- [✓] Add a ChangeLog entry describing what your PR does.
- [✓] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [✓] Write a good description on what the PR does.

## Description

Added ``load_configuration()`` hook for plugins.
    
New optional hook for plugins is added: ``load_configuration()``. This hook is called by pylint after configuration is loaded to prevent against overwriting plugin specific configuration via user-based configuration. Plugins are supposed to adjust configuration e.g. by extending ``good_names`` or extending ``black_list``, etc...


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓ | :bug: Bug fix  |
| ✓ | :sparkles: New feature |
|    | :hammer: Refactoring  |
| ✓ | :scroll: Docs |

## Related Issue
Closes #2635  
<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes ####
-->
