### PR TITLE
Make pytest-runner a requirement with test only targets

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -346,3 +346,5 @@ contributors:
 * Hugues Bruant: contributor
 
 * Tim Gates: contributor
+
+* Enji Cooper: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -95,6 +95,11 @@ Release date: TBA
   PyLinter object (and all its members except reporter) needs to support
   pickling so the PyLinter object can be passed to worker processes.
 
+* Clean up setup.py
+
+  Make pytest-runner a requirement only if running tests, similar to McCabe.
+
+  Clean up the setup.py file, resolving a number of warnings around it.
 
 What's New in Pylint 2.4.4?
 ===========================

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# pylint: disable=W0404,W0622,W0704,W0613
+# pylint: disable=W0404,W0622,W0613
 # Copyright (c) 2006, 2009-2010, 2012-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2010 Julien Jehannet <julien.jehannet@logilab.fr>
 # Copyright (c) 2012 FELD Boris <lothiraldan@gmail.com>
@@ -20,10 +20,10 @@
 
 """Generic Setup script, takes package info from __pkginfo__.py file.
 """
-import os
-import sys
 from distutils.command.build_py import build_py
+import os
 from os.path import exists, isdir, join
+import sys
 
 __docformat__ = "restructuredtext en"
 
@@ -31,12 +31,12 @@ __docformat__ = "restructuredtext en"
 try:
     from setuptools import setup
     from setuptools.command import easy_install as easy_install_lib
-    from setuptools.command import install_lib
+    from setuptools.command import install_lib  # pylint: disable=unused-import
 
     USE_SETUPTOOLS = 1
 except ImportError:
     from distutils.core import setup
-    from distutils.command import install_lib
+    from distutils.command import install_lib  # pylint: disable=unused-import
 
     USE_SETUPTOOLS = 0
     easy_install_lib = None
@@ -45,8 +45,8 @@ except ImportError:
 base_dir = os.path.dirname(__file__)
 
 __pkginfo__ = {}
-with open(os.path.join(base_dir, "pylint", "__pkginfo__.py")) as f:
-    exec(f.read(), __pkginfo__)
+with open(os.path.join(base_dir, "pylint", "__pkginfo__.py")) as pkginfo_fp:
+    exec(pkginfo_fp.read(), __pkginfo__)
 scripts = __pkginfo__.get("scripts", [])
 data_files = __pkginfo__.get("data_files", None)
 ext_modules = __pkginfo__.get("ext_modules", None)

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,10 @@ else:
     long_description = ""
 
 
+needs_pytest = set(['pytest', 'test', 'ptr']).intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
+
+
 def ensure_scripts(linux_scripts):
     """Creates the proper script names required for each platform
     (taken from 4Suite)
@@ -143,7 +147,7 @@ def install(**kwargs):
         extras_require=extras_require,
         test_suite="test",
         python_requires=">=3.5.*",
-        setup_requires=["pytest-runner"],
+        setup_requires=pytest_runner,
         tests_require=["pytest"],
         **kwargs
     )


### PR DESCRIPTION
## Description

The primary goal of this change was to remove an explicit requirement on pytest-runner for building/installing pylint*, as it is only required when running tests. This change is similar to what was done in the McCabe project, starting with [PyCQA/mccabe@cf1c36f84](https://github.com/PyCQA/mccabe/commit/cf1c36f842e252b8efd9e8fe853584ce69020b7f).

While here, fix a variety of pylint warnings with `setup.py` that were being omitted with the latest copy of pylint.

Finally, do some book keeping items around adding myself to CONTRIBUTORS and an entry to the ChangeLog for the change.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

This is loosely related to similar work I did with https://github.com/PyCQA/astroid/pull/721 .