### PR TITLE
Set version to 2.4.0-dev0

### DIFF
--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -25,14 +25,13 @@ from os.path import join
 
 modname = distname = "pylint"
 
+# For an official release, use dev_version = None
 numversion = (2, 4, 0)
-dev_version = None
-string_version = ".".join(str(num) for num in numversion)
+dev_version = 0
 
-if dev_version:
-    version = string_version + "-dev" + str(dev_version)
-else:
-    version = string_version
+version = ".".join(str(num) for num in numversion)
+if dev_version is not None:
+    version += "-dev" + str(dev_version)
 
 install_requires = ["astroid>=2.2.0,<3", "isort>=4.2.5,<5", "mccabe>=0.6,<0.7"]
 


### PR DESCRIPTION
## Description
Make sure the master branch is tagged as a development version (`2.4.0-dev0` in this case) so that it is not mistaken for an official release.

Also modify the version string logic to avoid misinterpreting development version 0 as an official release (since 0 == False) by enforcing `dev_version = None` for non-development versions.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |
