### PR TITLE
Allow a `.` as a prefix for Sphinx name resolution.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -315,3 +315,5 @@ contributors:
 * Andrés Pérez Hortal: contributor
 
 * Niko Wenselowski: contributor
+
+* Danny Hermes: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -223,6 +223,8 @@ Release date: TBA
 
 * Changed description of W0199 to use the term 2-item-tuple instead of 2-uple.
 
+* Allow a `.` as a prefix for Sphinx name resolution.
+
 
 What's New in Pylint 2.3.0?
 ===========================

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -230,7 +230,7 @@ class Docstring:
 
 class SphinxDocstring(Docstring):
     re_type = r"""
-        [~!]?                # Optional link style prefix
+        [~!.]?               # Optional link style prefix
         \w(?:\w|\.[^\.])*    # Valid python name
         """
 

--- a/tests/extensions/test_check_raise_docs.py
+++ b/tests/extensions/test_check_raise_docs.py
@@ -167,6 +167,24 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
 
+    def test_google_raises_local_reference(self):
+        raise_node = astroid.extract_node(
+            '''
+        def my_func(self):
+            """This is a google docstring.
+
+            Raises:
+                .LocalException: Always
+            """
+            from neighbor_module import LocalException
+            raise LocalException('hi') #@
+        '''
+        )
+        # pylint allows this to pass since the comparison between Raises and
+        # raise are based on the class name, not the qualified name.
+        with self.assertNoMessages():
+            self.checker.visit_raise(raise_node)
+
     @set_config(accept_no_raise_doc=False)
     def test_google_raises_with_prefix(self):
         code_snippet = '''


### PR DESCRIPTION
For context see https://github.com/PyCQA/pylint/issues/1502#issuecomment-448535694

In this issue it was agreed that `re.error`, `~re.error` and `!re.error` would all be accepted. However, it's also common in Sphinx to use a `.` prefix for local references.

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
