### PR TITLE
Cross reference between max-bool-expr and R0916

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -263,3 +263,5 @@ contributors:
 * Justin Li (justinnhli)
 
 * Nicolas Dickreuter
+
+* Michael Scott Cuthbert: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -92,6 +92,8 @@ Release date: TBA
  Close #2689
  
  * Add a new option 'check-str-concat-over-line-jumps' to check 'implicit-str-concat-in-sequence'
+ 
+ * Cross-reference between docs for max-bool-expr and R0916
 
 What's New in Pylint 2.2.2?
 ===========================

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -485,7 +485,7 @@ max-args=5
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7
 
-# Maximum number of boolean expressions in an if statement
+# Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5
 
 # Maximum number of branch for function / method body

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -285,7 +285,8 @@ class MisdesignChecker(BaseChecker):
                 "default": 5,
                 "type": "int",
                 "metavar": "<num>",
-                "help": "Maximum number of boolean expressions in an if " "statement.",
+                "help": "Maximum number of boolean expressions in an if " 
+                        "statement (see R0916).",
             },
         ),
     )


### PR DESCRIPTION
Updates a line of docs and the example pylintrc to show that max-bool-expr affects the behavior of R0916.  Minor edit.

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
