### PR TITLE
Fix black and isort excludes in pre-commit then apply black

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,5 +3,5 @@ multi_line_output=3
 line_length=88
 known_third_party=astroid, sphinx, isort, pytest, mccabe, six,
 include_trailing_comma=True
-skip_glob=tests/functional/**,tests/input/**,*/test/extension/**,tests/regrtest_data/**,*tests/data/**
+skip_glob=tests/functional/**,tests/input/**,tests/extensions/data/**,tests/regrtest_data/**,tests/data/**
 project=pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     - id: black
       args: [--safe, --quiet]
-      exclude: functional|input|test/extension|test/regrtest_data|test/data
+      exclude: tests/functional|tests/input|tests/extensions/data|tests/regrtest_data/|tests/data/
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.1.0
     hooks:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -138,7 +138,7 @@ html_theme_options = {
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = "%b %d, %Y"
 
 smartquotes = False
 

--- a/tests/extensions/test_bad_builtin.py
+++ b/tests/extensions/test_bad_builtin.py
@@ -20,23 +20,22 @@ EXPECTED = [
 ]
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def checker(checker):
     return BadBuiltinChecker
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def disable(disable):
-    return ['I']
+    return ["I"]
 
 
 def test_types_redefined(linter):
-    elif_test = osp.join(osp.dirname(osp.abspath(__file__)), 'data',
-                         'bad_builtin.py')
+    elif_test = osp.join(osp.dirname(osp.abspath(__file__)), "data", "bad_builtin.py")
     with fix_import_path([elif_test]):
         linter.check([elif_test])
     msgs = sorted(linter.reporter.messages, key=lambda item: item.line)
     assert len(msgs) == 2
     for msg, expected in zip(msgs, EXPECTED):
-        assert msg.symbol == 'bad-builtin'
+        assert msg.symbol == "bad-builtin"
         assert msg.msg == expected

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -29,16 +29,16 @@ from pylint.testutils import CheckerTestCase, Message, set_config
 
 class TestParamDocChecker(CheckerTestCase):
     """Tests for pylint_plugin.ParamDocChecker"""
+
     CHECKER_CLASS = DocstringParameterChecker
-    CONFIG = {
-        'accept_no_param_doc': False,
-    }
+    CONFIG = {"accept_no_param_doc": False}
 
     def test_missing_func_params_in_sphinx_docstring(self):
         """Example of a function with missing Sphinx parameter documentation in
         the docstring
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(x, y, z):
             '''docstring ...
 
@@ -47,16 +47,11 @@ class TestParamDocChecker(CheckerTestCase):
             :param int z: bar
             '''
             pass
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('y',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('x, y',))
+            Message(msg_id="missing-param-doc", node=node, args=("y",)),
+            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -64,7 +59,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a function with missing Google style parameter
         documentation in the docstring
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(x, y, z):
             '''docstring ...
 
@@ -75,16 +71,11 @@ class TestParamDocChecker(CheckerTestCase):
             some other stuff
             '''
             pass
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('y',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('x, y',))
+            Message(msg_id="missing-param-doc", node=node, args=("y",)),
+            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -92,7 +83,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a function with missing Google style parameter
         documentation in the docstring.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(x: int, y: bool, z):
             '''docstring ...
 
@@ -104,7 +96,8 @@ class TestParamDocChecker(CheckerTestCase):
             some other stuff
             '''
             pass
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -112,7 +105,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a function with missing Google style parameter
         documentation in the docstring.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(x: int, y: bool, z: int = 786):
             '''docstring ...
 
@@ -124,7 +118,8 @@ class TestParamDocChecker(CheckerTestCase):
             some other stuff
             '''
             pass
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -132,7 +127,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a function with missing Google style parameter
         documentation in the docstring.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(x, y: bool, z):
             '''docstring ...
 
@@ -144,12 +140,10 @@ class TestParamDocChecker(CheckerTestCase):
             some other stuff
             '''
             pass
-        """)
+        """
+        )
         with self.assertAddsMessages(
-                Message(
-                    msg_id='missing-type-doc',
-                    node=node,
-                    args=('x',))
+            Message(msg_id="missing-type-doc", node=node, args=("x",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -157,7 +151,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a function with missing Google style parameter
         documentation in the docstring.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def area(bottomleft: Point, topright: Point) -> float:
             '''Calculate area of fake rectangle.
                 Args:
@@ -165,7 +160,8 @@ class TestParamDocChecker(CheckerTestCase):
                     topright: top right point of rectangle
             '''
             pass
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -173,7 +169,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a function with missing Google style parameter
         documentation in the docstring.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def get_midpoint(bottomleft: Point, topright: Point) -> Point:
             '''Calculate midpoint of fake rectangle.
                 Args:
@@ -181,7 +178,8 @@ class TestParamDocChecker(CheckerTestCase):
                     topright: top right point of rectangle
             '''
             pass
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -189,7 +187,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a function with Google style parameter splitted
         in Args and Keyword Args in the docstring
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def my_func(this, other, that=True):
             '''Prints this, other and that
 
@@ -201,7 +200,8 @@ class TestParamDocChecker(CheckerTestCase):
                     that (bool): Printed second
             '''
             print(this, that, other)
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -209,7 +209,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a function with Google style parameter splitted
         in Args and Keyword Args in the docstring but with wrong keyword args
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def my_func(this, other, that=True):
             '''Prints this, other and that
 
@@ -221,32 +222,22 @@ class TestParamDocChecker(CheckerTestCase):
                     these (bool): Printed second
             '''
             print(this, that, other)
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('that',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('that',)),
-            Message(
-                msg_id='differing-param-doc',
-                node=node,
-                args=('these',)),
-            Message(
-                msg_id='differing-type-doc',
-                node=node,
-                args=('these',))
-            ):
+            Message(msg_id="missing-param-doc", node=node, args=("that",)),
+            Message(msg_id="missing-type-doc", node=node, args=("that",)),
+            Message(msg_id="differing-param-doc", node=node, args=("these",)),
+            Message(msg_id="differing-type-doc", node=node, args=("these",)),
+        ):
             self.checker.visit_functiondef(node)
 
     def test_missing_func_params_in_numpy_docstring(self):
         """Example of a function with missing NumPy style parameter
         documentation in the docstring
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(x, y, z):
             '''docstring ...
 
@@ -260,16 +251,11 @@ class TestParamDocChecker(CheckerTestCase):
             some other stuff
             '''
             pass
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('y',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('x, y',))
+            Message(msg_id="missing-param-doc", node=node, args=("y",)),
+            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -279,13 +265,15 @@ class TestParamDocChecker(CheckerTestCase):
 
         No error message is emitted.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(x, y):
             '''docstring ...
 
             missing parameter documentation'''
             pass
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -294,22 +282,18 @@ class TestParamDocChecker(CheckerTestCase):
 
         Missing documentation error message is emitted.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(x, y):
             '''docstring ...
 
             missing parameter documentation'''
             pass
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('x, y',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('x, y',))
+            Message(msg_id="missing-param-doc", node=node, args=("x, y",)),
+            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -317,14 +301,16 @@ class TestParamDocChecker(CheckerTestCase):
         """Example for the usage of "For the parameters, see"
         to suppress missing-param warnings.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(x, y):
             '''docstring ...
 
             For the parameters, see :func:`blah`
             '''
             pass
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -335,15 +321,17 @@ class TestParamDocChecker(CheckerTestCase):
         :type node: :class:`astroid.scoped_nodes.Class`
         """
         for body_item in node.body:
-            if (isinstance(body_item, astroid.FunctionDef)
-                    and hasattr(body_item, 'name')):
+            if isinstance(body_item, astroid.FunctionDef) and hasattr(
+                body_item, "name"
+            ):
                 self.checker.visit_functiondef(body_item)
 
     def test_missing_method_params_in_sphinx_docstring(self):
         """Example of a class method with missing parameter documentation in
         the Sphinx style docstring
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class Foo(object):
             def method_foo(self, x, y):
                 '''docstring ...
@@ -353,17 +341,12 @@ class TestParamDocChecker(CheckerTestCase):
                 :param x: bla
                 '''
                 pass
-        """)
+        """
+        )
         method_node = node.body[0]
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=method_node,
-                args=('y',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=method_node,
-                args=('x, y',))
+            Message(msg_id="missing-param-doc", node=method_node, args=("y",)),
+            Message(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -371,7 +354,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a class method with missing parameter documentation in
         the Google style docstring
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class Foo(object):
             def method_foo(self, x, y):
                 '''docstring ...
@@ -382,17 +366,12 @@ class TestParamDocChecker(CheckerTestCase):
                     x: bla
                 '''
                 pass
-        """)
+        """
+        )
         method_node = node.body[0]
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=method_node,
-                args=('y',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=method_node,
-                args=('x, y',))
+            Message(msg_id="missing-param-doc", node=method_node, args=("y",)),
+            Message(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -400,7 +379,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a class method with missing parameter documentation in
         the Numpy style docstring
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class Foo(object):
             def method_foo(self, x, y):
                 '''docstring ...
@@ -413,17 +393,12 @@ class TestParamDocChecker(CheckerTestCase):
                     bla
                 '''
                 pass
-        """)
+        """
+        )
         method_node = node.body[0]
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=method_node,
-                args=('y',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=method_node,
-                args=('x, y',))
+            Message(msg_id="missing-param-doc", node=method_node, args=("y",)),
+            Message(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -431,7 +406,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a function with correctly documented parameters and
         return values (Sphinx style)
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(xarg, yarg, zarg, warg):
             '''function foo ...
 
@@ -449,7 +425,8 @@ class TestParamDocChecker(CheckerTestCase):
             :rtype: float
             '''
             return xarg + yarg
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -457,7 +434,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a function with correctly documented parameters and
         return values (Google style)
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(xarg, yarg, zarg, warg):
             '''function foo ...
 
@@ -473,7 +451,8 @@ class TestParamDocChecker(CheckerTestCase):
                 float: sum
             '''
             return xarg + yarg
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -481,7 +460,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a function with correctly documented parameters and
         return values (Numpy style)
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(xarg, yarg, zarg, warg):
             '''function foo ...
 
@@ -503,7 +483,8 @@ class TestParamDocChecker(CheckerTestCase):
                 sum
             '''
             return xarg + yarg
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -511,7 +492,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of functions with inconsistent parameter names in the
         signature and in the Sphinx style documentation
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(xarg, yarg, zarg):
             '''function foo ...
 
@@ -524,28 +506,18 @@ class TestParamDocChecker(CheckerTestCase):
             :param str zarg1: bla zarg
             '''
             return xarg + yarg
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('xarg, zarg',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('yarg, zarg',)),
-            Message(
-                    msg_id='differing-param-doc',
-                    node=node,
-                    args=('xarg1, zarg1',)),
-            Message(
-                msg_id='differing-type-doc',
-                node=node,
-                args=('yarg1, zarg1',)),
+            Message(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
+            Message(msg_id="missing-type-doc", node=node, args=("yarg, zarg",)),
+            Message(msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)),
+            Message(msg_id="differing-type-doc", node=node, args=("yarg1, zarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(xarg, yarg):
             '''function foo ...
 
@@ -555,16 +527,11 @@ class TestParamDocChecker(CheckerTestCase):
             For the other parameters, see bla.
             '''
             return xarg + yarg
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='differing-param-doc',
-                node=node,
-                args=('yarg1',)),
-            Message(
-                msg_id='differing-type-doc',
-                node=node,
-                args=('yarg1',)),
+            Message(msg_id="differing-param-doc", node=node, args=("yarg1",)),
+            Message(msg_id="differing-type-doc", node=node, args=("yarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -572,7 +539,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of functions with inconsistent parameter names in the
         signature and in the Google style documentation
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(xarg, yarg, zarg):
             '''function foo ...
 
@@ -583,28 +551,18 @@ class TestParamDocChecker(CheckerTestCase):
                 zarg1 (str): bla zarg
             '''
             return xarg + yarg
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('xarg, zarg',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('xarg, zarg',)),
-            Message(
-                msg_id='differing-param-doc',
-                node=node,
-                args=('xarg1, zarg1',)),
-            Message(
-                msg_id='differing-type-doc',
-                node=node,
-                args=('xarg1, zarg1',)),
+            Message(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
+            Message(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
+            Message(msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)),
+            Message(msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(xarg, yarg):
             '''function foo ...
 
@@ -614,16 +572,11 @@ class TestParamDocChecker(CheckerTestCase):
             For the other parameters, see bla.
             '''
             return xarg + yarg
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='differing-param-doc',
-                node=node,
-                args=('yarg1',)),
-            Message(
-                msg_id='differing-type-doc',
-                node=node,
-                args=('yarg1',))
+            Message(msg_id="differing-param-doc", node=node, args=("yarg1",)),
+            Message(msg_id="differing-type-doc", node=node, args=("yarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -631,7 +584,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of functions with inconsistent parameter names in the
         signature and in the Numpy style documentation
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(xarg, yarg, zarg):
             '''function foo ...
 
@@ -646,28 +600,18 @@ class TestParamDocChecker(CheckerTestCase):
                 bla zarg
             '''
             return xarg + yarg
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('xarg, zarg',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('xarg, zarg',)),
-            Message(
-                msg_id='differing-param-doc',
-                node=node,
-                args=('xarg1, zarg1',)),
-            Message(
-                msg_id='differing-type-doc',
-                node=node,
-                args=('xarg1, zarg1',)),
+            Message(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
+            Message(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
+            Message(msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)),
+            Message(msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(xarg, yarg):
             '''function foo ...
 
@@ -679,16 +623,11 @@ class TestParamDocChecker(CheckerTestCase):
             For the other parameters, see bla.
             '''
             return xarg + yarg
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='differing-param-doc',
-                node=node,
-                args=('yarg1',)),
-            Message(
-                msg_id='differing-type-doc',
-                node=node,
-                args=('yarg1',))
+            Message(msg_id="differing-param-doc", node=node, args=("yarg1",)),
+            Message(msg_id="differing-type-doc", node=node, args=("yarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -697,7 +636,8 @@ class TestParamDocChecker(CheckerTestCase):
         too many repetitions, e.g. in functions or methods adhering to a
         given interface (Sphinx style)
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(xarg, yarg):
             '''function foo ...
 
@@ -707,7 +647,8 @@ class TestParamDocChecker(CheckerTestCase):
             For the other parameters, see :func:`bla`
             '''
             return xarg + yarg
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -716,7 +657,8 @@ class TestParamDocChecker(CheckerTestCase):
         too many repetitions, e.g. in functions or methods adhering to a
         given interface (Google style)
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(xarg, yarg):
             '''function foo ...
 
@@ -726,7 +668,8 @@ class TestParamDocChecker(CheckerTestCase):
             For the other parameters, see :func:`bla`
             '''
             return xarg + yarg
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -735,7 +678,8 @@ class TestParamDocChecker(CheckerTestCase):
         too many repetitions, e.g. in functions or methods adhering to a
         given interface (Numpy style)
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         def function_foo(xarg, yarg):
             '''function foo ...
 
@@ -747,7 +691,8 @@ class TestParamDocChecker(CheckerTestCase):
             For the other parameters, see :func:`bla`
             '''
             return xarg + yarg
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -757,7 +702,8 @@ class TestParamDocChecker(CheckerTestCase):
 
         Everything is completely analogous to functions.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class ClassFoo(object):
             '''docstring foo
 
@@ -769,16 +715,11 @@ class TestParamDocChecker(CheckerTestCase):
             def __init__(self, x, y):
                 pass
 
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('x',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('x, y',))
+            Message(msg_id="missing-param-doc", node=node, args=("x",)),
+            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -788,7 +729,8 @@ class TestParamDocChecker(CheckerTestCase):
 
         Everything is completely analogous to functions.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class ClassFoo(object):
             '''docstring foo
 
@@ -801,16 +743,11 @@ class TestParamDocChecker(CheckerTestCase):
             def __init__(self, x, y):
                 pass
 
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('x',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('x, y',))
+            Message(msg_id="missing-param-doc", node=node, args=("x",)),
+            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -820,7 +757,8 @@ class TestParamDocChecker(CheckerTestCase):
 
         Everything is completely analogous to functions.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class ClassFoo(object):
             '''docstring foo
 
@@ -835,16 +773,11 @@ class TestParamDocChecker(CheckerTestCase):
             def __init__(self, x, y):
                 pass
 
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('x',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('x, y',))
+            Message(msg_id="missing-param-doc", node=node, args=("x",)),
+            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -852,7 +785,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a class with correct constructor parameter documentation
         and an attributes section (Numpy style)
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class ClassFoo(object):
             '''
             Parameters
@@ -867,7 +801,8 @@ class TestParamDocChecker(CheckerTestCase):
             '''
             def __init__(self, foo):
                 self.bar = None
-        """)
+        """
+        )
         with self.assertNoMessages():
             self._visit_methods_of_class(node)
 
@@ -877,7 +812,8 @@ class TestParamDocChecker(CheckerTestCase):
 
         Everything is completely analogous to functions.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class ClassFoo(object):
             def __init__(self, x, y):
                 '''docstring foo constructor
@@ -889,17 +825,12 @@ class TestParamDocChecker(CheckerTestCase):
 
                 pass
 
-        """)
+        """
+        )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=constructor_node,
-                args=('x',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=constructor_node,
-                args=('x, y',))
+            Message(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            Message(msg_id="missing-type-doc", node=constructor_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -909,7 +840,8 @@ class TestParamDocChecker(CheckerTestCase):
 
         Everything is completely analogous to functions.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class ClassFoo(object):
             def __init__(self, x, y):
                 '''docstring foo constructor
@@ -921,17 +853,12 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 pass
 
-        """)
+        """
+        )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=constructor_node,
-                args=('x',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=constructor_node,
-                args=('x, y',))
+            Message(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            Message(msg_id="missing-type-doc", node=constructor_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -941,7 +868,8 @@ class TestParamDocChecker(CheckerTestCase):
 
         Everything is completely analogous to functions.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class ClassFoo(object):
             def __init__(self, x, y):
                 '''docstring foo constructor
@@ -955,23 +883,19 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 pass
 
-        """)
+        """
+        )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=constructor_node,
-                args=('x',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=constructor_node,
-                args=('x, y',))
+            Message(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            Message(msg_id="missing-type-doc", node=constructor_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
     def test_see_sentence_for_constr_params_in_class(self):
         """Example usage of "For the parameters, see" in class docstring"""
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class ClassFoo(object):
             '''docstring foo
 
@@ -982,13 +906,15 @@ class TestParamDocChecker(CheckerTestCase):
                 '''init'''
                 pass
 
-        """)
+        """
+        )
         with self.assertNoMessages():
             self._visit_methods_of_class(node)
 
     def test_see_sentence_for_constr_params_in_init(self):
         """Example usage of "For the parameters, see" in init docstring"""
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class ClassFoo(object):
             '''foo'''
 
@@ -999,10 +925,10 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 pass
 
-        """)
+        """
+        )
         with self.assertNoMessages():
             self._visit_methods_of_class(node)
-
 
     def test_constr_params_in_class_and_init_sphinx(self):
         """Example of a class with missing constructor parameter documentation
@@ -1011,7 +937,8 @@ class TestParamDocChecker(CheckerTestCase):
 
         Everything is completely analogous to functions.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class ClassFoo(object):
             '''docstring foo
 
@@ -1029,29 +956,15 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 pass
 
-        """)
+        """
+        )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            Message(
-                msg_id='multiple-constructor-doc',
-                node=node,
-                args=(node.name,)),
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('x',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('x, y',)),
-            Message(
-                msg_id='missing-param-doc',
-                node=constructor_node,
-                args=('x',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=constructor_node,
-                args=('x, y',)),
+            Message(msg_id="multiple-constructor-doc", node=node, args=(node.name,)),
+            Message(msg_id="missing-param-doc", node=node, args=("x",)),
+            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            Message(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            Message(msg_id="missing-type-doc", node=constructor_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -1062,7 +975,8 @@ class TestParamDocChecker(CheckerTestCase):
 
         Everything is completely analogous to functions.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class ClassFoo(object):
             '''docstring foo
 
@@ -1082,29 +996,15 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 pass
 
-        """)
+        """
+        )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            Message(
-                msg_id='multiple-constructor-doc',
-                node=node,
-                args=(node.name,)),
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('x',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('x, y',)),
-            Message(
-                msg_id='missing-param-doc',
-                node=constructor_node,
-                args=('x',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=constructor_node,
-                args=('x, y',)),
+            Message(msg_id="multiple-constructor-doc", node=node, args=(node.name,)),
+            Message(msg_id="missing-param-doc", node=node, args=("x",)),
+            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            Message(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            Message(msg_id="missing-type-doc", node=constructor_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -1115,7 +1015,8 @@ class TestParamDocChecker(CheckerTestCase):
 
         Everything is completely analogous to functions.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class ClassFoo(object):
             '''docstring foo
 
@@ -1139,55 +1040,39 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 pass
 
-        """)
+        """
+        )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            Message(
-                msg_id='multiple-constructor-doc',
-                node=node,
-                args=(node.name,)),
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('x',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('x, y',)),
-            Message(
-                msg_id='missing-param-doc',
-                node=constructor_node,
-                args=('x',)),
-            Message(
-                msg_id='missing-type-doc',
-                node=constructor_node,
-                args=('x, y',)),
+            Message(msg_id="multiple-constructor-doc", node=node, args=(node.name,)),
+            Message(msg_id="missing-param-doc", node=node, args=("x",)),
+            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            Message(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            Message(msg_id="missing-type-doc", node=constructor_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
     @pytest.mark.skipif(sys.version_info[0] != 3, reason="Enabled on Python 3")
     def test_kwonlyargs_are_taken_in_account(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(arg, *, kwonly, missing_kwonly):
             """The docstring
 
             :param int arg: The argument.
             :param bool kwonly: A keyword-arg.
             """
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('missing_kwonly', )),
-            Message(
-                msg_id='missing-type-doc',
-                node=node,
-                args=('missing_kwonly', ))):
+            Message(msg_id="missing-param-doc", node=node, args=("missing_kwonly",)),
+            Message(msg_id="missing-type-doc", node=node, args=("missing_kwonly",)),
+        ):
             self.checker.visit_functiondef(node)
 
     def test_warns_missing_args_sphinx(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg, *args):
             """The docstring
 
@@ -1198,16 +1083,16 @@ class TestParamDocChecker(CheckerTestCase):
             """
             if args:
                 return named_arg
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('args',))):
+            Message(msg_id="missing-param-doc", node=node, args=("args",))
+        ):
             self.checker.visit_functiondef(node)
 
     def test_warns_missing_kwargs_sphinx(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg, **kwargs):
             """The docstring
 
@@ -1218,16 +1103,16 @@ class TestParamDocChecker(CheckerTestCase):
             """
             if kwargs:
                 return named_arg
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('kwargs',))):
+            Message(msg_id="missing-param-doc", node=node, args=("kwargs",))
+        ):
             self.checker.visit_functiondef(node)
 
     def test_warns_missing_args_google(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg, *args):
             """The docstring
 
@@ -1239,16 +1124,16 @@ class TestParamDocChecker(CheckerTestCase):
             """
             if args:
                 return named_arg
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('args',))):
+            Message(msg_id="missing-param-doc", node=node, args=("args",))
+        ):
             self.checker.visit_functiondef(node)
 
     def test_warns_missing_kwargs_google(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg, **kwargs):
             """The docstring
 
@@ -1260,16 +1145,16 @@ class TestParamDocChecker(CheckerTestCase):
             """
             if kwargs:
                 return named_arg
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('kwargs',))):
+            Message(msg_id="missing-param-doc", node=node, args=("kwargs",))
+        ):
             self.checker.visit_functiondef(node)
 
     def test_warns_missing_args_numpy(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg, *args):
             """The docstring
 
@@ -1285,16 +1170,16 @@ class TestParamDocChecker(CheckerTestCase):
             """
             if args:
                 return named_arg
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('args',))):
+            Message(msg_id="missing-param-doc", node=node, args=("args",))
+        ):
             self.checker.visit_functiondef(node)
 
     def test_warns_missing_kwargs_numpy(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg, **kwargs):
             """The docstring
 
@@ -1310,16 +1195,16 @@ class TestParamDocChecker(CheckerTestCase):
             """
             if kwargs:
                 return named_arg
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-param-doc',
-                node=node,
-                args=('kwargs',))):
+            Message(msg_id="missing-param-doc", node=node, args=("kwargs",))
+        ):
             self.checker.visit_functiondef(node)
 
     def test_finds_args_without_type_sphinx(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg, *args):
             """The docstring
 
@@ -1331,12 +1216,14 @@ class TestParamDocChecker(CheckerTestCase):
             """
             if args:
                 return named_arg
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_finds_kwargs_without_type_sphinx(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg, **kwargs):
             """The docstring
 
@@ -1348,12 +1235,14 @@ class TestParamDocChecker(CheckerTestCase):
             """
             if kwargs:
                 return named_arg
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_finds_args_without_type_google(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg, *args):
             """The docstring
 
@@ -1366,12 +1255,14 @@ class TestParamDocChecker(CheckerTestCase):
             """
             if args:
                 return named_arg
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_finds_kwargs_without_type_google(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg, **kwargs):
             """The docstring
 
@@ -1384,12 +1275,14 @@ class TestParamDocChecker(CheckerTestCase):
             """
             if kwargs:
                 return named_arg
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_finds_args_without_type_numpy(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg, *args):
             """The docstring
 
@@ -1407,12 +1300,14 @@ class TestParamDocChecker(CheckerTestCase):
             """
             if args:
                 return named_arg
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_finds_args_with_xref_type_google(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg, **kwargs):
             """The docstring
 
@@ -1425,12 +1320,14 @@ class TestParamDocChecker(CheckerTestCase):
             """
             if kwargs:
                 return named_arg
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_finds_args_with_xref_type_numpy(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg, *args):
             """The docstring
 
@@ -1448,12 +1345,14 @@ class TestParamDocChecker(CheckerTestCase):
             """
             if args:
                 return named_arg
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_finds_kwargs_without_type_numpy(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg, **kwargs):
             """The docstring
 
@@ -1471,29 +1370,31 @@ class TestParamDocChecker(CheckerTestCase):
             """
             if kwargs:
                 return named_arg
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     CONTAINER_TYPES = [
-        'dict(str,str)',
-        'dict[str,str]',
-        'tuple(int)',
-        'list[tokenize.TokenInfo]',
+        "dict(str,str)",
+        "dict[str,str]",
+        "tuple(int)",
+        "list[tokenize.TokenInfo]",
     ]
 
     COMPLEX_TYPES = CONTAINER_TYPES + [
-        'dict(str, str)',
-        'dict[str, str]',
-        'int or str',
-        'tuple(int or str)',
-        'tuple(int) or list(int)',
-        'tuple(int or str) or list(int or str)',
+        "dict(str, str)",
+        "dict[str, str]",
+        "int or str",
+        "tuple(int or str)",
+        "tuple(int) or list(int)",
+        "tuple(int or str) or list(int or str)",
     ]
 
-    @pytest.mark.parametrize('complex_type', COMPLEX_TYPES)
+    @pytest.mark.parametrize("complex_type", COMPLEX_TYPES)
     def test_finds_multiple_types_sphinx(self, complex_type):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg):
             """The docstring
 
@@ -1504,13 +1405,17 @@ class TestParamDocChecker(CheckerTestCase):
             :rtype: {0}
             """
             return named_arg
-        '''.format(complex_type))
+        '''.format(
+                complex_type
+            )
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
-    @pytest.mark.parametrize('complex_type', COMPLEX_TYPES)
+    @pytest.mark.parametrize("complex_type", COMPLEX_TYPES)
     def test_finds_multiple_types_google(self, complex_type):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg):
             """The docstring
 
@@ -1521,13 +1426,17 @@ class TestParamDocChecker(CheckerTestCase):
                 {0}: named_arg
             """
             return named_arg
-        '''.format(complex_type))
+        '''.format(
+                complex_type
+            )
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
-    @pytest.mark.parametrize('complex_type', COMPLEX_TYPES)
+    @pytest.mark.parametrize("complex_type", COMPLEX_TYPES)
     def test_finds_multiple_types_numpy(self, complex_type):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg):
             """The docstring
 
@@ -1542,13 +1451,17 @@ class TestParamDocChecker(CheckerTestCase):
                     named_arg
             """
             return named_arg
-        '''.format(complex_type))
+        '''.format(
+                complex_type
+            )
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
-    @pytest.mark.parametrize('container_type', CONTAINER_TYPES)
+    @pytest.mark.parametrize("container_type", CONTAINER_TYPES)
     def test_finds_compact_container_types_sphinx(self, container_type):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(named_arg):
             """The docstring
 
@@ -1558,12 +1471,16 @@ class TestParamDocChecker(CheckerTestCase):
             :rtype: {0}
             """
             return named_arg
-        '''.format(container_type))
+        '''.format(
+                container_type
+            )
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_ignores_optional_specifier_google(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def do_something(param1, param2, param3=(), param4=[], param5=[], param6=True):
             """Do something.
 
@@ -1579,12 +1496,14 @@ class TestParamDocChecker(CheckerTestCase):
                 int: Description.
             """
             return param1, param2, param3, param4, param5, param6
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_ignores_optional_specifier_numpy(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def do_something(param, param2='all'):
             """Do something.
 
@@ -1601,12 +1520,14 @@ class TestParamDocChecker(CheckerTestCase):
                 Description.
             """
             return param, param2
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_finds_short_name_exception(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         from fake_package import BadError
 
         def do_something(): #@
@@ -1616,7 +1537,8 @@ class TestParamDocChecker(CheckerTestCase):
                 ~fake_package.exceptions.BadError: When something bad happened.
             """
             raise BadError("A bad thing happened.")
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -1624,7 +1546,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a setter having missing raises documentation in
         the Sphinx style docstring of the property
         """
-        property_node, node = astroid.extract_node("""
+        property_node, node = astroid.extract_node(
+            """
         class Foo(object):
             @property
             def foo(self): #@
@@ -1637,12 +1560,14 @@ class TestParamDocChecker(CheckerTestCase):
             @foo.setter
             def foo(self, value):
                 raise AttributeError() #@
-        """)
+        """
+        )
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-raises-doc',
+                msg_id="missing-raises-doc",
                 node=property_node,
-                args=('AttributeError',)),
+                args=("AttributeError",),
+            )
         ):
             self.checker.visit_raise(node)
 
@@ -1650,7 +1575,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a setter having missing raises documentation in
         the Google style docstring of the property
         """
-        property_node, node = astroid.extract_node("""
+        property_node, node = astroid.extract_node(
+            """
         class Foo(object):
             @property
             def foo(self): #@
@@ -1668,12 +1594,14 @@ class TestParamDocChecker(CheckerTestCase):
             @foo.setter
             def foo(self, value):
                 raises AttributeError() #@
-        """)
+        """
+        )
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-raises-doc',
+                msg_id="missing-raises-doc",
                 node=property_node,
-                args=('AttributeError',)),
+                args=("AttributeError",),
+            )
         ):
             self.checker.visit_raise(node)
 
@@ -1681,7 +1609,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a setter having missing raises documentation in
         the Numpy style docstring of the property
         """
-        property_node, node = astroid.extract_node("""
+        property_node, node = astroid.extract_node(
+            """
         class Foo(object):
             @property
             def foo(self): #@
@@ -1701,12 +1630,14 @@ class TestParamDocChecker(CheckerTestCase):
             @foo.setter
             def foo(self, value):
                 raises AttributeError() #@
-        """)
+        """
+        )
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-raises-doc',
+                msg_id="missing-raises-doc",
                 node=property_node,
-                args=('AttributeError',)),
+                args=("AttributeError",),
+            )
         ):
             self.checker.visit_raise(node)
 
@@ -1714,7 +1645,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a setter having missing raises documentation in
         its own Sphinx style docstring
         """
-        setter_node, node = astroid.extract_node("""
+        setter_node, node = astroid.extract_node(
+            """
         class Foo(object):
             @property
             def foo(self):
@@ -1733,12 +1665,12 @@ class TestParamDocChecker(CheckerTestCase):
                 :type: None
                 '''
                 raise AttributeError() #@
-        """)
+        """
+        )
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-raises-doc',
-                node=setter_node,
-                args=('AttributeError',)),
+                msg_id="missing-raises-doc", node=setter_node, args=("AttributeError",)
+            )
         ):
             self.checker.visit_raise(node)
 
@@ -1746,7 +1678,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a setter having missing raises documentation in
         its own Google style docstring of the property
         """
-        setter_node, node = astroid.extract_node("""
+        setter_node, node = astroid.extract_node(
+            """
         class Foo(object):
             @property
             def foo(self):
@@ -1768,12 +1701,12 @@ class TestParamDocChecker(CheckerTestCase):
                 if True:
                     raise AttributeError() #@
                 raise RuntimeError()
-        """)
+        """
+        )
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-raises-doc',
-                node=setter_node,
-                args=('AttributeError',)),
+                msg_id="missing-raises-doc", node=setter_node, args=("AttributeError",)
+            )
         ):
             self.checker.visit_raise(node)
 
@@ -1781,7 +1714,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a setter having missing raises documentation in
         its own Numpy style docstring of the property
         """
-        setter_node, node = astroid.extract_node("""
+        setter_node, node = astroid.extract_node(
+            """
         class Foo(object):
             @property
             def foo(self):
@@ -1807,12 +1741,12 @@ class TestParamDocChecker(CheckerTestCase):
                 if True:
                     raise AttributeError() #@
                 raise RuntimeError()
-        """)
+        """
+        )
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-raises-doc',
-                node=setter_node,
-                args=('AttributeError',)),
+                msg_id="missing-raises-doc", node=setter_node, args=("AttributeError",)
+            )
         ):
             self.checker.visit_raise(node)
 
@@ -1820,7 +1754,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a property having return documentation in
         a Sphinx style docstring
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class Foo(object):
             @property
             def foo(self): #@
@@ -1829,7 +1764,8 @@ class TestParamDocChecker(CheckerTestCase):
                 :type: int
                 '''
                 return 10
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -1837,7 +1773,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a property having return documentation in
         a Google style docstring
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class Foo(object):
             @property
             def foo(self): #@
@@ -1848,7 +1785,8 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 raise RuntimeError()
                 return 10
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -1856,7 +1794,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a property having return documentation in
         a numpy style docstring
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class Foo(object):
             @property
             def foo(self): #@
@@ -1869,7 +1808,8 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 raise RuntimeError()
                 return 10
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -1877,7 +1817,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a property having missing return documentation in
         a Sphinx style docstring
         """
-        property_node, node = astroid.extract_node("""
+        property_node, node = astroid.extract_node(
+            """
         class Foo(object):
             @property
             def foo(self) -> int: #@
@@ -1887,7 +1828,8 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 raise RuntimeError()
                 return 10 #@
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_return(node)
 
@@ -1895,7 +1837,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a property having missing return documentation in
         a Sphinx style docstring
         """
-        property_node, node = astroid.extract_node("""
+        property_node, node = astroid.extract_node(
+            """
         class Foo(object):
             @property
             def foo(self): #@
@@ -1905,11 +1848,10 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 raise RuntimeError()
                 return 10 #@
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-return-type-doc',
-                node=property_node),
+            Message(msg_id="missing-return-type-doc", node=property_node)
         ):
             self.checker.visit_return(node)
 
@@ -1917,7 +1859,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a property having return documentation in
         a Google style docstring
         """
-        property_node, node = astroid.extract_node("""
+        property_node, node = astroid.extract_node(
+            """
         class Foo(object):
             @property
             def foo(self) -> int: #@
@@ -1928,7 +1871,8 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 raise RuntimeError()
                 return 10 #@
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_return(node)
 
@@ -1936,7 +1880,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a property having return documentation in
         a Google style docstring
         """
-        property_node, node = astroid.extract_node("""
+        property_node, node = astroid.extract_node(
+            """
         class Foo(object):
             @property
             def foo(self): #@
@@ -1947,11 +1892,10 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 raise RuntimeError()
                 return 10 #@
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-return-type-doc',
-                node=property_node),
+            Message(msg_id="missing-return-type-doc", node=property_node)
         ):
             self.checker.visit_return(node)
 
@@ -1959,7 +1903,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a property having return documentation in
         a numpy style docstring
         """
-        property_node, node = astroid.extract_node("""
+        property_node, node = astroid.extract_node(
+            """
         class Foo(object):
             @property
             def foo(self): #@
@@ -1972,11 +1917,10 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 raise RuntimeError()
                 return 10 #@
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-return-type-doc',
-                node=property_node),
+            Message(msg_id="missing-return-type-doc", node=property_node)
         ):
             self.checker.visit_return(node)
 
@@ -1984,7 +1928,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a class function trying to use `type` as return
         documentation in a Sphinx style docstring
         """
-        func_node, node = astroid.extract_node("""
+        func_node, node = astroid.extract_node(
+            """
         class Foo(object):
             def foo(self): #@
                 '''docstring ...
@@ -1992,14 +1937,11 @@ class TestParamDocChecker(CheckerTestCase):
                 :type: int
                 '''
                 return 10 #@
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-return-doc',
-                node=func_node),
-            Message(
-                msg_id='missing-return-type-doc',
-                node=func_node),
+            Message(msg_id="missing-return-doc", node=func_node),
+            Message(msg_id="missing-return-type-doc", node=func_node),
         ):
             self.checker.visit_return(node)
 
@@ -2007,7 +1949,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a class function trying to use `type` as return
         documentation in a Google style docstring
         """
-        func_node, node = astroid.extract_node("""
+        func_node, node = astroid.extract_node(
+            """
         class Foo(object):
             def foo(self): #@
                 '''int: docstring ...
@@ -2017,14 +1960,11 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 raise RuntimeError()
                 return 10 #@
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-return-doc',
-                node=func_node),
-            Message(
-                msg_id='missing-return-type-doc',
-                node=func_node),
+            Message(msg_id="missing-return-doc", node=func_node),
+            Message(msg_id="missing-return-type-doc", node=func_node),
         ):
             self.checker.visit_return(node)
 
@@ -2032,7 +1972,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a class function trying to use `type` as return
         documentation in a numpy style docstring
         """
-        func_node, node = astroid.extract_node("""
+        func_node, node = astroid.extract_node(
+            """
         class Foo(object):
             def foo(self): #@
                 '''int: docstring ...
@@ -2044,14 +1985,11 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 raise RuntimeError()
                 return 10 #@
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-return-doc',
-                node=func_node),
-            Message(
-                msg_id='missing-return-type-doc',
-                node=func_node),
+            Message(msg_id="missing-return-doc", node=func_node),
+            Message(msg_id="missing-return-type-doc", node=func_node),
         ):
             self.checker.visit_return(node)
 
@@ -2059,7 +1997,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a class function trying to use `type` as return
         documentation in a numpy style docstring
         """
-        func_node, node = astroid.extract_node("""
+        func_node, node = astroid.extract_node(
+            """
         class Foo(object):
             def foo(self) -> int: #@
                 '''int: docstring ...
@@ -2071,11 +2010,10 @@ class TestParamDocChecker(CheckerTestCase):
                 '''
                 raise RuntimeError()
                 return 10 #@
-        """)
+        """
+        )
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-return-doc',
-                node=func_node),
+            Message(msg_id="missing-return-doc", node=func_node)
         ):
             self.checker.visit_return(node)
 
@@ -2083,7 +2021,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of an abstract method documenting the return type that an
         implementation should return.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         import abc
         class Foo(object):
             @abc.abstractmethod
@@ -2094,7 +2033,8 @@ class TestParamDocChecker(CheckerTestCase):
                 :rtype: int
                 '''
                 return 10
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -2102,7 +2042,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of an abstract method documenting the return type that an
         implementation should return.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         import abc
         class Foo(object):
             @abc.abstractmethod
@@ -2113,7 +2054,8 @@ class TestParamDocChecker(CheckerTestCase):
                     int: Ten
                 '''
                 return 10
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -2121,7 +2063,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of an abstract method documenting the return type that an
         implementation should return.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         import abc
         class Foo(object):
             @abc.abstractmethod
@@ -2134,14 +2077,16 @@ class TestParamDocChecker(CheckerTestCase):
                     Ten
                 '''
                 return 10
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_ignores_raise_notimplementederror_sphinx(self):
         """Example of an abstract
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class Foo(object):
             def foo(self, arg): #@
                 '''docstring ...
@@ -2150,7 +2095,8 @@ class TestParamDocChecker(CheckerTestCase):
                 :type arg: int
                 '''
                 raise NotImplementedError()
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -2158,7 +2104,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a method documenting the return type that an
         implementation should return.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class Foo(object):
             def foo(self, arg): #@
                 '''docstring ...
@@ -2167,7 +2114,8 @@ class TestParamDocChecker(CheckerTestCase):
                     arg (int): An argument.
                 '''
                 raise NotImplementedError()
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -2175,7 +2123,8 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a method documenting the return type that an
         implementation should return.
         """
-        node = astroid.extract_node("""
+        node = astroid.extract_node(
+            """
         class Foo(object):
             def foo(self, arg): #@
                 '''docstring ...
@@ -2186,6 +2135,7 @@ class TestParamDocChecker(CheckerTestCase):
                     An argument.
                 '''
                 raise NotImplementedError()
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)

--- a/tests/extensions/test_check_docs_utils.py
+++ b/tests/extensions/test_check_docs_utils.py
@@ -17,47 +17,64 @@ import pytest
 import pylint.extensions._check_docs_utils as utils
 
 
-@pytest.mark.parametrize("string,count", [
-    ('abc',        0),
-    ('',           0),
-    ('  abc',      2),
-    ('\n  abc',    0),
-    ('   \n  abc', 3),
-])
+@pytest.mark.parametrize(
+    "string,count",
+    [("abc", 0), ("", 0), ("  abc", 2), ("\n  abc", 0), ("   \n  abc", 3)],
+)
 def test_space_indentation(string, count):
     """Test for pylint_plugin.ParamDocChecker"""
     assert utils.space_indentation(string) == count
 
 
-@pytest.mark.parametrize("raise_node,expected", [
-    (astroid.extract_node('''
+@pytest.mark.parametrize(
+    "raise_node,expected",
+    [
+        (
+            astroid.extract_node(
+                """
     def my_func():
         raise NotImplementedError #@
-    '''), {"NotImplementedError"}),
-
-    (astroid.extract_node('''
+    """
+            ),
+            {"NotImplementedError"},
+        ),
+        (
+            astroid.extract_node(
+                """
     def my_func():
         raise NotImplementedError("Not implemented!") #@
-    '''), {"NotImplementedError"}),
-
-    (astroid.extract_node('''
+    """
+            ),
+            {"NotImplementedError"},
+        ),
+        (
+            astroid.extract_node(
+                """
     def my_func():
         try:
             fake_func()
         except RuntimeError:
             raise #@
-    '''), {"RuntimeError"}),
-
-    (astroid.extract_node('''
+    """
+            ),
+            {"RuntimeError"},
+        ),
+        (
+            astroid.extract_node(
+                """
     def my_func():
         try:
             fake_func()
         except RuntimeError:
             if another_func():
                 raise #@
-    '''), {"RuntimeError"}),
-
-    (astroid.extract_node('''
+    """
+            ),
+            {"RuntimeError"},
+        ),
+        (
+            astroid.extract_node(
+                """
     def my_func():
         try:
             fake_func()
@@ -67,9 +84,13 @@ def test_space_indentation(string, count):
                 raise #@
             except NameError:
                 pass
-    '''), {"RuntimeError"}),
-
-    (astroid.extract_node('''
+    """
+            ),
+            {"RuntimeError"},
+        ),
+        (
+            astroid.extract_node(
+                """
     def my_func():
         try:
             fake_func()
@@ -78,34 +99,49 @@ def test_space_indentation(string, count):
                 another_func()
             except NameError:
                 raise #@
-    '''), {"NameError"}),
-
-    (astroid.extract_node('''
+    """
+            ),
+            {"NameError"},
+        ),
+        (
+            astroid.extract_node(
+                """
     def my_func():
         try:
             fake_func()
         except:
             raise #@
-    '''), set()),
-
-    (astroid.extract_node('''
+    """
+            ),
+            set(),
+        ),
+        (
+            astroid.extract_node(
+                """
     def my_func():
         try:
             fake_func()
         except (RuntimeError, ValueError):
             raise #@
-    '''), {"RuntimeError", "ValueError"}),
-
-    (astroid.extract_node('''
+    """
+            ),
+            {"RuntimeError", "ValueError"},
+        ),
+        (
+            astroid.extract_node(
+                """
     import not_a_module
     def my_func():
         try:
             fake_func()
         except not_a_module.Error:
             raise #@
-    '''), set()),
-
-])
+    """
+            ),
+            set(),
+        ),
+    ],
+)
 def test_exception(raise_node, expected):
     found = utils.possible_exc_types(raise_node)
     assert found == expected

--- a/tests/extensions/test_check_mccabe.py
+++ b/tests/extensions/test_check_mccabe.py
@@ -34,12 +34,12 @@ EXPECTED_MSGS = [
 
 @pytest.fixture(scope="module")
 def enable(enable):
-    return ['too-complex']
+    return ["too-complex"]
 
 
 @pytest.fixture(scope="module")
 def disable(disable):
-    return ['all']
+    return ["all"]
 
 
 @pytest.fixture(scope="module")
@@ -49,15 +49,14 @@ def register(register):
 
 @pytest.fixture
 def fname_mccabe_example():
-    return osp.join(osp.dirname(osp.abspath(__file__)), 'data', 'mccabe.py')
+    return osp.join(osp.dirname(osp.abspath(__file__)), "data", "mccabe.py")
 
 
-@pytest.mark.parametrize("complexity, expected", [
-    (0, EXPECTED_MSGS),
-    (9, EXPECTED_MSGS[-2:]),
-])
+@pytest.mark.parametrize(
+    "complexity, expected", [(0, EXPECTED_MSGS), (9, EXPECTED_MSGS[-2:])]
+)
 def test_max_mccabe_rate(linter, fname_mccabe_example, complexity, expected):
-    linter.global_set_option('max-complexity', complexity)
+    linter.global_set_option("max-complexity", complexity)
     linter.check([fname_mccabe_example])
     real_msgs = [message.msg for message in linter.reporter.messages]
     assert sorted(expected) == sorted(real_msgs)

--- a/tests/extensions/test_check_raise_docs.py
+++ b/tests/extensions/test_check_raise_docs.py
@@ -20,43 +20,49 @@ from pylint.testutils import CheckerTestCase, Message, set_config
 
 class TestDocstringCheckerRaise(CheckerTestCase):
     """Tests for pylint_plugin.RaiseDocChecker"""
+
     CHECKER_CLASS = DocstringParameterChecker
 
     def test_ignores_no_docstring(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            """
         def my_func(self):
             raise RuntimeError('hi') #@
-        ''')
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_ignores_unknown_style(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring."""
             raise RuntimeError('hi')
-        ''')
+        '''
+        )
         raise_node = node.body[0]
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     @set_config(accept_no_raise_doc=False)
     def test_warns_unknown_style(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring."""
             raise RuntimeError('hi')
-        ''')
+        '''
+        )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-raises-doc',
-                node=node,
-                args=('RuntimeError', ))):
+            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_find_missing_sphinx_raises(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -64,17 +70,17 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             raise RuntimeError('hi')
             raise NameError('hi')
-        ''')
+        '''
+        )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-raises-doc',
-                node=node,
-                args=('RuntimeError', ))):
+            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_find_missing_google_raises(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -83,17 +89,17 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             raise RuntimeError('hi')
             raise NameError('hi')
-        ''')
+        '''
+        )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-raises-doc',
-                node=node,
-                args=('RuntimeError', ))):
+            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_find_google_attr_raises_exact_exc(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a google docstring.
 
@@ -102,13 +108,15 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             import re
             raise re.error('hi')  #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
         pass
 
     def test_find_google_attr_raises_substr_exc(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a google docstring.
 
@@ -117,12 +125,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             from re import error
             raise error('hi')  #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_find_valid_missing_google_attr_raises(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a google docstring.
 
@@ -131,17 +141,17 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             from re import error
             raise error('hi')
-        ''')
+        '''
+        )
         raise_node = node.body[1]
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-raises-doc',
-                node=node,
-                args=('error', ))):
+            Message(msg_id="missing-raises-doc", node=node, args=("error",))
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_find_invalid_missing_google_attr_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a google docstring.
 
@@ -150,7 +160,8 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             from re import error
             raise error('hi') #@
-        ''')
+        '''
+        )
         # pylint allows this to pass since the comparison between Raises and
         # raise are based on the class name, not the qualified name.
         with self.assertNoMessages():
@@ -174,7 +185,8 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 self.checker.visit_raise(raise_node)
 
     def test_find_missing_numpy_raises(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -185,17 +197,17 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             raise RuntimeError('hi')
             raise NameError('hi')
-        ''')
+        '''
+        )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-raises-doc',
-                node=node,
-                args=('RuntimeError', ))):
+            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_ignore_spurious_sphinx_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -205,12 +217,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             :exception ValueError: Never
             """
             raise RuntimeError('Blah') #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_find_all_sphinx_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -223,12 +237,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             raise NameError('hi')
             raise OSError(2, 'abort!')
             raise ValueError('foo')
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_find_all_google_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -238,12 +254,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             raise RuntimeError('hi') #@
             raise NameError('hi')
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_find_all_numpy_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -256,12 +274,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             raise RuntimeError('hi') #@
             raise NameError('hi')
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_finds_rethrown_sphinx_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -273,17 +293,17 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 raise #@
 
             raise NameError('hi')
-        ''')
+        '''
+        )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-raises-doc',
-                node=node,
-                args=('RuntimeError', ))):
+            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_find_rethrown_google_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -296,17 +316,17 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 raise #@
 
             raise NameError('hi')
-        ''')
+        '''
+        )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-raises-doc',
-                node=node,
-                args=('RuntimeError', ))):
+            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_find_rethrown_numpy_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -321,17 +341,17 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 raise #@
 
             raise NameError('hi')
-        ''')
+        '''
+        )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-raises-doc',
-                node=node,
-                args=('RuntimeError', ))):
+            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_finds_rethrown_sphinx_multiple_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -343,17 +363,21 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 raise #@
 
             raise NameError('hi')
-        ''')
+        '''
+        )
         node = raise_node.frame()
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-raises-doc',
+                msg_id="missing-raises-doc",
                 node=node,
-                args=('RuntimeError, ValueError', ))):
+                args=("RuntimeError, ValueError",),
+            )
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_find_rethrown_google_multiple_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -366,17 +390,21 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 raise #@
 
             raise NameError('hi')
-        ''')
+        '''
+        )
         node = raise_node.frame()
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-raises-doc',
+                msg_id="missing-raises-doc",
                 node=node,
-                args=('RuntimeError, ValueError', ))):
+                args=("RuntimeError, ValueError",),
+            )
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_find_rethrown_numpy_multiple_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -391,17 +419,21 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 raise #@
 
             raise NameError('hi')
-        ''')
+        '''
+        )
         node = raise_node.frame()
         with self.assertAddsMessages(
             Message(
-                msg_id='missing-raises-doc',
+                msg_id="missing-raises-doc",
                 node=node,
-                args=('RuntimeError, ValueError', ))):
+                args=("RuntimeError, ValueError",),
+            )
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_ignores_caught_sphinx_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -413,12 +445,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 pass
 
             raise NameError('hi')
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_ignores_caught_google_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -431,12 +465,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 pass
 
             raise NameError('hi')
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_ignores_caught_numpy_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a numpy docstring.
 
@@ -451,12 +487,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 pass
 
             raise NameError('hi')
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_find_numpy_attr_raises_exact_exc(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a numpy docstring.
 
@@ -467,13 +505,15 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             import re
             raise re.error('hi')  #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
         pass
 
     def test_find_numpy_attr_raises_substr_exc(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a numpy docstring.
 
@@ -484,12 +524,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             from re import error
             raise error('hi')  #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_find_valid_missing_numpy_attr_raises(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a numpy docstring.
 
@@ -500,17 +542,17 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             from re import error
             raise error('hi')
-        ''')
+        '''
+        )
         raise_node = node.body[1]
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-raises-doc',
-                node=node,
-                args=('error', ))):
+            Message(msg_id="missing-raises-doc", node=node, args=("error",))
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_find_invalid_missing_numpy_attr_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a numpy docstring.
 
@@ -521,7 +563,8 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             from re import error
             raise error('hi') #@
-        ''')
+        '''
+        )
         # pylint allows this to pass since the comparison between Raises and
         # raise are based on the class name, not the qualified name.
         with self.assertNoMessages():
@@ -547,7 +590,8 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 self.checker.visit_raise(raise_node)
 
     def test_find_missing_sphinx_raises_infer_from_instance(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -556,17 +600,17 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             my_exception = RuntimeError('hi')
             raise my_exception #@
             raise NameError('hi')
-        ''')
+        '''
+        )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-raises-doc',
-                node=node,
-                args=('RuntimeError', ))):
+            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_find_missing_sphinx_raises_infer_from_function(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -576,17 +620,17 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 return RuntimeError(val)
             raise ex_func('hi') #@
             raise NameError('hi')
-        ''')
+        '''
+        )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-raises-doc',
-                node=node,
-                args=('RuntimeError', ))):
+            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_find_sphinx_attr_raises_exact_exc(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a sphinx docstring.
 
@@ -594,12 +638,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             import re
             raise re.error('hi')  #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_find_sphinx_attr_raises_substr_exc(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a sphinx docstring.
 
@@ -607,12 +653,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             from re import error
             raise error('hi')  #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_find_valid_missing_sphinx_attr_raises(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a sphinx docstring.
 
@@ -620,17 +668,17 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             from re import error
             raise error('hi')
-        ''')
+        '''
+        )
         raise_node = node.body[1]
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-raises-doc',
-                node=node,
-                args=('error', ))):
+            Message(msg_id="missing-raises-doc", node=node, args=("error",))
+        ):
             self.checker.visit_raise(raise_node)
 
     def test_find_invalid_missing_sphinx_attr_raises(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a sphinx docstring.
 
@@ -638,7 +686,8 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             from re import error
             raise error('hi') #@
-        ''')
+        '''
+        )
         # pylint allows this to pass since the comparison between Raises and
         # raise are based on the class name, not the qualified name.
         with self.assertNoMessages():
@@ -660,12 +709,12 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             with self.assertNoMessages():
                 self.checker.visit_raise(raise_node)
 
-
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_ignores_raise_uninferable(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         from unknown import Unknown
 
         def my_func(self):
@@ -675,12 +724,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             raise Unknown('hi') #@
             raise NameError('hi')
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_ignores_returns_from_inner_functions(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -692,18 +743,18 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 return RuntimeError(val)
             raise ex_func('hi') #@
             raise NameError('hi')
-        ''')
+        '''
+        )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(
-                msg_id='missing-raises-doc',
-                node=node,
-                args=('RuntimeError', ))):
+            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+        ):
             # we do NOT expect a warning about the OSError in inner_func!
             self.checker.visit_raise(raise_node)
 
     def test_ignores_returns_use_only_names(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def myfunc():
             """This is a docstring
 
@@ -713,12 +764,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 return 42
 
             raise inner_func() #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_ignores_returns_use_only_exception_instances(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def myfunc():
             """This is a docstring
 
@@ -730,12 +783,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
                 return MyException
 
             raise inner_func() #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_no_crash_when_inferring_handlers(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         import collections
 
         def test():
@@ -747,12 +802,14 @@ class TestDocstringCheckerRaise(CheckerTestCase):
               pass
            except collections.U as exc:
               raise #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_no_crash_when_cant_find_exception(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         import collections
 
         def test():
@@ -764,18 +821,21 @@ class TestDocstringCheckerRaise(CheckerTestCase):
               pass
            except U as exc:
               raise #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
     def test_no_error_notimplemented_documented(self):
-        raise_node = astroid.extract_node('''
+        raise_node = astroid.extract_node(
+            '''
         def my_func():
             """
             Raises:
                 NotImplementedError: When called.
             """
             raise NotImplementedError #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)

--- a/tests/extensions/test_check_return_docs.py
+++ b/tests/extensions/test_check_return_docs.py
@@ -22,94 +22,110 @@ from pylint.testutils import CheckerTestCase, Message, set_config
 
 class TestDocstringCheckerReturn(CheckerTestCase):
     """Tests for pylint_plugin.RaiseDocChecker"""
+
     CHECKER_CLASS = DocstringParameterChecker
 
     def test_ignores_no_docstring(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            """
         def my_func(self):
             return False #@
-        ''')
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     @set_config(accept_no_return_doc=False)
     def test_warns_no_docstring(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            """
         def my_func(self):
             return False
-        ''')
+        """
+        )
         return_node = node.body[0]
         with self.assertAddsMessages(
-                Message(msg_id='missing-return-doc', node=node),
-                Message(msg_id='missing-return-type-doc', node=node)):
+            Message(msg_id="missing-return-doc", node=node),
+            Message(msg_id="missing-return-type-doc", node=node),
+        ):
             self.checker.visit_return(return_node)
 
     def test_ignores_unknown_style(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring."""
             return False #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_warn_partial_sphinx_returns(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
             :returns: Always False
             """
             return False
-        ''')
+        '''
+        )
         return_node = node.body[0]
         with self.assertAddsMessages(
-                Message(msg_id='missing-return-type-doc', node=node)):
+            Message(msg_id="missing-return-type-doc", node=node)
+        ):
             self.checker.visit_return(return_node)
 
     def test_sphinx_returns_annotations(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self) -> bool:
             """This is a docstring.
 
             :returns: Always False
             """
             return False
-        ''')
+        '''
+        )
         return_node = node.body[0]
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_sphinx_missing_return_type_with_annotations(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
            def my_func(self) -> bool:
                """This is a docstring.
 
                :returns: Always False
                """
                return False
-           ''')
+           '''
+        )
         return_node = node.body[0]
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
-
     def test_warn_partial_sphinx_returns_type(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
             :rtype: bool
             """
             return False
-        ''')
+        '''
+        )
         return_node = node.body[0]
-        with self.assertAddsMessages(
-                Message(msg_id='missing-return-doc', node=node)):
+        with self.assertAddsMessages(Message(msg_id="missing-return-doc", node=node)):
             self.checker.visit_return(return_node)
 
     def test_warn_missing_sphinx_returns(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self, doc_type):
             """This is a docstring.
 
@@ -117,15 +133,18 @@ class TestDocstringCheckerReturn(CheckerTestCase):
             :type doc_type: str
             """
             return False
-        ''')
+        '''
+        )
         return_node = node.body[0]
         with self.assertAddsMessages(
-                Message(msg_id='missing-return-doc', node=node),
-                Message(msg_id='missing-return-type-doc', node=node)):
+            Message(msg_id="missing-return-doc", node=node),
+            Message(msg_id="missing-return-type-doc", node=node),
+        ):
             self.checker.visit_return(return_node)
 
     def test_warn_partial_google_returns(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -133,14 +152,17 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 Always False
             """
             return False
-        ''')
+        '''
+        )
         return_node = node.body[0]
         with self.assertAddsMessages(
-                Message(msg_id='missing-return-type-doc', node=node)):
+            Message(msg_id="missing-return-type-doc", node=node)
+        ):
             self.checker.visit_return(return_node)
 
     def test_warn_partial_google_returns_type(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -148,14 +170,15 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 bool:
             """
             return False
-        ''')
+        '''
+        )
         return_node = node.body[0]
-        with self.assertAddsMessages(
-                Message(msg_id='missing-return-doc', node=node)):
+        with self.assertAddsMessages(Message(msg_id="missing-return-doc", node=node)):
             self.checker.visit_return(return_node)
 
     def test_warn_missing_google_returns(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self, doc_type):
             """This is a docstring.
 
@@ -163,15 +186,18 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 doc_type (str): Google
             """
             return False
-        ''')
+        '''
+        )
         return_node = node.body[0]
         with self.assertAddsMessages(
-                Message(msg_id='missing-return-doc', node=node),
-                Message(msg_id='missing-return-type-doc', node=node)):
+            Message(msg_id="missing-return-doc", node=node),
+            Message(msg_id="missing-return-type-doc", node=node),
+        ):
             self.checker.visit_return(return_node)
 
     def test_warn_partial_numpy_returns_type(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self, doc_type):
             """This is a docstring.
 
@@ -185,14 +211,15 @@ class TestDocstringCheckerReturn(CheckerTestCase):
             bool
             """
             return False
-        ''')
+        '''
+        )
         return_node = node.body[0]
-        with self.assertAddsMessages(
-                Message(msg_id='missing-return-doc', node=node)):
+        with self.assertAddsMessages(Message(msg_id="missing-return-doc", node=node)):
             self.checker.visit_return(return_node)
 
     def test_warn_missing_numpy_returns(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self, doc_type):
             """This is a docstring.
 
@@ -202,15 +229,18 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 Numpy
             """
             return False
-        ''')
+        '''
+        )
         return_node = node.body[0]
         with self.assertAddsMessages(
-                Message(msg_id='missing-return-doc', node=node),
-                Message(msg_id='missing-return-type-doc', node=node)):
+            Message(msg_id="missing-return-doc", node=node),
+            Message(msg_id="missing-return-type-doc", node=node),
+        ):
             self.checker.visit_return(return_node)
 
     def test_find_sphinx_returns(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -218,12 +248,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
             :rtype: bool
             """
             return False #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_find_google_returns(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -231,12 +263,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 bool: Always False
             """
             return False #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_find_numpy_returns(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -246,12 +280,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 Always False
             """
             return False #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_find_numpy_returns_with_of(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -261,12 +297,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 List of strings
             """
             return ["hi", "bye"] #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_ignores_sphinx_return_none(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            '''
         def my_func(self, doc_type):
             """This is a docstring.
 
@@ -274,12 +312,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
             :type doc_type: str
             """
             return #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_ignores_google_return_none(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            '''
         def my_func(self, doc_type):
             """This is a docstring.
 
@@ -287,12 +327,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 doc_type (str): Google
             """
             return #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_ignores_numpy_return_none(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            '''
         def my_func(self, doc_type):
             """This is a docstring.
 
@@ -302,12 +344,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 Numpy
             """
             return #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_finds_sphinx_return_custom_class(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -315,12 +359,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
             :rtype: :class:`mymodule.Class`
             """
             return mymodule.Class() #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_finds_google_return_custom_class(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -328,12 +374,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 mymodule.Class: An object
             """
             return mymodule.Class() #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_finds_numpy_return_custom_class(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -343,12 +391,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                     An object
             """
             return mymodule.Class() #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_finds_sphinx_return_list_of_custom_class(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -356,12 +406,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
             :rtype: list(:class:`mymodule.Class`)
             """
             return [mymodule.Class()] #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_finds_google_return_list_of_custom_class(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -369,12 +421,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 list(:class:`mymodule.Class`): An object
             """
             return [mymodule.Class()] #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_finds_numpy_return_list_of_custom_class(self):
-        return_node = astroid.extract_node('''
+        return_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -384,26 +438,29 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                     An object
             """
             return [mymodule.Class()] #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_return(return_node)
 
     def test_warns_sphinx_return_list_of_custom_class_without_description(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
             :rtype: list(:class:`mymodule.Class`)
             """
             return [mymodule.Class()]
-        ''')
+        '''
+        )
         return_node = node.body[0]
-        with self.assertAddsMessages(
-                Message(msg_id='missing-return-doc', node=node)):
+        with self.assertAddsMessages(Message(msg_id="missing-return-doc", node=node)):
             self.checker.visit_return(return_node)
 
     def test_warns_google_return_list_of_custom_class_without_description(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -411,14 +468,15 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 list(:class:`mymodule.Class`):
             """
             return [mymodule.Class()]
-        ''')
+        '''
+        )
         return_node = node.body[0]
-        with self.assertAddsMessages(
-                Message(msg_id='missing-return-doc', node=node)):
+        with self.assertAddsMessages(Message(msg_id="missing-return-doc", node=node)):
             self.checker.visit_return(return_node)
 
     def test_warns_numpy_return_list_of_custom_class_without_description(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -427,40 +485,47 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 list(:class:`mymodule.Class`)
             """
             return [mymodule.Class()]
-        ''')
+        '''
+        )
         return_node = node.body[0]
-        with self.assertAddsMessages(
-                Message(msg_id='missing-return-doc', node=node)):
+        with self.assertAddsMessages(Message(msg_id="missing-return-doc", node=node)):
             self.checker.visit_return(return_node)
 
     def test_warns_sphinx_redundant_return_doc(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
             :returns: One
             """
             return None
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-                Message(msg_id='redundant-returns-doc', node=node)):
+            Message(msg_id="redundant-returns-doc", node=node)
+        ):
             self.checker.visit_functiondef(node)
 
     def test_warns_sphinx_redundant_rtype_doc(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
             :rtype: int
             """
             return None
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-                Message(msg_id='redundant-returns-doc', node=node)):
+            Message(msg_id="redundant-returns-doc", node=node)
+        ):
             self.checker.visit_functiondef(node)
 
     def test_warns_google_redundant_return_doc(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -468,13 +533,16 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 One
             """
             return None
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-                Message(msg_id='redundant-returns-doc', node=node)):
+            Message(msg_id="redundant-returns-doc", node=node)
+        ):
             self.checker.visit_functiondef(node)
 
     def test_warns_google_redundant_rtype_doc(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -482,13 +550,16 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 int:
             """
             return None
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-                Message(msg_id='redundant-returns-doc', node=node)):
+            Message(msg_id="redundant-returns-doc", node=node)
+        ):
             self.checker.visit_functiondef(node)
 
     def test_warns_numpy_redundant_return_doc(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -498,13 +569,16 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                     One
             """
             return None
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-                Message(msg_id='redundant-returns-doc', node=node)):
+            Message(msg_id="redundant-returns-doc", node=node)
+        ):
             self.checker.visit_functiondef(node)
 
     def test_warns_numpy_redundant_rtype_doc(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -513,13 +587,16 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 int
             """
             return None
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-                Message(msg_id='redundant-returns-doc', node=node)):
+            Message(msg_id="redundant-returns-doc", node=node)
+        ):
             self.checker.visit_functiondef(node)
 
     def test_ignores_sphinx_redundant_return_doc_multiple_returns(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -532,12 +609,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
             if a_func():
                 return None
             return 1
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_ignores_google_redundant_return_doc_multiple_returns(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -547,12 +626,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
             if a_func():
                 return None
             return 1
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_ignores_numpy_redundant_return_doc_multiple_returns(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -566,12 +647,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
             if a_func():
                 return None
             return 1
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_ignore_sphinx_redundant_return_doc_yield(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func_with_yield(self):
             """This is a docstring.
 
@@ -580,12 +663,14 @@ class TestDocstringCheckerReturn(CheckerTestCase):
             """
             for value in range(3):
                 yield value
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_warns_google_redundant_return_doc_yield(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -593,13 +678,16 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                 int: One
             """
             yield 1
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-                Message(msg_id='redundant-returns-doc', node=node)):
+            Message(msg_id="redundant-returns-doc", node=node)
+        ):
             self.checker.visit_functiondef(node)
 
     def test_warns_numpy_redundant_return_doc_yield(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -609,7 +697,9 @@ class TestDocstringCheckerReturn(CheckerTestCase):
                     One
             """
             yield 1
-        ''')
+        '''
+        )
         with self.assertAddsMessages(
-                Message(msg_id='redundant-returns-doc', node=node)):
+            Message(msg_id="redundant-returns-doc", node=node)
+        ):
             self.checker.visit_functiondef(node)

--- a/tests/extensions/test_check_yields_docs.py
+++ b/tests/extensions/test_check_yields_docs.py
@@ -19,67 +19,80 @@ from pylint.testutils import CheckerTestCase, Message, set_config
 
 class TestDocstringCheckerYield(CheckerTestCase):
     """Tests for pylint_plugin.RaiseDocChecker"""
+
     CHECKER_CLASS = DocstringParameterChecker
 
     def test_ignores_no_docstring(self):
-        yield_node = astroid.extract_node('''
+        yield_node = astroid.extract_node(
+            """
         def my_func(self):
             yield False #@
-        ''')
+        """
+        )
         with self.assertNoMessages():
             self.checker.visit_yield(yield_node)
 
     @set_config(accept_no_yields_doc=False)
     def test_warns_no_docstring(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            """
         def my_func(self):
             yield False
-        ''')
+        """
+        )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-                Message(msg_id='missing-yield-doc', node=node),
-                Message(msg_id='missing-yield-type-doc', node=node)):
+            Message(msg_id="missing-yield-doc", node=node),
+            Message(msg_id="missing-yield-type-doc", node=node),
+        ):
             self.checker.visit_yield(yield_node)
 
     def test_ignores_unknown_style(self):
-        yield_node = astroid.extract_node('''
+        yield_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring."""
             yield False #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_yield(yield_node)
 
     def test_warn_partial_sphinx_yields(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
             :returns: Always False
             """
             yield False
-        ''')
+        '''
+        )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-                Message(msg_id='missing-yield-type-doc', node=node)):
+            Message(msg_id="missing-yield-type-doc", node=node)
+        ):
             self.checker.visit_yield(yield_node)
 
     def test_warn_partial_sphinx_yields_type(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
             :rtype: bool
             """
             yield False
-        ''')
+        '''
+        )
         yield_node = node.body[0]
-        with self.assertAddsMessages(
-                Message(msg_id='missing-yield-doc', node=node)):
+        with self.assertAddsMessages(Message(msg_id="missing-yield-doc", node=node)):
             self.checker.visit_yield(yield_node)
 
     def test_warn_missing_sphinx_yields(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self, doc_type):
             """This is a docstring.
 
@@ -87,15 +100,18 @@ class TestDocstringCheckerYield(CheckerTestCase):
             :type doc_type: str
             """
             yield False
-        ''')
+        '''
+        )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-                Message(msg_id='missing-yield-doc', node=node),
-                Message(msg_id='missing-yield-type-doc', node=node)):
+            Message(msg_id="missing-yield-doc", node=node),
+            Message(msg_id="missing-yield-type-doc", node=node),
+        ):
             self.checker.visit_yield(yield_node)
 
     def test_warn_partial_google_yields(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -103,14 +119,17 @@ class TestDocstringCheckerYield(CheckerTestCase):
                 Always False
             """
             yield False
-        ''')
+        '''
+        )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-                Message(msg_id='missing-yield-type-doc', node=node)):
+            Message(msg_id="missing-yield-type-doc", node=node)
+        ):
             self.checker.visit_yield(yield_node)
 
     def test_warn_partial_google_yields_type(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -118,14 +137,15 @@ class TestDocstringCheckerYield(CheckerTestCase):
                 bool:
             """
             yield False
-        ''')
+        '''
+        )
         yield_node = node.body[0]
-        with self.assertAddsMessages(
-                Message(msg_id='missing-yield-doc', node=node)):
+        with self.assertAddsMessages(Message(msg_id="missing-yield-doc", node=node)):
             self.checker.visit_yield(yield_node)
 
     def test_warn_missing_google_yields(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self, doc_type):
             """This is a docstring.
 
@@ -133,15 +153,18 @@ class TestDocstringCheckerYield(CheckerTestCase):
                 doc_type (str): Google
             """
             yield False
-        ''')
+        '''
+        )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-                Message(msg_id='missing-yield-doc', node=node),
-                Message(msg_id='missing-yield-type-doc', node=node)):
+            Message(msg_id="missing-yield-doc", node=node),
+            Message(msg_id="missing-yield-type-doc", node=node),
+        ):
             self.checker.visit_yield(yield_node)
 
     def test_warn_missing_numpy_yields(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self, doc_type):
             """This is a docstring.
 
@@ -151,15 +174,18 @@ class TestDocstringCheckerYield(CheckerTestCase):
                 Numpy
             """
             yield False
-        ''')
+        '''
+        )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-                Message(msg_id='missing-yield-doc', node=node),
-                Message(msg_id='missing-yield-type-doc', node=node)):
+            Message(msg_id="missing-yield-doc", node=node),
+            Message(msg_id="missing-yield-type-doc", node=node),
+        ):
             self.checker.visit_yield(yield_node)
 
     def test_find_sphinx_yields(self):
-        yield_node = astroid.extract_node('''
+        yield_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -167,12 +193,14 @@ class TestDocstringCheckerYield(CheckerTestCase):
             :rtype: bool
             """
             yield False #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_yield(yield_node)
 
     def test_find_google_yields(self):
-        yield_node = astroid.extract_node('''
+        yield_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -180,12 +208,14 @@ class TestDocstringCheckerYield(CheckerTestCase):
                 bool: Always False
             """
             yield False #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_yield(yield_node)
 
     def test_find_numpy_yields(self):
-        yield_node = astroid.extract_node('''
+        yield_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -195,12 +225,14 @@ class TestDocstringCheckerYield(CheckerTestCase):
                 Always False
             """
             yield False #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_yield(yield_node)
 
     def test_finds_sphinx_yield_custom_class(self):
-        yield_node = astroid.extract_node('''
+        yield_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -208,12 +240,14 @@ class TestDocstringCheckerYield(CheckerTestCase):
             :rtype: :class:`mymodule.Class`
             """
             yield mymodule.Class() #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_yield(yield_node)
 
     def test_finds_google_yield_custom_class(self):
-        yield_node = astroid.extract_node('''
+        yield_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -221,12 +255,14 @@ class TestDocstringCheckerYield(CheckerTestCase):
                 mymodule.Class: An object
             """
             yield mymodule.Class() #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_yield(yield_node)
 
     def test_finds_numpy_yield_custom_class(self):
-        yield_node = astroid.extract_node('''
+        yield_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -236,12 +272,14 @@ class TestDocstringCheckerYield(CheckerTestCase):
                     An object
             """
             yield mymodule.Class() #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_yield(yield_node)
 
     def test_finds_sphinx_yield_list_of_custom_class(self):
-        yield_node = astroid.extract_node('''
+        yield_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -249,12 +287,14 @@ class TestDocstringCheckerYield(CheckerTestCase):
             :rtype: list(:class:`mymodule.Class`)
             """
             yield [mymodule.Class()] #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_yield(yield_node)
 
     def test_finds_google_yield_list_of_custom_class(self):
-        yield_node = astroid.extract_node('''
+        yield_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -262,12 +302,14 @@ class TestDocstringCheckerYield(CheckerTestCase):
                 list(:class:`mymodule.Class`): An object
             """
             yield [mymodule.Class()] #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_yield(yield_node)
 
     def test_finds_numpy_yield_list_of_custom_class(self):
-        yield_node = astroid.extract_node('''
+        yield_node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -277,26 +319,29 @@ class TestDocstringCheckerYield(CheckerTestCase):
                     An object
             """
             yield [mymodule.Class()] #@
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_yield(yield_node)
 
     def test_warns_sphinx_yield_list_of_custom_class_without_description(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
             :rtype: list(:class:`mymodule.Class`)
             """
             yield [mymodule.Class()]
-        ''')
+        '''
+        )
         yield_node = node.body[0]
-        with self.assertAddsMessages(
-                Message(msg_id='missing-yield-doc', node=node)):
+        with self.assertAddsMessages(Message(msg_id="missing-yield-doc", node=node)):
             self.checker.visit_yield(yield_node)
 
     def test_warns_google_yield_list_of_custom_class_without_description(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -304,14 +349,15 @@ class TestDocstringCheckerYield(CheckerTestCase):
                 list(:class:`mymodule.Class`):
             """
             yield [mymodule.Class()]
-        ''')
+        '''
+        )
         yield_node = node.body[0]
-        with self.assertAddsMessages(
-                Message(msg_id='missing-yield-doc', node=node)):
+        with self.assertAddsMessages(Message(msg_id="missing-yield-doc", node=node)):
             self.checker.visit_yield(yield_node)
 
     def test_warns_numpy_yield_list_of_custom_class_without_description(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -320,17 +366,18 @@ class TestDocstringCheckerYield(CheckerTestCase):
                 list(:class:`mymodule.Class`)
             """
             yield [mymodule.Class()]
-        ''')
+        '''
+        )
         yield_node = node.body[0]
-        with self.assertAddsMessages(
-                Message(msg_id='missing-yield-doc', node=node)):
+        with self.assertAddsMessages(Message(msg_id="missing-yield-doc", node=node)):
             self.checker.visit_yield(yield_node)
 
     # No such thing as redundant yield documentation for sphinx because it
     # doesn't support yield documentation
 
     def test_ignores_google_redundant_yield_doc_multiple_yields(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -340,12 +387,14 @@ class TestDocstringCheckerYield(CheckerTestCase):
             if a_func():
                 yield None
             yield 1
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_ignores_numpy_redundant_yield_doc_multiple_yields(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -359,7 +408,8 @@ class TestDocstringCheckerYield(CheckerTestCase):
             if a_func():
                 yield None
             yield 1
-        ''')
+        '''
+        )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
@@ -367,7 +417,8 @@ class TestDocstringCheckerYield(CheckerTestCase):
     # doesn't support yield documentation
 
     def test_warns_google_redundant_yield_doc_return(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -375,13 +426,14 @@ class TestDocstringCheckerYield(CheckerTestCase):
                 int: One
             """
             return 1
-        ''')
-        with self.assertAddsMessages(
-                Message(msg_id='redundant-yields-doc', node=node)):
+        '''
+        )
+        with self.assertAddsMessages(Message(msg_id="redundant-yields-doc", node=node)):
             self.checker.visit_functiondef(node)
 
     def test_warns_numpy_redundant_yield_doc_return(self):
-        node = astroid.extract_node('''
+        node = astroid.extract_node(
+            '''
         def my_func(self):
             """This is a docstring.
 
@@ -391,7 +443,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
                     One
             """
             return 1
-        ''')
-        with self.assertAddsMessages(
-                Message(msg_id='redundant-yields-doc', node=node)):
+        '''
+        )
+        with self.assertAddsMessages(Message(msg_id="redundant-yields-doc", node=node)):
             self.checker.visit_functiondef(node)

--- a/tests/extensions/test_comparetozero.py
+++ b/tests/extensions/test_comparetozero.py
@@ -20,7 +20,6 @@ from pylint.reporters import BaseReporter
 
 
 class CompareToZeroTestReporter(BaseReporter):
-
     def handle_message(self, msg):
         self.messages.append(msg)
 
@@ -29,29 +28,29 @@ class CompareToZeroTestReporter(BaseReporter):
 
 
 class CompareToZeroUsedTC(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls._linter = PyLinter()
         cls._linter.set_reporter(CompareToZeroTestReporter())
         checkers.initialize(cls._linter)
         cls._linter.register_checker(CompareToZeroChecker(cls._linter))
-        cls._linter.disable('I')
+        cls._linter.disable("I")
 
     def test_comparetozero_message(self):
-        elif_test = osp.join(osp.dirname(osp.abspath(__file__)), 'data',
-                             'compare_to_zero.py')
+        elif_test = osp.join(
+            osp.dirname(osp.abspath(__file__)), "data", "compare_to_zero.py"
+        )
         self._linter.check([elif_test])
         msgs = self._linter.reporter.messages
         self.assertEqual(len(msgs), 4)
         for msg in msgs:
-            self.assertEqual(msg.symbol, 'compare-to-zero')
-            self.assertEqual(msg.msg, 'Avoid comparisons to zero')
+            self.assertEqual(msg.symbol, "compare-to-zero")
+            self.assertEqual(msg.msg, "Avoid comparisons to zero")
         self.assertEqual(msgs[0].line, 6)
         self.assertEqual(msgs[1].line, 9)
         self.assertEqual(msgs[2].line, 12)
         self.assertEqual(msgs[3].line, 15)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/extensions/test_docstyle.py
+++ b/tests/extensions/test_docstyle.py
@@ -15,23 +15,23 @@ import pytest
 from pylint.extensions.docstyle import DocStringStyleChecker
 
 EXPECTED_MSGS = [
-    'First line empty in function docstring',
-    'First line empty in class docstring',
-    'First line empty in method docstring',
-    'Bad docstring quotes in method, expected """, given \'\'\'',
+    "First line empty in function docstring",
+    "First line empty in class docstring",
+    "First line empty in method docstring",
+    "Bad docstring quotes in method, expected \"\"\", given '''",
     'Bad docstring quotes in method, expected """, given "',
     'Bad docstring quotes in method, expected """, given \'',
     'Bad docstring quotes in method, expected """, given \'',
 ]
 
 EXPECTED_SYMBOLS = [
-    'docstring-first-line-empty',
-    'docstring-first-line-empty',
-    'docstring-first-line-empty',
-    'bad-docstring-quotes',
-    'bad-docstring-quotes',
-    'bad-docstring-quotes',
-    'bad-docstring-quotes',
+    "docstring-first-line-empty",
+    "docstring-first-line-empty",
+    "docstring-first-line-empty",
+    "bad-docstring-quotes",
+    "bad-docstring-quotes",
+    "bad-docstring-quotes",
+    "bad-docstring-quotes",
 ]
 
 
@@ -41,12 +41,12 @@ def checker(checker):
 
 
 def test_docstring_message(linter):
-    docstring_test = join(dirname(abspath(__file__)), 'data', 'docstring.py')
+    docstring_test = join(dirname(abspath(__file__)), "data", "docstring.py")
     linter.check([docstring_test])
     msgs = linter.reporter.messages
     assert len(msgs) == 7
-    for msg, expected_symbol, expected_msg in zip(msgs,
-                                                  EXPECTED_SYMBOLS,
-                                                  EXPECTED_MSGS):
+    for msg, expected_symbol, expected_msg in zip(
+        msgs, EXPECTED_SYMBOLS, EXPECTED_MSGS
+    ):
         assert msg.symbol == expected_symbol
         assert msg.msg == expected_msg

--- a/tests/extensions/test_elseif_used.py
+++ b/tests/extensions/test_elseif_used.py
@@ -21,13 +21,12 @@ def checker(checker):
 
 
 def test_elseif_message(linter):
-    elif_test = osp.join(osp.dirname(osp.abspath(__file__)), 'data',
-                         'elif.py')
+    elif_test = osp.join(osp.dirname(osp.abspath(__file__)), "data", "elif.py")
     linter.check([elif_test])
     msgs = linter.reporter.messages
     assert len(msgs) == 2
     for msg in msgs:
-        assert msg.symbol == 'else-if-used'
+        assert msg.symbol == "else-if-used"
         assert msg.msg == 'Consider using "elif" instead of "else if"'
     assert msgs[0].line == 9
     assert msgs[1].line == 21

--- a/tests/extensions/test_emptystring.py
+++ b/tests/extensions/test_emptystring.py
@@ -17,24 +17,25 @@ import pytest
 from pylint.extensions.emptystring import CompareToEmptyStringChecker
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def checker(checker):
     return CompareToEmptyStringChecker
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def disable(disable):
-    return ['I']
+    return ["I"]
 
 
 def test_emptystring_message(linter):
-    elif_test = osp.join(osp.dirname(osp.abspath(__file__)), 'data',
-                         'empty_string_comparison.py')
+    elif_test = osp.join(
+        osp.dirname(osp.abspath(__file__)), "data", "empty_string_comparison.py"
+    )
     linter.check([elif_test])
     msgs = linter.reporter.messages
     expected_lineno = [6, 9, 12, 15]
     assert len(msgs) == len(expected_lineno)
     for msg, lineno in zip(msgs, expected_lineno):
-        assert msg.symbol == 'compare-to-empty-string'
-        assert msg.msg == 'Avoid comparisons to empty string'
+        assert msg.symbol == "compare-to-empty-string"
+        assert msg.msg == "Avoid comparisons to empty string"
         assert msg.line == lineno

--- a/tests/extensions/test_overlapping_exceptions.py
+++ b/tests/extensions/test_overlapping_exceptions.py
@@ -12,58 +12,78 @@ import pytest
 from pylint.extensions.overlapping_exceptions import OverlappingExceptionsChecker
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def checker(checker):
     return OverlappingExceptionsChecker
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def disable(disable):
-    return ['I']
+    return ["I"]
 
 
 def test_overlapping_exceptions(linter):
-    test = join(dirname(__file__), 'data', 'overlapping_exceptions.py')
+    test = join(dirname(__file__), "data", "overlapping_exceptions.py")
     linter.check([test])
     msgs = linter.reporter.messages
 
     expected = [
-        (13, 'Overlapping exceptions (SomeException and SomeException are the same)'),
-        (18, 'Overlapping exceptions (SomeException is an ancestor class of SubclassException)'),
-        (23, 'Overlapping exceptions (SomeException and AliasException are the same)'),
-        (28, 'Overlapping exceptions (AliasException is an ancestor class of SubclassException)'),
-        (34, 'Overlapping exceptions (SomeException and AliasException are the same)'),
-        (34, 'Overlapping exceptions (SomeException is an ancestor class of SubclassException)'),
-        (34, 'Overlapping exceptions (AliasException is an ancestor class of SubclassException)'),
-        (39, 'Overlapping exceptions (ArithmeticError is an ancestor class of FloatingPointError)'),
-        (44, 'Overlapping exceptions (ValueError is an ancestor class of UnicodeDecodeError)')
+        (13, "Overlapping exceptions (SomeException and SomeException are the same)"),
+        (
+            18,
+            "Overlapping exceptions (SomeException is an ancestor class of SubclassException)",
+        ),
+        (23, "Overlapping exceptions (SomeException and AliasException are the same)"),
+        (
+            28,
+            "Overlapping exceptions (AliasException is an ancestor class of SubclassException)",
+        ),
+        (34, "Overlapping exceptions (SomeException and AliasException are the same)"),
+        (
+            34,
+            "Overlapping exceptions (SomeException is an ancestor class of SubclassException)",
+        ),
+        (
+            34,
+            "Overlapping exceptions (AliasException is an ancestor class of SubclassException)",
+        ),
+        (
+            39,
+            "Overlapping exceptions (ArithmeticError is an ancestor class of FloatingPointError)",
+        ),
+        (
+            44,
+            "Overlapping exceptions (ValueError is an ancestor class of UnicodeDecodeError)",
+        ),
     ]
 
     assert len(msgs) == len(expected)
     for msg, exp in zip(msgs, expected):
-        assert msg.msg_id == 'W0714'
-        assert msg.symbol == 'overlapping-except'
-        assert msg.category == 'warning'
+        assert msg.msg_id == "W0714"
+        assert msg.symbol == "overlapping-except"
+        assert msg.category == "warning"
         assert (msg.line, msg.msg) == exp
 
 
-@pytest.mark.skipif(version_info < (3, 3),
-                    reason="not relevant to Python version")
+@pytest.mark.skipif(version_info < (3, 3), reason="not relevant to Python version")
 def test_overlapping_exceptions_py33(linter):
     """From Python 3.3 both IOError and socket.error are aliases for OSError."""
-    test = join(dirname(__file__), 'data', 'overlapping_exceptions_py33.py')
+    test = join(dirname(__file__), "data", "overlapping_exceptions_py33.py")
     linter.check([test])
     msgs = linter.reporter.messages
 
     expected = [
-        (7,  'Overlapping exceptions (IOError and OSError are the same)'),
-        (12, 'Overlapping exceptions (socket.error and OSError are the same)'),
-        (17, 'Overlapping exceptions (socket.error is an ancestor class of ConnectionError)'),
+        (7, "Overlapping exceptions (IOError and OSError are the same)"),
+        (12, "Overlapping exceptions (socket.error and OSError are the same)"),
+        (
+            17,
+            "Overlapping exceptions (socket.error is an ancestor class of ConnectionError)",
+        ),
     ]
 
     assert len(msgs) == len(expected)
     for msg, exp in zip(msgs, expected):
-        assert msg.msg_id == 'W0714'
-        assert msg.symbol == 'overlapping-except'
-        assert msg.category == 'warning'
+        assert msg.msg_id == "W0714"
+        assert msg.symbol == "overlapping-except"
+        assert msg.category == "warning"
         assert (msg.line, msg.msg) == exp


### PR DESCRIPTION
## Description

This change the exclusion filter in the `pre-commit` configuration and the `isort` configuration, so that code tests files are formatted automatically but not fixtures and data file used in tests. Also, format code files without other any modifications to them. This bug affected pylint developpers and was probably caused by [the commit where we moved tests](https://github.com/PyCQA/pylint/commit/33b8185a455c1686d038258697bb93005f2441c2)

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :hammer: Refactoring  |

## Related Issue

I opened #3017 initially (I'm just modifying `test_functional.py`), but looking at the excludes, there was a little more to do than I initially thought.
