### PR TITLE
Allow f-strings as a valid logging string formatting choice

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -252,6 +252,10 @@ Release date: TBA
 Caused by #1164. It means if you do a partial old_names for a message definition an exception will tell you that you
 must rename the associated identification.
 
+* Allow the choice of f-strings as a valid way of formatting logging strings.
+
+Closes #2395
+
 
 What's New in Pylint 2.3.0?
 ===========================

--- a/doc/whatsnew/2.4.rst
+++ b/doc/whatsnew/2.4.rst
@@ -193,3 +193,11 @@ would mean that `no-value-for-parameter` would not be raised for::
     @given(img=arrays(dtype=np.float32, shape=(3, 3, 3, 3)))
     def test_image(img):
         ...
+
+* Allow the option of f-strings as a valid logging string formatting method.
+
+`logging-fstring--interpolation` has been merged into
+`logging-format-interpolation` to allow the `logging-format-style` option
+to control which logging string format style is valid.
+To allow this, a new `fstr` value is valid for the `logging-format-style`
+option.

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -40,24 +40,12 @@ MSGS = {
         "http://www.python.org/dev/peps/pep-0282/.",
     ),
     "W1202": (
-        "Use % formatting in logging functions and pass the % "
-        "parameters as arguments",
+        "Use %s formatting in logging functions%s",
         "logging-format-interpolation",
         "Used when a logging statement has a call form of "
-        '"logging.<logging method>(format_string.format(format_args...))"'
-        ". Such calls should use % formatting instead, but leave "
-        "interpolation to the logging function by passing the parameters "
-        "as arguments.",
-    ),
-    "W1203": (
-        "Use % formatting in logging functions and pass the % "
-        "parameters as arguments",
-        "logging-fstring-interpolation",
-        "Used when a logging statement has a call form of "
-        '"logging.method(f"..."))"'
-        ". Such calls should use % formatting instead, but leave "
-        "interpolation to the logging function by passing the parameters "
-        "as arguments.",
+        '"logging.<logging method>(<string formatting>)".'
+        " with invalid string formatting. "
+        "Use another way for format the string instead.",
     ),
     "E1200": (
         "Unsupported logging format character %r (%#02x) at index %d",
@@ -139,10 +127,11 @@ class LoggingChecker(checkers.BaseChecker):
             {
                 "default": "old",
                 "type": "choice",
-                "metavar": "<old (%) or new ({)>",
-                "choices": ["old", "new"],
+                "metavar": "<old (%) or new ({) or fstr (f'')>",
+                "choices": ["old", "new", "fstr"],
                 "help": "Format style used to check logging format string. "
-                "`old` means using % formatting, while `new` is for `{}` formatting.",
+                "`old` means using % formatting, `new` is for `{}` formatting,"
+                "and `fstr` is for f-strings.",
             },
         ),
     )
@@ -156,6 +145,13 @@ class LoggingChecker(checkers.BaseChecker):
         logging_mods = self.config.logging_modules
 
         self._format_style = self.config.logging_format_style
+        format_styles = {"old": "%", "new": "{", "fstr": "f-string"}
+        format_style_help = ""
+        if self._format_style == "old":
+            format_style_help = " and pass the % parameters as arguments"
+
+        self._format_style_args = (format_styles[self._format_style], format_style_help)
+
         self._logging_modules = set(logging_mods)
         self._from_imports = {}
         for logging_mod in logging_mods:
@@ -251,7 +247,12 @@ class LoggingChecker(checkers.BaseChecker):
         elif isinstance(
             node.args[format_pos], (astroid.FormattedValue, astroid.JoinedStr)
         ):
-            self.add_message("logging-fstring-interpolation", node=node)
+            if self._format_style != "fstr":
+                self.add_message(
+                    "logging-format-interpolation",
+                    node=node,
+                    args=self._format_style_args,
+                )
 
     @staticmethod
     def _is_operand_literal_str(operand):
@@ -273,7 +274,9 @@ class LoggingChecker(checkers.BaseChecker):
         if is_method_call(func, types, methods) and not is_complex_format_str(
             func.bound
         ):
-            self.add_message("logging-format-interpolation", node=node)
+            self.add_message(
+                "logging-format-interpolation", node=node, args=self._format_style_args
+            )
 
     def _check_format_string(self, node, format_arg):
         """Checks that format string tokens match the supplied arguments.
@@ -312,6 +315,12 @@ class LoggingChecker(checkers.BaseChecker):
                     )
                     required_num_args = (
                         keyword_args_cnt + implicit_pos_args + explicit_pos_args
+                    )
+                else:
+                    self.add_message(
+                        "logging-format-interpolation",
+                        node=node,
+                        args=self._format_style_args,
                     )
             except utils.UnsupportedFormatCharacter as ex:
                 char = format_string[ex.index]

--- a/tests/functional/logging_format_interpolation_py36.py
+++ b/tests/functional/logging_format_interpolation_py36.py
@@ -2,4 +2,4 @@
 import logging as renamed_logging
 
 
-renamed_logging.info(f'Read {renamed_logging} from globals')  # [logging-fstring-interpolation]
+renamed_logging.info(f'Read {renamed_logging} from globals')  # [logging-format-interpolation]

--- a/tests/functional/logging_format_interpolation_py36.txt
+++ b/tests/functional/logging_format_interpolation_py36.txt
@@ -1,1 +1,1 @@
-logging-fstring-interpolation:5::Use % formatting in logging functions and pass the % parameters as arguments
+logging-format-interpolation:5::Use % formatting in logging functions and pass the % parameters as arguments

--- a/tests/functional/logging_fstring_interpolation_py36.py
+++ b/tests/functional/logging_fstring_interpolation_py36.py
@@ -1,4 +1,4 @@
-"""Test logging-fstring-interpolation for Python 3.6"""
+"""Test logging-format-interpolation for Python 3.6"""
 # pylint: disable=invalid-name
 
 from datetime import datetime
@@ -14,8 +14,8 @@ pi = 3.14159265
 may_14 = datetime(year=2018, month=5, day=14)
 
 # Statements that should be flagged:
-renamed_logging.debug(f'{local_var_1} {local_var_2}') # [logging-fstring-interpolation]
-renamed_logging.log(renamed_logging.DEBUG, f'msg: {local_var_2}') # [logging-fstring-interpolation]
-renamed_logging.log(renamed_logging.DEBUG, f'pi: {pi:.3f}') # [logging-fstring-interpolation]
-renamed_logging.info(f"{local_var_2.upper()}") # [logging-fstring-interpolation]
-renamed_logging.info(f"{may_14:'%b %d: %Y'}") # [logging-fstring-interpolation]
+renamed_logging.debug(f'{local_var_1} {local_var_2}') # [logging-format-interpolation]
+renamed_logging.log(renamed_logging.DEBUG, f'msg: {local_var_2}') # [logging-format-interpolation]
+renamed_logging.log(renamed_logging.DEBUG, f'pi: {pi:.3f}') # [logging-format-interpolation]
+renamed_logging.info(f"{local_var_2.upper()}") # [logging-format-interpolation]
+renamed_logging.info(f"{may_14:'%b %d: %Y'}") # [logging-format-interpolation]

--- a/tests/functional/logging_fstring_interpolation_py36.txt
+++ b/tests/functional/logging_fstring_interpolation_py36.txt
@@ -1,5 +1,5 @@
-logging-fstring-interpolation:17::Use % formatting in logging functions and pass the % parameters as arguments
-logging-fstring-interpolation:18::Use % formatting in logging functions and pass the % parameters as arguments
-logging-fstring-interpolation:19::Use % formatting in logging functions and pass the % parameters as arguments
-logging-fstring-interpolation:20::Use % formatting in logging functions and pass the % parameters as arguments
-logging-fstring-interpolation:21::Use % formatting in logging functions and pass the % parameters as arguments
+logging-format-interpolation:17::Use % formatting in logging functions and pass the % parameters as arguments
+logging-format-interpolation:18::Use % formatting in logging functions and pass the % parameters as arguments
+logging-format-interpolation:19::Use % formatting in logging functions and pass the % parameters as arguments
+logging-format-interpolation:20::Use % formatting in logging functions and pass the % parameters as arguments
+logging-format-interpolation:21::Use % formatting in logging functions and pass the % parameters as arguments


### PR DESCRIPTION
## Steps

- [*] Add yourself to CONTRIBUTORS if you are a new contributor.
- [*] Add a ChangeLog entry describing what your PR does.
- [*] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [*] Write a good description on what the PR does.

## Description
This PR allows users to choose f-strings as an option to format fstrings. To allow this, the `logging-fstring-interpolation` message has been merged into `logging-format-interpolation`, which now raises if any logging string formatting is found that does not match the type specified in the `logging-format-style` option. This option is also now allowed the new value `fstr`.

Doing it this way, rather than adding a new message to disallow modulo formatting means that users can select only a single way of doing logging string formatting, which may not be desirable. I chose this because if you allow multiple ways of doing string formatting through different messages, it makes it impossible for the messages to give a recommendation on what formatting to change to.

## Type of Changes
|   | Type |
| ------------- | ------------- |
|    | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Closes #2395
