### PR TITLE
Fixed ``missing-yield-type-doc`` ignoring type annotation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -53,6 +53,11 @@ Release date: TBA
 
   Close #3150
 
+* Fixed ``missing-yield-type-doc`` getting incorrectly raised when
+  a generator does not document a yield type but has a type annotation.
+
+  Closes #3185
+
 
 What's New in Pylint 2.4.2?
 ===========================
@@ -386,7 +391,7 @@ must rename the associated identification.
 
 * Allow the choice of f-strings as a valid way of formatting logging strings.
 
-Closes #2395
+  Closes #2395
 
 * Added ``--list-msgs-enabled`` command to list all enabled and disabled messages given the current RC file and command line arguments.
 

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -316,7 +316,7 @@ class DocstringParameterChecker(BaseChecker):
         if not doc_has_yields:
             self.add_message("missing-yield-doc", node=func_node)
 
-        if not doc_has_yields_type:
+        if not (doc_has_yields_type or func_node.returns):
             self.add_message("missing-yield-type-doc", node=func_node)
 
     def visit_yieldfrom(self, node):

--- a/tests/extensions/test_check_return_docs.py
+++ b/tests/extensions/test_check_return_docs.py
@@ -76,21 +76,6 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         ):
             self.checker.visit_return(return_node)
 
-    def test_sphinx_returns_annotations(self):
-        node = astroid.extract_node(
-            '''
-        def my_func(self) -> bool:
-            """This is a docstring.
-
-            :returns: Always False
-            """
-            return False
-        '''
-        )
-        return_node = node.body[0]
-        with self.assertNoMessages():
-            self.checker.visit_return(return_node)
-
     def test_sphinx_missing_return_type_with_annotations(self):
         node = astroid.extract_node(
             '''

--- a/tests/extensions/test_check_yields_docs.py
+++ b/tests/extensions/test_check_yields_docs.py
@@ -445,3 +445,38 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         with self.assertAddsMessages(Message(msg_id="redundant-yields-doc", node=node)):
             self.checker.visit_functiondef(node)
+
+    def test_sphinx_missing_yield_type_with_annotations(self):
+        node = astroid.extract_node(
+            '''
+            import typing
+
+            def generator() -> typing.Iterator[int]:
+                """A simple function for checking type hints.
+
+                :returns: The number 0
+                """
+                yield 0
+            '''
+        )
+        yield_node = node.body[0]
+        with self.assertNoMessages():
+            self.checker.visit_yield(yield_node)
+
+    def test_google_missing_yield_type_with_annotations(self):
+        node = astroid.extract_node(
+            '''
+            import typing
+
+            def generator() -> typing.Iterator[int]:
+                """A simple function for checking type hints.
+
+                Yields:
+                    The number 0
+                """
+                yield 0
+            '''
+        )
+        yield_node = node.body[0]
+        with self.assertNoMessages():
+            self.checker.visit_yield(yield_node)


### PR DESCRIPTION
## Steps

- [*] Add yourself to CONTRIBUTORS if you are a new contributor.
- [*] Add a ChangeLog entry describing what your PR does.
- [*] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [*] Write a good description on what the PR does.

## Description
This fixes ``missing-yield-type-doc`` getting raised on a generator that has a type annotation and does not document a yield type. Returns documentation already caters for this case and so do parameters. Yields were missed out.

I've also removed a duplicate test.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue
Closes #3185