### PR TITLE
Remove legacy null symbol handling

### DIFF
--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -29,12 +29,9 @@ class MessageDefinition:
         if not msgid[0] in MSG_TYPES:
             raise InvalidMessageError("Bad message type %s in %r" % (msgid[0], msgid))
         self.msgid = msgid
+        self.symbol = symbol
         self.msg = msg
         self.description = description
-        if not symbol:
-            # backward compatibility, message may not have a symbol
-            symbol = msgid
-        self.symbol = symbol
         self.scope = scope
         self.minversion = minversion
         self.maxversion = maxversion
@@ -60,10 +57,6 @@ class MessageDefinition:
         if checkerref:
             desc += " This message belongs to the %s checker." % self.checker.name
         title = self.msg
-        if self.symbol:
-            msgid = "%s (%s)" % (self.symbol, self.msgid)
-        else:
-            msgid = self.msgid
         if self.minversion or self.maxversion:
             restr = []
             if self.minversion:
@@ -75,9 +68,9 @@ class MessageDefinition:
                 desc += " It can't be emitted when using Python %s." % restr
             else:
                 desc += " This message can't be emitted when using Python %s." % restr
-        desc = normalize_text(" ".join(desc.split()), indent="  ")
+        msg_help = normalize_text(" ".join(desc.split()), indent="  ")
+        message_id = "%s (%s)" % (self.symbol, self.msgid)
         if title != "%s":
             title = title.splitlines()[0]
-
-            return ":%s: *%s*\n%s" % (msgid, title.rstrip(" "), desc)
-        return ":%s:\n%s" % (msgid, desc)
+            return ":%s: *%s*\n%s" % (message_id, title.rstrip(" "), msg_help)
+        return ":%s:\n%s" % (message_id, msg_help)

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -31,6 +31,9 @@ class MessageDefinition:
         self.msgid = msgid
         self.msg = msg
         self.description = description
+        if not symbol:
+            # backward compatibility, message may not have a symbol
+            symbol = msgid
         self.symbol = symbol
         self.scope = scope
         self.minversion = minversion

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -171,10 +171,7 @@ class MessageDefinitionStore:
         raise UnknownMessageError(error_msg)
 
     def get_msg_display_string(self, msgid):
-        """Generates a user-consumable representation of a message.
-
-        Can be just the message ID or the ID and the symbol.
-        """
+        """Generates a user-consumable representation of a message. """
         message_definitions = self.get_message_definitions(msgid)
         if len(message_definitions) == 1:
             return repr(message_definitions[0].symbol)

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -271,8 +271,6 @@ class MessagesHandlerMixIn:
     def add_one_message(
         self, message_definition, line, node, args, confidence, col_offset
     ):
-        # backward compatibility, message may not have a symbol
-        symbol = message_definition.symbol or message_definition.msgid
         self.check_message_definition(message_definition, line, node)
         if line is None and node is not None:
             line = node.fromlineno
@@ -298,9 +296,9 @@ class MessagesHandlerMixIn:
         self.stats[msg_cat] += 1
         self.stats["by_module"][self.current_name][msg_cat] += 1
         try:
-            self.stats["by_msg"][symbol] += 1
+            self.stats["by_msg"][message_definition.symbol] += 1
         except KeyError:
-            self.stats["by_msg"][symbol] = 1
+            self.stats["by_msg"][message_definition.symbol] = 1
         # expand message ?
         msg = message_definition.msg
         if args:
@@ -317,7 +315,7 @@ class MessagesHandlerMixIn:
         self.reporter.handle_message(
             Message(
                 message_definition.msgid,
-                symbol,
+                message_definition.symbol,
                 (abspath, path, module, obj, line or 1, col_offset or 0),
                 msg,
                 confidence,


### PR DESCRIPTION
## Description

Remove a mechanism that was handling symbol equal to None. It does not happens in the current tests and we want to have a 1-1 link between symbol and msgid anyway.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Related Issue

Permit to make #2992 easier to review.
