### PR TITLE
Feat - Makes C0412 (ungrouped-imports) compatible with isort

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -285,3 +285,6 @@ contributors:
 * Bluesheeptoken: contributor
 
 * Michael Scott Cuthbert: contributor
+
+* Pierre Sassoulas : contributor
+    - Made C0412 (ungrouped import) compatible with isort

--- a/ChangeLog
+++ b/ChangeLog
@@ -56,6 +56,11 @@ Release date: TBA
 
   Close #2816
 
+* C0412 (ungrouped-import) is now compatible with isort.
+
+  Close #2806
+
+
 What's New in Pylint 2.3.0?
 ===========================
 

--- a/doc/whatsnew/2.4.rst
+++ b/doc/whatsnew/2.4.rst
@@ -66,3 +66,15 @@ Other Changes
   command line. In addition to the ``--from-stdin`` flag a (single) file
   name needs to be specified on the command line, which is needed for the
   report.
+
+* The checker for ungrouped imports is now more permissive.
+
+The import can now be sorted alphabetically by import style.
+This makes pylint compatible with isort.
+
+The following imports do not trigger an ``ungrouped-imports`` anymore ::
+
+    import unittest
+    import zipfile
+    from unittest import TestCase
+    from unittest.mock import MagicMock

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -504,14 +504,19 @@ class ImportsChecker(BaseChecker):
         # Check imports are grouped by category (standard, 3rd party, local)
         std_imports, ext_imports, loc_imports = self._check_imports_order(node)
 
-        # Check imports are grouped by package within a given category
-        met = set()
+        # Check that imports are grouped by package within a given category
+        met_import = set()  #  set for 'import x' style
+        met_from = set()  #  set for 'from x import y' style
         current_package = None
         for import_node, import_name in std_imports + ext_imports + loc_imports:
             if not self.linter.is_message_enabled(
                 "ungrouped-imports", import_node.fromlineno
             ):
                 continue
+            if isinstance(import_node, astroid.node_classes.ImportFrom):
+                met = met_from
+            else:
+                met = met_import
             package, _, _ = import_name.partition(".")
             if current_package and current_package != package and package in met:
                 self.add_message("ungrouped-imports", node=import_node, args=package)

--- a/pylint/test/functional/disable_ungrouped_imports.py
+++ b/pylint/test/functional/disable_ungrouped_imports.py
@@ -2,7 +2,7 @@
 imports from being considered ungrouped in respect to it."""
 # pylint: disable=unused-import,relative-import,wrong-import-position,wrong-import-order,using-constant-test
 # pylint: disable=import-error
-import os
+from os.path import basename
 import logging.config  # pylint: disable=ungrouped-imports
 import os.path
 import logging

--- a/pylint/test/functional/disable_wrong_import_order.py
+++ b/pylint/test/functional/disable_wrong_import_order.py
@@ -8,4 +8,4 @@ import logging
 import os.path
 import sys
 from astroid import are_exclusive
-import first_party  # [ungrouped-imports]
+from first_party.bar import foo # [ungrouped-imports]

--- a/pylint/test/functional/ungrouped_imports.py
+++ b/pylint/test/functional/ungrouped_imports.py
@@ -14,7 +14,13 @@ except ImportError:
 from os import pardir
 import scipy
 from os import sep
-import astroid  # [ungrouped-imports]
+from astroid import exceptions # [ungrouped-imports]
 if True:
     import logging.handlers  # [ungrouped-imports]
 from os.path import join  # [ungrouped-imports]
+# Test related to compatibility with isort:
+# We check that we do not create error with the old way pylint was handling it
+import subprocess
+import unittest
+from unittest import TestCase
+from unittest.mock import MagicMock

--- a/pylint/test/functional/ungrouped_imports_isort_compatible.py
+++ b/pylint/test/functional/ungrouped_imports_isort_compatible.py
@@ -1,0 +1,6 @@
+"""Checks import order rule with imports that isort could generate"""
+# pylint: disable=unused-import
+import astroid
+import isort
+from astroid import are_exclusive, decorators
+from astroid.modutils import get_module_part, is_standard_module


### PR DESCRIPTION
## Description

C0412 and isort are incompatible when there is a mix of from x import y and import x.  See #2806 for details.

## Type of Changes

|   | Type |
| ✓  | :sparkles: New feature |

## Related Issue

Closes #2806 
