### PR TITLE
Skip methods without arguments when generating the dot format. 

### DIFF
--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -131,7 +131,10 @@ class DotWriter(DiagramWriter):
         if not self.config.only_classnames:
             label = r"%s|%s\l|" % (label, r"\l".join(obj.attrs))
             for func in obj.methods:
-                args = [arg.name for arg in func.args.args if arg.name != "self"]
+                if func.args.args:
+                    args = [arg.name for arg in func.args.args if arg.name != "self"]
+                else:
+                    args = []
                 label = r"%s%s(%s)\l" % (label, func.name, ", ".join(args))
             label = "{%s}" % label
         if is_exception(obj.node):


### PR DESCRIPTION
Close #3351
