### PR TITLE
Some generators can have __enter__ __exit__ members

### DIFF
--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -443,6 +443,11 @@ def _emit_no_member(node, owner, owner_name, ignored_mixins=True, ignored_none=T
             return False
         except astroid.NotFoundError:
             pass
+    if isinstance(owner, bases.Generator):
+        if node.attrname in ("__enter__", "__exit__") and decorated_with(
+            owner.parent, ["contextlib.contextmanager"]
+        ):
+            return False
     if owner_name and node.attrname.startswith("_" + owner_name):
         # Test if an attribute has been mangled ('private' attribute)
         unmangled_name = node.attrname.split("_" + owner_name)[-1]

--- a/tests/functional/member_checks.py
+++ b/tests/functional/member_checks.py
@@ -209,7 +209,6 @@ class Cls(enum.IntEnum):
 SOME_VALUE = Cls.Baz  # [no-member]
 
 
-
 # Does not crash when inferring the `append` attribute on the slice object
 class SomeClassUsingSlice:
     def __init__(self, flag):
@@ -218,3 +217,15 @@ class SomeClassUsingSlice:
         else:
             self.attribute = []
             self.attribute.append(1)
+
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def context_manager_to_check_members():
+    yield
+
+CM = context_manager_to_check_members()
+CM.__enter__()
+CM.__exit__(None, None, None)


### PR DESCRIPTION
Fix (no-member) false-positives for generators created with contextmanager.

Closes #2567

I have no idea why but `tox -e py37` was failing with (invalid-name) in added test.
pylint from master run on the snippet - did not complain.
So I had to add  `# pylint: disable=invalid-name` .