### PR TITLE
Add broad try clause extension.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -294,3 +294,5 @@ contributors:
 * Taewon Kim : contributor
 
 * Daniil Kharkov: contributor
+
+* Tyler N. Thieding: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -95,6 +95,10 @@ Release date: TBA
 
   Close #2806
 
+* Added new extension to detect too much code in a try clause
+
+  Close #2877
+
 
 What's New in Pylint 2.3.0?
 ===========================

--- a/pylint/extensions/broad_try_clause.py
+++ b/pylint/extensions/broad_try_clause.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Tyler N. Thieding <python@thieding.com>
+
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+"""Looks for try/except statements with too much code in the try clause."""
+
+from pylint import checkers, interfaces
+
+
+class BroadTryClauseChecker(checkers.BaseChecker):
+    """Checks for try clauses with too many lines.
+
+    According to PEP 8, ``try`` clauses shall contain the absolute minimum
+    amount of code. This checker enforces a maximum number of statements within
+    ``try`` clauses.
+
+    """
+
+    __implements__ = interfaces.IAstroidChecker
+
+    # configuration section name
+    name = "broad_try_clause"
+    msgs = {
+        "W0717": (
+            "%s",
+            "too-many-try-statements",
+            "Try clause contains too many statements.",
+        )
+    }
+
+    priority = -2
+    options = (
+        (
+            "max-try-statements",
+            {
+                "default": 1,
+                "type": "int",
+                "metavar": "<int>",
+                "help": "Maximum number of statements allowed in a try clause",
+            },
+        ),
+    )
+
+    def visit_tryexcept(self, node):
+        try_clause_statements = len(node.body)
+        if try_clause_statements > self.config.max_try_statements:
+            msg = "try clause contains {0} statements, at most {1} expected".format(
+                try_clause_statements, self.config.max_try_statements
+            )
+            self.add_message(
+                "too-many-try-statements", node.lineno, node=node, args=msg
+            )
+
+
+def register(linter):
+    """Required method to auto register this checker."""
+    linter.register_checker(BroadTryClauseChecker(linter))

--- a/pylint/test/extensions/data/broad_try_clause.py
+++ b/pylint/test/extensions/data/broad_try_clause.py
@@ -1,0 +1,14 @@
+# pylint: disable=missing-docstring, invalid-name
+
+MY_DICTIONARY = {"key_one": 1, "key_two": 2, "key_three": 3}
+
+try:  # [max-try-statements]
+    value = MY_DICTIONARY["key_one"]
+    value += 1
+except KeyError:
+    pass
+
+try:
+    value = MY_DICTIONARY["key_one"]
+except KeyError:
+    value = 0

--- a/pylint/test/extensions/test_broad_try_clause.py
+++ b/pylint/test/extensions/test_broad_try_clause.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Tyler N. Thieding <python@thieding.com>
+
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+"""Tests for the pylint checker in :mod:`pylint.extensions.broad_try_clause
+"""
+
+import os.path as osp
+import unittest
+
+from pylint import checkers
+from pylint.extensions.broad_try_clause import BroadTryClauseChecker
+from pylint.lint import PyLinter
+from pylint.reporters import BaseReporter
+
+
+class BroadTryClauseTestReporter(BaseReporter):
+    def handle_message(self, msg):
+        self.messages.append(msg)
+
+    def on_set_current_module(self, module, filepath):
+        self.messages = []
+
+
+class BroadTryClauseTC(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._linter = PyLinter()
+        cls._linter.set_reporter(BroadTryClauseTestReporter())
+        checkers.initialize(cls._linter)
+        cls._linter.register_checker(BroadTryClauseChecker(cls._linter))
+        cls._linter.disable("I")
+
+    def test_broad_try_clause_message(self):
+        elif_test = osp.join(
+            osp.dirname(osp.abspath(__file__)), "data", "broad_try_clause.py"
+        )
+        self._linter.check([elif_test])
+        msgs = self._linter.reporter.messages
+        self.assertEqual(len(msgs), 1)
+
+        self.assertEqual(msgs[0].symbol, "too-many-try-statements")
+        self.assertEqual(
+            msgs[0].msg, "try clause contains 2 statements, at most 1 expected"
+        )
+        self.assertEqual(msgs[0].line, 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Add an extension checker (``pylint.extensions.broad_try_clause``) that enforces a configurable maximum number of statements inside of a ``try`` clause. This facilitates enforcing PEP 8's guidelines about try/except statements and the amount of code in the try clause: "Additionally, for all try/except clauses, limit the try clause to the absolute minimum amount of code necessary. Again, this avoids masking bugs."

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Related Issue

Closes #2877 
