### PR TITLE
Remove import of Counter from types (unneeded and prevents use in python 3.5.3 or lower)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -365,3 +365,5 @@ contributors:
     Fixed dict-keys-not-iterating false positive for inverse containment checks
 
 * Anubhav: contributor
+
+* Anthony Tan: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in Pylint 2.5.0?
 
 Release date: TBA
 
+* Remove unused import 
+  
+  Close #3379
+
 * Add a check for asserts on string literals.
 
   Close #3284

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -27,7 +27,8 @@ import collections
 import numbers
 import re
 import tokenize
-from typing import Counter, Iterable
+import typing
+from typing import Iterable
 
 import astroid
 from astroid.arguments import CallSite
@@ -737,7 +738,7 @@ class StringConstantChecker(BaseTokenChecker):
         Args:
           tokens: The tokens to be checked against for consistent usage.
         """
-        string_delimiters = collections.Counter()  # type: Counter[str]
+        string_delimiters = collections.Counter()  # type: typing.Counter[str]
 
         # First, figure out which quote character predominates in the module
         for tok_type, token, _, _, _ in tokens:


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Remove import of Counter from types. It's unused and it also prevents use in python 3.5.3 or lower.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #3379
