### PR TITLE
Support `# noqa: ...` pragmas

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,11 @@ Release date: TBA
 
 * Allow parallel linting when run under Prospector
 
+* ``# noqa: ...` pragmas are now supported as an alternative to
+  ``# pylint: disable=...``.
+
+  Closes #2493
+  
 
 What's New in Pylint 2.4.3?
 ===========================

--- a/doc/user_guide/message-control.rst
+++ b/doc/user_guide/message-control.rst
@@ -1,3 +1,5 @@
+.. _messages-control:
+
 Messages control
 ================
 
@@ -24,6 +26,18 @@ For all of these controls, ``pylint`` accepts the following values:
   * ``F`` fatal, if an error occurred which prevented ``pylint`` from doing further processing.
 
 * All the checks with ``all``
+
+.. note::
+
+    ``pylint`` also supports using the ``# noqa: ...`` pragma
+    as an alternative to ``# pylint: disable=...``.
+    Note that other linters may not be able to parse pragmas that use
+    symbolic messages.
+    Therefore is it recommended to use numerical IDs inside ``# noqa`` pragmas
+    when using ``pylint`` with another linter.
+    Disabling ``use-symbolic-message-instead`` may be needed in this case.
+
+    Bare ``# noqa`` pragmas without a list of messages to disable is not supported.
 
 
 Block disables

--- a/doc/whatsnew/2.5.rst
+++ b/doc/whatsnew/2.5.rst
@@ -32,3 +32,9 @@ Other Changes
   These files can also be passed in on the command line.
 
 * Mutable ``collections.*`` are now flagged as dangerous defaults.
+
+* ``# noqa: ...` pragmas are now supported as an alternative to
+  ``# pylint: disable=...``.
+  See :ref:`messages-control` for detailed usage.
+
+  Closes #2493

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -9,6 +9,7 @@ import re
 # so that an option can be continued with the reasons
 # why it is active or disabled.
 OPTION_RGX = re.compile(r"\s*#.*\bpylint:\s*([^;#]+)[;#]{0,1}")
+NOQA_RGX = re.compile(r"# noqa:[\s]?([^;#]+)[;#]{0,1}", re.IGNORECASE)
 
 PY_EXTS = (".py", ".pyc", ".pyo", ".pyw", ".so", ".dll")
 

--- a/tests/functional/n/noqa_pragma.py
+++ b/tests/functional/n/noqa_pragma.py
@@ -1,0 +1,13 @@
+"""Test that a noqa pragma has an effect."""
+# pylint: disable=too-few-public-methods
+
+class Foo:
+    """block-disable test"""
+
+    def meth3(self):
+        """test one line disabling"""
+        print(self.bla)  # noqa: E1101
+
+        print(self.bla)  # noqa: no-member
+
+        self.thing = self.bla  # noqa: E1101, attribute-defined-outside-init

--- a/tests/functional/p/pragma_after_backslash.py
+++ b/tests/functional/p/pragma_after_backslash.py
@@ -8,3 +8,9 @@ class Foo:
         """test one line disabling"""
         print(self.bla) \
            # pylint: disable=E1101
+
+        print(self.bla \
+              + self.bla)  # pylint: disable=E1101
+
+        print(self.bla) \
+           # noqa: E1101


### PR DESCRIPTION
## Steps

- [*] Add yourself to CONTRIBUTORS if you are a new contributor.
- [*] Add a ChangeLog entry describing what your PR does.
- [*] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [*] Write a good description on what the PR does.

## Description

Added support for understanding `# noqa: ...` pragmas. Bare `# noqa` pragmas are not supported.

Cc @sigmavirus24 who may be interested in this change. Also we've added support for parsing symbolic message IDs (eg `no-member` instead of `E1101`) but this would mean that flake8 cannot parse other messages in that same pragma (See `doc/user_guide/message-control.rst`). I don't know if you think it's worth making a change in flake8 to parse and ignore those types of IDs before we merge this?
There was also discussion on the original issue about whether we should be namespacing message IDs in pragmas to avoid conflicts.

## Type of Changes
|   | Type |
| ------------- | ------------- |
|    | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|    | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related Issue

Closes #2493

