### PR TITLE
Fixes "exception-escape" false positive with generators (#3128)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -333,3 +333,6 @@ contributors:
     - Added --list-msgs-enabled command
 
 * Rémi Cardona: contributor
+
+* Gabriel R. Sezefredo: contributor
+    - Fixed "exception-escape" false positive with generators

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,10 @@ Release date: TBA
 
   Close #617
 
+* Fix exception-escape false positive with generators
+
+  Close #3128
+
 
 What's New in Pylint 2.4.3?
 ===========================

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -1265,16 +1265,11 @@ class Python3Checker(checkers.BaseChecker):
     def visit_excepthandler(self, node):
         """Visit an except handler block and check for exception unpacking."""
 
-        def _is_used_in_except_block(node):
-            scope = node.scope()
+        def _is_used_in_except_block(node, block):
             current = node
-            while (
-                current
-                and current != scope
-                and not isinstance(current, astroid.ExceptHandler)
-            ):
+            while current and current is not block:
                 current = current.parent
-            return isinstance(current, astroid.ExceptHandler) and current.type != node
+            return current is not None
 
         if isinstance(node.name, (astroid.Tuple, astroid.List)):
             self.add_message("unpacking-in-except", node=node)
@@ -1292,7 +1287,7 @@ class Python3Checker(checkers.BaseChecker):
             for scope_name in scope_names
             if scope_name.name == node.name.name
             and scope_name.lineno > node.lineno
-            and not _is_used_in_except_block(scope_name)
+            and not _is_used_in_except_block(scope_name, node)
         ]
         reassignments_for_same_name = {
             assign_name.lineno

--- a/tests/unittest_checker_python3.py
+++ b/tests/unittest_checker_python3.py
@@ -857,6 +857,11 @@ class TestPython3Checker(testutils.CheckerTestCase):
            2/0
         except (ValueError, TypeError): #@
            exc = 2
+        exc #@
+        try:
+           1/0
+        except (ValueError, TypeError) as exc:
+           foo(bar for bar in exc.bar)
         """
         )
         message = testutils.Message("exception-escape", node=module.body[1].value)
@@ -865,6 +870,7 @@ class TestPython3Checker(testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_excepthandler(module.body[2].handlers[0])
             self.checker.visit_excepthandler(module.body[4].handlers[0])
+            self.checker.visit_excepthandler(module.body[6].handlers[0])
 
     def test_bad_sys_attribute(self):
         node = astroid.extract_node(


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

As reported on #3128, there is a bug when the handler bound object is being used inside a generator causing a false positive. I identified that this was due to the way we were identifying if the object was "inside" its handler or not. In the previous implementation we would visit the node parents until we reached the object scope (in the generator case, the scope of the node is the generator, not the handler), my change continues to go up the parent stack until it reaches its parent handler, or, if it's not inside its handler, it reaches the module's parent (`None`). 

Object is considered inside its handler if it reaches it by going up in the parent chain. It's considered outside its handler if it reaches `None`.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
Closes #3128
