### PR TITLE
Fixed false positive for `undefined-loop-variable`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -117,6 +117,10 @@ Release date: TBA
 
   Close #2877
 
+* Fixed false `undefined-loop-variable` for a function defined in the loop,
+  that uses the variable defined in that loop.
+
+  Close #202
 
 What's New in Pylint 2.3.0?
 ===========================

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1186,6 +1186,16 @@ class VariablesChecker(BaseChecker):
         if not self.linter.is_message_enabled("undefined-loop-variable"):
             return
         astmts = [stmt for stmt in node.lookup(name)[1] if hasattr(stmt, "assign_type")]
+        # If this variable usage exists inside a function definition
+        # that exists in the same loop,
+        # the usage is safe because the function will not be defined either if
+        # the variable is not defined.
+        scope = node.scope()
+        if isinstance(scope, astroid.FunctionDef) and any(
+            asmt.statement().parent_of(scope) for asmt in astmts
+        ):
+            return
+
         # filter variables according their respective scope test is_statement
         # and parent to avoid #74747. This is not a total fix, which would
         # introduce a mechanism similar to special attribute lookup in

--- a/pylint/test/functional/nested_func_defined_in_loop.py
+++ b/pylint/test/functional/nested_func_defined_in_loop.py
@@ -1,0 +1,11 @@
+# pylint: disable=W0640
+"""Check a nested function defined in a loop."""
+
+def example(args):
+    """The check"""
+    for i in args:
+        def nested():
+            print(i)
+        nested()
+    for i in args:
+        print(i)


### PR DESCRIPTION
## Description
This fixes the case described in the original issue where `undefined-loop-variable` was raised when a function defined in a loop uses a variable defined by the same loop.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Closes #202