### PR TITLE
Create a MessageId class

### DIFF
--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -896,7 +896,7 @@ def get_exception_handlers(
         return [
             handler for handler in context.handlers if error_of_type(handler, exception)
         ]
-    return None
+    return []
 
 
 def is_node_inside_try_except(node: astroid.Raise) -> bool:

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -78,7 +78,7 @@ from astroid.builder import AstroidBuilder
 from pylint import checkers, config, exceptions, interfaces, reporters
 from pylint.__pkginfo__ import version
 from pylint.constants import MAIN_CHECKER_NAME, MSG_TYPES, OPTION_RGX
-from pylint.message import Message, MessagesHandlerMixIn, MessagesStore
+from pylint.message import Message, MessageDefinitionStore, MessagesHandlerMixIn
 from pylint.reporters.ureports import nodes as report_nodes
 from pylint.utils import ASTWalker, FileState, utils
 
@@ -593,7 +593,7 @@ class PyLinter(
         # some stuff has to be done before ancestors initialization...
         #
         # messages store / checkers / reporter / astroid manager
-        self.msgs_store = MessagesStore()
+        self.msgs_store = MessageDefinitionStore()
         self.reporter = None
         self._reporter_name = None
         self._reporters = {}

--- a/pylint/message/__init__.py
+++ b/pylint/message/__init__.py
@@ -43,10 +43,12 @@ from pylint.message.message import Message
 from pylint.message.message_definition import MessageDefinition
 from pylint.message.message_definition_store import MessageDefinitionStore
 from pylint.message.message_handler_mix_in import MessagesHandlerMixIn
+from pylint.message.message_id import MessageId
 
 __all__ = [
     "Message",
     "MessageDefinition",
     "MessageDefinitionStore",
     "MessagesHandlerMixIn",
+    "MessageId",
 ]

--- a/pylint/message/__init__.py
+++ b/pylint/message/__init__.py
@@ -41,7 +41,12 @@
 
 from pylint.message.message import Message
 from pylint.message.message_definition import MessageDefinition
+from pylint.message.message_definition_store import MessageDefinitionStore
 from pylint.message.message_handler_mix_in import MessagesHandlerMixIn
-from pylint.message.message_store import MessagesStore
 
-__all__ = ["Message", "MessageDefinition", "MessagesHandlerMixIn", "MessagesStore"]
+__all__ = [
+    "Message",
+    "MessageDefinition",
+    "MessageDefinitionStore",
+    "MessagesHandlerMixIn",
+]

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -10,7 +10,7 @@ import collections
 from pylint.exceptions import InvalidMessageError, UnknownMessageError
 
 
-class MessagesStore:
+class MessageDefinitionStore:
 
     """The messages store knows information about every possible message but has
     no particular state during analysis.

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -244,14 +244,11 @@ class MessagesHandlerMixIn:
                 message_definition, line, node, args, confidence, col_offset
             )
 
-    def add_one_message(
-        self, message_definition, line, node, args, confidence, col_offset
-    ):
-        # backward compatibility, message may not have a symbol
-        symbol = message_definition.symbol or message_definition.msgid
-        # Fatal messages and reports are special, the node/scope distinction
-        # does not apply to them.
+    @staticmethod
+    def check_message_definition(message_definition, line, node):
         if message_definition.msgid[0] not in _SCOPE_EXEMPT:
+            # Fatal messages and reports are special, the node/scope distinction
+            # does not apply to them.
             if message_definition.scope == WarningScope.LINE:
                 if line is None:
                     raise InvalidMessageError(
@@ -271,6 +268,12 @@ class MessagesHandlerMixIn:
                         % message_definition.msgid
                     )
 
+    def add_one_message(
+        self, message_definition, line, node, args, confidence, col_offset
+    ):
+        # backward compatibility, message may not have a symbol
+        symbol = message_definition.symbol or message_definition.msgid
+        self.check_message_definition(message_definition, line, node)
         if line is None and node is not None:
             line = node.fromlineno
         if col_offset is None and hasattr(node, "col_offset"):

--- a/pylint/message/message_id.py
+++ b/pylint/message/message_id.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+from pylint.constants import MSG_TYPES
+from pylint.exceptions import InvalidMessageError
+
+
+class MessageId:
+    def __init__(self, msgid, symbol):
+        self.msgid = msgid
+        self.symbol = symbol
+
+    def __str__(self):
+        return "%s (%s)" % (self.symbol, self.msgid)
+
+    def __hash__(self):
+        return "{}-{}".format(self.msgid, self.symbol).__hash__()
+
+    def __eq__(self, other):
+        return self.msgid == other.msgid and self.symbol == other.symbol
+
+    @staticmethod
+    def check_msgid(msgid: str) -> None:
+        """This is a static method used in MessageDefinition and not the
+        MessageId constructor for performance reasons."""
+        if len(msgid) != 5:
+            raise InvalidMessageError("Invalid message id %r" % msgid)
+        if msgid[0] not in MSG_TYPES:
+            raise InvalidMessageError("Bad message type %s in %r" % (msgid[0], msgid))

--- a/tests/message/unittest_message.py
+++ b/tests/message/unittest_message.py
@@ -7,12 +7,12 @@ import pytest
 
 from pylint.checkers import BaseChecker
 from pylint.exceptions import InvalidMessageError
-from pylint.message import MessageDefinition, MessagesStore
+from pylint.message import MessageDefinition, MessageDefinitionStore
 
 
 @pytest.fixture
 def store():
-    return MessagesStore()
+    return MessageDefinitionStore()
 
 
 @pytest.mark.parametrize(

--- a/tests/message/unittest_message.py
+++ b/tests/message/unittest_message.py
@@ -141,16 +141,3 @@ def test_register_error_new_id_duplicate_of_new(store):
         {"W1234": ("message two", "msg-symbol-two", "another msg description.")},
         "Message id 'W1234' cannot have both 'msg-symbol-one' and 'msg-symbol-two' as symbolic name.",
     )
-
-
-@pytest.mark.parametrize(
-    "msgid,expected",
-    [
-        ("Q1234", "Bad message type Q in 'Q1234'"),
-        ("W12345", "Invalid message id 'W12345'"),
-    ],
-)
-def test_create_invalid_message_type(msgid, expected):
-    with pytest.raises(InvalidMessageError) as cm:
-        MessageDefinition("checker", msgid, "msg", "descr", "symbol", "scope")
-    assert str(cm.value) == expected

--- a/tests/message/unittest_message_definition_store.py
+++ b/tests/message/unittest_message_definition_store.py
@@ -10,12 +10,12 @@ import pytest
 
 from pylint.checkers import BaseChecker
 from pylint.exceptions import InvalidMessageError, UnknownMessageError
-from pylint.message import MessageDefinition, MessagesStore
+from pylint.message import MessageDefinition, MessageDefinitionStore
 
 
 @pytest.fixture
 def store():
-    store = MessagesStore()
+    store = MessageDefinitionStore()
 
     class Checker(BaseChecker):
         name = "achecker"

--- a/tests/message/unittest_message_id.py
+++ b/tests/message/unittest_message_id.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+import pytest
+
+from pylint.exceptions import InvalidMessageError
+from pylint.message import MessageId
+
+
+@pytest.fixture
+def msgid():
+    return "W1234"
+
+
+@pytest.fixture
+def symbol():
+    return "msg-symbol"
+
+
+@pytest.fixture
+def message_id(msgid, symbol):
+    return MessageId(msgid, symbol)
+
+
+@pytest.mark.parametrize(
+    "msgid,expected",
+    [
+        ("Q1234", "Bad message type Q in 'Q1234'"),
+        ("W12345", "Invalid message id 'W12345'"),
+    ],
+)
+def test_create_invalid_message_type(msgid, expected):
+    with pytest.raises(InvalidMessageError) as cm:
+        MessageId.check_msgid(msgid)
+    assert str(cm.value) == expected
+
+
+def test_hash_and_eq(message_id):
+    """MessageId should be hashable"""
+    dict_ = {}
+    message_id_2 = MessageId("W1235", "msg-symbol-2")
+    dict_[message_id] = 1
+    dict_[message_id_2] = 2
+    assert dict_[message_id] != dict_[message_id_2]
+    assert message_id != message_id_2
+
+
+def test_str(message_id, msgid, symbol):
+    result = str(message_id)
+    assert msgid in result
+    assert symbol in result


### PR DESCRIPTION
## Description

This create a `MessageId` class with its unit tests, and permit some simplification in pylint.message. It rename `MessageStore` to `MessageDefinitionStore` because we anticipate to have a `MessageIdStore` later. It will permit other simplifications in the next step of this refactor, but let's keep the MR small.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Related Issue

Next step in order to make #2992 easier to review.
