### PR TITLE
Rename MessageStore to MessageDefinitionStore

### DIFF
--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -78,7 +78,7 @@ from astroid.builder import AstroidBuilder
 from pylint import checkers, config, exceptions, interfaces, reporters
 from pylint.__pkginfo__ import version
 from pylint.constants import MAIN_CHECKER_NAME, MSG_TYPES, OPTION_RGX
-from pylint.message import Message, MessagesHandlerMixIn, MessagesStore
+from pylint.message import Message, MessageDefinitionStore, MessagesHandlerMixIn
 from pylint.reporters.ureports import nodes as report_nodes
 from pylint.utils import ASTWalker, FileState, utils
 
@@ -593,7 +593,7 @@ class PyLinter(
         # some stuff has to be done before ancestors initialization...
         #
         # messages store / checkers / reporter / astroid manager
-        self.msgs_store = MessagesStore()
+        self.msgs_store = MessageDefinitionStore()
         self.reporter = None
         self._reporter_name = None
         self._reporters = {}

--- a/pylint/message/__init__.py
+++ b/pylint/message/__init__.py
@@ -41,7 +41,12 @@
 
 from pylint.message.message import Message
 from pylint.message.message_definition import MessageDefinition
+from pylint.message.message_definition_store import MessageDefinitionStore
 from pylint.message.message_handler_mix_in import MessagesHandlerMixIn
-from pylint.message.message_store import MessagesStore
 
-__all__ = ["Message", "MessageDefinition", "MessagesHandlerMixIn", "MessagesStore"]
+__all__ = [
+    "Message",
+    "MessageDefinition",
+    "MessageDefinitionStore",
+    "MessagesHandlerMixIn",
+]

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -10,7 +10,7 @@ import collections
 from pylint.exceptions import InvalidMessageError, UnknownMessageError
 
 
-class MessagesStore:
+class MessageDefinitionStore:
 
     """The messages store knows information about every possible message but has
     no particular state during analysis.

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -244,14 +244,11 @@ class MessagesHandlerMixIn:
                 message_definition, line, node, args, confidence, col_offset
             )
 
-    def add_one_message(
-        self, message_definition, line, node, args, confidence, col_offset
-    ):
-        # backward compatibility, message may not have a symbol
-        symbol = message_definition.symbol or message_definition.msgid
-        # Fatal messages and reports are special, the node/scope distinction
-        # does not apply to them.
+    @staticmethod
+    def check_message_definition(message_definition, line, node):
         if message_definition.msgid[0] not in _SCOPE_EXEMPT:
+            # Fatal messages and reports are special, the node/scope distinction
+            # does not apply to them.
             if message_definition.scope == WarningScope.LINE:
                 if line is None:
                     raise InvalidMessageError(
@@ -271,6 +268,12 @@ class MessagesHandlerMixIn:
                         % message_definition.msgid
                     )
 
+    def add_one_message(
+        self, message_definition, line, node, args, confidence, col_offset
+    ):
+        # backward compatibility, message may not have a symbol
+        symbol = message_definition.symbol or message_definition.msgid
+        self.check_message_definition(message_definition, line, node)
         if line is None and node is not None:
             line = node.fromlineno
         if col_offset is None and hasattr(node, "col_offset"):

--- a/tests/message/unittest_message.py
+++ b/tests/message/unittest_message.py
@@ -7,12 +7,12 @@ import pytest
 
 from pylint.checkers import BaseChecker
 from pylint.exceptions import InvalidMessageError
-from pylint.message import MessageDefinition, MessagesStore
+from pylint.message import MessageDefinition, MessageDefinitionStore
 
 
 @pytest.fixture
 def store():
-    return MessagesStore()
+    return MessageDefinitionStore()
 
 
 @pytest.mark.parametrize(

--- a/tests/message/unittest_message_definition_store.py
+++ b/tests/message/unittest_message_definition_store.py
@@ -10,12 +10,12 @@ import pytest
 
 from pylint.checkers import BaseChecker
 from pylint.exceptions import InvalidMessageError, UnknownMessageError
-from pylint.message import MessageDefinition, MessagesStore
+from pylint.message import MessageDefinition, MessageDefinitionStore
 
 
 @pytest.fixture
 def store():
-    store = MessagesStore()
+    store = MessageDefinitionStore()
 
     class Checker(BaseChecker):
         name = "achecker"
@@ -65,7 +65,7 @@ def test_get_msg_display_string(store):
     assert store.get_msg_display_string("E1234") == "'duplicate-keyword-arg'"
 
 
-class TestMessagesStore(object):
+class TestMessageDefinitionStore(object):
     def _compare_messages(self, desc, msg, checkerref=False):
         assert desc == msg.format_help(checkerref=checkerref)
 


### PR DESCRIPTION
## Description

It rename `MessageStore` to `MessageDefinitionStore` because we anticipate to have a `MessageIdStore` later. A lot of commits are impossible to isolate if this file is not renamed on the master branch.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Related Issue

Next step in order to make #2992 easier to review.
