### PR TITLE
Fixed writing graphs to relative paths

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -365,3 +365,5 @@ contributors:
     Fixed dict-keys-not-iterating false positive for inverse containment checks
 
 * Anubhav: contributor
+
+* Ben Graham: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in Pylint 2.5.0?
 
 Release date: TBA
 
+* Fixed graph creation for relative paths
+
 * Add a check for asserts on string literals.
 
   Close #3284

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -242,7 +242,7 @@ signature-mutators=
 [LOGGING]
 
 # Format style used to check logging format string. `old` means using %
-# formatting, while `new` is for `{}` formatting.
+# formatting, `new` is for `{}` formatting, and `fstr` is for f-strings.
 logging-format-style=old
 
 # Logging modules to check that the string format arguments are in logging

--- a/pylint/graph.py
+++ b/pylint/graph.py
@@ -71,7 +71,7 @@ class DotBackend:
 
     source = property(get_source)
 
-    def generate(self, outputfile=None, dotfile=None, mapfile=None):
+    def generate(self, outputfile=None, mapfile=None):
         """Generates a graph file.
 
         :param str outputfile: filename and path [defaults to graphname.png]

--- a/pylint/graph.py
+++ b/pylint/graph.py
@@ -75,7 +75,6 @@ class DotBackend:
         """Generates a graph file.
 
         :param str outputfile: filename and path [defaults to graphname.png]
-        :param str dotfile: filename and path [defaults to graphname.dot]
         :param str mapfile: filename and path
 
         :rtype: str


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
While playing around with the 'import-graph' setting, I noticed that attempting to write a graph to a relative path did not work as I would have expected.
For example, 'import-graph=docs/graph.dot' would attempt to add 'graph.dot' to '/LOCAL/PATH/docs/docs/'.
This was because the 'dot_sourcepath' in this scenario would be set to the combination of the 'storedir' ('/LOCAL/PATH/docs') and the 'outputfile' ('docs/graph.dot'). I am requesting that it be changed to just be 'outputfile' in this scenario.

Also, I have removed the instantiation of the 'dotfile' variable because it now has no use.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
