### PR TITLE
Take into account __class_getitem__ from PEP 560

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -263,3 +263,5 @@ contributors:
 * Justin Li (justinnhli)
 
 * Nicolas Dickreuter
+
+* Pascal Corpet

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in Pylint 2.3.0?
 
 Release date: TBA
 
+* Fixed false positives for ``no-self-argument`` and ``unsubscriptable-object`` when using ``__class_getitem__`` (new in Python 3.7)
+
+  Close #2416
+
 * ``fixme`` gets triggered only on comments.
 
   Close #2321

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -1407,7 +1407,7 @@ a metaclass class method.",
         # regular class
         else:
             # class method
-            if node.type == "classmethod":
+            if node.type == "classmethod" or node.name == "__class_getitem__":
                 self._check_first_arg_config(
                     first,
                     self.config.valid_classmethod_first_arg,

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -329,7 +329,7 @@ MSGS = {
         "Value '%s' is unsubscriptable",
         "unsubscriptable-object",
         "Emitted when a subscripted value doesn't support subscription "
-        "(i.e. doesn't define __getitem__ method).",
+        "(i.e. doesn't define __getitem__ method or __class_getitem__ for a class).",
     ),
     "E1137": (
         "%r does not support item assignment",

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -67,6 +67,7 @@ ITER_METHOD = "__iter__"
 AITER_METHOD = "__aiter__"
 NEXT_METHOD = "__next__"
 GETITEM_METHOD = "__getitem__"
+CLASS_GETITEM_METHOD = "__class_getitem__"
 SETITEM_METHOD = "__setitem__"
 DELITEM_METHOD = "__delitem__"
 CONTAINS_METHOD = "__contains__"
@@ -1035,6 +1036,9 @@ def supports_membership_test(value: astroid.node_classes.NodeNG) -> bool:
 
 
 def supports_getitem(value: astroid.node_classes.NodeNG) -> bool:
+    if isinstance(value, astroid.ClassDef):
+        if _supports_protocol_method(value, CLASS_GETITEM_METHOD):
+            return True
     return _supports_protocol(value, _supports_getitem_protocol)
 
 

--- a/pylint/test/functional/no_self_argument_py37.py
+++ b/pylint/test/functional/no_self_argument_py37.py
@@ -1,0 +1,15 @@
+"""Test detection of self as argument of first method in Python 3.7 and above."""
+
+# pylint: disable=missing-docstring,too-few-public-methods,useless-object-inheritance
+
+
+class Toto(object):
+
+    def __class_getitem__(cls, params):
+        # This is actually a special method which is always a class method.
+        # See https://www.python.org/dev/peps/pep-0560/#class-getitem
+        pass
+
+    def __class_other__(cls, params):  # [no-self-argument]
+        # This is not a special case and as such is an instance method.
+        pass

--- a/pylint/test/functional/no_self_argument_py37.rc
+++ b/pylint/test/functional/no_self_argument_py37.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.7

--- a/pylint/test/functional/no_self_argument_py37.txt
+++ b/pylint/test/functional/no_self_argument_py37.txt
@@ -1,0 +1,1 @@
+no-self-argument:13:Toto.__class_other__:Method should have "self" as first argument

--- a/pylint/test/functional/unsubscriptable_value_py37.py
+++ b/pylint/test/functional/unsubscriptable_value_py37.py
@@ -1,0 +1,19 @@
+"""
+Checks that class used in a subscript supports subscription
+(i.e. defines __class_getitem__ method).
+"""
+# pylint: disable=missing-docstring,pointless-statement,expression-not-assigned,wrong-import-position
+# pylint: disable=too-few-public-methods,import-error,invalid-name,wrong-import-order, useless-object-inheritance
+
+import typing
+
+class Subscriptable(object):
+
+    def __class_getitem__(cls, params):
+        pass
+
+
+Subscriptable[0]
+Subscriptable()[0]  # [unsubscriptable-object]
+
+a: typing.List[int]

--- a/pylint/test/functional/unsubscriptable_value_py37.rc
+++ b/pylint/test/functional/unsubscriptable_value_py37.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.7

--- a/pylint/test/functional/unsubscriptable_value_py37.txt
+++ b/pylint/test/functional/unsubscriptable_value_py37.txt
@@ -1,0 +1,1 @@
+unsubscriptable-object:17::Value 'Subscriptable()' is unsubscriptable


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [X] Write a good description on what the PR does.

## Description

Take into account `__class_getitem__` from [PEP 560](https://www.python.org/dev/peps/pep-0560/) and fixes some false positives for `no-self-argument` and `unsubscriptable-object`.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #2416
