### PR TITLE
Remove dead code

### DIFF
--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -1134,10 +1134,6 @@ class PyLinter(
         try:
             if data is None:
                 return MANAGER.ast_from_file(filepath, modname, source=True)
-
-            cached = MANAGER.astroid_cache.get(modname)
-            if cached and cached.file == filepath:
-                return cached
             return AstroidBuilder(MANAGER).string_build(data, modname, filepath)
         except astroid.AstroidSyntaxError as ex:
             # pylint: disable=no-member


### PR DESCRIPTION
This code is not needed, since get_ast with `data` != None is only
needed for the --from-stdin feature, where get_ast is only called
once. Therefore, a cache is not needed.

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
