### PR TITLE
Fix problem with syntaxerrors in file from stdin

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -101,6 +101,12 @@ Release date: TBA
 
   Clean up the setup.py file, resolving a number of warnings around it.
 
+* Handle SyntaxError in files passed via ``--from-stdin`` option
+
+  Pylint no longer outputs a traceback, if a file, read from stdin,
+  contains a syntaxerror.
+
+
 What's New in Pylint 2.4.4?
 ===========================
 Release date: 2019-11-13

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -595,6 +595,19 @@ class TestRunTC(object):
         finally:
             os.chdir(curdir)
 
+    def test_stdin_syntaxerror(self):
+        expected_output = (
+            "************* Module a\n"
+            "a.py:1:4: E0001: invalid syntax (<unknown>, line 1) (syntax-error)"
+        )
+
+        with mock.patch("pylint.lint._read_stdin", return_value="for\n") as mock_stdin:
+            self._test_output(
+                ["--from-stdin", "a.py", "--disable=all", "--enable=syntax-error"],
+                expected_output=expected_output,
+            )
+            assert mock_stdin.call_count == 1
+
     def test_version(self):
         def check(lines):
             assert lines[0].startswith("pylint ")


### PR DESCRIPTION
Exceptions raised in ``_ast_from_string`` were not properly handled in
``Pylint.check``. Therefore, the output of `echo "for" | pylint --disable=all
--enable=syntax-error --from-stdin module.py` contained a traceback.

This issue is fixed by integrating the code from ``_ast_from_string into
Pylint.get_ast``.

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
