### PR TITLE
Can choose decorators that mutate a function's signature

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -117,6 +117,11 @@ Release date: TBA
 
   Close #2877
 
+* Can choose to ignore `too-many-function-args`, `unexpected-keyword-arg`,
+  and `no-value-for-parameter` for functions decorated with certain decorators.
+
+  Close #259
+
 
 What's New in Pylint 2.3.0?
 ===========================

--- a/doc/whatsnew/2.4.rst
+++ b/doc/whatsnew/2.4.rst
@@ -116,3 +116,14 @@ The following does not trigger a ``missing-return-doc`` anymore ::
             List of strings
         """
         return ["hi", "bye"] #@
+
+* Can choose to ignore `too-many-function-args`, `unexpected-keyword-arg`,
+  and `no-value-for-parameter` for functions decorated with certain decorators.
+
+For example a test may want to make use of hypothesis.
+Adding `hypothesis.extra.numpy.arrays` to `function_mutators`
+would mean that `no-value-for-parameter` would not be raised for::
+
+    @given(img=arrays(dtype=np.float32, shape=(3, 3, 3, 3)))
+    def test_image(img):
+        ...

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -765,6 +765,16 @@ accessed. Python regular expressions are accepted.",
                 "found. The aspect of finding the hint is based on edit distance.",
             },
         ),
+        (
+            "signature-mutators",
+            {
+                "default": [],
+                "type": "csv",
+                "metavar": "<decorator names>",
+                "help": "List of decorators that change the signature of "
+                "a decorated function.",
+            },
+        ),
     )
 
     @decorators.cachedproperty
@@ -1089,6 +1099,12 @@ accessed. Python regular expressions are accepted.",
 
         if call_site.has_invalid_arguments() or call_site.has_invalid_keywords():
             # Can't make sense of this.
+            return
+
+        # Has the function signature changed in ways we cannot reliably detect?
+        if hasattr(called, "decorators") and decorated_with(
+            called, self.config.signature_mutators
+        ):
             return
 
         num_positional_args = len(call_site.positional_arguments)

--- a/pylint/test/functional/arguments.py
+++ b/pylint/test/functional/arguments.py
@@ -215,3 +215,23 @@ partial(some_func, 1, third=2)(second=3)
 partial(some_func, 1)(1)  # [no-value-for-parameter]
 partial(some_func, 1)(third=1)  # [no-value-for-parameter]
 partial(some_func, 1, 2)(third=1, fourth=4)  # [unexpected-keyword-arg]
+
+
+def mutation_decorator(fun):
+    """Decorator that changes a function's signature."""
+    def wrapper(*args, do_something=True, **kwargs):
+        if do_something:
+            return fun(*args, **kwargs)
+
+        return None
+
+    return wrapper
+
+
+@mutation_decorator
+def mutated_function(arg):
+    return arg
+
+
+mutated_function(do_something=False)
+mutated_function()

--- a/pylint/test/functional/arguments.rc
+++ b/pylint/test/functional/arguments.rc
@@ -1,0 +1,2 @@
+[TYPECHECK]
+signature-mutators=functional.arguments.mutation_decorator


### PR DESCRIPTION
## Description
This adds a new option `function_mutators` that allows `too-many-function-args`, `unexpected-keyword-arg`, and `no-value-for-parameter` to not get raised for functions that are decorated with a decorator mentioned in `function_mutators`.

I figured it would be too difficult to try and infer what a decorator was doing so this seemed like the best solution, even though it means that there will be cases where a function is called with incorrect arguments will be missed by pylint when the function is decorated with a mutator decorator.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Close #259