### PR TITLE
avoid popping __main__

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -261,3 +261,5 @@ contributors:
 * Sardorbek Imomaliev: contributor
 
 * Justin Li (justinnhli)
+
+* Nicolas Dickreuter

--- a/ChangeLog
+++ b/ChangeLog
@@ -83,6 +83,10 @@ Release date: TBA
   Previous version incorrectly detects `a < b < c and b < d` and fails to
   detect `a < b < c and c < d`.
 
+ * Avoid popping __main__ when using multiple jobs for python >= 3.3
+
+ Close #2689
+
 What's New in Pylint 2.2.2?
 ===========================
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -83,7 +83,7 @@ Release date: TBA
   Previous version incorrectly detects `a < b < c and b < d` and fails to
   detect `a < b < c and c < d`.
 
- * Avoid popping __main__ when using multiple jobs for python >= 3.3
+ * Avoid popping __main__ when using multiple jobs
 
  Close #2689
 

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -149,7 +149,7 @@ def _patch_sysmodules():
     try:
         yield
     finally:
-        if mock_main:
+        if mock_main and sys.version_info < (3, 3):
             sys.modules.pop("__main__")
 
 

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -146,11 +146,7 @@ def _patch_sysmodules():
     if mock_main:
         sys.modules["__main__"] = sys.modules[__name__]
 
-    try:
-        yield
-    finally:
-        if mock_main and sys.version_info < (3, 3):
-            sys.modules.pop("__main__")
+    yield
 
 
 # Python Linter class #########################################################

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -135,20 +135,6 @@ def _merge_stats(stats):
     return merged
 
 
-@contextlib.contextmanager
-def _patch_sysmodules():
-    # Context manager that permits running pylint, on Windows, with -m switch
-    # and with --jobs, as in 'python -2 -m pylint .. --jobs'.
-    # For more details why this is needed,
-    # see Python issue http://bugs.python.org/issue10845.
-
-    mock_main = __name__ != "__main__"  # -m switch
-    if mock_main:
-        sys.modules["__main__"] = sys.modules[__name__]
-
-    yield
-
-
 # Python Linter class #########################################################
 
 MSGS = {
@@ -949,8 +935,7 @@ class PyLinter(
         if self.config.jobs == 1:
             self._do_check(files_or_modules)
         else:
-            with _patch_sysmodules():
-                self._parallel_check(files_or_modules)
+            self._parallel_check(files_or_modules)
 
     def _get_jobs_config(self):
         child_config = collections.OrderedDict()


### PR DESCRIPTION
## Description
Avoid popping __main__ when using multiple jobs.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #2689 
