### PR TITLE
W0199: Change description to use the term 2-item-tuple

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -313,3 +313,5 @@ contributors:
 * Andrzej Klajnert: contributor
 
 * Andrés Pérez Hortal: contributor
+
+* Niko Wenselowski: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -216,6 +216,9 @@ Release date: TBA
 
   Close #2581
 
+* Changed description of W0199 to use the term 2-item-tuple instead of 2-uple.
+
+
 What's New in Pylint 2.3.0?
 ===========================
 

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -953,7 +953,7 @@ class BasicChecker(_BasicChecker):
             "re-raised.",
         ),
         "W0199": (
-            "Assert called on a 2-uple. Did you mean 'assert x,y'?",
+            "Assert called on a 2-item-tuple. Did you mean 'assert x,y'?",
             "assert-on-tuple",
             "A call of assert on a tuple will always evaluate to true if "
             "the tuple is not empty, and will always evaluate to false if "

--- a/tests/functional/assert_on_tuple.txt
+++ b/tests/functional/assert_on_tuple.txt
@@ -1,2 +1,2 @@
-assert-on-tuple:5::Assert called on a 2-uple. Did you mean 'assert x,y'?
-assert-on-tuple:11::Assert called on a 2-uple. Did you mean 'assert x,y'?
+assert-on-tuple:5::Assert called on a 2-item-tuple. Did you mean 'assert x,y'?
+assert-on-tuple:11::Assert called on a 2-item-tuple. Did you mean 'assert x,y'?


### PR DESCRIPTION

## Description

Change the description of W0199 to refer to _2-item-tuple_ instead of _2-uple_.

This makes it more-clear what the problem is and I think is easier to understand for non-native-speakers as it does not rely on the pronounciation of _two_.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |
