### PR TITLE
Fix - do not raise `attribute-defined-outside-init` for `__post_init__`

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -305,3 +305,5 @@ contributors:
 * Agustin Toledo: contributor
 
 * Nicholas Smith: contributor
+
+* Andrzej Klajnert: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -158,6 +158,10 @@ Release date: TBA
 
   Close #2963
 
+* Added ``__post_init__`` to ``defining-attr-methods`` in order to avoid ``attribute-defined-outside-init`` in dataclasses.
+
+  Close #2581
+
 What's New in Pylint 2.3.0?
 ===========================
 

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -460,7 +460,8 @@ redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,
                       __new__,
-                      setUp
+                      setUp,
+                      __post_init__
 
 # List of member names, which should be excluded from the protected access
 # warning.

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -666,7 +666,7 @@ class ClassChecker(BaseChecker):
         (
             "defining-attr-methods",
             {
-                "default": ("__init__", "__new__", "setUp"),
+                "default": ("__init__", "__new__", "setUp", "__post_init__"),
                 "type": "csv",
                 "metavar": "<method names>",
                 "help": "List of method names used to declare (i.e. assign) \

--- a/pylintrc
+++ b/pylintrc
@@ -334,7 +334,7 @@ max-public-methods=25
 [CLASSES]
 
 # List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods=__init__,__new__,setUp
+defining-attr-methods=__init__,__new__,setUp,__post_init__
 
 # List of valid names for the first argument in a class method.
 valid-classmethod-first-arg=cls

--- a/tests/functional/attribute_defined_outside_init.py
+++ b/tests/functional/attribute_defined_outside_init.py
@@ -78,3 +78,7 @@ class Mine:
     @prop.setter
     def prop(self, value):
         self.__prop = value
+
+class DataClass:
+    def __post_init__(self):
+        self.a = 42


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Description

Currently ``astroid`` seems to not support dataclass in a way that would allow to still raise the ``attribute-defined-outside-init`` if attribute is defined in ``__post_init__`` in a class that is not dataclass. I think it is reasonable to add ``__post_init__`` into ``defining-attr-methods``, especially that the ``setUp`` method is already there and pylint doesn't check if it is ``TestCase`` class.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Closes #2581 
