### PR TITLE
Emit ``unused-argument`` for functions that partially uses their argument list before raising an exception.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -181,6 +181,10 @@ Release date: TBA
 
   Close #1603
 
+* Emit ``unused-argument`` for functions that partially uses their argument list before raising an exception.
+
+  Close #3246
+
 * Fixed ``broad_try_clause`` extension to check try/finally statements and to
   check for nested statements (e.g., inside of an ``if`` statement).
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -263,16 +263,9 @@ def is_super(node: astroid.node_classes.NodeNG) -> bool:
     return False
 
 
-def is_error(node: astroid.node_classes.NodeNG) -> bool:
-    """return true if the function does nothing but raising an exception"""
-    raises = False
-    returns = False
-    for child_node in node.nodes_of_class((astroid.Raise, astroid.Return)):
-        if isinstance(child_node, astroid.Raise):
-            raises = True
-        if isinstance(child_node, astroid.Return):
-            returns = True
-    return raises and not returns
+def is_error(node: astroid.scoped_nodes.FunctionDef) -> bool:
+    """Return true if the given function node only raises an exception"""
+    return len(node.body) == 1 and isinstance(node.body[0], astroid.Raise)
 
 
 builtins = builtins.__dict__.copy()  # type: ignore

--- a/tests/functional/u/unused_argument_py3.py
+++ b/tests/functional/u/unused_argument_py3.py
@@ -2,3 +2,8 @@
 
 def func(first, *, second): # [unused-argument, unused-argument]
     pass
+
+
+def only_raises(first, second=42): # [unused-argument]
+    if first == 24:
+        raise ValueError

--- a/tests/functional/u/unused_argument_py3.txt
+++ b/tests/functional/u/unused_argument_py3.txt
@@ -1,2 +1,3 @@
 unused-argument:3:func:Unused argument 'first'
 unused-argument:3:func:Unused argument 'second'
+unused-argument:7:only_raises:Unused argument 'second'


### PR DESCRIPTION
## Description

The original intention of `pylint.checkers.utils.is_error()` was to verify that a function only raises an error similar to being an abstract method by raising `NotImplementedError`. Unfortunately the implementation only inspected the body of the function to find at least a `raise` node, which means it was checking more than it should have in the first place.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Close #3246