### PR TITLE
Fix not-callable false positive on uninferable property

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -267,3 +267,5 @@ contributors:
 * Pascal Corpet
 
 * Svetoslav Neykov: contributor
+
+* Federico Bond: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -124,6 +124,8 @@ Release date: TBA
   The number of arguments was not handled properly, leading to an always
   successful check.
 
+* Fix false positive ``not-callable`` for uninferable properties.
+
 
 What's New in Pylint 2.2.2?
 ===========================

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1022,7 +1022,7 @@ accessed. Python regular expressions are accepted.",
 
                 try:
                     all_returns_are_callable = all(
-                        return_node.callable()
+                        return_node.callable() or return_node is astroid.Uninferable
                         for return_node in attr.infer_call_result(node)
                     )
                 except astroid.InferenceError:

--- a/pylint/test/unittest_checker_typecheck.py
+++ b/pylint/test/unittest_checker_typecheck.py
@@ -297,6 +297,24 @@ class TestTypeChecker(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_call(call)
 
+    def test_not_callable_uninferable_property(self):
+        """Make sure not-callable isn't raised for uninferable
+        properties
+        """
+        call = astroid.extract_node(
+            """
+        class A:
+            @property
+            def call(self):
+                return undefined
+
+        a = A()
+        a.call() #@
+        """
+        )
+        with self.assertNoMessages():
+            self.checker.visit_call(call)
+
     def test_descriptor_call(self):
         call = astroid.extract_node(
             """


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

When the return type for a property is uninferable, it should not emit `not-callable`.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |