### PR TITLE
Do not allow ``python -m pylint ...`` to import user code

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,15 @@ What's New in Pylint 2.5.0?
 
 Release date: TBA
 
+* Do not allow ``python -m pylint ...`` to import user code
+
+  ``python -m pylint ...`` adds the current working directory as the first element
+  of ``sys.path``. This opens up a potential security hole where ``pylint`` will import
+  user level code as long as that code resides in modules having the same name as stdlib
+  or pylint's own modules.
+
+  Close #3386
+
 * Add `dummy-variables-rgx` option for `_redeclared-assigned-name` check.
 
   Close #3341

--- a/pylint/__init__.py
+++ b/pylint/__init__.py
@@ -10,14 +10,13 @@
 import sys
 
 from pylint.__pkginfo__ import version as __version__
-from pylint.checkers.similar import Run as SimilarRun
-from pylint.epylint import Run as EpylintRun
-from pylint.lint import Run as PylintRun
-from pylint.pyreverse.main import Run as PyreverseRun
+
+# pylint: disable=import-outside-toplevel
 
 
 def run_pylint():
     """run pylint"""
+    from pylint.lint import Run as PylintRun
 
     try:
         PylintRun(sys.argv[1:])
@@ -27,17 +26,20 @@ def run_pylint():
 
 def run_epylint():
     """run pylint"""
+    from pylint.epylint import Run as EpylintRun
 
     EpylintRun()
 
 
 def run_pyreverse():
     """run pyreverse"""
+    from pylint.pyreverse.main import Run as PyreverseRun
 
     PyreverseRun(sys.argv[1:])
 
 
 def run_symilar():
     """run symilar"""
+    from pylint.checkers.similar import Run as SimilarRun
 
     SimilarRun(sys.argv[1:])

--- a/pylint/__main__.py
+++ b/pylint/__main__.py
@@ -2,6 +2,18 @@
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
 #!/usr/bin/env python
+import os
+import sys
+
 import pylint
+
+# Strip out the current working directory from sys.path.
+# Having the working directory in `sys.path` means that `pylint` might
+# inadvertently import user code from modules having the same name as
+# stdlib or pylint's own modules.
+# CPython issue: https://bugs.python.org/issue33053
+if sys.path[0] == "" or sys.path[0] == os.getcwd():
+    sys.path.pop(0)
+
 
 pylint.run_pylint()


### PR DESCRIPTION
## Description
``python -m pylint ...`` adds the current working directory as the first element
of ``sys.path``. This opens up a potential security hole where ``pylint`` will import
user level code as long as that code resides in modules having the same name as stdlib
or pylint's own modules.

CPython issue: https://bugs.python.org/issue33053

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Close #3386
