### PR TITLE
update examples/pylintrc with new logging-format-style help

### DIFF
--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -242,7 +242,7 @@ signature-mutators=
 [LOGGING]
 
 # Format style used to check logging format string. `old` means using %
-# formatting, while `new` is for `{}` formatting.
+# formatting, `new` is for `{}` formatting, and `fstr` is for f-strings.
 logging-format-style=old
 
 # Logging modules to check that the string format arguments are in logging


### PR DESCRIPTION
## Description

update examples/pylintrc with new logging-format-style help added in #3095

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |
