### PR TITLE
Pin dependencies to non-breaking version ranges

### DIFF
--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -34,7 +34,7 @@ if dev_version:
 else:
     version = string_version
 
-install_requires = ["astroid>=2.2.0", "isort >= 4.2.5", "mccabe"]
+install_requires = ["astroid>=2.2.0,<3", "isort>=4.2.5,<5", "mccabe>=0.6,<0.7"]
 
 dependency_links = []  # type: ignore
 


### PR DESCRIPTION
Pylint currently specifies unbounded versions of its dependencies. Assuming semver-compliant dependencies, this is dangerous because from one day to the next, your users can end up transitively picking up a breaking version of your dependencies. (This just happened to me [via astroid](PyCQA/astroid#651).\*)

This pins your dependencies within non-breaking version ranges to hopefully protect your users from breaking this way.

\* The fact that astroid's minor version bump was a breaking change goes to show this isn't foolproof, but it's strictly an improvement over the status quo of having no bound whatsoever.