### PR TITLE
Adds a new check 'inconsistent-quotes'.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -358,3 +358,5 @@ contributors:
 * Matthijs Blom: contributor
 
 * Andy Palmer: contributor
+
+* Wes Turner (Google): added new check 'inconsistent-quotes'

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in Pylint 2.5.0?
 
 Release date: TBA
 
+* A new check `inconsistent-quotes` was added.
+
 * Add a check for non string assignment to __name__ attribute.
 
   Close #583

--- a/doc/whatsnew/2.5.rst
+++ b/doc/whatsnew/2.5.rst
@@ -32,6 +32,14 @@ New checkers
    * ``invalid-getnewargs-returned)``: ``__getnewargs__`` did not return a tuple
    * ``invalid-getnewargs-ex-returned)``: ``__getnewargs_ex__`` did not return a tuple of the form (tuple, dict)
 
+* A new check ``inconsistent-quotes`` was added.
+
+  This check is emitted when quotes delimiters (" and ') are not used
+  consistently throughout a module.  It makes allowances for avoiding
+  unnecessary escaping, allowing, for example, ``"Don't error"`` in a module in
+  which single-quotes otherwise delimit strings so that the single quote in
+  ``Don't`` doesn't need to be escaped.
+
 
 Other Changes
 =============

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -476,6 +476,10 @@ notes=FIXME,
 # several lines.
 check-str-concat-over-line-jumps=no
 
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
 
 [IMPORTS]
 

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -734,7 +734,7 @@ class StringConstantChecker(BaseTokenChecker):
         Args:
           tokens: The tokens to be checked against for consistent usage.
         """
-        string_delimiters: Counter[str] = collections.Counter()
+        string_delimiters = collections.Counter()  # type: Counter[str]
 
         # First, figure out which quote character predominates in the module
         for tok_type, token, _, _, _ in tokens:

--- a/tests/functional/i/inconsistent_quotes.py
+++ b/tests/functional/i/inconsistent_quotes.py
@@ -1,0 +1,16 @@
+"""Tests for inconsistent quoting strategy.
+
+In this file, double quotes are the majority quote delimiter.
+"""
+
+FIRST_STRING = "double-quoted string"
+SECOND_STRING = 'single-quoted string' # [inconsistent-quotes]
+THIRD_STRING = "another double-quoted string"
+FOURTH_STRING = "yet another double-quoted string"
+FIFTH_STRING = 'single-quoted string with an unescaped "double quote"'
+
+def function_with_docstring():
+    '''This is a multi-line docstring that should not raise a warning even though the
+    delimiter it uses for quotes is not the delimiter used in the majority of the
+    module.
+    '''

--- a/tests/functional/i/inconsistent_quotes.rc
+++ b/tests/functional/i/inconsistent_quotes.rc
@@ -1,0 +1,2 @@
+[STRING]
+check-quote-consistency=yes

--- a/tests/functional/i/inconsistent_quotes.txt
+++ b/tests/functional/i/inconsistent_quotes.txt
@@ -1,0 +1,1 @@
+inconsistent-quotes:7::Quote delimiter ' is inconsistent with the rest of the file

--- a/tests/functional/i/inconsistent_quotes2.py
+++ b/tests/functional/i/inconsistent_quotes2.py
@@ -1,0 +1,10 @@
+"""Tests for inconsistent quoting strategy.
+
+In this file, single quotes are the majority quote delimiter.
+"""
+
+FIRST_STRING = "double-quoted string"  # [inconsistent-quotes]
+SECOND_STRING = 'single-quoted string'
+THIRD_STRING = 'another single-quoted string'
+FOURTH_STRING = 'yet another single-quoted string'
+FIFTH_STRING = "double-quoted string with an unescaped 'single quote'"

--- a/tests/functional/i/inconsistent_quotes2.rc
+++ b/tests/functional/i/inconsistent_quotes2.rc
@@ -1,0 +1,2 @@
+[STRING]
+check-quote-consistency=yes

--- a/tests/functional/i/inconsistent_quotes2.txt
+++ b/tests/functional/i/inconsistent_quotes2.txt
@@ -1,0 +1,1 @@
+inconsistent-quotes:6::Quote delimiter " is inconsistent with the rest of the file


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

This change implements a check for a recommendation in PEP-8.  It is emitted when quotes delimiters (" and ') are not used consistently throughout a module.  It makes allowances for avoiding unnecessary escaping, allowing, for example, ``"Don't error"`` in a module in which single-quotes otherwise delimit strings so that the single quote in ``Don't`` doesn't need to be escaped.

Quoting PEP-8:
> In Python, single-quoted strings and double-quoted strings are the same. This PEP does not make a recommendation for this. Pick a rule and stick to it. When a string contains single or double quote characters, however, use the other one to avoid backslashes in the string. It improves readability.

Features:
* Accounts for strings where the delimiter is swapped so an internal quote doesn't need to be escaped
* Only errors on those lines that represent the module's minority delimiter.
* Ignores longstrings (they could be docstrings, and checking those delimiters is someone else's responsibility)

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Related Issue
