### PR TITLE
Move inspect.getargvalues and inspect.formatargvalues out of deprecated functions

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -333,3 +333,5 @@ contributors:
     - Added --list-msgs-enabled command
 
 * Rémi Cardona: contributor
+
+* laike9m: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,8 @@ Release date: TBA
 
   Close #617
 
+* ``inspect.getargvalues`` is no longer marked as deprecated.
+
 
 What's New in Pylint 2.4.3?
 ===========================

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -234,7 +234,6 @@ class StdlibChecker(BaseChecker):
             (3, 5, 0): {
                 "fractions.gcd",
                 "inspect.formatargspec",
-                "inspect.formatargvalues",
                 "inspect.getcallargs",
                 "platform.linux_distribution",
                 "platform.dist",

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -233,7 +233,6 @@ class StdlibChecker(BaseChecker):
             (3, 4, 4): {"asyncio.tasks.async"},
             (3, 5, 0): {
                 "fractions.gcd",
-                "inspect.getargvalues",
                 "inspect.formatargspec",
                 "inspect.formatargvalues",
                 "inspect.getcallargs",


### PR DESCRIPTION
inspect.getargvalues was inadvertently marked as deprecated in Python 3.5, and was deprecated in Python 3.6. See https://bugs.python.org/issue28814 for details.

## Description
`inspect.getargvalues` and `inspect.formatargvalues` were inadvertently marked as deprecated in Python 3.5, and was deprecated in Python 3.6. See https://bugs.python.org/issue28814 for details.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |