### PR TITLE
Add a check for asserts on string literals

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in Pylint 2.5.0?
 
 Release date: TBA
 
+* Add a check for asserts on string literals.
+
+  Close #3284
+
 * Clean up plugin HOWTO documentation.
 
 * `not in` is considered iterating context for some of the Python 3 porting checkers.

--- a/doc/whatsnew/2.5.rst
+++ b/doc/whatsnew/2.5.rst
@@ -13,6 +13,12 @@ Summary -- Release highlights
 New checkers
 ============
 
+* A new check ``assert-on-string-literal`` was added.
+
+  This check is emitted whenever **pylint** finds an assert statement
+  with a string literal as its first argument. Such assert statements
+  are probably unintended as they will always pass.
+
 * A new check ``f-string-without-interpolation`` was added.
 
   This check is emitted whenever **pylint** detects the use of an

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1393,7 +1393,7 @@ class BasicChecker(_BasicChecker):
         ):
             self.add_message("assert-on-tuple", node=node)
 
-        if isinstance(node.test.value, str):
+        if isinstance(node.test, astroid.Const) and isinstance(node.test.value, str):
             self.add_message("assert-on-string-literal", node=node)
 
     @utils.check_messages("duplicate-key")

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1016,6 +1016,12 @@ class BasicChecker(_BasicChecker):
             'print("value: {}".format(123)). This might not be what the user '
             "intended to do.",
         ),
+        "W0129": (
+            "Assert statement has a string literal as its first argument. The assert will never fail.",
+            "assert-on-string-literal",
+            "Used when an assert statement has a string literal as its first argument, which will "
+            "cause the assert to always pass.",
+        ),
     }
 
     reports = (("RP0101", "Statistics by type", report_by_type_stats),)
@@ -1377,15 +1383,18 @@ class BasicChecker(_BasicChecker):
                 elif name == "eval":
                     self.add_message("eval-used", node=node)
 
-    @utils.check_messages("assert-on-tuple")
+    @utils.check_messages("assert-on-tuple", "assert-on-string-literal")
     def visit_assert(self, node):
-        """check the use of an assert statement on a tuple."""
+        """check whether assert is used on a tuple or string literal."""
         if (
             node.fail is None
             and isinstance(node.test, astroid.Tuple)
             and len(node.test.elts) == 2
         ):
             self.add_message("assert-on-tuple", node=node)
+
+        if isinstance(node.test.value, str):
+            self.add_message("assert-on-string-literal", node=node)
 
     @utils.check_messages("duplicate-key")
     def visit_dict(self, node):

--- a/tests/functional/a/assert_on_string_literal.py
+++ b/tests/functional/a/assert_on_string_literal.py
@@ -1,3 +1,3 @@
 # pylint: disable=missing-module-docstring, undefined-variable
 assert [foo, bar], "No AssertionError"
-assert "There is an AssertionError"
+assert "There is an AssertionError" # [assert-on-string-literal]

--- a/tests/functional/a/assert_on_string_literal.py
+++ b/tests/functional/a/assert_on_string_literal.py
@@ -1,0 +1,3 @@
+# pylint: disable=missing-module-docstring, undefined-variable
+assert [foo, bar], "No AssertionError"
+assert "There is an AssertionError"

--- a/tests/functional/a/assert_on_string_literal.txt
+++ b/tests/functional/a/assert_on_string_literal.txt
@@ -1,0 +1,1 @@
+assert-on-string-literal:3::Assert statement has a string literal as its first argument. The assert will never fail.


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
This PR adds a warning for assert statements that have string literals as their first argument.
Such assert statements will never fail.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Related Issue
Fixes #3284 
<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
