### PR TITLE
Cleanup tmpdir related code in test

### DIFF
--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -563,10 +563,8 @@ class TestRunTC(object):
             a.join("b.py").write(b_code)
         a.join("c.py").write(c_code)
 
-        curdir = os.getcwd()
-        try:
+        with tmpdir.as_cwd():
             # why don't we start pylint in a subprocess?
-            os.chdir(str(tmpdir))
             expected = (
                 "************* Module a.b\n"
                 "a/b.py:3:0: E0401: Unable to import 'a.d' (import-error)\n\n"
@@ -591,9 +589,6 @@ class TestRunTC(object):
                     ],
                     expected_output=expected,
                 )
-
-        finally:
-            os.chdir(curdir)
 
     def test_stdin_syntaxerror(self):
         expected_output = (


### PR DESCRIPTION
``py.path.as_cwd`` _(return context manager which changes to current dir during the managed "with" context. On __enter__ it returns the old dir.)_ is a nice ctx manager, that can be used in one test
instead of a try/finally block.

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
