### PR TITLE
Fix false positive for inverse containment tests

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -360,3 +360,6 @@ contributors:
 * Andy Palmer: contributor
 
 * Wes Turner (Google): added new check 'inconsistent-quotes'
+
+* Athos Ribeiro
+    Fixed dict-keys-not-iterating false positive for inverse containment checks

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in Pylint 2.5.0?
 
 Release date: TBA
 
+* `not in` is considered iterating context for some of the Python 3 porting checkers.
+
 * A new check `inconsistent-quotes` was added.
 
 * Add a check for non string assignment to __name__ attribute.

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -139,7 +139,7 @@ def _in_iterating_context(node):
     elif (
         isinstance(parent, astroid.Compare)
         and len(parent.ops) == 1
-        and parent.ops[0][0] == "in"
+        and parent.ops[0][0] in ["in", "not in"]
     ):
         return True
     # Also if it's an `yield from`, that's fair

--- a/tests/unittest_checker_python3.py
+++ b/tests/unittest_checker_python3.py
@@ -243,6 +243,7 @@ class TestPython3Checker(testutils.CheckerTestCase):
             "max({}())",
             "min({}())",
             "3 in {}()",
+            "3 not in {}()",
             "set().update({}())",
             "[].extend({}())",
             "{{}}.update({}())",


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

While dict-keys-not-iterating does not generate false positives for the
'in' containment test, the check does generate false positives for the
inverse counterpart of the containment test, 'not in'. This patch
changes the check behavior to also consider the 'not in' operator as an
iterating context.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:


-->

Relates to  #2186