### PR TITLE
dangerous-default-value accounts for kwargs defaults. Close #3373

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in Pylint 2.5.0?
 
 Release date: TBA
 
+* Fix dangerous-default-value rule to account for keyword argument defaults
+
+  Close #3373
+
 * Add a check for cases where the second argument to `isinstance` is not a type.
 
   Close #3308

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1265,7 +1265,10 @@ class BasicChecker(_BasicChecker):
     def _check_dangerous_default(self, node):
         # check for dangerous default values as arguments
         is_iterable = lambda n: isinstance(n, (astroid.List, astroid.Set, astroid.Dict))
-        for default in node.args.defaults:
+        defaults = node.args.defaults or [] + node.args.kw_defaults or []
+        for default in defaults:
+            if not default:
+                continue
             try:
                 value = next(default.infer())
             except astroid.InferenceError:

--- a/tests/functional/d/dangerous_default_value_py30.py
+++ b/tests/functional/d/dangerous_default_value_py30.py
@@ -105,3 +105,7 @@ def function22(value=collections.UserDict()):  # [dangerous-default-value]
 def function23(value=collections.UserList()):  # [dangerous-default-value]
     """mutable, dangerous"""
     return value
+
+def function24(*, value=[]): # [dangerous-default-value]
+    """dangerous default value in kwarg."""
+    return value

--- a/tests/functional/d/dangerous_default_value_py30.txt
+++ b/tests/functional/d/dangerous_default_value_py30.txt
@@ -19,3 +19,4 @@ dangerous-default-value:93:function20:Dangerous default value OrderedDict() (col
 dangerous-default-value:97:function21:Dangerous default value defaultdict() (collections.defaultdict) as argument
 dangerous-default-value:101:function22:Dangerous default value UserDict() (collections.UserDict) as argument
 dangerous-default-value:105:function23:Dangerous default value UserList() (collections.UserList) as argument
+dangerous-default-value:109:function24:Dangerous default value [] as argument


### PR DESCRIPTION

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description
It looks like the rule wasn't accounting for kwargs defaults, I also had to add a None check to the for loop, because in cases like

```
def f(*, foo):
    pass
```
The `node.args.kw_defaults` will be `[None]`

Please, let me know if there's anything missing


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

#3373