### PR TITLE
Speedup py3k mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,8 @@ Release date: TBA
 
 * Allow parallel linting when run under Prospector
 
+* Python 3 porting mode is 30-50% faster on most codebases
+
 
 What's New in Pylint 2.4.3?
 ===========================


### PR DESCRIPTION
Avoid costly inference in visit_call and visit_attribute
when the attribute name is one that cannot possibly trigger
a message.

This typically leads to a 30-50% speedup when running pylint
in python3 porting mode on most codebases.

Benchmark results on pylint's own code, on a 2018 macbook pro,
with python 3.6.8, using `hyperfine`.

pylint-2.4.2
```
  Time (mean ± σ):     10.071 s ±  1.136 s    [User: 9.724 s, System: 0.246 s]
  Range (min … max):    9.352 s … 12.015 s    5 runs
```

pylint-2.4.2 + this patch
```
  Time (mean ± σ):      6.282 s ±  0.046 s    [User: 6.099 s, System: 0.155 s]
  Range (min … max):    6.232 s …  6.327 s    5 runs
```