### PR TITLE
Clear `sys.argv` before calling out to the isort lib

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -231,6 +231,8 @@ Release date: 2019-09-30
 
   Close #3028
 
+* Clear `sys.argv` before calling out to the isort lib on the imports checker. Prevent's PyLint's usage header to be printed out for each cheked file.
+
 
 What's New in Pylint 2.4.1?
 ===========================

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -700,11 +700,20 @@ class ImportsChecker(BaseChecker):
         third_party_not_ignored = []
         first_party_not_ignored = []
         local_not_ignored = []
-        isort_obj = isort.SortImports(
-            file_contents="",
-            known_third_party=self.config.known_third_party,
-            known_standard_library=self.config.known_standard_library,
-        )
+
+        # We need to cleanup sys.argv or we'll get pylint's usage header
+        # for each checked file
+        argv = sys.argv[:]
+        sys.argv = []
+        try:
+            isort_obj = isort.SortImports(
+                file_contents="",
+                known_third_party=self.config.known_third_party,
+                known_standard_library=self.config.known_standard_library,
+            )
+        finally:
+            sys.argv = argv
+
         for node, modname in self._imports_stack:
             if modname.startswith("."):
                 package = "." + modname.split(".")[1]


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
See title.
Before fix:
```
pylint --rcfile=.pylintrc --disable=I salt/fileserver/s3fs.py
Usage: pylint [options]

------------------------------------
Your code has been rated at 10.00/10
```

After fix:
```
pylint --rcfile=.pylintrc --disable=I salt/fileserver/s3fs.py

------------------------------------
Your code has been rated at 10.00/10
```

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
