### PR TITLE
Fixed pragmas on their own line after a backlash being ignored

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -117,6 +117,10 @@ Release date: TBA
 
   Close #2877
 
+* Fixed a pragma comment on its own physical line being ignored when part
+  of a logical line with the previous physical line.
+
+  Close #199
 
 What's New in Pylint 2.3.0?
 ===========================

--- a/pylint/test/functional/pragma_after_backslash.py
+++ b/pylint/test/functional/pragma_after_backslash.py
@@ -1,0 +1,10 @@
+"""Test that a pragma has an effect when separated by a backslash."""
+# pylint: disable=too-few-public-methods
+
+class Foo:
+    """block-disable test"""
+
+    def meth3(self):
+        """test one line disabling"""
+        print(self.bla) \
+           # pylint: disable=E1101


### PR DESCRIPTION
## Description
As described in the original issue, pragmas on their own line after a backslash were getting ignored. This fixes that so that a pragma comment affects the whole logical line, and not just the physical line.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Closes #199