### PR TITLE
user configurable list of levels to check for lazy formatting

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -311,3 +311,5 @@ contributors:
 * Oisin Moran: contributor
 
 * Andrzej Klajnert: contributor
+
+* Erik Aronesty: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -166,6 +166,8 @@ Release date: TBA
 
   Close #2581
 
+# Added `logging-lazy-levels` option to allow users to configure which levels must be lazy
+
 What's New in Pylint 2.3.0?
 ===========================
 

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -17,9 +17,8 @@
 
 """checker for use of Python logging
 """
-import string
-
 import logging
+import string
 
 import astroid
 

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -19,6 +19,8 @@
 """
 import string
 
+import logging
+
 import astroid
 
 from pylint import checkers, interfaces
@@ -166,7 +168,7 @@ class LoggingChecker(checkers.BaseChecker):
         logging_mods = self.config.logging_modules
 
         self._format_style = self.config.logging_format_style
-        self._check_levels = set([level.lower() for level in self.config.logging_lazy_levels])
+        self._check_levels = {level.lower() for level in self.config.logging_lazy_levels}
         self._logging_modules = set(logging_mods)
         self._from_imports = {}
         for logging_mod in logging_mods:
@@ -230,17 +232,18 @@ class LoggingChecker(checkers.BaseChecker):
         level = level.lower()
 
         if 'all' not in self._check_levels:
-            if type(level) != str:
+            if not isinstance(level, str):
                 try:
                     level = logging.getLevelName(level)
-                except:
+                except TypeError:
                     level = "unknown"
 
-                if type(level) != str:
+                if not isinstance(level, str):
                     level = "unknown"
+
             return level in self._check_levels
-        else:
-            return True
+
+        return True
 
     def _check_log_method(self, node, name):
         """Checks calls to logging.log(level, format, *format_args)."""

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -168,7 +168,9 @@ class LoggingChecker(checkers.BaseChecker):
         logging_mods = self.config.logging_modules
 
         self._format_style = self.config.logging_format_style
-        self._check_levels = {level.lower() for level in self.config.logging_lazy_levels}
+        self._check_levels = {
+            level.lower() for level in self.config.logging_lazy_levels
+        }
         self._logging_modules = set(logging_mods)
         self._from_imports = {}
         for logging_mod in logging_mods:
@@ -231,7 +233,7 @@ class LoggingChecker(checkers.BaseChecker):
     def _is_lazy_needed(self, level):
         level = level.lower()
 
-        if 'all' not in self._check_levels:
+        if "all" not in self._check_levels:
             if not isinstance(level, str):
                 try:
                     level = logging.getLevelName(level)

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ setenv =
     COVERAGE_FILE = {toxinidir}/.coverage.{envname}
 
 commands =
-    python -Wi {envsitepackagesdir}/coverage run -m pytest {toxinidir}/tests/ {posargs:}
+    python -Wi {envsitepackagesdir}/coverage run -m pytest {toxinidir}/tests/{posargs:}
 
     ; Transform absolute path to relative path
     ; for compatibility with coveralls.io and fix 'source not available' error.


### PR DESCRIPTION
## Description

Add a `logging-lazy-levels` option so that users can choose allow certain levels (error, info, etc) to use f-string formatting and make their own determination as to where performance benefits outweigh code readability.

Also, I currently use a variation on this as a plugin, but because of the tight integration with the logging code, the plugin model is unwieldy.

NOTE FOR REVIEW: I think, maybe, this should *only* affect f-string checks, simply because other code styles are both non-readable *and* non-lazy.   Also, not sure about the name of the option (least confusing, etc.).

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |
