### PR TITLE
fix old-division check for int(...)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
     - id: black
       args: [--safe, --quiet]
       exclude: functional|input|test/extension|test/regrtest_data|test/data
-      python_version: python3.6
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.1.0
     hooks:

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -1069,13 +1069,17 @@ class Python3Checker(checkers.BaseChecker):
         if not self._future_division and node.op == "/":
             for arg in (node.left, node.right):
                 inferred = utils.safe_infer(arg)
-                # If we can infer the object and that object is not a numeric one, bail out.
+                # If we can infer the object and that object is not an int, bail out.
                 if inferred and not (
-                    isinstance(inferred, astroid.Const)
-                    and isinstance(inferred.value, (int, float))
+                    (
+                        isinstance(inferred, astroid.Const)
+                        and isinstance(inferred.value, int)
+                    )
+                    or (
+                        isinstance(inferred, astroid.Instance)
+                        and inferred.name == "int"
+                    )
                 ):
-                    break
-                if isinstance(arg, astroid.Const) and isinstance(arg.value, float):
                     break
             else:
                 self.add_message("old-division", node=node)


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

`old-division` will now only fire for:
- `int / int`
- `unknown / int`
- `int / unknown`
- `unknown / unknown`

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Resolves #2887