### PR TITLE
BasicChecker: fix typo in 'visit_with' method

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -363,3 +363,5 @@ contributors:
 
 * Athos Ribeiro
     Fixed dict-keys-not-iterating false positive for inverse containment checks
+
+* Anubhav: contributor

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1491,7 +1491,7 @@ class BasicChecker(_BasicChecker):
 
     @utils.check_messages("confusing-with-statement")
     def visit_with(self, node):
-        # a "with" statement with multiple managers coresponds
+        # a "with" statement with multiple managers corresponds
         # to one AST "With" node with multiple items
         pairs = node.items
         if pairs:


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
This PR fixes a typo in the `visit_with` method of `BasicChecker` (`pylint/checkers/base.py`).
The typo fix: coresponds  --> corresponds

I did not add this change to the changelog. Please let me know if this is needed.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
