### PR TITLE
docparams can identify multiple types in raises sections

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,11 @@ Release date: TBA
 
   Close #3183
 
+* ``docparams`` extension supports multiple types in raises sections.
+  Multiple types can also be separated by commas in all valid sections.
+
+  Closes #2729
+
 
 What's New in Pylint 2.4.3?
 ===========================

--- a/tests/extensions/test_check_raise_docs.py
+++ b/tests/extensions/test_check_raise_docs.py
@@ -110,7 +110,6 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
-        pass
 
     def test_find_google_attr_raises_substr_exc(self):
         raise_node = astroid.extract_node(
@@ -290,6 +289,43 @@ class TestDocstringCheckerRaise(CheckerTestCase):
             """
             raise RuntimeError('hi') #@
             raise NameError('hi')
+        '''
+        )
+        with self.assertNoMessages():
+            self.checker.visit_raise(raise_node)
+
+    def test_find_multiple_sphinx_raises(self):
+        raise_node = astroid.extract_node(
+            '''
+        def my_func(self):
+            """This is a docstring.
+
+            :raises RuntimeError: Always
+            :raises NameError, OSError, ValueError: Never
+            """
+            raise RuntimeError('hi')
+            raise NameError('hi') #@
+            raise OSError(2, 'abort!')
+            raise ValueError('foo')
+        '''
+        )
+        with self.assertNoMessages():
+            self.checker.visit_raise(raise_node)
+
+    def test_find_multiple_google_raises(self):
+        raise_node = astroid.extract_node(
+            '''
+        def my_func(self):
+            """This is a docstring.
+
+            Raises:
+                RuntimeError: Always
+                NameError, OSError, ValueError: Never
+            """
+            raise RuntimeError('hi')
+            raise NameError('hi') #@
+            raise OSError(2, 'abort!')
+            raise ValueError('foo')
         '''
         )
         with self.assertNoMessages():


### PR DESCRIPTION
## Steps

- [*] Add yourself to CONTRIBUTORS if you are a new contributor.
- [*] Add a ChangeLog entry describing what your PR does.
- [*] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [*] Write a good description on what the PR does.

## Description
Types in a `:raises Exc1, Exc2, Exc: Description` and `Raises:\n    Exc1, Exc2, Exc3: Description` can be identified. The types can be split by a `or` or `,` (but not brackets). See https://github.com/sphinx-doc/sphinx/blob/685e3fdb49c42b464e09ec955e1033e2a8729fff/sphinx/domains/python.py#L136

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Closes #2729