### PR TITLE
Disable too-few-public-methods for dataclasses

### DIFF
--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -93,53 +93,17 @@ DATACLASS_IMPORT = "dataclasses"
 TYPING_NAMEDTUPLE = "typing.NamedTuple"
 
 
-def _is_typing_namedtuple(node: astroid.ClassDef) -> bool:
-    """Check if a class node is a typing.NamedTuple class"""
-    for base in node.ancestors():
-        if base.qname() == TYPING_NAMEDTUPLE:
+def _is_exempt_from_public_methods(node: astroid.ClassDef) -> bool:
+    """Check if a class is exempt from too-few-public-methods"""
+
+    # If it's a typing.Namedtuple or an Enum
+    for ancestor in node.ancestors():
+        if ancestor.name == "Enum" and ancestor.root().name == "enum":
             return True
-    return False
+        if ancestor.qname() == TYPING_NAMEDTUPLE:
+            return True
 
-
-def _is_enum_class(node: astroid.ClassDef) -> bool:
-    """Check if a class definition defines an Enum class.
-
-    :param node: The class node to check.
-    :type node: astroid.ClassDef
-
-    :returns: True if the given node represents an Enum class. False otherwise.
-    :rtype: bool
-    """
-    for base in node.bases:
-        try:
-            inferred_bases = base.inferred()
-        except astroid.InferenceError:
-            continue
-
-        for ancestor in inferred_bases:
-            if not isinstance(ancestor, astroid.ClassDef):
-                continue
-
-            if ancestor.name == "Enum" and ancestor.root().name == "enum":
-                return True
-
-    return False
-
-
-def _is_dataclass_like(node: astroid.ClassDef) -> bool:
-    """Check if a class definition defines a Python data class
-
-    A list of decorator names are introspected, such as the builtin
-    `dataclass` decorator, as well as the popular `attrs` one from
-    the `attrs` library.
-
-    :param node: The class node to check.
-    :type node: astroid.ClassDef
-
-    :returns:
-        `True` if the given node represents a dataclass class, `False` otherwise.
-    :rtype: bool
-    """
+    # Or if it's a dataclass
     if not node.decorators:
         return False
 
@@ -366,12 +330,7 @@ class MisdesignChecker(BaseChecker):
 
         # Stop here for exception, metaclass, interface classes and other
         # classes for which we don't need to count the methods.
-        if (
-            node.type != "class"
-            or _is_enum_class(node)
-            or _is_dataclass_like(node)
-            or _is_typing_namedtuple(node)
-        ):
+        if node.type != "class" or _is_exempt_from_public_methods(node):
             return
 
         # Does the class contain more than n public methods ?

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -153,8 +153,9 @@ def _is_dataclass_like(node: astroid.ClassDef) -> bool:
             name = decorator.name
         else:
             name = decorator.attrname
-        if name in DATACLASSES_DECORATORS and root_locals.intersection(
-            DATACLASSES_DECORATORS
+        if name in DATACLASSES_DECORATORS and (
+            root_locals.intersection(DATACLASSES_DECORATORS)
+            or DATACLASS_IMPORT in root_locals
         ):
             return True
     return False

--- a/tests/functional/too/too_few_public_methods_37.py
+++ b/tests/functional/too/too_few_public_methods_37.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-docstring
-import typing
 import dataclasses
+import typing
 from dataclasses import dataclass
 
 
@@ -22,3 +22,16 @@ class Test:
 
 class Example(typing.NamedTuple):
     some_int: int
+
+
+@dataclasses.dataclass(frozen=True)
+class Point:
+    """A three dimensional point with x, y and z components."""
+
+    x: float
+    y: float
+    z: float
+
+    def to_array(self):
+        """Convert to a NumPy array `np.array((x, y, z))`."""
+        return self.x


### PR DESCRIPTION
## Steps

- [X] Add yourself to CONTRIBUTORS if you are a new contributor.
- [] Add a ChangeLog entry describing what your PR does.
- [] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [X ] Write a good description on what the PR does.

## Description

We were disabling `too-few-public-methods` for dataclasses, but only when the `dataclass` decorator was present in the root scope. Unfortunately that's not the case when using the fully qualified name e.g. `dataclasses.dataclass` which will result in the dataclass check to fail.

Also refactored the three checks for exempted classes into a single one for performance reasons.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

Close #3025 
