### PR TITLE
Allow instances of tuple of the isinstance() type check

### DIFF
--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -81,6 +81,7 @@ from pylint.utils import get_global_option
 BUILTINS = builtins.__name__
 STR_FORMAT = {"%s.str.format" % BUILTINS}
 ASYNCIO_COROUTINE = "asyncio.coroutines.coroutine"
+BUILTIN_TUPLE = "builtins.tuple"
 
 
 def _unflatten(iterable):
@@ -687,6 +688,8 @@ def _is_invalid_isinstance_type(arg):
     if isinstance(inferred, astroid.Tuple):
         return any(_is_invalid_isinstance_type(elt) for elt in inferred.elts)
     if isinstance(inferred, astroid.ClassDef):
+        return False
+    if isinstance(inferred, astroid.Instance) and inferred.qname() == BUILTIN_TUPLE:
         return False
     return True
 

--- a/tests/functional/i/isinstance_second_argument.py
+++ b/tests/functional/i/isinstance_second_argument.py
@@ -1,4 +1,7 @@
-#pylint: disable=missing-docstring, undefined-variable, invalid-name, too-few-public-methods, wrong-import-position
+#pylint: disable=missing-docstring, undefined-variable, invalid-name, too-few-public-methods, wrong-import-position,import-error
+
+import collections
+from unknown import Unknown
 
 # Positive test cases
 class A:
@@ -14,12 +17,11 @@ isinstance(-9999, int)
 isinstance(True and False, bool)
 isinstance("a 'string'", type("test"))
 
-import collections
-
 isinstance(3.123213, collections.OrderedDict)
 isinstance(foo, (int, collections.Counter))
 isinstance("a string", ((int, type(False)), (float, set), str))
 isinstance(10, (int,) + (str, bool) + (dict, list, tuple))
+isinstance(10, tuple(Unknown))
 
 # Negative test cases
 isinstance({a:1}, hash) # [isinstance-second-argument-not-valid-type]

--- a/tests/functional/i/isinstance_second_argument.txt
+++ b/tests/functional/i/isinstance_second_argument.txt
@@ -1,5 +1,5 @@
-isinstance-second-argument-not-valid-type:25::Second argument of isinstance is not a type
-isinstance-second-argument-not-valid-type:26::Second argument of isinstance is not a type
 isinstance-second-argument-not-valid-type:27::Second argument of isinstance is not a type
 isinstance-second-argument-not-valid-type:28::Second argument of isinstance is not a type
 isinstance-second-argument-not-valid-type:29::Second argument of isinstance is not a type
+isinstance-second-argument-not-valid-type:30::Second argument of isinstance is not a type
+isinstance-second-argument-not-valid-type:31::Second argument of isinstance is not a type


### PR DESCRIPTION
astroid can either infer a tuple call as a `Tuple()` node on successful
inference or it can infer the call as an `Instance` of the builtin tuple
object, on unsuccessful inference.

Should address the false positives from `astroid`: https://travis-ci.org/PyCQA/astroid/jobs/653410221?utm_medium=notification&utm_source=github_status