### PR TITLE
Fix number of statements in by_module stats

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -311,3 +311,5 @@ contributors:
 * Oisin Moran: contributor
 
 * Andrzej Klajnert: contributor
+
+* Andrés Pérez Hortal: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in Pylint 2.4.0?
 
 Release date: TBA
 
+* Fix the "statement" values in the PyLinter's stats reports by module.
+
 * Added a new check, ``invalid-overridden-method``
 
   This check is emitted when we detect that a method is overridden

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -1144,7 +1144,9 @@ class PyLinter(
                 # fix the current file (if the source file was not available or
                 # if it's actually a c extension)
                 self.current_file = ast_node.file  # pylint: disable=maybe-no-member
+                before_check_statements = walker.nbstatements
                 self.check_astroid_module(ast_node, walker, rawcheckers, tokencheckers)
+                self.stats["by_module"][modname]["statement"] = walker.nbstatements-before_check_statements
                 # warn about spurious inline messages handling
                 spurious_messages = self.file_state.iter_spurious_suppression_messages(
                     self.msgs_store

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -1146,7 +1146,9 @@ class PyLinter(
                 self.current_file = ast_node.file  # pylint: disable=maybe-no-member
                 before_check_statements = walker.nbstatements
                 self.check_astroid_module(ast_node, walker, rawcheckers, tokencheckers)
-                self.stats["by_module"][modname]["statement"] = walker.nbstatements-before_check_statements
+                self.stats["by_module"][modname]["statement"] = (
+                    walker.nbstatements - before_check_statements
+                )
                 # warn about spurious inline messages handling
                 spurious_messages = self.file_state.iter_spurious_suppression_messages(
                     self.msgs_store

--- a/tests/unittest_lint.py
+++ b/tests/unittest_lint.py
@@ -769,3 +769,21 @@ def test_filename_with__init__(init_linter):
     linter.check([filepath])
     messages = reporter.messages
     assert len(messages) == 0
+
+
+def test_by_module_statement_value(init_linter):
+    """Test "statement" for each module analized of computed correctly."""
+    linter = init_linter
+    linter.check(os.path.join(os.path.dirname(__file__), "data"))
+
+    for module, module_stats in linter.stats['by_module'].items():
+
+        linter2 = init_linter
+        if module == "data":
+            linter2.check(os.path.join(os.path.dirname(__file__), "data/__init__.py"))
+        else:
+            linter2.check(os.path.join(os.path.dirname(__file__), module))
+
+        # Check that the by_module "statement" is equal to the global "statement"
+        # computed for that module
+        assert module_stats['statement'] == linter2.stats['statement']


### PR DESCRIPTION
## Checklist

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.
- [x] Add a test for the new feature

## Description

Fix the "statement" values in the PyLinter's stats reports by module.

Before, the PyLinter class initialized the stats['by_module'][modname]["statement"] attribute to 0 (initialized in the **PyLinter.set_current_module** method). But it was never updated after each module was checked. This pull request fix that issue. 

Having the number of statements by module, in addition to the number of other warnings, may be used for example to compute an evaluation note for each module during a post-processing of the output.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

