### PR TITLE
Fixed method-hidden when subclass defines the method

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,11 @@ Release date: TBA
 
 * Allow parallel linting when run under Prospector
 
+* Fixed false positives of ``method-hidden`` when a subclass defines
+  the method that is being hidden.
+
+  Closes #414
+
 
 What's New in Pylint 2.4.3?
 ===========================

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -955,6 +955,12 @@ a metaclass class method.",
             if isinstance(overridden_frame, astroid.ClassDef) and klass.is_subtype_of(
                 overridden_frame.qname()
             ):
+                # If a subclass defined the method then it's not our fault.
+                mro = klass.mro()
+                for subklass in mro[1 : mro.index(overridden_frame) + 1]:
+                    for obj in subklass.lookup(node.name)[1]:
+                        if isinstance(obj, astroid.FunctionDef):
+                            return
                 args = (overridden.root().name, overridden.fromlineno)
                 self.add_message("method-hidden", args=args, node=node)
         except astroid.NotFoundError:

--- a/tests/functional/m/method_hidden.py
+++ b/tests/functional/m/method_hidden.py
@@ -15,6 +15,14 @@ class Cdef(Abcd):
         """
         print(self)
 
+class AbcdMixin:
+    def abcd(self):
+        pass
+
+class Dabc(AbcdMixin, Abcd):
+    def abcd(self):
+        pass
+
 class CustomProperty:
     """dummy"""
     def __init__(self, _):
@@ -58,3 +66,16 @@ class Foo:
 
     def do_something_with_baz(self, value):
         self.method = value
+
+
+class One:
+    def __init__(self, one=None):
+        if one is not None:
+            self.one = one
+
+    def one(self): # [method-hidden]
+        pass
+
+class Two(One):
+    def one(self):
+        pass

--- a/tests/functional/m/method_hidden.txt
+++ b/tests/functional/m/method_hidden.txt
@@ -1,1 +1,2 @@
 method-hidden:13:Cdef.abcd:An attribute defined in functional.m.method_hidden line 9 hides this method
+method-hidden:76:One.one:An attribute defined in functional.m.method_hidden line 74 hides this method


### PR DESCRIPTION
## Steps

- [*] Add yourself to CONTRIBUTORS if you are a new contributor.
- [*] Add a ChangeLog entry describing what your PR does.
- [*] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [*] Write a good description on what the PR does.

## Description
`method-hidden` is not raised when a subclass defines the method. In this case the subclass is at fault and the parent class is trying to override the method that already exists.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Closes #414
