### PR TITLE
Arg var name clash

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -294,3 +294,5 @@ contributors:
 * Taewon Kim : contributor
 
 * Daniil Kharkov: contributor
+
+* Felix Lawrence: 'arg-var-name-clash' check

--- a/ChangeLog
+++ b/ChangeLog
@@ -95,6 +95,8 @@ Release date: TBA
 
   Close #2806
 
+* Add check for clashes between function argument and variable names (W1114)
+
 
 What's New in Pylint 2.3.0?
 ===========================

--- a/doc/whatsnew/2.4.rst
+++ b/doc/whatsnew/2.4.rst
@@ -46,6 +46,28 @@ New checkers
   to make ``pylint`` suggest using ``defusedxml`` instead of ``xml``
   and ``ujson`` rather than ``json``.
 
+* A new check ``arg-var-name-clash`` was added.
+
+  This is emitted when the names of variables being supplied to a function or method appear to clash with the function/method's argument names.
+
+  For example, the following function calls would raise this warning::
+
+    def example_fn(x, y=None):
+        pass
+
+    example_fn(y, x)
+    example_fn(y)
+
+  because a casual reader might not be familiar with the order of arguments to ``example_fn`` and would expect a variable ``y`` to be passed to the function argument ``y``. Furthermore, this is likely to catch issues when the function arguments become misaligned when a positional argument is inadvertently deleted, added or mis-ordered.
+
+  If you really do want to pass ``x`` in as ``y`` and/or ``y`` in as ``x``, then you can avoid the warning by using keyword arguments to clarify your intent::
+
+    example_fn(x=y, y=x)
+    example_fn(y, y=x)
+
+    example_fn(x=y)
+
+
 Other Changes
 =============
 

--- a/pylint/test/functional/argument_names_differ.py
+++ b/pylint/test/functional/argument_names_differ.py
@@ -1,0 +1,53 @@
+"""Test that we are emitting arguments-differ when the arguments are different."""
+# pylint: disable=missing-docstring, too-few-public-methods, unused-argument,useless-super-delegation, useless-object-inheritance, invalid-name
+
+def minimal_example(x, y):
+    pass
+
+def put_things_in_scope():
+    x = 10
+    y = 20
+    z = 30
+
+    minimal_example(x, y)
+    minimal_example(x, x)
+    minimal_example(y, y)
+    minimal_example(x, z)
+    minimal_example(x, 0)
+    minimal_example(z, y)
+    minimal_example(z, z)
+    minimal_example(x=y, y=x)
+    minimal_example(z, y=x)
+
+    minimal_example(y, x)  # [arg-var-name-clash, arg-var-name-clash]
+    minimal_example(y, z)  # [arg-var-name-clash]
+    minimal_example(y, 0)  # [arg-var-name-clash]
+    minimal_example(z, x)  # [arg-var-name-clash]
+
+def realistic_example(a, b, c=None, d=None):
+    pass
+
+def scope_2():
+    a = 1
+    b = 2
+    c = 3
+    other_args = [3, 4]
+
+    realistic_example(a, b, *other_args)
+    realistic_example(a, c, c=1)
+    realistic_example(b, *other_args) # [arg-var-name-clash]
+    realistic_example(a, c) # [arg-var-name-clash]
+
+
+class MethodsToo(object):
+    def a_method(self, x, y):
+        pass
+
+
+def scope_3():
+    m = MethodsToo()
+
+    x = 10
+    y = 20
+
+    m.a_method(y, x)  # [arg-var-name-clash, arg-var-name-clash]

--- a/pylint/test/functional/argument_names_differ.py
+++ b/pylint/test/functional/argument_names_differ.py
@@ -15,7 +15,7 @@ def put_things_in_scope():
     minimal_example(x, z)
     minimal_example(x, 0)
     minimal_example(z, y)
-    minimal_example(z, z)
+    minimal_example(y, y=x)
     minimal_example(x=y, y=x)
     minimal_example(z, y=x)
 

--- a/pylint/test/functional/argument_names_differ.txt
+++ b/pylint/test/functional/argument_names_differ.txt
@@ -1,0 +1,9 @@
+arg-var-name-clash:22:put_things_in_scope:In this call to minimal_example, a variable named x supplied the argument y, and not the argument x.
+arg-var-name-clash:22:put_things_in_scope:In this call to minimal_example, a variable named y supplied the argument x, and not the argument y.
+arg-var-name-clash:23:put_things_in_scope:In this call to minimal_example, a variable named y supplied the argument x, and not the argument y.
+arg-var-name-clash:24:put_things_in_scope:In this call to minimal_example, a variable named y supplied the argument x, and not the argument y.
+arg-var-name-clash:25:put_things_in_scope:In this call to minimal_example, a variable named x supplied the argument y, and not the argument x.
+arg-var-name-clash:38:scope_2:In this call to realistic_example, a variable named b supplied the argument a, and not the argument b.
+arg-var-name-clash:39:scope_2:In this call to realistic_example, a variable named c supplied the argument b, and not the argument c.
+arg-var-name-clash:53:scope_3:In this call to a_method, a variable named x supplied the argument y, and not the argument x.
+arg-var-name-clash:53:scope_3:In this call to a_method, a variable named y supplied the argument x, and not the argument y.


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
It's common for a variable supplied as a positional argument to a
function or method to share the same name as the function argument. It's
rare for the variable name to match a _different_ function argument -
frequently this mismatch is due to an error: mis-ordered arguments,
missing arguments, or extra arguments supplied to the function. In the
cases where the mismatch is intentional, it is good form to supply the
argument as a keyword argument rather than a positional argument, so
that the reader does not assume that the function's argument is not
being set by the correspondingly named variable: this lint rule ignores
such cases.

Someone who is more familiar with pylint or `TypeChecker.visit_call` may
be able to significantly improve my code: I'm unfamiliar with the
important edge cases (e.g. I didn't test `functools.partial`), and half
the code is spent constructing things that might already be available
from convenience functions?

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
