### PR TITLE
Fix mypy 0.710 errors

### DIFF
--- a/pylint/config.py
+++ b/pylint/config.py
@@ -46,6 +46,7 @@ import pickle
 import re
 import sys
 import time
+from typing import Any, Dict, Tuple
 
 from pylint import utils
 
@@ -796,7 +797,7 @@ class OptionsProviderMixIn:
     # those attributes should be overridden
     priority = -1
     name = "default"
-    options = ()
+    options = ()  # type: Tuple[Tuple[str, Dict[str, Any]], ...]
     level = 0
 
     def __init__(self):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Fixes new errors emitted by mypy 0.710:
```
pylint/checkers/similar.py:295: error: Incompatible types in assignment (expression has type "Tuple[Tuple[str, Dict[str, object]], Tuple[str, Dict[str, object]], Tuple[str, Dict[str, object]], Tuple[str, Dict[str, object]]]", base class "OptionsProviderMixIn" defined the type as "Tuple[]")
pylint/checkers/strings.py:577: error: Incompatible types in assignment (expression has type "Tuple[Tuple[str, Dict[str, object]]]", base class "OptionsProviderMixIn" defined the type as "Tuple[]")
pylint/checkers/spelling.py:178: error: Incompatible types in assignment (expression has type "Tuple[Tuple[str, Dict[str, Sequence[str]]], Tuple[str, Dict[str, str]], Tuple[str, Dict[str, str]], Tuple[str, Dict[str, str]], Tuple[str, Dict[str, object]]]", base class "OptionsProviderMixIn" defined the type as "Tuple[]")
pylint/checkers/refactoring.py:268: error: Incompatible types in assignment (expression has type "Tuple[Tuple[str, Dict[str, object]], Tuple[str, Dict[str, object]]]", base class "OptionsProviderMixIn" defined the type as "Tuple[]")
pylint/checkers/format.py:594: error: Incompatible types in assignment (expression has type "Tuple[Tuple[str, Dict[str, object]], Tuple[str, Dict[str, str]], Tuple[str, Dict[str, object]], Tuple[str, Dict[str, object]], Tuple[str, Dict[str, Sequence[str]]], Tuple[str, Dict[str, object]], Tuple[str, Dict[str, str]], Tuple[str, Dict[str, object]], Tuple[str, Dict[str, Sequence[str]]]]", base class "OptionsProviderMixIn" defined the type as "Tuple[]")
pylint/checkers/base.py:1886: error: Incompatible types in assignment (expression has type "Tuple[Tuple[str, Dict[str, object]], Tuple[str, Dict[str, object]]]", base class "OptionsProviderMixIn" defined the type as "Tuple[]")
```

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
