### PR TITLE
Added method arguments to the pyreverse dot file writer

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -271,3 +271,5 @@ contributors:
 * Federico Bond: contributor
 
 * Fantix King (UChicago): contributor
+
+* Goudcode: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,9 @@ What's New in Pylint 2.4.0?
 
 Release date: TBA
 
+* Added method arguments to the dot writer for pyreverse.
 
+Close #2139
 
 What's New in Pylint 2.3.0?
 ===========================

--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -131,7 +131,11 @@ class DotWriter(DiagramWriter):
         if not self.config.only_classnames:
             label = r"%s|%s\l|" % (label, r"\l".join(obj.attrs))
             for func in obj.methods:
-                label = r"%s%s()\l" % (label, func.name)
+                args = []
+                for arg in func.args.args:
+                    if arg.name != 'self':
+                        args.append(arg.name)
+                label = r"%s%s(%s)\l" % (label, func.name, ', '.join(args))
             label = "{%s}" % label
         if is_exception(obj.node):
             return dict(fontcolor="red", label=label, shape="record")

--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -131,10 +131,7 @@ class DotWriter(DiagramWriter):
         if not self.config.only_classnames:
             label = r"%s|%s\l|" % (label, r"\l".join(obj.attrs))
             for func in obj.methods:
-                args = []
-                for arg in func.args.args:
-                    if arg.name != "self":
-                        args.append(arg.name)
+                args = [arg.name for arg in func.args.args if arg.name != "self"]
                 label = r"%s%s(%s)\l" % (label, func.name, ", ".join(args))
             label = "{%s}" % label
         if is_exception(obj.node):

--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -133,9 +133,9 @@ class DotWriter(DiagramWriter):
             for func in obj.methods:
                 args = []
                 for arg in func.args.args:
-                    if arg.name != 'self':
+                    if arg.name != "self":
                         args.append(arg.name)
-                label = r"%s%s(%s)\l" % (label, func.name, ', '.join(args))
+                label = r"%s%s(%s)\l" % (label, func.name, ", ".join(args))
             label = "{%s}" % label
         if is_exception(obj.node):
             return dict(fontcolor="red", label=label, shape="record")

--- a/pylint/test/data/classes_No_Name.dot
+++ b/pylint/test/data/classes_No_Name.dot
@@ -1,9 +1,9 @@
 digraph "classes_No_Name" {
 charset="utf-8"
 rankdir=BT
-"0" [label="{Ancestor|attr : str\lcls_member\l|get_value()\lset_value()\l}", shape="record"];
+"0" [label="{Ancestor|attr : str\lcls_member\l|get_value()\lset_value(value)\l}", shape="record"];
 "1" [label="{DoNothing|\l|}", shape="record"];
-"2" [label="{Interface|\l|get_value()\lset_value()\l}", shape="record"];
+"2" [label="{Interface|\l|get_value()\lset_value(value)\l}", shape="record"];
 "3" [label="{Specialization|TYPE : str\lrelation\ltop : str\l|}", shape="record"];
 "3" -> "0" [arrowhead="empty", arrowtail="none"];
 "0" -> "2" [arrowhead="empty", arrowtail="node", style="dashed"];


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
When generating a dot file with pyreverse, the method arguments are not utilized.
This pull request will fix this issue.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue
Closes #2139 
<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
