### PR TITLE
Fixed false positives for function stubs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -147,6 +147,10 @@ Release date: TBA
 
   Close #202
 
+* Fixed `unused-argument` and `function-redefined` getting raised for
+  functions decorated with `typing.overload`.
+
+  Close #1581
 
 What's New in Pylint 2.3.0?
 ===========================

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1225,3 +1225,15 @@ def is_subclass_of(child: astroid.ClassDef, parent: astroid.ClassDef) -> bool:
         except _NonDeducibleTypeHierarchy:
             continue
     return False
+
+
+@lru_cache(maxsize=1024)
+def is_overload_stub(node: astroid.node_classes.NodeNG) -> bool:
+    """Check if a node if is a function stub decorated with typing.overload.
+
+    :param node: Node to check.
+    :returns: True if node is an overload function stub. False otherwise.
+    """
+    return isinstance(node, astroid.FunctionDef) and decorated_with(
+        node, ["typing.overload"]
+    )

--- a/pylint/test/functional/typing_use.py
+++ b/pylint/test/functional/typing_use.py
@@ -1,0 +1,51 @@
+# pylint: disable=missing-docstring
+
+import typing
+
+
+@typing.overload
+def double_with_docstring(arg: str) -> str:
+    """Return arg, concatenated with itself."""
+
+
+@typing.overload
+def double_with_docstring(arg: int) -> int:
+    """Return twice arg."""
+
+
+def double_with_docstring(arg):
+    """Return 2 * arg."""
+    return 2 * arg
+
+
+def double_with_docstring(arg):  # [function-redefined]
+    """Redefined function implementation"""
+    return 2 * arg
+
+
+@typing.overload
+def double_with_ellipsis(arg: str) -> str:
+    ...
+
+
+@typing.overload
+def double_with_ellipsis(arg: int) -> int:
+    ...
+
+
+def double_with_ellipsis(arg):
+    return 2 * arg
+
+
+@typing.overload
+def double_with_pass(arg: str) -> str:
+    pass
+
+
+@typing.overload
+def double_with_pass(arg: int) -> int:
+    pass
+
+
+def double_with_pass(arg):
+    return 2 * arg

--- a/pylint/test/functional/typing_use.rc
+++ b/pylint/test/functional/typing_use.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.6

--- a/pylint/test/functional/typing_use.txt
+++ b/pylint/test/functional/typing_use.txt
@@ -1,0 +1,1 @@
+function-redefined:21:double_with_docstring:"function already defined line 16"


### PR DESCRIPTION
## Description
This change fixes `unused-argument` and `function-redefined` getting raised for functions decorated with `typing.overload`.
`unused-argument` ignores these functions altogether. `function-redefined` does not treat them as actual definitions, both when checking the node itself and when looking for duplicate definition nodes.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Close #1581