### PR TITLE
Refactor `pylint.utils.category_id()` that is used one time only

### DIFF
--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -14,18 +14,14 @@ from pylint.constants import (
     MSG_STATE_SCOPE_CONFIG,
     MSG_STATE_SCOPE_MODULE,
     MSG_TYPES,
+    MSG_TYPES_LONG,
     MSG_TYPES_STATUS,
     WarningScope,
 )
 from pylint.exceptions import InvalidMessageError, UnknownMessageError
 from pylint.interfaces import UNDEFINED
 from pylint.message.message import Message
-from pylint.utils import (
-    category_id,
-    get_module_and_frameid,
-    get_rst_section,
-    get_rst_title,
-)
+from pylint.utils import get_module_and_frameid, get_rst_section, get_rst_title
 
 
 class MessagesHandlerMixIn:
@@ -99,6 +95,12 @@ class MessagesHandlerMixIn:
             return
 
         # msgid is a category?
+        def category_id(cid):
+            cid = cid.upper()
+            if cid in MSG_TYPES:
+                return cid
+            return MSG_TYPES_LONG.get(cid)
+
         catid = category_id(msgid)
         if catid is not None:
             for _msgid in self.msgs_store._msgs_by_category.get(catid):

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -95,15 +95,11 @@ class MessagesHandlerMixIn:
             return
 
         # msgid is a category?
-        def category_id(cid):
-            cid = cid.upper()
-            if cid in MSG_TYPES:
-                return cid
-            return MSG_TYPES_LONG.get(cid)
-
-        catid = category_id(msgid)
-        if catid is not None:
-            for _msgid in self.msgs_store._msgs_by_category.get(catid):
+        category_id = msgid.upper()
+        if category_id not in MSG_TYPES:
+            category_id = MSG_TYPES_LONG.get(category_id)
+        if category_id is not None:
+            for _msgid in self.msgs_store._msgs_by_category.get(category_id):
                 self._set_msg_status(_msgid, enable, scope, line)
             return
 

--- a/pylint/utils/__init__.py
+++ b/pylint/utils/__init__.py
@@ -49,7 +49,6 @@ from pylint.utils.utils import (
     _format_option_value,
     _splitstrip,
     _unquote,
-    category_id,
     decoding_stream,
     deprecated_option,
     expand_modules,

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -15,7 +15,7 @@ from os.path import basename, dirname, exists, isdir, join, normpath, splitext
 
 from astroid import Module, modutils
 
-from pylint.constants import MSG_TYPES, MSG_TYPES_LONG, PY_EXTS
+from pylint.constants import PY_EXTS
 
 
 def normalize_text(text, line_len=80, indent=""):
@@ -42,13 +42,6 @@ def get_module_and_frameid(node):
             frame = None
     obj.reverse()
     return module, ".".join(obj)
-
-
-def category_id(cid):
-    cid = cid.upper()
-    if cid in MSG_TYPES:
-        return cid
-    return MSG_TYPES_LONG.get(cid)
 
 
 def get_rst_title(title, character):


### PR DESCRIPTION
## Description 

`category_id()` in pylint.utils is used only once in pylint.message, so without it pylint is simpler to understand. (less imports and code in pylint.utils and the possibility to see what is done directly in pylint.message without going elsewhere).

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |
