### PR TITLE
Ignore raw docstrings in Similarities check with `ignore-docstring=yes`

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -290,3 +290,5 @@ contributors:
     - Made C0412 (ungrouped import) compatible with isort
 
 * Nathan Marrow
+
+* Taewon Kim : contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in Pylint 2.4.0?
 
 Release date: TBA
 
+* Ignore raw docstrings when running Similarities checker with `ignore-docstrings=yes` option
+
 * Fix crash when calling ``inherit_from_std_ex`` on a class which is its own ancestor
 
   Close #2680

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -176,7 +176,9 @@ def stripped_lines(lines, ignore_comments, ignore_docstrings, ignore_imports):
     for lineno, line in enumerate(lines, start=1):
         line = line.strip()
         if ignore_docstrings:
-            if not docstring and (line.startswith('"""') or line.startswith("'''")):
+            if not docstring and any(
+                line.startswith(i) for i in ['"""', "'''", 'r"""', "r'''"]
+            ):
                 docstring = line[:3]
                 line = line[3:]
             if docstring:

--- a/pylint/test/input/similar1
+++ b/pylint/test/input/similar1
@@ -20,3 +20,11 @@ fifteen
 sixteen
 seventeen
 eighteen
+
+
+
+
+nineteen
+r"""
+twenty
+"""

--- a/pylint/test/input/similar2
+++ b/pylint/test/input/similar2
@@ -20,3 +20,11 @@ FIFTEEN
 sixteen
 seventeen
 eighteen
+
+
+
+
+NINETEEN
+r"""
+twenty
+"""

--- a/pylint/test/unittest_checker_similar.py
+++ b/pylint/test/unittest_checker_similar.py
@@ -48,7 +48,7 @@ def test_ignore_comments():
    eight
    nine
    ''' ten
-TOTAL lines=44 duplicates=10 percent=22.73
+TOTAL lines=60 duplicates=10 percent=16.67
 """
             % (SIMILAR1, SIMILAR2)
         ).strip()
@@ -84,7 +84,7 @@ def test_ignore_docsrings():
    three
    four
    five
-TOTAL lines=44 duplicates=13 percent=29.55
+TOTAL lines=60 duplicates=13 percent=21.67
 """
             % ((SIMILAR1, SIMILAR2) * 2)
         ).strip()
@@ -99,7 +99,7 @@ def test_ignore_imports():
     assert (
         output.getvalue().strip()
         == """
-TOTAL lines=44 duplicates=0 percent=0.00
+TOTAL lines=60 duplicates=0 percent=0.00
 """.strip()
     )
 
@@ -169,7 +169,7 @@ def test_ignore_nothing():
    three
    four
    five
-TOTAL lines=44 duplicates=5 percent=11.36
+TOTAL lines=60 duplicates=5 percent=8.33
 """
             % (SIMILAR1, SIMILAR2)
         ).strip()


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Raw docstrings are not ignored inside Similarities checker even when docstrings are ignored. This PR addresses this issue:
- raw docstring was added to the condition inside `pylint.checkers.similar.stripped_lines` for ignoring docstrings
- existing tests were modified to check for raw docstrings

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #2829 