### PR TITLE
Update base.py

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -294,3 +294,6 @@ contributors:
 * Taewon Kim : contributor
 
 * Daniil Kharkov: contributor
+
+* Alan Yee : contributor
+

--- a/ChangeLog
+++ b/ChangeLog
@@ -95,6 +95,10 @@ Release date: TBA
 
   Close #2806
 
+* Updates check on comparing boolean values to ``True`` or ``False`` using ``is`` 
+
+  Close #2868
+
 
 What's New in Pylint 2.3.0?
 ===========================

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -2110,10 +2110,10 @@ class ComparisonChecker(_BasicChecker):
         is_other_literal = isinstance(literal, nodes)
         is_const = False
         if isinstance(literal, astroid.Const):
-            if isinstance(literal.value, bool) or literal.value is None:
-                # Not interested in this values.
+            if literal.value is None:
+                # Not interested in this singleton.
                 return
-            is_const = isinstance(literal.value, (bytes, str, int, float))
+            is_const = isinstance(literal.value, (bytes, str, int, float, bool))
 
         if is_const or is_other_literal:
             self.add_message("literal-comparison", node=node)


### PR DESCRIPTION
Raise a message for comparing values to `True` or `False` using `is`.

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Previous behavior would say nothing about`if greeting is True` which goes against pep 8 guidelines:
```
Yes:   if greeting:
No:    if greeting == True:
Worse: if greeting is True:
```

So
```
""""Test module"""

def run_check(air):
    """Test function"""
    if air is True:
        return air
    return air is False
```
would be consider 10/10. With the new behavior, the code is rated at 5.00/10.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:-->

Closes #2868 

