### PR TITLE
Do not emit `logging-too-many-args` when `logging-format-interpolation` is emitted

### DIFF
--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -324,6 +324,7 @@ class LoggingChecker(checkers.BaseChecker):
                         node=node,
                         args=self._format_style_args,
                     )
+                    return
             except utils.UnsupportedFormatCharacter as ex:
                 char = format_string[ex.index]
                 self.add_message(

--- a/tests/unittest_checker_logging.py
+++ b/tests/unittest_checker_logging.py
@@ -148,7 +148,7 @@ class TestLoggingModuleDetection(CheckerTestCase):
     def test_modulo_not_fstr_format_style_matching_arguments(self):
         msg = "logging-format-interpolation"
         args = ("f-string", "")
-        with_too_many = True
+        with_too_many = False
         self._assert_logging_format_message(msg, "('%s', 1)", args, with_too_many)
         self._assert_logging_format_message(
             msg, "('%(named)s', {'named': 1})", args, with_too_many
@@ -161,7 +161,7 @@ class TestLoggingModuleDetection(CheckerTestCase):
     def test_brace_not_fstr_format_style_matching_arguments(self):
         msg = "logging-format-interpolation"
         args = ("f-string", "")
-        with_too_many = True
+        with_too_many = False
         self._assert_logging_format_message(msg, "('{}', 1)", args, with_too_many)
         self._assert_logging_format_message(msg, "('{0}', 1)", args, with_too_many)
         self._assert_logging_format_message(


### PR DESCRIPTION
The intention for `logging-too-many-args` and `logging-too-few-args` is to be emitted
when the logging string matches the expected format interpolation.
Otherwise `logging-too-many-args` will always be emitted when the logging string
does not match the expected format interpolation, especially since the arguments
have more bearing for the old style interpolation format, using modulo.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Close #3362
