### PR TITLE
Fix crash in callable check

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -299,3 +299,5 @@ contributors:
 
 * Zeb Nicholls: contributor
     - Made W9011 compatible with 'of' syntax in return types
+
+* Martin Vielsmaier: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in Pylint 2.4.0?
 
 Release date: TBA
 
+* Fix crash happening when parent of called object cannot be determined
+
 * Allow of in `GoogleDocstring.re_multiple_type`
 
 * Added `subprocess-run-check` to handle subrocess.run without explicitly set `check` keyword.

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1051,7 +1051,8 @@ accessed. Python regular expressions are accepted.",
             if isinstance(called, astroid.Instance) and (
                 not has_known_bases(called)
                 or (
-                    isinstance(called.scope(), astroid.ClassDef)
+                    called.parent is not None
+                    and isinstance(called.scope(), astroid.ClassDef)
                     and "__get__" in called.locals
                 )
             ):

--- a/pylint/test/unittest_checker_typecheck.py
+++ b/pylint/test/unittest_checker_typecheck.py
@@ -339,12 +339,12 @@ class TestTypeChecker(CheckerTestCase):
         """
         call = astroid.extract_node(
             """
-        @lazy
         def get_num(n):
             return 2 * n
-        res = get_num(10)
-        res()
+        get_num(10)()
         """
         )
-        with self.assertAddsMessages(Message("not-callable", node=call, args="res")):
+        with self.assertAddsMessages(
+            Message("not-callable", node=call, args="get_num(10)")
+        ):
             self.checker.visit_call(call)

--- a/pylint/test/unittest_checker_typecheck.py
+++ b/pylint/test/unittest_checker_typecheck.py
@@ -332,3 +332,19 @@ class TestTypeChecker(CheckerTestCase):
         )
         with self.assertNoMessages():
             self.checker.visit_call(call)
+
+    def test_unknown_parent(self):
+        """Make sure the callable check does not crash when a node's parent
+        cannot be determined.
+        """
+        call = astroid.extract_node(
+            """
+        @lazy
+        def get_num(n):
+            return 2 * n
+        res = get_num(10)
+        res()
+        """
+        )
+        with self.assertAddsMessages(Message("not-callable", node=call, args="res")):
+            self.checker.visit_call(call)


### PR DESCRIPTION
## Steps
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description
When you run pylint against this file
```python
def get_num(n):
    return 2 * n

get_num(10)()
```
you will get a crash:
```
$ pylint minimal.py
Traceback (most recent call last):
  File "XXX/code/pylint/.venv/bin/pylint", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "XXX/code/pylint/bin/pylint", line 4, in <module>
    run_pylint()
  File "XXX/code/pylint/pylint/__init__.py", line 20, in run_pylint
    Run(sys.argv[1:])
  File "XXX/code/pylint/pylint/lint.py", line 1684, in __init__
    linter.check(args)
  File "XXX/code/pylint/pylint/lint.py", line 969, in check
    self._do_check(files_or_modules)
  File "XXX/code/pylint/pylint/lint.py", line 1131, in _do_check
    self.check_astroid_module(ast_node, walker, rawcheckers, tokencheckers)
  File "XXX/code/pylint/pylint/lint.py", line 1214, in check_astroid_module
    walker.walk(ast_node)
  File "XXX/code/pylint/pylint/utils/ast_walker.py", line 78, in walk
    self.walk(child)
  File "XXX/code/pylint/pylint/utils/ast_walker.py", line 78, in walk
    self.walk(child)
  File "XXX/code/pylint/pylint/utils/ast_walker.py", line 75, in walk
    cb(astroid)
  File "XXX/code/pylint/pylint/checkers/typecheck.py", line 1054, in visit_call
    isinstance(called.scope(), astroid.ClassDef)
  File "XXX/code/pylint/.venv/lib/python3.6/site-packages/astroid/node_classes.py", line 494, in scope
    return self.parent.scope()
AttributeError: 'NoneType' object has no attribute 'scope'
```

This PR fixes the issue by adding a check to `pylint.checkers.typecheck.TypeChecker#visit_call` that will prevent the call to `scope` when parent is `None` on the called node.


## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue
didn't bother to create one :-)

## Library Versions
If you want to reproduce the error, here are the versions I had installed:
```
$ pip freeze
appdirs==1.4.3
astroid==2.2.5
atomicwrites==1.3.0
attrs==19.1.0
black==19.3b0
Click==7.0
isort==4.3.18
lazy-object-proxy==1.3.1
mccabe==0.6.1
more-itertools==7.0.0
pkg-resources==0.0.0
pluggy==0.9.0
py==1.8.0
-e git+git@github.com:moser/pylint.git@c26bd45edb74f1857471fcd134c8443058670790#egg=pylint
pytest==4.4.1
six==1.12.0
toml==0.10.0
typed-ast==1.3.5
wrapt==1.11.1
```
