### PR TITLE
Avoid importing files from the local directory when running pylint

### DIFF
--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -776,7 +776,6 @@ class ImportsChecker(BaseChecker):
         except astroid.TooManyLevelsError:
             if _ignore_import_failure(importnode, modname, self._ignored_modules):
                 return None
-
             self.add_message("relative-beyond-top-level", node=importnode)
         except astroid.AstroidSyntaxError as exc:
             message = "Cannot import {!r} due to syntax error {!r}".format(

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -1462,7 +1462,6 @@ def _patch_sys_path(args):
     original = list(sys.path)
     changes = []
     seen = set()
-    cwd = os.getcwd()
     for arg in args:
         path = utils.get_python_path(arg)
         if path not in seen:

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -1475,11 +1475,15 @@ def fix_import_path(args):
     """
     orig = list(sys.path)
     changes = []
+    seen = set()
+    cwd = os.getcwd()
     for arg in args:
         path = _get_python_path(arg)
-        if path not in changes:
+        if path not in seen and path != cwd:
             changes.append(path)
-    sys.path[:] = changes + ["."] + sys.path
+            seen.add(path)
+
+    sys.path[:] = changes + sys.path
     try:
         yield
     finally:

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -114,20 +114,6 @@ def _get_new_args(message):
     return (message.msg_id, message.symbol, location, message.msg, message.confidence)
 
 
-def _get_python_path(filepath):
-    dirname = os.path.realpath(os.path.expanduser(filepath))
-    if not os.path.isdir(dirname):
-        dirname = os.path.dirname(dirname)
-    while True:
-        if not os.path.exists(os.path.join(dirname, "__init__.py")):
-            return dirname
-        old_dirname = dirname
-        dirname = os.path.dirname(dirname)
-        if old_dirname == dirname:
-            return os.getcwd()
-    return None
-
-
 def _merge_stats(stats):
     merged = {}
     by_msg = collections.Counter()
@@ -1478,7 +1464,7 @@ def fix_import_path(args):
     seen = set()
     cwd = os.getcwd()
     for arg in args:
-        path = _get_python_path(arg)
+        path = utils.get_python_path(arg)
         if path not in seen and path != cwd:
             changes.append(path)
             seen.add(path)

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -115,6 +115,20 @@ def _modpath_from_file(filename, is_namespace):
     )
 
 
+def get_python_path(filepath):
+    dirname = os.path.realpath(os.path.expanduser(filepath))
+    if not os.path.isdir(dirname):
+        dirname = os.path.dirname(dirname)
+    while True:
+        if not os.path.exists(os.path.join(dirname, "__init__.py")):
+            return dirname
+        old_dirname = dirname
+        dirname = os.path.dirname(dirname)
+        if old_dirname == dirname:
+            return os.getcwd()
+    return None
+
+
 def expand_modules(files_or_modules, black_list, black_list_re):
     """take a list of files/modules/packages and return the list of tuple
     (file, module name) which have to be actually checked

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -664,3 +664,35 @@ class TestRunTC(object):
             ],
             code=0,
         )
+
+    def test_do_not_import_files_from_local_directory(self, tmpdir):
+        p_astroid = tmpdir / "astroid.py"
+        p_astroid.write("'Docstring'\nimport completely_unknown\n")
+        p_hmac = tmpdir / "hmac.py"
+        p_hmac.write("'Docstring'\nimport completely_unknown\n")
+
+        with tmpdir.as_cwd():
+            subprocess.check_output(
+                [
+                    sys.executable,
+                    "-m",
+                    "pylint",
+                    "astroid.py",
+                    "--disable=import-error,unused-import",
+                ],
+                cwd=str(tmpdir),
+            )
+
+        # Test with multiple jobs
+        with tmpdir.as_cwd():
+            subprocess.call(
+                [
+                    sys.executable,
+                    "-m",
+                    "pylint",
+                    "-j2",
+                    "hmac.py",
+                    "--disable=import-error,unused-import",
+                ],
+                cwd=str(tmpdir),
+            )

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -683,7 +683,22 @@ class TestRunTC(object):
                 cwd=str(tmpdir),
             )
 
-        # Test with multiple jobs
+        # Linting this astroid file does not import it
+        with tmpdir.as_cwd():
+            subprocess.check_output(
+                [
+                    sys.executable,
+                    "-m",
+                    "pylint",
+                    "-j2",
+                    "astroid.py",
+                    "--disable=import-error,unused-import",
+                ],
+                cwd=str(tmpdir),
+            )
+
+        # Test with multiple jobs for hmac.py for which we have a
+        # CVE against: https://github.com/PyCQA/pylint/issues/959
         with tmpdir.as_cwd():
             subprocess.call(
                 [

--- a/tests/unittest_lint.py
+++ b/tests/unittest_lint.py
@@ -165,7 +165,7 @@ def fake_path():
 
 def test_no_args(fake_path):
     with lint.fix_import_path([]):
-        assert sys.path == ["."] + fake_path
+        assert sys.path == fake_path
     assert sys.path == fake_path
 
 
@@ -175,7 +175,7 @@ def test_no_args(fake_path):
 def test_one_arg(fake_path, case):
     with tempdir() as chroot:
         create_files(["a/b/__init__.py"])
-        expected = [join(chroot, "a")] + ["."] + fake_path
+        expected = [join(chroot, "a")] + fake_path
 
         assert sys.path == fake_path
         with lint.fix_import_path(case):
@@ -195,7 +195,7 @@ def test_one_arg(fake_path, case):
 def test_two_similar_args(fake_path, case):
     with tempdir() as chroot:
         create_files(["a/b/__init__.py", "a/c/__init__.py"])
-        expected = [join(chroot, "a")] + ["."] + fake_path
+        expected = [join(chroot, "a")] + fake_path
 
         assert sys.path == fake_path
         with lint.fix_import_path(case):
@@ -214,14 +214,10 @@ def test_two_similar_args(fake_path, case):
 def test_more_args(fake_path, case):
     with tempdir() as chroot:
         create_files(["a/b/c/__init__.py", "a/d/__init__.py", "a/e/f.py"])
-        expected = (
-            [
-                join(chroot, suffix)
-                for suffix in [sep.join(("a", "b")), "a", sep.join(("a", "e"))]
-            ]
-            + ["."]
-            + fake_path
-        )
+        expected = [
+            join(chroot, suffix)
+            for suffix in [sep.join(("a", "b")), "a", sep.join(("a", "e"))]
+        ] + fake_path
 
         assert sys.path == fake_path
         with lint.fix_import_path(case):


### PR DESCRIPTION
## Description

---

**Do not add the current directory to `sys.path` any longer** (ac2c4986)

Adding the current directory to `sys.path` can also mean that we're
going to load modules having the same name as stdlib modules or
astroid modules, which can break pylint.
We were doing this since 4becf6f9e596b45401680c4947e2d92c953d5e08,
but there was indication on why we were doing that.

---

**Add test for checking that files are not imported from local directory** (c8dc18eb)

Close #959
Close #2952

---

**Replace individual member imports with `os` in utils file** (50621cd5)


---

**Move _get_python_path in utils to be accessible by that file as well** (04d69fee)


---

**Pass an additional search path to modutils.modpath_from_file and friends** (814774b9)


---

**Continue adding the current working directory to sys.path with `fix_import_path`** (f80dd97a)

This behaviour was previously removed in ac2c49867077cea9d0542560590999f2ebe00276
along with the removal of `''` to not force `pylint` load local files having the
same name as stdlib or pylint dependencies.

But we need the current working directory in sys.path in order to properly solve
relative imports.
For instance, given a package `pkg` and two modules, `pkg.A` and `pkg.B`,
pylint would not be able to import a relative import `from .B import X`
because it does not know where it can look for `.B` in the first place.
Having the current working directory in sys.path means that
`astroid.modutils.file_info_from_modpath` is still able to solve relative
imports.

At the same time, having the cwd in sys.path means that we might still load
files local to this directory during pylint's initialization.
The second part of this commit is to move `fix_import_path` before doing any
AST processing. As a side effect, this removes a nasty bug with multiple jobs
linting. Because the path was previously modified before spinning up new workers,
those new workers would have had the cwd in sys.path and as a result, they would
have been "able" to load local files from the directory, such as a malitious `astroid.py`.

---

**Add more tests for loading a malicious astroid file** (8f07bf2e)





## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Close #959
Close #2952
Close #2969
