### PR TITLE
Add 'of' to GoogleDocstring multiple type

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -294,3 +294,6 @@ contributors:
 * Taewon Kim : contributor
 
 * Daniil Kharkov: contributor
+
+* Zeb Nicholls: contributor
+    - Made W9011 compatible with 'of' syntax in return types

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in Pylint 2.4.0?
 
 Release date: TBA
 
+* Allow of in `GoogleDocstring.re_multiple_type`
+
 * Added `subprocess-run-check` to handle subrocess.run without explicitly set `check` keyword.
 
   Close #2848

--- a/doc/whatsnew/2.4.rst
+++ b/doc/whatsnew/2.4.rst
@@ -91,3 +91,17 @@ The following imports do not trigger an ``ungrouped-imports`` anymore ::
     import zipfile
     from unittest import TestCase
     from unittest.mock import MagicMock
+    
+* The checker for missing return documentation is now more flexible.
+
+The following does not trigger a ``missing-return-doc`` anymore ::
+
+    def my_func(self):
+        """This is a docstring.
+
+        Returns
+        -------
+        :obj:`list` of :obj:`str`
+            List of strings
+        """
+        return ["hi", "bye"] #@

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -443,7 +443,7 @@ class GoogleDocstring(Docstring):
 
     re_multiple_type = r"""
         (?:{container_type}|{type}|{xref})
-        (?:\s+or\s+(?:{container_type}|{type}|{xref}))*
+        (?:\s+(?:of|or)\s+(?:{container_type}|{type}|{xref}))*
     """.format(
         type=re_type, xref=re_xref, container_type=re_container_type
     )

--- a/pylint/test/extensions/test_check_return_docs.py
+++ b/pylint/test/extensions/test_check_return_docs.py
@@ -250,6 +250,21 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
+    def test_find_numpy_returns_with_of(self):
+        return_node = astroid.extract_node('''
+        def my_func(self):
+            """This is a docstring.
+
+            Returns
+            -------
+            :obj:`list` of :obj:`str`
+                List of strings
+            """
+            return ["hi", "bye"] #@
+        ''')
+        with self.assertNoMessages():
+            self.checker.visit_return(return_node)
+
     def test_ignores_sphinx_return_none(self):
         return_node = astroid.extract_node('''
         def my_func(self, doc_type):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

This PR fixes a minor bug, which causes a docstring which should pass to fail. This new test is captured in `/pylint/test/extensions/test_check_return_docs.py::test_find_numpy_returns_with_of`.

### Further detail

A docstring of the following form should pass (see https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html, search for ':obj:`list` of :obj:`str`')

```python
def my_func(self):
    """This is a docstring.

    Returns
    -------
    :obj:`list` of :obj:`str`
        List of strings
    """
    return ["hi", "bye"] #@
```

But currently fails on master with 'W9011: Missing return documentation (missing-return-doc)' error.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
