### PR TITLE
Add unittests for MessageDefinition

### DIFF
--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -934,16 +934,16 @@ class PyLinter(
         if not self.config.reports:
             self.disable_reporters()
         # get needed checkers
-        neededcheckers = [self]
+        needed_checkers = [self]
         for checker in self.get_checkers()[1:]:
             messages = {msg for msg in checker.msgs if self.is_message_enabled(msg)}
             if messages or any(self.report_is_enabled(r[0]) for r in checker.reports):
-                neededcheckers.append(checker)
+                needed_checkers.append(checker)
         # Sort checkers by priority
-        neededcheckers = sorted(
-            neededcheckers, key=operator.attrgetter("priority"), reverse=True
+        needed_checkers = sorted(
+            needed_checkers, key=operator.attrgetter("priority"), reverse=True
         )
-        return neededcheckers
+        return needed_checkers
 
     # pylint: disable=unused-argument
     @staticmethod

--- a/pylint/message/__init__.py
+++ b/pylint/message/__init__.py
@@ -43,3 +43,5 @@ from pylint.message.message import Message
 from pylint.message.message_definition import MessageDefinition
 from pylint.message.message_handler_mix_in import MessagesHandlerMixIn
 from pylint.message.message_store import MessagesStore
+
+__all__ = ["Message", "MessageDefinition", "MessagesHandlerMixIn", "MessagesStore"]

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -38,7 +38,10 @@ class MessageDefinition:
         self.old_names = old_names or []
 
     def __repr__(self):
-        return "MessageDefinition:{}".format(self.__dict__)
+        return "MessageDefinition:%s (%s)" % (self.symbol, self.msgid)
+
+    def __str__(self):
+        return "%s:\n%s %s" % (repr(self), self.msg, self.description)
 
     def may_be_emitted(self):
         """return True if message may be emitted using the current interpreter"""

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -16,7 +16,7 @@ class MessageDefinition:
         checker,
         msgid,
         msg,
-        descr,
+        description,
         symbol,
         scope,
         minversion=None,
@@ -30,7 +30,7 @@ class MessageDefinition:
             raise InvalidMessageError("Bad message type %s in %r" % (msgid[0], msgid))
         self.msgid = msgid
         self.msg = msg
-        self.descr = descr
+        self.description = description
         self.symbol = symbol
         self.scope = scope
         self.minversion = minversion
@@ -50,7 +50,7 @@ class MessageDefinition:
 
     def format_help(self, checkerref=False):
         """return the help string for the given message id"""
-        desc = self.descr
+        desc = self.description
         if checkerref:
             desc += " This message belongs to the %s checker." % self.checker.name
         title = self.msg

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -228,13 +228,7 @@ class MessagesHandlerMixIn:
             return self._msgs_state.get(msgid, True)
 
     def add_message(
-        self,
-        msg_descr,
-        line=None,
-        node=None,
-        args=None,
-        confidence=UNDEFINED,
-        col_offset=None,
+        self, msgid, line=None, node=None, args=None, confidence=None, col_offset=None
     ):
         """Adds a message given by ID or name.
 
@@ -244,7 +238,9 @@ class MessagesHandlerMixIn:
         provide line if the line number is different), raw and token checkers
         must provide the line argument.
         """
-        message_definitions = self.msgs_store.get_message_definitions(msg_descr)
+        if confidence is None:
+            confidence = UNDEFINED
+        message_definitions = self.msgs_store.get_message_definitions(msgid)
         for message_definition in message_definitions:
             self.add_one_message(
                 message_definition, line, node, args, confidence, col_offset

--- a/pylint/message/message_store.py
+++ b/pylint/message/message_store.py
@@ -11,6 +11,7 @@ from pylint.exceptions import InvalidMessageError, UnknownMessageError
 
 
 class MessagesStore:
+
     """The messages store knows information about every possible message but has
     no particular state during analysis.
     """
@@ -30,7 +31,7 @@ class MessagesStore:
         self._msgs_by_category = collections.defaultdict(list)
 
     @property
-    def messages(self):
+    def messages(self) -> list:
         """The list of all active messages."""
         return self._messages_definitions.values()
 
@@ -78,7 +79,7 @@ class MessagesStore:
         """Check that a symbol is not already used. """
         other_message = self._messages_definitions.get(symbol)
         if other_message:
-            self._raise_duplicate_msg_id(symbol, msgid, other_message.msgid)
+            self._raise_duplicate_msgid(symbol, msgid, other_message.msgid)
         else:
             alternative_msgid = None
         alternative_message = self._alternative_names.get(symbol)
@@ -91,7 +92,7 @@ class MessagesStore:
                         alternative_msgid = old_msgid
                         break
             if msgid != alternative_msgid:
-                self._raise_duplicate_msg_id(symbol, msgid, alternative_msgid)
+                self._raise_duplicate_msgid(symbol, msgid, alternative_msgid)
 
     def _check_msgid(self, msgid, symbol):
         for message in self._messages_definitions.values():
@@ -130,8 +131,7 @@ class MessagesStore:
         :param str msgid: The msgid corresponding to the symbols
         :param str symbol: Offending symbol
         :param str other_symbol: Other offending symbol
-        :raises InvalidMessageError: when a symbol is duplicated.
-        """
+        :raises InvalidMessageError:"""
         symbols = [symbol, other_symbol]
         symbols.sort()
         error_message = "Message id '{msgid}' cannot have both ".format(msgid=msgid)
@@ -141,14 +141,13 @@ class MessagesStore:
         raise InvalidMessageError(error_message)
 
     @staticmethod
-    def _raise_duplicate_msg_id(symbol, msgid, other_msgid):
+    def _raise_duplicate_msgid(symbol, msgid, other_msgid):
         """Raise an error when a msgid is duplicated.
 
         :param str symbol: The symbol corresponding to the msgids
         :param str msgid: Offending msgid
         :param str other_msgid: Other offending msgid
-        :raises InvalidMessageError: when a msgid is duplicated.
-        """
+        :raises InvalidMessageError:"""
         msgids = [msgid, other_msgid]
         msgids.sort()
         error_message = "Message symbol '{symbol}' cannot be used for ".format(

--- a/pylint/message/message_store.py
+++ b/pylint/message/message_store.py
@@ -35,15 +35,6 @@ class MessagesStore:
         """The list of all active messages."""
         return self._messages_definitions.values()
 
-    def add_renamed_message(self, old_id, old_symbol, new_symbol):
-        """Register the old ID and symbol for a warning that was renamed.
-
-        This allows users to keep using the old ID/symbol in suppressions.
-        """
-        message_definition = self.get_message_definitions(new_symbol)[0]
-        message_definition.old_names.append((old_id, old_symbol))
-        self._register_alternative_name(message_definition, old_id, old_symbol)
-
     def register_messages_from_checker(self, checker):
         """Register all messages from a checker.
 

--- a/pylint/message/message_store.py
+++ b/pylint/message/message_store.py
@@ -151,13 +151,14 @@ class MessagesStore:
 
     def get_message_definitions(self, msgid_or_symbol: str) -> list:
         """Returns the Message object for this message.
-
         :param str msgid_or_symbol: msgid_or_symbol may be either a numeric or symbolic id.
         :raises UnknownMessageError: if the message id is not defined.
         :rtype: List of MessageDefinition
         :return: A message definition corresponding to msgid_or_symbol
         """
-        if msgid_or_symbol[1:].isdigit():
+        # Only msgid can have a digit as second letter
+        is_msgid = msgid_or_symbol[1:].isdigit()
+        if is_msgid:
             msgid_or_symbol = msgid_or_symbol.upper()
         for source in (self._alternative_names, self._messages_definitions):
             try:

--- a/tests/message/unittest_message_definition.py
+++ b/tests/message/unittest_message_definition.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+import sys
+
+from pylint.checkers import BaseChecker
+from pylint.constants import WarningScope
+from pylint.message import MessageDefinition
+
+
+class FalseChecker(BaseChecker):
+    name = "FalseChecker"
+    msgs = {
+        "W1234": ("message one", "msg-symbol-one", "msg description"),
+        "W1235": (
+            "message two",
+            "msg-symbol-two",
+            "msg description",
+            {"old_names": [("W1230", "msg-symbol-one")]},
+        ),
+    }
+
+
+class TestMessagesDefinition(object):
+    def assert_with_fail_msg(self, msg, expected=True):
+        fail_msg = "With minversion='{}' and maxversion='{}',".format(
+            msg.minversion, msg.maxversion
+        )
+        fail_msg += " and the python interpreter being {} ".format(sys.version_info)
+        fail_msg += "the message should{}be emitable"
+        if expected:
+            assert msg.may_be_emitted(), fail_msg.format(" ")
+        else:
+            assert not msg.may_be_emitted(), fail_msg.format(" not ")
+
+    def get_message_definition(self):
+        args = [
+            FalseChecker(),
+            "W1234",
+            "message",
+            "description",
+            "msg-symbol",
+            WarningScope.NODE,
+        ]
+        kwargs = {"minversion": None, "maxversion": None}
+        return MessageDefinition(*args, **kwargs)
+
+    def test_may_be_emitted(self):
+        major = sys.version_info.major
+        minor = sys.version_info.minor
+        msg = self.get_message_definition()
+        self.assert_with_fail_msg(msg, expected=True)
+        msg.minversion = (major, minor - 1)
+        msg.maxversion = (major, minor + 1)
+        self.assert_with_fail_msg(msg, expected=True)
+        msg.minversion = (major, minor + 1)
+        self.assert_with_fail_msg(msg, expected=False)
+        msg.minversion = (major, minor - 1)
+        self.assert_with_fail_msg(msg, expected=True)
+        msg.maxversion = (major, minor - 1)
+        self.assert_with_fail_msg(msg, expected=False)
+
+    def test_repr(self):
+        msg = self.get_message_definition()
+        repr_str = str([msg, msg])
+        assert "W1234" in repr_str
+        assert "msg-symbol" in repr_str
+        expected = "[MessageDefinition:msg-symbol-one (W1234), MessageDefinition:msg-symbol-two (W1235)]"
+        assert str(FalseChecker().messages) == expected
+
+    def test_format_help(self):
+        msg = self.get_message_definition()
+        major = sys.version_info.major
+        minor = sys.version_info.minor
+        msg.minversion = (major, minor - 1)
+        msg.maxversion = (major, minor + 1)
+        format_str_checker_ref = msg.format_help(checkerref=False)
+        format_str = msg.format_help(checkerref=True)
+        assert str(minor - 1) in format_str
+        assert str(major + 1) in format_str_checker_ref
+        expected_format_help = """:msg-symbol-one (W1234): *message one*
+  msg description"""
+        assert FalseChecker().messages[0].format_help() == expected_format_help

--- a/tests/message/unittest_message_store.py
+++ b/tests/message/unittest_message_store.py
@@ -115,23 +115,6 @@ class TestMessagesStore(object):
         # cursory examination of the output: we're mostly testing it completes
         assert ":msg-symbol (W1234): *message*" in output.getvalue()
 
-    def test_add_renamed_message(self, store):
-        store.add_renamed_message("W1234", "old-bad-name", "msg-symbol")
-        assert "msg-symbol" == store.get_message_definitions("W1234")[0].symbol
-        assert "msg-symbol" == store.get_message_definitions("old-bad-name")[0].symbol
-
-    def test_add_renamed_message_invalid(self, store):
-        # conflicting message ID
-        with pytest.raises(InvalidMessageError) as cm:
-            store.add_renamed_message(
-                "W1234", "old-msg-symbol", "duplicate-keyword-arg"
-            )
-        expected = (
-            "Message id 'W1234' cannot have both 'msg-symbol' and 'old-msg-symbol' "
-            "as symbolic name."
-        )
-        assert str(cm.value) == expected
-
     def test_renamed_message_register(self, store):
         assert "msg-symbol" == store.get_message_definitions("W0001")[0].symbol
         assert "msg-symbol" == store.get_message_definitions("old-symbol")[0].symbol


### PR DESCRIPTION
## Description

This fixes some minor naming problem and add unit tests for MessageDefinition to achieve better coverage without functional test. Adding unit tests also permitted to realise that add_message was not used anywhere but in tests.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Related Issue

Smaller merge request to make #2992 easier to review.
