### PR TITLE
Fix missing-raises-doc false positive (W9006)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,10 @@ Release date: TBA
 
   Close #2635
 
+* Fix missing-raises-doc false positive (W9006)
+
+  Close #1502
+
 * Exempt starred unpacking from ``*-not-iterating`` Python 3 checks
 
   Close #2651

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -102,7 +102,7 @@ def returns_something(return_node):
 def _get_raise_target(node):
     if isinstance(node.exc, astroid.Call):
         func = node.exc.func
-        if isinstance(func, astroid.Name) or isinstance(func, astroid.Attribute):
+        if isinstance(func, (astroid.Name, astroid.Attribute)):
             return utils.safe_infer(func)
     return None
 
@@ -229,7 +229,10 @@ class Docstring:
 
 
 class SphinxDocstring(Docstring):
-    re_type = r"[\w\.]+"
+    re_type = r"""
+        [~!]?                # Optional link style prefix
+        \w(?:\w|\.[^\.])*    # Valid python name
+        """
 
     re_simple_container_type = r"""
         {type}                        # a container type
@@ -294,13 +297,7 @@ class SphinxDocstring(Docstring):
         except|exception
         )
         \s+                     # whitespace
-
-        (?:                     # type declaration
-        ({type})
-        \s+
-        )?
-
-        (\w(?:\w|\.[^\.])+)     # Parameter name can include '.', e.g. re.error
+        ({type})                # exception type
         \s*                     # whitespace
         :                       # final colon
         """.format(
@@ -327,7 +324,7 @@ class SphinxDocstring(Docstring):
         types = set()
 
         for match in re.finditer(self.re_raise_in_docstring, self.doc):
-            raise_type = match.group(2)
+            raise_type = match.group(1)
             types.add(raise_type)
 
         return types

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -102,7 +102,7 @@ def returns_something(return_node):
 def _get_raise_target(node):
     if isinstance(node.exc, astroid.Call):
         func = node.exc.func
-        if isinstance(func, (astroid.Name, astroid.Attribute)):
+        if isinstance(func, astroid.Name) or isinstance(func, astroid.Attribute):
             return utils.safe_infer(func)
     return None
 

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -252,6 +252,7 @@ class DocstringParameterChecker(BaseChecker):
             return
 
         expected_excs = utils.possible_exc_types(node)
+
         if not expected_excs:
             return
 
@@ -269,6 +270,7 @@ class DocstringParameterChecker(BaseChecker):
             return
 
         found_excs_full_names = doc.exceptions()
+
         # Extract just the class name, e.g. "error" from "re.error"
         found_excs_class_names = {exc.split(".")[-1] for exc in found_excs_full_names}
         missing_excs = expected_excs - found_excs_class_names

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -268,8 +268,10 @@ class DocstringParameterChecker(BaseChecker):
                 self._handle_no_raise_doc(expected_excs, func_node)
             return
 
-        found_excs = doc.exceptions()
-        missing_excs = expected_excs - found_excs
+        found_excs_full_names = doc.exceptions()
+        # Extract just the class name, e.g. "error" from "re.error"
+        found_excs_class_names = {exc.split(".")[-1] for exc in found_excs_full_names}
+        missing_excs = expected_excs - found_excs_class_names
         self._add_raise_message(missing_excs, func_node)
 
     def visit_return(self, node):

--- a/pylint/test/extensions/test_check_raise_docs.py
+++ b/pylint/test/extensions/test_check_raise_docs.py
@@ -156,6 +156,23 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
+    @set_config(accept_no_raise_doc=False)
+    def test_google_raises_with_prefix(self):
+        code_snippet = '''
+        def my_func(self):
+            """This is a google docstring.
+
+            Raises:
+                {prefix}re.error: Sometimes
+            """
+            import re
+            raise re.error('hi') #@
+        '''
+        for prefix in ["~", "!"]:
+            raise_node = astroid.extract_node(code_snippet.format(prefix=prefix))
+            with self.assertNoMessages():
+                self.checker.visit_raise(raise_node)
+
     def test_find_missing_numpy_raises(self):
         node = astroid.extract_node('''
         def my_func(self):
@@ -510,6 +527,24 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
+    @set_config(accept_no_raise_doc=False)
+    def test_numpy_raises_with_prefix(self):
+        code_snippet = '''
+        def my_func(self):
+            """This is a numpy docstring.
+
+            Raises
+            ------
+            {prefix}re.error
+                Sometimes
+            """
+            import re
+            raise re.error('hi') #@
+        '''
+        for prefix in ["~", "!"]:
+            raise_node = astroid.extract_node(code_snippet.format(prefix=prefix))
+            with self.assertNoMessages():
+                self.checker.visit_raise(raise_node)
 
     def test_find_missing_sphinx_raises_infer_from_instance(self):
         raise_node = astroid.extract_node('''
@@ -562,7 +597,6 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         ''')
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
-        pass
 
     def test_find_sphinx_attr_raises_substr_exc(self):
         raise_node = astroid.extract_node('''
@@ -610,6 +644,25 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
+    @set_config(accept_no_raise_doc=False)
+    def test_sphinx_raises_with_prefix(self):
+        code_snippet = '''
+        def my_func(self):
+            """This is a sphinx docstring.
+
+            :raises {prefix}re.error: Sometimes
+            """
+            import re
+            raise re.error('hi') #@
+        '''
+        for prefix in ["~", "!"]:
+            raise_node = astroid.extract_node(code_snippet.format(prefix=prefix))
+            with self.assertNoMessages():
+                self.checker.visit_raise(raise_node)
+
+
+        with self.assertNoMessages():
+            self.checker.visit_raise(raise_node)
 
     def test_ignores_raise_uninferable(self):
         raise_node = astroid.extract_node('''

--- a/pylint/test/extensions/test_check_raise_docs.py
+++ b/pylint/test/extensions/test_check_raise_docs.py
@@ -92,6 +92,70 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 args=('RuntimeError', ))):
             self.checker.visit_raise(raise_node)
 
+    def test_find_google_attr_raises_exact_exc(self):
+        raise_node = astroid.extract_node('''
+        def my_func(self):
+            """This is a google docstring.
+
+            Raises:
+                re.error: Sometimes
+            """
+            import re
+            raise re.error('hi')  #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_raise(raise_node)
+        pass
+
+    def test_find_google_attr_raises_substr_exc(self):
+        raise_node = astroid.extract_node('''
+        def my_func(self):
+            """This is a google docstring.
+
+            Raises:
+                re.error: Sometimes
+            """
+            from re import error
+            raise error('hi')  #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_raise(raise_node)
+
+    def test_find_valid_missing_google_attr_raises(self):
+        node = astroid.extract_node('''
+        def my_func(self):
+            """This is a google docstring.
+
+            Raises:
+                re.anothererror: Sometimes
+            """
+            from re import error
+            raise error('hi')
+        ''')
+        raise_node = node.body[1]
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-raises-doc',
+                node=node,
+                args=('error', ))):
+            self.checker.visit_raise(raise_node)
+
+    def test_find_invalid_missing_google_attr_raises(self):
+        raise_node = astroid.extract_node('''
+        def my_func(self):
+            """This is a google docstring.
+
+            Raises:
+                bogusmodule.error: Sometimes
+            """
+            from re import error
+            raise error('hi') #@
+        ''')
+        # pylint allows this to pass since the comparison between Raises and
+        # raise are based on the class name, not the qualified name.
+        with self.assertNoMessages():
+            self.checker.visit_raise(raise_node)
+
     def test_find_missing_numpy_raises(self):
         node = astroid.extract_node('''
         def my_func(self):
@@ -357,7 +421,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
     def test_ignores_caught_numpy_raises(self):
         raise_node = astroid.extract_node('''
         def my_func(self):
-            """This is a docstring.
+            """This is a numpy docstring.
 
             Raises
             ------
@@ -373,6 +437,79 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         ''')
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
+
+    def test_find_numpy_attr_raises_exact_exc(self):
+        raise_node = astroid.extract_node('''
+        def my_func(self):
+            """This is a numpy docstring.
+
+            Raises
+            ------
+            re.error
+                Sometimes
+            """
+            import re
+            raise re.error('hi')  #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_raise(raise_node)
+        pass
+
+    def test_find_numpy_attr_raises_substr_exc(self):
+        raise_node = astroid.extract_node('''
+        def my_func(self):
+            """This is a numpy docstring.
+
+            Raises
+            ------
+            re.error
+                Sometimes
+            """
+            from re import error
+            raise error('hi')  #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_raise(raise_node)
+
+    def test_find_valid_missing_numpy_attr_raises(self):
+        node = astroid.extract_node('''
+        def my_func(self):
+            """This is a numpy docstring.
+
+            Raises
+            ------
+            re.anothererror
+                Sometimes
+            """
+            from re import error
+            raise error('hi')
+        ''')
+        raise_node = node.body[1]
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-raises-doc',
+                node=node,
+                args=('error', ))):
+            self.checker.visit_raise(raise_node)
+
+    def test_find_invalid_missing_numpy_attr_raises(self):
+        raise_node = astroid.extract_node('''
+        def my_func(self):
+            """This is a numpy docstring.
+
+            Raises
+            ------
+            bogusmodule.error
+                Sometimes
+            """
+            from re import error
+            raise error('hi') #@
+        ''')
+        # pylint allows this to pass since the comparison between Raises and
+        # raise are based on the class name, not the qualified name.
+        with self.assertNoMessages():
+            self.checker.visit_raise(raise_node)
+
 
     def test_find_missing_sphinx_raises_infer_from_instance(self):
         raise_node = astroid.extract_node('''
@@ -412,6 +549,67 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 node=node,
                 args=('RuntimeError', ))):
             self.checker.visit_raise(raise_node)
+
+    def test_find_sphinx_attr_raises_exact_exc(self):
+        raise_node = astroid.extract_node('''
+        def my_func(self):
+            """This is a sphinx docstring.
+
+            :raises re.error: Sometimes
+            """
+            import re
+            raise re.error('hi')  #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_raise(raise_node)
+        pass
+
+    def test_find_sphinx_attr_raises_substr_exc(self):
+        raise_node = astroid.extract_node('''
+        def my_func(self):
+            """This is a sphinx docstring.
+
+            :raises re.error: Sometimes
+            """
+            from re import error
+            raise error('hi')  #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_raise(raise_node)
+
+    def test_find_valid_missing_sphinx_attr_raises(self):
+        node = astroid.extract_node('''
+        def my_func(self):
+            """This is a sphinx docstring.
+
+            :raises re.anothererror: Sometimes
+            """
+            from re import error
+            raise error('hi')
+        ''')
+        raise_node = node.body[1]
+        with self.assertAddsMessages(
+            Message(
+                msg_id='missing-raises-doc',
+                node=node,
+                args=('error', ))):
+            self.checker.visit_raise(raise_node)
+
+    def test_find_invalid_missing_sphinx_attr_raises(self):
+        raise_node = astroid.extract_node('''
+        def my_func(self):
+            """This is a sphinx docstring.
+
+            :raises bogusmodule.error: Sometimes
+            """
+            from re import error
+            raise error('hi') #@
+        ''')
+        # pylint allows this to pass since the comparison between Raises and
+        # raise are based on the class name, not the qualified name.
+        with self.assertNoMessages():
+            self.checker.visit_raise(raise_node)
+
 
     def test_ignores_raise_uninferable(self):
         raise_node = astroid.extract_node('''


### PR DESCRIPTION
Updated checking of missing Raises to check exceptions that have
absolute paths.

Close #1502

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
This PR checks that the 'Raises' docstring matches the actual exceptions raised.  As suggested in #1502, it does a string-based comparison on the class name only since there's no straightforward mechanism to get an astroid NODE for the text in the 'Raises' clause.

If this PR is accepted then there should be (at least) two other issues opened:

1. missing-raise-doc warnings don't correctly check the fully qualified class names.
2. The syntax for what's allowed as the exception name in the Raises portion of the docstring should be updated to reflect usage; at minimum '~' should be allowed.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue


Closes #1502  
