### PR TITLE
Fix bug in W0120 with break deep in else of inner loop

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -269,3 +269,5 @@ contributors:
 * Svetoslav Neykov: contributor
 
 * Federico Bond: contributor
+
+* Fantix King (UChicago): contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -136,6 +136,9 @@ Release date: TBA
 
 * Fix false positive ``not-callable`` for uninferable properties.
 
+* Fix false positive ``useless-else-on-loop`` if the break is deep in the else
+  of an inner loop.
+
 
 What's New in Pylint 2.2.2?
 ===========================

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -246,6 +246,7 @@ def _get_break_loop_node(break_node):
     while not isinstance(parent, loop_nodes) or break_node in getattr(
         parent, "orelse", []
     ):
+        break_node = parent
         parent = parent.parent
         if parent is None:
             break

--- a/pylint/test/functional/useless_else_on_loop.py
+++ b/pylint/test/functional/useless_else_on_loop.py
@@ -67,7 +67,8 @@ def test_break_in_orelse_deep():
                 if 3 < 2:
                     break
             else:
-                break
+                if 1 < 2:
+                    break
     else:
         return True
     return False

--- a/pylint/test/functional/useless_else_on_loop.py
+++ b/pylint/test/functional/useless_else_on_loop.py
@@ -67,8 +67,7 @@ def test_break_in_orelse_deep():
                 if 3 < 2:
                     break
             else:
-                if 1 < 2:
-                    break
+                break
     else:
         return True
     return False
@@ -86,5 +85,19 @@ def test_break_in_orelse_deep2():
             else:
                 print("all right")
     else:  # [useless-else-on-loop]
+        return True
+    return False
+
+
+def test_break_in_orelse_deep3():
+    """no false positive for break deeply nested in else
+    """
+    for _ in range(10):
+        for _ in range(3):
+            pass
+        else:
+            if 1 < 2:
+                break
+    else:
         return True
     return False

--- a/pylint/test/functional/useless_else_on_loop.txt
+++ b/pylint/test/functional/useless_else_on_loop.txt
@@ -3,4 +3,4 @@ useless-else-on-loop:18:test_return_while:Else clause on loop without a break st
 useless-else-on-loop:28::Else clause on loop without a break statement
 useless-else-on-loop:35::Else clause on loop without a break statement
 useless-else-on-loop:40::Else clause on loop without a break statement
-useless-else-on-loop:88:test_break_in_orelse_deep2:Else clause on loop without a break statement
+useless-else-on-loop:87:test_break_in_orelse_deep2:Else clause on loop without a break statement

--- a/pylint/test/functional/useless_else_on_loop.txt
+++ b/pylint/test/functional/useless_else_on_loop.txt
@@ -3,4 +3,4 @@ useless-else-on-loop:18:test_return_while:Else clause on loop without a break st
 useless-else-on-loop:28::Else clause on loop without a break statement
 useless-else-on-loop:35::Else clause on loop without a break statement
 useless-else-on-loop:40::Else clause on loop without a break statement
-useless-else-on-loop:87:test_break_in_orelse_deep2:Else clause on loop without a break statement
+useless-else-on-loop:88:test_break_in_orelse_deep2:Else clause on loop without a break statement


### PR DESCRIPTION


<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

When break is deep in the else of an inner loop, W0120 was raised by mistake:

```python
for i in range(10):
    while False:
        pass
    else:
        if i > 2:
            break
else:
    print('else')
```

```
test.py:7:0: W0120: Else clause on loop without a break statement (useless-else-on-loop)
```

This PR fixed this issue.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
N/A