### PR TITLE
Expose/export BaseTokenChecker in __all__ as well?

### DIFF
--- a/pylint/checkers/__init__.py
+++ b/pylint/checkers/__init__.py
@@ -131,4 +131,4 @@ def initialize(linter):
     register_plugins(linter, __path__[0])
 
 
-__all__ = ("BaseChecker", "initialize")
+__all__ = ("BaseChecker", "BaseTokenChecker", "initialize")


### PR DESCRIPTION
Hi,

I was using `BaseTokenChecker` when my IDE complained it wasn't in the `__init__`'s `__all__` variable. Any reason for not having it there? Learned about `BaseTokenChecker` after finding it in [another checker that uses it too](https://github.com/PyCQA/pylint/blob/master/pylint/extensions/check_elif.py).

Cheers
Bruno

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
