### PR TITLE
Enforce 1 1 mapping between msgid and symbol

### DIFF
--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -2131,7 +2131,7 @@ class ComparisonChecker(_BasicChecker):
             "Python is to use isinstance(x, Y) rather than "
             "type(x) == Y, type(x) is Y. Though there are unusual "
             "situations where these give different results.",
-            {"old_names": [("W0154", "unidiomatic-typecheck")]},
+            {"old_names": [("W0154", "old-unidiomatic-typecheck")]},
         ),
         "R0123": (
             "Comparison to literal",

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -1678,8 +1678,8 @@ class SpecialMethodsChecker(BaseChecker):
             "iterable (i.e. has no `%s` method)" % NEXT_METHOD,
             {
                 "old_names": [
-                    ("W0234", "non-iterator-returned"),
-                    ("E0234", "non-iterator-returned"),
+                    ("W0234", "old-non-iterator-returned-1"),
+                    ("E0234", "old-non-iterator-returned-2"),
                 ]
             },
         ),

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -201,7 +201,7 @@ MSGS = {
         "Unable to import %s",
         "import-error",
         "Used when pylint has been unable to import a module.",
-        {"old_names": [("F0401", "import-error")]},
+        {"old_names": [("F0401", "old-import-error")]},
     ),
     "E0402": (
         "Attempted relative import beyond top-level package",

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -189,7 +189,7 @@ class Python3Checker(checkers.BaseChecker):
             "Python3 will not allow implicit unpacking of "
             "exceptions in except clauses. "
             "See http://www.python.org/dev/peps/pep-3110/",
-            {"old_names": [("W0712", "unpacking-in-except")]},
+            {"old_names": [("W0712", "old-unpacking-in-except")]},
         ),
         "E1604": (
             "Use raise ErrorClass(args) instead of raise ErrorClass, args.",
@@ -197,14 +197,14 @@ class Python3Checker(checkers.BaseChecker):
             "Used when the alternate raise syntax "
             "'raise foo, bar' is used "
             "instead of 'raise foo(bar)'.",
-            {"old_names": [("W0121", "old-raise-syntax")]},
+            {"old_names": [("W0121", "old-old-raise-syntax")]},
         ),
         "E1605": (
             "Use of the `` operator",
             "backtick",
             'Used when the deprecated "``" (backtick) operator is used '
             "instead  of the str() function.",
-            {"scope": WarningScope.NODE, "old_names": [("W0333", "backtick")]},
+            {"scope": WarningScope.NODE, "old_names": [("W0333", "old-backtick")]},
         ),
         "E1609": (
             "Import * only allowed at module level",
@@ -358,14 +358,14 @@ class Python3Checker(checkers.BaseChecker):
             "indexing-exception",
             "Indexing exceptions will not work on Python 3. Use "
             "`exception.args[index]` instead.",
-            {"old_names": [("W0713", "indexing-exception")]},
+            {"old_names": [("W0713", "old-indexing-exception")]},
         ),
         "W1625": (
             "Raising a string exception",
             "raising-string",
             "Used when a string exception is raised. This will not "
             "work on Python 3.",
-            {"old_names": [("W0701", "raising-string")]},
+            {"old_names": [("W0701", "old-raising-string")]},
         ),
         "W1626": (
             "reload built-in referenced",
@@ -1369,7 +1369,7 @@ class Python3TokenChecker(checkers.BaseTokenChecker):
             "old-ne-operator",
             'Used when the deprecated "<>" operator is used instead '
             'of "!=". This is removed in Python 3.',
-            {"maxversion": (3, 0), "old_names": [("W0331", "old-ne-operator")]},
+            {"maxversion": (3, 0), "old_names": [("W0331", "old-old-ne-operator")]},
         ),
         "E1608": (
             "Use of old octal literal",

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -141,13 +141,13 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             "Used when a function or a method has too many nested "
             "blocks. This makes the code less understandable and "
             "maintainable.",
-            {"old_names": [("R0101", "too-many-nested-blocks")]},
+            {"old_names": [("R0101", "old-too-many-nested-blocks")]},
         ),
         "R1703": (
             "The if statement can be replaced with %s",
             "simplifiable-if-statement",
             "Used when an if statement can be replaced with 'bool(test)'. ",
-            {"old_names": [("R0102", "simplifiable-if-statement")]},
+            {"old_names": [("R0102", "old-simplifiable-if-statement")]},
         ),
         "R1704": (
             "Redefining argument with the local name %r",

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -289,7 +289,7 @@ MSGS = {
         "assignment-from-none",
         "Used when an assignment is done on a function call but the "
         "inferred function returns nothing but None.",
-        {"old_names": [("W1111", "assignment-from-none")]},
+        {"old_names": [("W1111", "old-assignment-from-none")]},
     ),
     "E1129": (
         "Context manager '%s' doesn't implement __enter__ and __exit__.",

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -450,14 +450,14 @@ MSGS = {
         "left side has %d label(s), right side has %d value(s)",
         "unbalanced-tuple-unpacking",
         "Used when there is an unbalanced tuple unpacking in assignment",
-        {"old_names": [("E0632", "unbalanced-tuple-unpacking")]},
+        {"old_names": [("E0632", "old-unbalanced-tuple-unpacking")]},
     ),
     "E0633": (
         "Attempting to unpack a non-sequence%s",
         "unpacking-non-sequence",
         "Used when something which is not "
         "a sequence is used in an unpack assignment",
-        {"old_names": [("W0633", "unpacking-non-sequence")]},
+        {"old_names": [("W0633", "old-unpacking-non-sequence")]},
     ),
     "W0640": (
         "Cell variable %s defined in loop",

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -78,7 +78,7 @@ class DocstringParameterChecker(BaseChecker):
             "Missing return documentation",
             "missing-return-doc",
             "Please add documentation about what this method returns.",
-            {"old_names": [("W9007", "missing-returns-doc")]},
+            {"old_names": [("W9007", "old-missing-returns-doc")]},
         ),
         "W9012": (
             "Missing return type documentation",
@@ -91,7 +91,7 @@ class DocstringParameterChecker(BaseChecker):
             "Missing yield documentation",
             "missing-yield-doc",
             "Please add documentation about what this generator yields.",
-            {"old_names": [("W9009", "missing-yields-doc")]},
+            {"old_names": [("W9009", "old-missing-yields-doc")]},
         ),
         "W9014": (
             "Missing yield type documentation",
@@ -104,13 +104,13 @@ class DocstringParameterChecker(BaseChecker):
             '"%s" missing in parameter documentation',
             "missing-param-doc",
             "Please add parameter declarations for all parameters.",
-            {"old_names": [("W9003", "missing-param-doc")]},
+            {"old_names": [("W9003", "old-missing-param-doc")]},
         ),
         "W9016": (
             '"%s" missing in parameter type documentation',
             "missing-type-doc",
             "Please add parameter type declarations for all parameters.",
-            {"old_names": [("W9004", "missing-type-doc")]},
+            {"old_names": [("W9004", "old-missing-type-doc")]},
         ),
         "W9017": (
             '"%s" differing in parameter documentation',


### PR DESCRIPTION
## Description

This merge request enforce the 1-1 mapping between msgid and symbol by renaming the old symbol name to something else than the new name. It does not change anything for the user because the symbolic name still exists within the active message. This will be enforced in code later.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Related Issue

Next in line in order to make #2992  easier to review.
