### PR TITLE
Don't require super call from `typing.overload`ed __init__

### DIFF
--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -1550,7 +1550,7 @@ a metaclass class method.",
 
     def _check_init(self, node):
         """check that the __init__ method call super or ancestors'__init__
-        method
+        method (unless it is used for type hinting with `typing.overload`)
         """
         if not self.linter.is_message_enabled(
             "super-init-not-called"
@@ -1600,6 +1600,8 @@ a metaclass class method.",
             except astroid.InferenceError:
                 continue
         for klass, method in not_called_yet.items():
+            if decorated_with(node, ["typing.overload"]):
+                continue
             cls = node_frame_class(method)
             if klass.name == "object" or (cls and cls.name == "object"):
                 continue

--- a/tests/functional/init_not_called.py
+++ b/tests/functional/init_not_called.py
@@ -62,3 +62,25 @@ from missing import Missing
 
 class UnknownBases(Missing):
     """Don't emit no-init if the bases aren't known."""
+
+
+from typing import overload  # pylint: disable=wrong-import-order
+
+class Parent:
+
+    def __init__(self, num: int):
+        self.number = num
+
+
+class Child(Parent):
+
+    @overload
+    def __init__(self, num: int):
+        ...
+
+    @overload
+    def __init__(self, num: float):
+        ...
+
+    def __init__(self, num):
+        super().__init__(round(num))


### PR DESCRIPTION
Fix false positive (super-init-not-called) for `__init__` methods decorated with `typing.overload`.

Close #3020
