### PR TITLE
Add a new option 'check-str-concat-over-line-jumps' to check 'implicit-str-concat-in-sequence'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -90,6 +90,8 @@ Release date: TBA
  * Avoid popping __main__ when using multiple jobs
 
  Close #2689
+ 
+ * Add a new option 'check-str-concat-over-line-jumps' to check 'implicit-str-concat-in-sequence'
 
 What's New in Pylint 2.2.2?
 ===========================

--- a/pylint/test/functional/implicit_str_concat_in_sequence_multiline.py
+++ b/pylint/test/functional/implicit_str_concat_in_sequence_multiline.py
@@ -1,0 +1,4 @@
+#pylint: disable=bad-continuation,missing-docstring
+
+TEST_TUPLE = ('a', 'b'  # [implicit-str-concat-in-sequence]
+              'c')

--- a/pylint/test/functional/implicit_str_concat_in_sequence_multiline.rc
+++ b/pylint/test/functional/implicit_str_concat_in_sequence_multiline.rc
@@ -1,0 +1,2 @@
+[STRING_CONSTANT]
+check-str-concat-over-line-jumps=yes

--- a/pylint/test/functional/implicit_str_concat_in_sequence_multiline.txt
+++ b/pylint/test/functional/implicit_str_concat_in_sequence_multiline.txt
@@ -1,0 +1,1 @@
+implicit-str-concat-in-sequence:3::Implicit string concatenation found in tuple


### PR DESCRIPTION
Adding the option discussed in https://github.com/PyCQA/pylint/pull/1655