### PR TITLE
allow non-ASCII characters in identifiers in the invalid-name rule and add non-ascii-name

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -371,3 +371,5 @@ contributors:
 * Anthony Tan: contributor
 
 * Benny Müller: contributor
+
+* Bernie Gray: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,7 @@ What's New in Pylint 2.5.0?
 
 Release date: TBA
 
-* Adjust the `invalid-name` rule to work with non-ASCII identifiers.
+* Adjust the `invalid-name` rule to work with non-ASCII identifiers and add the `non-ascii-name` rule.
 
   Close #2725
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in Pylint 2.5.0?
 
 Release date: TBA
 
+* Adjust the `invalid-name` rule to work with non-ASCII identifiers.
+
+  Close #2725
+
 * Add a check for cases where the second argument to `isinstance` is not a type.
 
   Close #3308

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,6 @@ environment:
       TOXENV: "py37"
 
 init:
-  - ps: chcp 65001
   - ps: echo $env:TOXENV
   - ps: ls C:\Python*
   - ps: mkdir C:\tmp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ environment:
       TOXENV: "py37"
 
 init:
+  - ps: chcp 65001
   - ps: echo $env:TOXENV
   - ps: ls C:\Python*
   - ps: mkdir C:\tmp

--- a/doc/whatsnew/2.5.rst
+++ b/doc/whatsnew/2.5.rst
@@ -90,3 +90,5 @@ separated list of regexes, that if a name matches will be always marked as a bla
 * Add a new check (non-str-assignment-to-dunder-name) to ensure that only strings are assigned to ``__name__`` attributes
 
 * Add a new option ``notes-rgx`` to make fixme warnings more flexible. Now either ``notes`` or ``notes-rgx`` option can be used to detect fixme warnings. 
+
+* Non-ASCII characters are now allowed by ``invalid-name``.

--- a/doc/whatsnew/2.5.rst
+++ b/doc/whatsnew/2.5.rst
@@ -89,6 +89,8 @@ separated list of regexes, that if a name matches will be always marked as a bla
 
 * Add a new check (non-str-assignment-to-dunder-name) to ensure that only strings are assigned to ``__name__`` attributes
 
-* Add a new option ``notes-rgx`` to make fixme warnings more flexible. Now either ``notes`` or ``notes-rgx`` option can be used to detect fixme warnings. 
+* Add a new option ``notes-rgx`` to make fixme warnings more flexible. Now either ``notes`` or ``notes-rgx`` option can be used to detect fixme warnings.
 
 * Non-ASCII characters are now allowed by ``invalid-name``.
+
+* Add a new check ``non-ascii-name`` to detect identifiers with non-ASCII characters.

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -87,47 +87,47 @@ class NamingStyle:
 class SnakeCaseStyle(NamingStyle):
     """Regex rules for snake_case naming style."""
 
-    CLASS_NAME_RGX = re.compile("[a-z_][a-z0-9_]+$")
-    MOD_NAME_RGX = re.compile("[a-z_][a-z0-9_]*$")
-    CONST_NAME_RGX = re.compile("([a-z_][a-z0-9_]*|__.*__)$")
-    COMP_VAR_RGX = re.compile("[a-z_][a-z0-9_]*$")
+    CLASS_NAME_RGX = re.compile("[^\W\dA-Z][^\WA-Z]+$")
+    MOD_NAME_RGX = re.compile("[^\W\dA-Z][^\WA-Z]*$")
+    CONST_NAME_RGX = re.compile("([^\W\dA-Z][^\WA-Z]*|__.*__)$")
+    COMP_VAR_RGX = re.compile("[^\W\dA-Z][^\WA-Z]*$")
     DEFAULT_NAME_RGX = re.compile(
-        "([a-z_][a-z0-9_]{2,}|_[a-z0-9_]*|__[a-z][a-z0-9_]+__)$"
+        "([^\W\dA-Z][^\WA-Z]{2,}|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)$"
     )
-    CLASS_ATTRIBUTE_RGX = re.compile(r"([a-z_][a-z0-9_]{2,}|__.*__)$")
+    CLASS_ATTRIBUTE_RGX = re.compile("([^\W\dA-Z][^\WA-Z]{2,}|__.*__)$")
 
 
 class CamelCaseStyle(NamingStyle):
     """Regex rules for camelCase naming style."""
 
-    CLASS_NAME_RGX = re.compile("[a-z_][a-zA-Z0-9]+$")
-    MOD_NAME_RGX = re.compile("[a-z_][a-zA-Z0-9]*$")
-    CONST_NAME_RGX = re.compile("([a-z_][A-Za-z0-9]*|__.*__)$")
-    COMP_VAR_RGX = re.compile("[a-z_][A-Za-z0-9]*$")
-    DEFAULT_NAME_RGX = re.compile("([a-z_][a-zA-Z0-9]{2,}|__[a-z][a-zA-Z0-9_]+__)$")
-    CLASS_ATTRIBUTE_RGX = re.compile(r"([a-z_][A-Za-z0-9]{2,}|__.*__)$")
+    CLASS_NAME_RGX = re.compile("[^\W\dA-Z][^\W_]+$")
+    MOD_NAME_RGX = re.compile("[^\W\dA-Z][^\W_]*$")
+    CONST_NAME_RGX = re.compile("([^\W\dA-Z][^\W_]*|__.*__)$")
+    COMP_VAR_RGX = re.compile("[^\W\dA-Z][^\W_]*$")
+    DEFAULT_NAME_RGX = re.compile("([^\W\dA-Z][^\W_]{2,}|__[^\W\dA-Z_]\w+__)$")
+    CLASS_ATTRIBUTE_RGX = re.compile("([^\W\dA-Z][^\W_]{2,}|__.*__)$")
 
 
 class PascalCaseStyle(NamingStyle):
     """Regex rules for PascalCase naming style."""
 
-    CLASS_NAME_RGX = re.compile("[A-Z_][a-zA-Z0-9]+$")
-    MOD_NAME_RGX = re.compile("[A-Z_][a-zA-Z0-9]+$")
-    CONST_NAME_RGX = re.compile("([A-Z_][A-Za-z0-9]*|__.*__)$")
-    COMP_VAR_RGX = re.compile("[A-Z_][a-zA-Z0-9]+$")
-    DEFAULT_NAME_RGX = re.compile("([A-Z_][a-zA-Z0-9]{2,}|__[a-z][a-zA-Z0-9_]+__)$")
-    CLASS_ATTRIBUTE_RGX = re.compile("[A-Z_][a-zA-Z0-9]{2,}$")
+    CLASS_NAME_RGX = re.compile("[^\W\da-z][^\W_]+$")
+    MOD_NAME_RGX = re.compile("[^\W\da-z][^\W_]+$")
+    CONST_NAME_RGX = re.compile("([^\W\da-z][^\W_]*|__.*__)$")
+    COMP_VAR_RGX = re.compile("[^\W\da-z][^\W_]+$")
+    DEFAULT_NAME_RGX = re.compile("([^\W\da-z][^\W_]{2,}|__[^\W\dA-Z_]\w+__)$")
+    CLASS_ATTRIBUTE_RGX = re.compile("[^\W\da-z][^\W_]{2,}$")
 
 
 class UpperCaseStyle(NamingStyle):
     """Regex rules for UPPER_CASE naming style."""
 
-    CLASS_NAME_RGX = re.compile("[A-Z_][A-Z0-9_]+$")
-    MOD_NAME_RGX = re.compile("[A-Z_][A-Z0-9_]+$")
-    CONST_NAME_RGX = re.compile("([A-Z_][A-Z0-9_]*|__.*__)$")
-    COMP_VAR_RGX = re.compile("[A-Z_][A-Z0-9_]+$")
-    DEFAULT_NAME_RGX = re.compile("([A-Z_][A-Z0-9_]{2,}|__[a-z][a-zA-Z0-9_]+__)$")
-    CLASS_ATTRIBUTE_RGX = re.compile("[A-Z_][A-Z0-9_]{2,}$")
+    CLASS_NAME_RGX = re.compile("[^\W\da-z][^\Wa-z]+$")
+    MOD_NAME_RGX = re.compile("[^\W\da-z][^\Wa-z]+$")
+    CONST_NAME_RGX = re.compile("([^\W\da-z][^\Wa-z]*|__.*__)$")
+    COMP_VAR_RGX = re.compile("[^\W\da-z][^\Wa-z]+$")
+    DEFAULT_NAME_RGX = re.compile("([^\W\da-z][^\Wa-z]{2,}|__[^\W\dA-Z_]\w+__)$")
+    CLASS_ATTRIBUTE_RGX = re.compile("[^\W\da-z][^\Wa-z]{2,}$")
 
 
 class AnyStyle(NamingStyle):

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1781,6 +1781,7 @@ class NameChecker(_BasicChecker):
         self._name_hints = {}
         self._good_names_rgxs_compiled = []
         self._bad_names_rgxs_compiled = []
+        self._non_ascii_rgx_compiled = re.compile("[^\u0000-\u007F]")
 
     def open(self):
         self.stats = self.linter.add_stats(
@@ -1972,8 +1973,7 @@ class NameChecker(_BasicChecker):
     def _check_name(self, node_type, name, node, confidence=interfaces.HIGH):
         """check for a name using the type's regexp"""
 
-        non_ascii_regexp = re.compile("[^\u0000-\u007F]")
-        non_ascii_match = non_ascii_regexp.match(name)
+        non_ascii_match = self._non_ascii_rgx_compiled.match(name)
 
         if non_ascii_match is not None:
             self._raise_name_warning(

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1680,6 +1680,11 @@ class NameChecker(_BasicChecker):
             "Used when the name doesn't conform to naming rules "
             "associated to its type (constant, variable, class...).",
         ),
+        "CXXXX": (
+            '%s name "%s" contains a non-ASCII unicode character',
+            "non-ascii-name",
+            "Used when the name contains at least one non-ASCII unciode character.",
+        ),
         "W0111": (
             "Name %s will become a keyword in Python %s",
             "assign-to-new-keyword",
@@ -1826,7 +1831,7 @@ class NameChecker(_BasicChecker):
 
         return regexps, hints
 
-    @utils.check_messages("blacklisted-name", "invalid-name")
+    @utils.check_messages("blacklisted-name", "invalid-name", "non-ascii-name")
     def visit_module(self, node):
         self._check_name("module", node.name.split(".")[-1], node)
         self._bad_names = {}
@@ -1851,7 +1856,9 @@ class NameChecker(_BasicChecker):
             for args in warnings:
                 self._raise_name_warning(*args)
 
-    @utils.check_messages("blacklisted-name", "invalid-name", "assign-to-new-keyword")
+    @utils.check_messages(
+        "blacklisted-name", "invalid-name", "assign-to-new-keyword", "non-ascii-name"
+    )
     def visit_classdef(self, node):
         self._check_assign_to_new_keyword_violation(node.name, node)
         self._check_name("class", node.name, node)
@@ -1859,7 +1866,9 @@ class NameChecker(_BasicChecker):
             if not any(node.instance_attr_ancestors(attr)):
                 self._check_name("attr", attr, anodes[0])
 
-    @utils.check_messages("blacklisted-name", "invalid-name", "assign-to-new-keyword")
+    @utils.check_messages(
+        "blacklisted-name", "invalid-name", "assign-to-new-keyword", "non-ascii-name"
+    )
     def visit_functiondef(self, node):
         # Do not emit any warnings if the method is just an implementation
         # of a base class method.
@@ -1887,12 +1896,14 @@ class NameChecker(_BasicChecker):
 
     visit_asyncfunctiondef = visit_functiondef
 
-    @utils.check_messages("blacklisted-name", "invalid-name")
+    @utils.check_messages("blacklisted-name", "invalid-name", "non-ascii-name")
     def visit_global(self, node):
         for name in node.names:
             self._check_name("const", name, node)
 
-    @utils.check_messages("blacklisted-name", "invalid-name", "assign-to-new-keyword")
+    @utils.check_messages(
+        "blacklisted-name", "invalid-name", "assign-to-new-keyword", "non-ascii-name"
+    )
     def visit_assignname(self, node):
         """check module level assigned names"""
         self._check_assign_to_new_keyword_violation(node.name, node)

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1680,7 +1680,7 @@ class NameChecker(_BasicChecker):
             "Used when the name doesn't conform to naming rules "
             "associated to its type (constant, variable, class...).",
         ),
-        "CXXXX": (
+        "C0144": (
             '%s name "%s" contains a non-ASCII unicode character',
             "non-ascii-name",
             "Used when the name contains at least one non-ASCII unciode character.",
@@ -1833,6 +1833,7 @@ class NameChecker(_BasicChecker):
 
     @utils.check_messages("blacklisted-name", "invalid-name", "non-ascii-name")
     def visit_module(self, node):
+        self._check_non_ascii_name("module", node.name.split(".")[-1], node)
         self._check_name("module", node.name.split(".")[-1], node)
         self._bad_names = {}
 
@@ -1861,6 +1862,7 @@ class NameChecker(_BasicChecker):
     )
     def visit_classdef(self, node):
         self._check_assign_to_new_keyword_violation(node.name, node)
+        self._check_non_ascii_name("class", node.name, node)
         self._check_name("class", node.name, node)
         for attr, anodes in node.instance_attrs.items():
             if not any(node.instance_attr_ancestors(attr)):
@@ -1873,6 +1875,7 @@ class NameChecker(_BasicChecker):
         # Do not emit any warnings if the method is just an implementation
         # of a base class method.
         self._check_assign_to_new_keyword_violation(node.name, node)
+        self._check_non_ascii_name("function", node.name, node)
         confidence = interfaces.HIGH
         if node.is_method():
             if utils.overrides_a_method(node.parent.frame(), node.name):
@@ -1900,6 +1903,7 @@ class NameChecker(_BasicChecker):
     def visit_global(self, node):
         for name in node.names:
             self._check_name("const", name, node)
+            self._check_non_ascii_name("const", name, node)
 
     @utils.check_messages(
         "blacklisted-name", "invalid-name", "assign-to-new-keyword", "non-ascii-name"
@@ -1911,26 +1915,32 @@ class NameChecker(_BasicChecker):
         assign_type = node.assign_type()
         if isinstance(assign_type, astroid.Comprehension):
             self._check_name("inlinevar", node.name, node)
+            self._check_non_ascii_name("inlinevar", node.name, node)
         elif isinstance(frame, astroid.Module):
             if isinstance(assign_type, astroid.Assign) and not in_loop(assign_type):
                 if isinstance(utils.safe_infer(assign_type.value), astroid.ClassDef):
                     self._check_name("class", node.name, node)
+                    self._check_non_ascii_name("class", node.name, node)
                 # Don't emit if the name redefines an import
                 # in an ImportError except handler.
                 elif not _redefines_import(node) and isinstance(
                     utils.safe_infer(assign_type.value), astroid.Const
                 ):
                     self._check_name("const", node.name, node)
+                    self._check_non_ascii_name("const", node.name, node)
             elif isinstance(assign_type, astroid.ExceptHandler):
                 self._check_name("variable", node.name, node)
+                self._check_non_ascii_name("variable", node.name, node)
         elif isinstance(frame, astroid.FunctionDef):
             # global introduced variable aren't in the function locals
             if node.name in frame and node.name not in frame.argnames():
                 if not _redefines_import(node):
                     self._check_name("variable", node.name, node)
+                    self._check_non_ascii_name("variable", node.name, node)
         elif isinstance(frame, astroid.ClassDef):
             if not list(frame.local_attr_ancestors(node.name)):
                 self._check_name("class_attribute", node.name, node)
+                self._check_non_ascii_name("class_attribute", node.name, node)
 
     def _recursive_check_names(self, args, node):
         """check names in a possibly recursive list <arg>"""
@@ -2013,6 +2023,18 @@ class NameChecker(_BasicChecker):
             if name in keywords and sys.version_info < version:
                 return ".".join(map(str, version))
         return None
+
+    def _check_non_ascii_name(self, node_type, name, node):
+        regexp = re.compile("[^\u0000-\u007F]")
+        match = regexp.match(name)
+
+        if match is not None:
+            self.add_message(
+                "non-ascii-name",
+                node=node,
+                args=(HUMAN_READABLE_TYPES[node_type].title(), name),
+                confidence=interfaces.HIGH,
+            )
 
 
 class DocStringChecker(_BasicChecker):

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -87,47 +87,47 @@ class NamingStyle:
 class SnakeCaseStyle(NamingStyle):
     """Regex rules for snake_case naming style."""
 
-    CLASS_NAME_RGX = re.compile("[^\W\dA-Z][^\WA-Z]+$")
-    MOD_NAME_RGX = re.compile("[^\W\dA-Z][^\WA-Z]*$")
-    CONST_NAME_RGX = re.compile("([^\W\dA-Z][^\WA-Z]*|__.*__)$")
-    COMP_VAR_RGX = re.compile("[^\W\dA-Z][^\WA-Z]*$")
+    CLASS_NAME_RGX = re.compile(r"[^\W\dA-Z][^\WA-Z]+$")
+    MOD_NAME_RGX = re.compile(r"[^\W\dA-Z][^\WA-Z]*$")
+    CONST_NAME_RGX = re.compile(r"([^\W\dA-Z][^\WA-Z]*|__.*__)$")
+    COMP_VAR_RGX = re.compile(r"[^\W\dA-Z][^\WA-Z]*$")
     DEFAULT_NAME_RGX = re.compile(
-        "([^\W\dA-Z][^\WA-Z]{2,}|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)$"
+        r"([^\W\dA-Z][^\WA-Z]{2,}|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)$"
     )
-    CLASS_ATTRIBUTE_RGX = re.compile("([^\W\dA-Z][^\WA-Z]{2,}|__.*__)$")
+    CLASS_ATTRIBUTE_RGX = re.compile(r"([^\W\dA-Z][^\WA-Z]{2,}|__.*__)$")
 
 
 class CamelCaseStyle(NamingStyle):
     """Regex rules for camelCase naming style."""
 
-    CLASS_NAME_RGX = re.compile("[^\W\dA-Z][^\W_]+$")
-    MOD_NAME_RGX = re.compile("[^\W\dA-Z][^\W_]*$")
-    CONST_NAME_RGX = re.compile("([^\W\dA-Z][^\W_]*|__.*__)$")
-    COMP_VAR_RGX = re.compile("[^\W\dA-Z][^\W_]*$")
-    DEFAULT_NAME_RGX = re.compile("([^\W\dA-Z][^\W_]{2,}|__[^\W\dA-Z_]\w+__)$")
-    CLASS_ATTRIBUTE_RGX = re.compile("([^\W\dA-Z][^\W_]{2,}|__.*__)$")
+    CLASS_NAME_RGX = re.compile(r"[^\W\dA-Z][^\W_]+$")
+    MOD_NAME_RGX = re.compile(r"[^\W\dA-Z][^\W_]*$")
+    CONST_NAME_RGX = re.compile(r"([^\W\dA-Z][^\W_]*|__.*__)$")
+    COMP_VAR_RGX = re.compile(r"[^\W\dA-Z][^\W_]*$")
+    DEFAULT_NAME_RGX = re.compile(r"([^\W\dA-Z][^\W_]{2,}|__[^\W\dA-Z_]\w+__)$")
+    CLASS_ATTRIBUTE_RGX = re.compile(r"([^\W\dA-Z][^\W_]{2,}|__.*__)$")
 
 
 class PascalCaseStyle(NamingStyle):
     """Regex rules for PascalCase naming style."""
 
-    CLASS_NAME_RGX = re.compile("[^\W\da-z][^\W_]+$")
-    MOD_NAME_RGX = re.compile("[^\W\da-z][^\W_]+$")
-    CONST_NAME_RGX = re.compile("([^\W\da-z][^\W_]*|__.*__)$")
-    COMP_VAR_RGX = re.compile("[^\W\da-z][^\W_]+$")
-    DEFAULT_NAME_RGX = re.compile("([^\W\da-z][^\W_]{2,}|__[^\W\dA-Z_]\w+__)$")
-    CLASS_ATTRIBUTE_RGX = re.compile("[^\W\da-z][^\W_]{2,}$")
+    CLASS_NAME_RGX = re.compile(r"[^\W\da-z][^\W_]+$")
+    MOD_NAME_RGX = re.compile(r"[^\W\da-z][^\W_]+$")
+    CONST_NAME_RGX = re.compile(r"([^\W\da-z][^\W_]*|__.*__)$")
+    COMP_VAR_RGX = re.compile(r"[^\W\da-z][^\W_]+$")
+    DEFAULT_NAME_RGX = re.compile(r"([^\W\da-z][^\W_]{2,}|__[^\W\dA-Z_]\w+__)$")
+    CLASS_ATTRIBUTE_RGX = re.compile(r"[^\W\da-z][^\W_]{2,}$")
 
 
 class UpperCaseStyle(NamingStyle):
     """Regex rules for UPPER_CASE naming style."""
 
-    CLASS_NAME_RGX = re.compile("[^\W\da-z][^\Wa-z]+$")
-    MOD_NAME_RGX = re.compile("[^\W\da-z][^\Wa-z]+$")
-    CONST_NAME_RGX = re.compile("([^\W\da-z][^\Wa-z]*|__.*__)$")
-    COMP_VAR_RGX = re.compile("[^\W\da-z][^\Wa-z]+$")
-    DEFAULT_NAME_RGX = re.compile("([^\W\da-z][^\Wa-z]{2,}|__[^\W\dA-Z_]\w+__)$")
-    CLASS_ATTRIBUTE_RGX = re.compile("[^\W\da-z][^\Wa-z]{2,}$")
+    CLASS_NAME_RGX = re.compile(r"[^\W\da-z][^\Wa-z]+$")
+    MOD_NAME_RGX = re.compile(r"[^\W\da-z][^\Wa-z]+$")
+    CONST_NAME_RGX = re.compile(r"([^\W\da-z][^\Wa-z]*|__.*__)$")
+    COMP_VAR_RGX = re.compile(r"[^\W\da-z][^\Wa-z]+$")
+    DEFAULT_NAME_RGX = re.compile(r"([^\W\da-z][^\Wa-z]{2,}|__[^\W\dA-Z_]\w+__)$")
+    CLASS_ATTRIBUTE_RGX = re.compile(r"[^\W\da-z][^\Wa-z]{2,}$")
 
 
 class AnyStyle(NamingStyle):

--- a/pylint/pyreverse/utils.py
+++ b/pylint/pyreverse/utils.py
@@ -48,9 +48,9 @@ def insert_default_options():
 
 # astroid utilities ###########################################################
 
-SPECIAL = re.compile("^__[A-Za-z0-9]+[A-Za-z0-9_]*__$")
-PRIVATE = re.compile("^__[_A-Za-z0-9]*[A-Za-z0-9]+_?$")
-PROTECTED = re.compile("^_[_A-Za-z0-9]*$")
+SPECIAL = re.compile("^__[^\W_]+\w*__$")
+PRIVATE = re.compile("^__\w*[^\W_]+_?$")
+PROTECTED = re.compile("^_\w*$")
 
 
 def get_visibility(name):
@@ -69,7 +69,7 @@ def get_visibility(name):
 
 
 ABSTRACT = re.compile("^.*Abstract.*")
-FINAL = re.compile("^[A-Z_]*$")
+FINAL = re.compile("^[^\W\da-z]*$")
 
 
 def is_abstract(node):

--- a/pylint/pyreverse/utils.py
+++ b/pylint/pyreverse/utils.py
@@ -48,9 +48,9 @@ def insert_default_options():
 
 # astroid utilities ###########################################################
 
-SPECIAL = re.compile("^__[^\W_]+\w*__$")
-PRIVATE = re.compile("^__\w*[^\W_]+_?$")
-PROTECTED = re.compile("^_\w*$")
+SPECIAL = re.compile(r"^__[^\W_]+\w*__$")
+PRIVATE = re.compile(r"^__\w*[^\W_]+_?$")
+PROTECTED = re.compile(r"^_\w*$")
 
 
 def get_visibility(name):
@@ -68,8 +68,8 @@ def get_visibility(name):
     return visibility
 
 
-ABSTRACT = re.compile("^.*Abstract.*")
-FINAL = re.compile("^[^\W\da-z]*$")
+ABSTRACT = re.compile(r"^.*Abstract.*")
+FINAL = re.compile(r"^[^\W\da-z]*$")
 
 
 def is_abstract(node):

--- a/tests/functional/n/namePresetCamelCase.txt
+++ b/tests/functional/n/namePresetCamelCase.txt
@@ -1,3 +1,3 @@
-invalid-name:3::"Constant name ""SOME_CONSTANT"" doesn't conform to camelCase naming style ('([a-z_][A-Za-z0-9]*|__.*__)$' pattern)"
-invalid-name:10:MyClass:"Class name ""MyClass"" doesn't conform to camelCase naming style ('[a-z_][a-zA-Z0-9]+$' pattern)"
-invalid-name:22:say_hello:"Function name ""say_hello"" doesn't conform to camelCase naming style ('([a-z_][a-zA-Z0-9]{2,}|__[a-z][a-zA-Z0-9_]+__)$' pattern)"
+invalid-name:3::"Constant name ""SOME_CONSTANT"" doesn't conform to camelCase naming style ('([^\\W\\dA-Z][^\\W_]*|__.*__)$' pattern)"
+invalid-name:10:MyClass:"Class name ""MyClass"" doesn't conform to camelCase naming style ('[^\\W\\dA-Z][^\\W_]+$' pattern)"
+invalid-name:22:say_hello:"Function name ""say_hello"" doesn't conform to camelCase naming style ('([^\\W\\dA-Z][^\\W_]{2,}|__[^\\W\\dA-Z_]\\w+__)$' pattern)"

--- a/tests/functional/n/name_good_bad_names_regex.txt
+++ b/tests/functional/n/name_good_bad_names_regex.txt
@@ -1,3 +1,3 @@
 blacklisted-name:5::"Black listed name ""explicit_bad_some_constant"""
-invalid-name:7::"Constant name ""snake_case_bad_SOME_CONSTANT"" doesn't conform to snake_case naming style ('([a-z_][a-z0-9_]*|__.*__)$' pattern)"
+invalid-name:7::"Constant name ""snake_case_bad_SOME_CONSTANT"" doesn't conform to snake_case naming style ('([^\\W\\dA-Z][^\\WA-Z]*|__.*__)$' pattern)"
 blacklisted-name:19:blacklisted_2_snake_case:"Black listed name ""blacklisted_2_snake_case"""

--- a/tests/functional/n/name_preset_snake_case.txt
+++ b/tests/functional/n/name_preset_snake_case.txt
@@ -1,3 +1,3 @@
-invalid-name:3::"Constant name ""SOME_CONSTANT"" doesn't conform to snake_case naming style ('([a-z_][a-z0-9_]*|__.*__)$' pattern)"
-invalid-name:10:MyClass:"Class name ""MyClass"" doesn't conform to snake_case naming style ('[a-z_][a-z0-9_]+$' pattern)"
-invalid-name:22:sayHello:"Function name ""sayHello"" doesn't conform to snake_case naming style ('([a-z_][a-z0-9_]{2,}|_[a-z0-9_]*|__[a-z][a-z0-9_]+__)$' pattern)"
+invalid-name:3::"Constant name ""SOME_CONSTANT"" doesn't conform to snake_case naming style ('([^\\W\\dA-Z][^\\WA-Z]*|__.*__)$' pattern)"
+invalid-name:10:MyClass:"Class name ""MyClass"" doesn't conform to snake_case naming style ('[^\\W\\dA-Z][^\\WA-Z]+$' pattern)"
+invalid-name:22:sayHello:"Function name ""sayHello"" doesn't conform to snake_case naming style ('([^\\W\\dA-Z][^\\WA-Z]{2,}|_[^\\WA-Z]*|__[^\\WA-Z\\d_][^\\WA-Z]+__)$' pattern)"

--- a/tests/functional/n/non_ascii_name.py
+++ b/tests/functional/n/non_ascii_name.py
@@ -1,0 +1,6 @@
+""" Tests for non-ascii-name checker. """
+
+áéíóú = 4444 # [non-ascii-name]
+
+def úóíéá(): # [non-ascii-name]
+    """yo"""

--- a/tests/functional/n/non_ascii_name.txt
+++ b/tests/functional/n/non_ascii_name.txt
@@ -1,0 +1,2 @@
+non-ascii-name:3::"Constant name ""áéíóú"" contains a non-ASCII unicode character"
+non-ascii-name:5:úóíéá:"Function name ""úóíéá"" contains a non-ASCII unicode character"

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -70,6 +70,9 @@ def get_tests():
         if dirpath.endswith("__pycache__"):
             continue
         for filename in filenames:
+            if filename == "non_ascii_name.py" and os.name == "nt":
+                # skip this test on Windows since it involves Unicode
+                continue
             if filename != "__init__.py" and filename.endswith(".py"):
                 suite.append(testutils.FunctionalTestFile(dirpath, filename))
     return suite
@@ -82,7 +85,9 @@ TESTS_NAMES = [t.base for t in TESTS]
 @pytest.mark.parametrize("test_file", TESTS, ids=TESTS_NAMES)
 def test_functional(test_file):
     LintTest = (
-        LintModuleOutputUpdate(test_file) if UPDATE else testutils.LintModuleTest(test_file)
+        LintModuleOutputUpdate(test_file)
+        if UPDATE
+        else testutils.LintModuleTest(test_file)
     )
     LintTest.setUp()
     LintTest._runTest()

--- a/tests/unittest_checker_base.py
+++ b/tests/unittest_checker_base.py
@@ -443,10 +443,10 @@ class TestComparison(CheckerTestCase):
 
 
 class TestNamePresets(unittest.TestCase):
-    SNAKE_CASE_NAMES = {"test_snake_case", "test_snake_case11", "test_https_200"}
-    CAMEL_CASE_NAMES = {"testCamelCase", "testCamelCase11", "testHTTP200"}
-    UPPER_CASE_NAMES = {"TEST_UPPER_CASE", "TEST_UPPER_CASE11", "TEST_HTTP_200"}
-    PASCAL_CASE_NAMES = {"TestPascalCase", "TestPascalCase11", "TestHTTP200"}
+    SNAKE_CASE_NAMES = {"tést_snake_case", "test_snake_case11", "test_https_200"}
+    CAMEL_CASE_NAMES = {"téstCamelCase", "testCamelCase11", "testHTTP200"}
+    UPPER_CASE_NAMES = {"TÉST_UPPER_CASE", "TEST_UPPER_CASE11", "TEST_HTTP_200"}
+    PASCAL_CASE_NAMES = {"TéstPascalCase", "TestPascalCase11", "TestHTTP200"}
     ALL_NAMES = (
         SNAKE_CASE_NAMES | CAMEL_CASE_NAMES | UPPER_CASE_NAMES | PASCAL_CASE_NAMES
     )


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

This PR attempts to allow non-ASCII characters in identifiers in the `invalid-name` rule.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Related Issue

This PR is in reference to issue #2725 but I have not closed it in the commit message yet because I have not yet implemented the second [part](https://github.com/PyCQA/pylint/issues/2725#issuecomment-522041148) and there are likely more changes required to this PR as well.
