### PR TITLE
useless-suppression detection now ignores cyclic-import

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -317,3 +317,5 @@ contributors:
 * Niko Wenselowski: contributor
 
 * Danny Hermes: contributor
+
+* Eric Froemling: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,12 @@ What's New in Pylint 2.4.0?
 
 Release date: TBA
 
+* ``useless-suppression`` check now ignores ``cyclic-import`` suppressions,
+  which could lead to false postiives due to incomplete context at the time
+  of the check.
+
+  Close #3064
+
 * Don't emit ``protected-access`` when a single underscore prefixed attribute
   is used inside a special method
 

--- a/pylint/utils/file_state.py
+++ b/pylint/utils/file_state.py
@@ -120,9 +120,12 @@ class FileState:
         for warning, lines in self._raw_module_msgs_state.items():
             for line, enable in lines.items():
                 if not enable and (warning, line) not in self._ignored_msgs:
-                    yield "useless-suppression", line, (
-                        msgs_store.get_msg_display_string(warning),
-                    )
+                    # ignore cyclic-import check which can show false positives
+                    # here due to incomplete context
+                    if warning != 'R0401':
+                        yield "useless-suppression", line, (
+                            msgs_store.get_msg_display_string(warning),
+                        )
         # don't use iteritems here, _ignored_msgs may be modified by add_message
         for (warning, from_), lines in list(self._ignored_msgs.items()):
             for line in lines:

--- a/pylint/utils/file_state.py
+++ b/pylint/utils/file_state.py
@@ -122,7 +122,7 @@ class FileState:
                 if not enable and (warning, line) not in self._ignored_msgs:
                     # ignore cyclic-import check which can show false positives
                     # here due to incomplete context
-                    if warning != 'R0401':
+                    if warning != "R0401":
                         yield "useless-suppression", line, (
                             msgs_store.get_msg_display_string(warning),
                         )


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [X] Add yourself to CONTRIBUTORS if you are a new contributor.
- [X] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [X] Write a good description on what the PR does.

## Description
This simply tweaks iter_spurious_suppression_messages() to ignore any 'R0401' warnings it comes across (cyclic-import). The cyclic-import checker seems to have incomplete context at the point when this runs so is always flagged as a useless suppression.
Please holler if this is not the best place to add the ignore; happy to revise the PR if needed.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #3064 
<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #xxx
-->