### PR TITLE
Fix #2830. Ignore just the raw docstring, no more.

### DIFF
--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -176,11 +176,13 @@ def stripped_lines(lines, ignore_comments, ignore_docstrings, ignore_imports):
     for lineno, line in enumerate(lines, start=1):
         line = line.strip()
         if ignore_docstrings:
-            if not docstring and any(
-                line.startswith(i) for i in ['"""', "'''", 'r"""', "r'''"]
-            ):
-                docstring = line[:3]
-                line = line[3:]
+            if not docstring:
+                if line.startswith('"""') or line.startswith("'''"):
+                    docstring = line[:3]
+                    line = line[3:]
+                elif line.startswith('r"""') or line.startswith("r'''"):
+                    docstring = line[1:4]
+                    line = line[4:]
             if docstring:
                 if line.endswith(docstring):
                     docstring = None


### PR DESCRIPTION
## Summary

#2830 ignores all lines in a module after the start of a raw docstring i.e. `r"""` or `r'''`. This PR fixes this and just ignores the raw docstring.

## Steps to reproduce

To reproduce the bug, create two identical modules `package/similar1.py` and `package/similar2.py` with the content:

```
r"""A raw docstring.
"""


def look_busy():
    xxxx = 1
    yyyy = 2
    zzzz = 3
    wwww = 4
    vvvv = xxxx + yyyy + zzzz + wwww
    return vvvv
```

Run `pylint --disable W9011,W9012 package`.

### Expected result

Duplicate code in function `look_busy` is flagged.

### Actual result

No duplicate code warning raised.

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
