### PR TITLE
Fix last updated date in sphinx documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -138,7 +138,7 @@ html_theme_options = {
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-# html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = '%b %d, %Y'
 
 smartquotes = False
 


### PR DESCRIPTION
## Description
The "last updated" date was displaying as "None", which we can fix
by uncommenting `html_last_updated_fmt` in the sphinx configuration.

Current (taken from ReadTheDocs):
![image](https://user-images.githubusercontent.com/846186/54857726-1cab5b00-4cbe-11e9-9a61-cf95e1be3263.png)

Proposed (generated locally):
![image](https://user-images.githubusercontent.com/846186/54857889-efab7800-4cbe-11e9-8b9c-5316962e7bad.png)


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |