### PR TITLE
Simplify pre-commit configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,4 @@
     name: pylint
     entry: pylint
     language: python
-    'types': [python]
-    args: []
-    additional_dependencies: []
+    types: [python]


### PR DESCRIPTION
- no need to quote `types`
- the other keys are optional and were their defaults