### PR TITLE
Don't recurse in inherit_from_std_ex

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -261,3 +261,5 @@ contributors:
 * Sardorbek Imomaliev: contributor
 
 * Justin Li (justinnhli)
+
+* Nathan Marrow

--- a/ChangeLog
+++ b/ChangeLog
@@ -79,6 +79,10 @@ Release date: TBA
   Previous version incorrectly detects `a < b < c and b < d` and fails to
   detect `a < b < c and c < d`.
 
+* Fix crash when calling ``inherit_from_std_ex`` on a class which is its own ancestor
+
+  Close #2680
+
 What's New in Pylint 2.2.2?
 ===========================
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -668,14 +668,17 @@ def inherit_from_std_ex(node: astroid.node_classes.NodeNG) -> bool:
     Return true if the given class node is subclass of
     exceptions.Exception.
     """
-    if (
-        node.name in ("Exception", "BaseException")
-        and node.root().name == EXCEPTIONS_MODULE
-    ):
-        return True
     if not hasattr(node, "ancestors"):
-        return False
-    return any(inherit_from_std_ex(parent) for parent in node.ancestors(recurs=True))
+        ancestors = []
+    else:
+        ancestors = node.ancestors()
+    for ancestor in itertools.chain([node], ancestors):
+        if (
+            ancestor.name in ("Exception", "BaseException")
+            and ancestor.root().name == EXCEPTIONS_MODULE
+        ):
+            return True
+    return False
 
 
 def error_of_type(handler: astroid.ExceptHandler, error_type) -> bool:

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -668,10 +668,7 @@ def inherit_from_std_ex(node: astroid.node_classes.NodeNG) -> bool:
     Return true if the given class node is subclass of
     exceptions.Exception.
     """
-    if not hasattr(node, "ancestors"):
-        ancestors = []
-    else:
-        ancestors = node.ancestors()
+    ancestors = node.ancestors() if hasattr(node, "ancestors") else []
     for ancestor in itertools.chain([node], ancestors):
         if (
             ancestor.name in ("Exception", "BaseException")

--- a/pylint/test/unittest_checkers_utils.py
+++ b/pylint/test/unittest_checkers_utils.py
@@ -170,3 +170,18 @@ def test_parse_format_method_string():
         keys, num_args, pos_args = utils.parse_format_method_string(fmt)
         keyword_args = len(set(k for k, l in keys if not isinstance(k, int)))
         assert keyword_args + num_args + pos_args == count
+
+
+def test_inherit_from_std_ex_recursive_definition():
+    node = astroid.extract_node(
+        """
+      import datetime
+      class First(datetime.datetime):
+        pass
+      class Second(datetime.datetime): #@
+        pass
+      datetime.datetime = First
+      datetime.datetime = Second
+      """
+    )
+    assert not utils.inherit_from_std_ex(node)


### PR DESCRIPTION
## Description

Commit 79c71de changed inherit_from_std_ex to pass recurs=True to the
call to ancestors. Since the ancestors call now recurses, there is no
need for the inherit_from_std_ex function to recurse as well, especially
since ancestors handles circular references (A inherits from B which
inherits from A).

This fixes #2680 so that calling `inherit_from_std_ex` for each classdef in the following code works:
```
import datetime
class MyDate(datetime.datetime):
  pass
class MyDate2(datetime.datetime):
  pass

datetime.datetime = MyDate
datetime.datetime = MyDate2
```

Here I'm assuming that this code:
```
def do_check(node):
 if test_fn(node): return True
 for ancestor in node.ancestors(recurs=False):
  return do_check(ancestor)
 return False
```
would be equivalent to:
```
def do_check(node):
  if test_fn(node): return True
  return any(test_fn(ancestor) for ancestor in node.ancestors(recurs=True)
```

If this assumption is incorrect, then my change is wrong.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue


Closes #2680 

