### PR TITLE
Fix py3k

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -342,3 +342,6 @@ contributors:
 * laike9m: contributor
 
 * Janne Rönkkö: contributor
+
+* Hugues Bruant: contributor
+

--- a/ChangeLog
+++ b/ChangeLog
@@ -40,6 +40,10 @@ Release date: TBA
 
 * Python 3 porting mode is 30-50% faster on most codebases
 
+* Python 3 porting mode no longer swallows syntax errors
+
+  Closes #2956
+
 
 What's New in Pylint 2.4.3?
 ===========================

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -748,6 +748,11 @@ class PyLinter(
     def python3_porting_mode(self):
         """Disable all other checkers and enable Python 3 warnings."""
         self.disable("all")
+        # re-enable some errors, or 'print', 'raise', 'async', 'await' will mistakenly lint fine
+        self.enable("fatal")  # F0001
+        self.enable("astroid-error")  # F0002
+        self.enable("parse-error")  # F0010
+        self.enable("syntax-error")  # E0001
         self.enable("python3")
         if self._error_mode:
             # The error mode was activated, using the -E flag.

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -245,14 +245,14 @@ class TestRunTC(object):
         # Test that --py3k flag works.
         rc_code = 0
         self._runtest(
-            [join(HERE, "functional", "u", "unpacked_exceptions.py"), "--py3k"],
+            [join(HERE, "functional", "u", "unnecessary_lambda.py"), "--py3k"],
             code=rc_code,
         )
 
     def test_py3k_jobs_option(self):
         rc_code = 0
         self._runtest(
-            [join(HERE, "functional", "u", "unpacked_exceptions.py"), "--py3k", "-j 2"],
+            [join(HERE, "functional", "u", "unnecessary_lambda.py"), "--py3k", "-j 2"],
             code=rc_code,
         )
 


### PR DESCRIPTION
Enable syntax errors to properly surface invalid code in py3
porting mode, instead of silently swallowing them and giving
the incorrect impression that the code is valid for py3.

:bug: Bug fix

Closes #2956
