### PR TITLE
Issue tbd invalid import

### DIFF
--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -206,16 +206,24 @@ def _fix_dot_imports(not_consumed):
                 continue
             for imports in stmt.names:
                 second_name = None
-                if imports[0] == "*":
+                import_module_name = imports[0]
+                if import_module_name == "*":
                     # In case of wildcard imports,
                     # pick the name from inside the imported module.
                     second_name = name
                 else:
-                    if imports[0].find(".") > -1 or name in imports:
+                    name_matches_dotted_import = False
+                    if (
+                        import_module_name.startswith(name)
+                        and import_module_name.find(".") > -1
+                    ):
+                        name_matches_dotted_import = True
+
+                    if name_matches_dotted_import or name in imports:
                         # Most likely something like 'xml.etree',
                         # which will appear in the .locals as 'xml'.
                         # Only pick the name if it wasn't consumed.
-                        second_name = imports[0]
+                        second_name = import_module_name
                 if second_name and second_name not in names:
                     names[second_name] = stmt
     return sorted(names.items(), key=lambda a: a[1].fromlineno)

--- a/pylint/test/functional/no_else_raise.py
+++ b/pylint/test/functional/no_else_raise.py
@@ -20,7 +20,7 @@ def foo2(x, y, w, z):
         raise Exception(w)
     else:
         c = 3
-        raise Exception(z)
+        return z
 
 
 def foo3(x, y, z):
@@ -31,7 +31,7 @@ def foo3(x, y, z):
             raise Exception(y)
         else:
             c = 3
-            raise Exception(x)
+            return x
     else:
         d = 4
         raise Exception(z)
@@ -60,7 +60,7 @@ def foo5(x, y, z):
         raise Exception(y)
     else:
         c = 3
-    raise Exception(z)
+    return z
 
 
 def foo6(x, y):

--- a/pylint/test/functional/no_else_return.py
+++ b/pylint/test/functional/no_else_return.py
@@ -20,7 +20,7 @@ def foo2(x, y, w, z):
         return w
     else:
         c = 3
-        return z
+        raise Exception(z)
 
 
 def foo3(x, y, z):
@@ -31,7 +31,7 @@ def foo3(x, y, z):
             return y
         else:
             c = 3
-            return x
+            raise Exception(x)
     else:
         d = 4
         return z
@@ -60,7 +60,7 @@ def foo5(x, y, z):
         c = 2
     else:
         c = 3
-    return
+    raise Exception(x)
 
 
 def foo6(x, y):

--- a/pylint/test/functional/unused_import.py
+++ b/pylint/test/functional/unused_import.py
@@ -1,5 +1,5 @@
 """unused import"""
-# pylint: disable=undefined-all-variable, import-error, no-absolute-import, too-few-public-methods, missing-docstring,wrong-import-position, useless-object-inheritance
+# pylint: disable=undefined-all-variable, import-error, no-absolute-import, too-few-public-methods, missing-docstring,wrong-import-position, useless-object-inheritance, multiple-imports
 import xml.etree  # [unused-import]
 import xml.sax  # [unused-import]
 import os.path as test  # [unused-import]
@@ -7,6 +7,7 @@ from sys import argv as test2  # [unused-import]
 from sys import flags  # [unused-import]
 # +1:[unused-import,unused-import]
 from collections import deque, OrderedDict, Counter
+import re, html.parser  # [unused-import]
 DATA = Counter()
 
 from fake import SomeName, SomeOtherName  # [unused-import]
@@ -33,3 +34,6 @@ def get_ordered_dict() -> 'collections.OrderedDict':
 
 def get_itertools_obj() -> 'itertools.count':
     return []
+
+def use_html_parser() -> 'html.parser.HTMLParser':
+    return html.parser.HTMLParser

--- a/pylint/test/functional/unused_import.txt
+++ b/pylint/test/functional/unused_import.txt
@@ -5,4 +5,5 @@ unused-import:6::Unused argv imported from sys as test2
 unused-import:7::Unused flags imported from sys
 unused-import:9::Unused OrderedDict imported from collections
 unused-import:9::Unused deque imported from collections
-unused-import:12::Unused SomeOtherName imported from fake
+unused-import:10::Unused import re
+unused-import:13::Unused SomeOtherName imported from fake


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Write a good description on what the PR does.

## Description

This PR has two checkins:

1. Adds mixed no-else-return and no-else-raise testing as suggested in issue #2558.
2. Fixes minor bug whereby multi-line import statements would flag the incorrect import statement

Repro for item (2) above:

Given the following input:
```
import re, os.path

print(os.path.exists("/"))
```

pylint output was:

```
eg.py:1:0: C0410: Multiple imports on one line (re, os.path) (multiple-imports)
eg.py:1:0: W0611: Unused import re (unused-import)
eg.py:1:0: W0611: Unused import os.path (unused-import)
```

The third line above regardong unused os.path is incorrect; this PR fixes that incorrect assignment.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

Adds additional testing for #2558 
