### PR TITLE
Refactor file checking

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -311,3 +311,5 @@ contributors:
 * Oisin Moran: contributor
 
 * Andrzej Klajnert: contributor
+
+* Janne Rönkkö: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,11 @@ What's New in Pylint 2.4.0?
 
 Release date: TBA
 
+* Refactor file checking
+
+  Remove code duplication and prepare for supporting parallel linting
+  under Prospector.
+
 * Added a new check, ``invalid-overridden-method``
 
   This check is emitted when we detect that a method is overridden


### PR DESCRIPTION
## Description

This change prepares the code for enabling Prospector to take advantage
of running PyLint parallel.

Iterating files is moved into generator (_iterate_file_items) so that
parallel checking can use the same implementation (_check_file_items) just
by providing different kind of generator that reads the files from parent
process.

The refactoring removes code duplication that existed in PyLinter._do_check
method; checking module content from stdin had identical implementation to
checking content from a source file.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Related Issue
https://github.com/PyCQA/prospector/issues/320
