### PR TITLE
Fix overzealous `arguments-differ` for variadics

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -375,3 +375,5 @@ contributors:
 * Bernie Gray: contributor
 
 * Slavfox: contributor
+
+* Matthew Beckers (mattlbeck): contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -244,6 +244,15 @@ Release date: TBA
 
   Closes #3098
 
+* Fix overzealous `arguments-differ` when overridden function uses variadics
+
+  No message is emitted if the overriding function provides positional or
+  keyword variadics in its signature that can feasibly accept and pass on
+  all parameters given by the overridden function.
+
+  Close #1482
+  Close #1553
+
 What's New in Pylint 2.4.4?
 ===========================
 Release date: 2019-11-13

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -282,7 +282,7 @@ def _different_parameters(original, overridden, dummy_parameter_regex):
     overridden_parameters = _positional_parameters(overridden)
 
     # Copy kwonlyargs list so that we don't affect later function linting
-    original_kwonlyargs = [v for v in original.args.kwonlyargs]
+    original_kwonlyargs = original.args.kwonlyargs
 
     # Allow positional/keyword variadic in overridden to match against any
     # positional/keyword argument in original.

--- a/tests/functional/a/arguments_differ.py
+++ b/tests/functional/a/arguments_differ.py
@@ -154,8 +154,10 @@ class SuperClass(object):
 
 class MyClass(SuperClass):
 
-    def impl(self, *args, **kwargs): # [arguments-differ]
-
+    def impl(self, *args, **kwargs):
+        """
+        Acceptable use of vararg in subclass because it does not violate LSP.
+        """
         super(MyClass, self).impl(*args, **kwargs)
 
 
@@ -170,6 +172,7 @@ class SecondChangesArgs(FirstHasArgs):
     def test(self, first, second, *args): # [arguments-differ]
         pass
 
+
 class Positional(object):
 
     def test(self, first, second):
@@ -178,12 +181,34 @@ class Positional(object):
 
 class PositionalChild(Positional):
 
-    def test(self, *args): # [arguments-differ]
-        """Accepts too many.
-
-        Why subclassing in the first case if the behavior is different?
+    def test(self, *args):
+        """
+        Acceptable use of vararg in subclass because it does not violate LSP.
         """
         super(PositionalChild, self).test(args[0], args[1])
+
+class Mixed(object):
+
+    def mixed(self, first, second, *, third, fourth):
+        pass
+
+
+class MixedChild1(Mixed):
+
+    def mixed(self, first, *args, **kwargs):
+        """
+        Acceptable use of vararg in subclass because it does not violate LSP.
+        """
+        super(MixedChild1, self).mixed(first, *args, **kwargs)
+
+
+class MixedChild2(Mixed):
+
+    def mixed(self, first, *args, third, **kwargs):
+        """
+        Acceptable use of vararg in subclass because it does not violate LSP.
+        """
+        super(MixedChild2, self).mixed(first, *args, third, **kwargs)
 
 
 class HasSpecialMethod(object):

--- a/tests/functional/a/arguments_differ.txt
+++ b/tests/functional/a/arguments_differ.txt
@@ -3,6 +3,4 @@ arguments-differ:23:ChildDefaults.test:Parameters differ from overridden 'test' 
 arguments-differ:41:ClassmethodChild.func:Parameters differ from overridden 'func' method
 arguments-differ:68:VarargsChild.has_kwargs:Parameters differ from overridden 'has_kwargs' method
 arguments-differ:71:VarargsChild.no_kwargs:Parameters differ from overridden 'no_kwargs' method
-arguments-differ:157:MyClass.impl:Parameters differ from overridden 'impl' method
-arguments-differ:170:SecondChangesArgs.test:Parameters differ from overridden 'test' method
-arguments-differ:181:PositionalChild.test:Parameters differ from overridden 'test' method
+arguments-differ:172:SecondChangesArgs.test:Parameters differ from overridden 'test' method

--- a/tests/functional/a/arguments_differ_py3.py
+++ b/tests/functional/a/arguments_differ_py3.py
@@ -16,6 +16,9 @@ class AbstractFoo:
     def kwonly_5(self, *, first, **kwargs):
         "Keyword only and keyword variadics."
 
+    def kwonly_6(self, first, second, *, third):
+        "Two positional and one keyword"
+
 
 class Foo(AbstractFoo):
 
@@ -33,4 +36,12 @@ class Foo(AbstractFoo):
 
     def kwonly_5(self, *, first): # [arguments-differ]
         "Keyword only, but no variadics."
-    
+
+    def kwonly_6(self, *args, **kwargs): # valid override
+        "Positional and keyword variadics to pass through parent params"
+
+
+class Foo2(AbstractFoo):
+
+    def kwonly_6(self, first, *args, **kwargs): # valid override
+        "One positional with the rest variadics to pass through parent params"

--- a/tests/functional/a/arguments_differ_py3.txt
+++ b/tests/functional/a/arguments_differ_py3.txt
@@ -1,5 +1,5 @@
-arguments-differ:22:Foo.kwonly_1:Parameters differ from overridden 'kwonly_1' method
-arguments-differ:25:Foo.kwonly_2:Parameters differ from overridden 'kwonly_2' method
-arguments-differ:28:Foo.kwonly_3:Parameters differ from overridden 'kwonly_3' method
-arguments-differ:31:Foo.kwonly_4:Parameters differ from overridden 'kwonly_4' method
-arguments-differ:34:Foo.kwonly_5:Parameters differ from overridden 'kwonly_5' method
+arguments-differ:25:Foo.kwonly_1:Parameters differ from overridden 'kwonly_1' method
+arguments-differ:28:Foo.kwonly_2:Parameters differ from overridden 'kwonly_2' method
+arguments-differ:31:Foo.kwonly_3:Parameters differ from overridden 'kwonly_3' method
+arguments-differ:34:Foo.kwonly_4:Parameters differ from overridden 'kwonly_4' method
+arguments-differ:37:Foo.kwonly_5:Parameters differ from overridden 'kwonly_5' method


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

This PR suppresses the `arguments-differ` message if the overriding function provides positional or keyword variadics in its signature that can feasibly accept and pass on all parameters given by the overridden function.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
Closes #1482
Closes #1553
