### PR TITLE
pyupgrade: automated removal of python2 constructs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Pylint documentation build configuration file, created by
 # sphinx-quickstart on Thu Apr  4 20:31:25 2013.

--- a/doc/exts/pylint_extensions.py
+++ b/doc/exts/pylint_extensions.py
@@ -85,7 +85,7 @@ def get_plugins_info(linter, doc_files):
         doc = ""
         doc_file = doc_files.get(module)
         if doc_file:
-            with open(doc_file, "r") as f:
+            with open(doc_file) as f:
                 doc = f.read()
         try:
             by_checker[checker]["checker"] = checker

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006-2016 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2010 Daniel Harding <dharding@gmail.com>
 # Copyright (c) 2012-2014 Google, Inc.
@@ -312,7 +311,7 @@ def _get_properties(config):
     if config is not None:
         property_classes.update(config.property_classes)
         property_names.update(
-            (prop.rsplit(".", 1)[-1] for prop in config.property_classes)
+            prop.rsplit(".", 1)[-1] for prop in config.property_classes
         )
     return property_classes, property_names
 

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006-2016 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2010 Maarten ter Huurne <maarten@treewalker.org>
 # Copyright (c) 2012-2014 Google, Inc.

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006, 2009-2010, 2012-2015 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2012, 2014 Google, Inc.
 # Copyright (c) 2014-2018 Claudiu Popa <pcmanticore@gmail.com>

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006-2011, 2013-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2011-2014 Google, Inc.
 # Copyright (c) 2012 Tim Hatch <tim@timhatch.com>
@@ -262,7 +261,7 @@ class ExceptionsChecker(checkers.BaseChecker):
 
     def open(self):
         self._builtin_exceptions = _builtin_exceptions()
-        super(ExceptionsChecker, self).open()
+        super().open()
 
     @utils.check_messages(
         "misplaced-bare-raise",

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2012-2015 Google, Inc.
 # Copyright (c) 2013 moxian <aleftmail@inbox.ru>

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006-2015 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2012-2014 Google, Inc.
 # Copyright (c) 2013 buck@yelp.com <buck@yelp.com>

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2009-2011, 2013-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2009, 2012, 2014 Google, Inc.
 # Copyright (c) 2012 Mike Bryant <leachim@leachim.info>
@@ -313,7 +312,7 @@ class LoggingChecker(checkers.BaseChecker):
                     ) = utils.parse_format_method_string(format_string)
 
                     keyword_args_cnt = len(
-                        set(k for k, l in keyword_arguments if not isinstance(k, int))
+                        {k for k, l in keyword_arguments if not isinstance(k, int)}
                     )
                     required_num_args = (
                         keyword_args_cnt + implicit_pos_args + explicit_pos_args

--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006, 2009-2013 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2012-2014 Google, Inc.
 # Copyright (c) 2014-2018 Claudiu Popa <pcmanticore@gmail.com>

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2014-2018 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2014-2015 Brett Cannon <brett@python.org>
 # Copyright (c) 2015 Simu Toni <simutoni@gmail.com>
@@ -909,14 +908,14 @@ class Python3Checker(checkers.BaseChecker):
         self._future_absolute_import = False
         self._modules_warned_about = set()
         self._branch_stack = []
-        super(Python3Checker, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     # pylint: disable=keyword-arg-before-vararg, arguments-differ
     def add_message(self, msg_id, always_warn=False, *args, **kwargs):
         if always_warn or not (
             self._branch_stack and self._branch_stack[-1].is_py2_only
         ):
-            super(Python3Checker, self).add_message(msg_id, *args, **kwargs)
+            super().add_message(msg_id, *args, **kwargs)
 
     def _is_py2_test(self, node):
         if isinstance(node.test, astroid.Attribute) and isinstance(

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016-2018 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2016-2017 Łukasz Rogalski <rogalski.91@gmail.com>
 # Copyright (c) 2016 Moises Lopez <moylop260@vauxoo.com>

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -149,8 +149,7 @@ class Similar:
         """
         for idx, lineset in enumerate(self.linesets[:-1]):
             for lineset2 in self.linesets[idx + 1 :]:
-                for sim in self._find_common(lineset, lineset2):
-                    yield sim
+                yield from self._find_common(lineset, lineset2)
 
 
 def stripped_lines(lines, ignore_comments, ignore_docstrings, ignore_imports):

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2014-2017 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2014 Michal Nowikowski <godfryd@gmail.com>
 # Copyright (c) 2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2013-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2013-2014 Google, Inc.
 # Copyright (c) 2014-2018 Claudiu Popa <pcmanticore@gmail.com>

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2009 Charles Hebert <charles.hebert@logilab.fr>
 # Copyright (c) 2010-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2010 Daniel Harding <dharding@gmail.com>
@@ -676,7 +675,7 @@ class StringConstantChecker(BaseTokenChecker):
     UNICODE_ESCAPE_CHARACTERS = "uUN"
 
     def __init__(self, *args, **kwargs):
-        super(StringConstantChecker, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.string_tokens = {}  # token position -> (token value, next token)
 
     def process_module(self, module):

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2009 James Lingard <jchl@aristanetworks.com>
 # Copyright (c) 2012-2014 Google, Inc.
@@ -87,8 +86,7 @@ BUILTIN_TUPLE = "builtins.tuple"
 def _unflatten(iterable):
     for index, elem in enumerate(iterable):
         if isinstance(elem, Sequence) and not isinstance(elem, str):
-            for single_elem in _unflatten(elem):
-                yield single_elem
+            yield from _unflatten(elem)
         elif elem and not index:
             # We're interested only in the first element.
             yield elem

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006-2007, 2009-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2009 Mads Kiilerich <mads@kiilerich.com>
 # Copyright (c) 2010 Daniel Harding <dharding@gmail.com>
@@ -539,8 +538,7 @@ def collect_string_fields(format_string) -> Iterable[Optional[str]]:
             nested = result[2]
             yield name
             if nested:
-                for field in collect_string_fields(nested):
-                    yield field
+                yield from collect_string_fields(nested)
     except ValueError as exc:
         # Probably the format string is invalid.
         if exc.args[0].startswith("cannot switch from manual"):

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2009 Mads Kiilerich <mads@kiilerich.com>
 # Copyright (c) 2010 Daniel Harding <dharding@gmail.com>

--- a/pylint/config.py
+++ b/pylint/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006-2010, 2012-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2008 pyves@crater.logilab.fr <pyves@crater.logilab.fr>
 # Copyright (c) 2010 Julien Jehannet <julien.jehannet@logilab.fr>
@@ -38,7 +37,6 @@ import configparser
 import contextlib
 import copy
 import functools
-import io
 import optparse
 import os
 import pickle
@@ -86,12 +84,12 @@ def save_results(results, base):
     try:
         with open(data_file, "wb") as stream:
             pickle.dump(results, stream)
-    except (IOError, OSError) as ex:
+    except OSError as ex:
         print("Unable to create file %s: %s" % (data_file, ex), file=sys.stderr)
 
 
 def _toml_has_config(path):
-    with open(path, "r") as toml_handle:
+    with open(path) as toml_handle:
         content = toml.load(toml_handle)
         try:
             content["tool"]["pylint"]
@@ -734,14 +732,14 @@ class OptionsManagerMixIn:
         if config_file is not None:
             config_file = os.path.expanduser(config_file)
             if not os.path.exists(config_file):
-                raise IOError("The config file {:s} doesn't exist!".format(config_file))
+                raise OSError("The config file {:s} doesn't exist!".format(config_file))
 
         use_config_file = config_file and os.path.exists(config_file)
         if use_config_file:
             parser = self.cfgfile_parser
 
             if config_file.endswith(".toml"):
-                with open(config_file, "r") as fp:
+                with open(config_file) as fp:
                     content = toml.load(fp)
 
                 try:
@@ -753,7 +751,7 @@ class OptionsManagerMixIn:
                         parser._sections[section.upper()] = values
             else:
                 # Use this encoding in order to strip the BOM marker, if any.
-                with io.open(config_file, "r", encoding="utf_8_sig") as fp:
+                with open(config_file, encoding="utf_8_sig") as fp:
                     parser.read_file(fp)
 
                 # normalize sections'title

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/pylint/epylint.py
+++ b/pylint/epylint.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8;
 # mode: python; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4
 # -*- vim:fenc=utf-8:ft=python:et:sw=4:ts=4:sts=4
 

--- a/pylint/exceptions.py
+++ b/pylint/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016-2017 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2016 Glenn Matthews <glenn@e-dad.net>
 # Copyright (c) 2017 Łukasz Rogalski <rogalski.91@gmail.com>

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016-2018 Ashley Whetter <ashley@awhetter.co.uk>
 # Copyright (c) 2016-2017 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2016 Yuri Bochkarev <baltazar.bz@gmail.com>

--- a/pylint/extensions/broad_try_clause.py
+++ b/pylint/extensions/broad_try_clause.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019 Tyler N. Thieding <python@thieding.com>
 
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
@@ -57,7 +56,7 @@ class BroadTryClauseChecker(checkers.BaseChecker):
     def visit_tryexcept(self, node):
         try_clause_statements = self._count_statements(node)
         if try_clause_statements > self.config.max_try_statements:
-            msg = "try clause contains {0} statements, expected at most {1}".format(
+            msg = "try clause contains {} statements, expected at most {}".format(
                 try_clause_statements, self.config.max_try_statements
             )
             self.add_message(

--- a/pylint/extensions/check_elif.py
+++ b/pylint/extensions/check_elif.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2015 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2016-2017 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2016 Glenn Matthews <glmatthe@cisco.com>

--- a/pylint/extensions/comparetozero.py
+++ b/pylint/extensions/comparetozero.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016 Alexander Todorov <atodorov@otb.bg>
 # Copyright (c) 2017 Claudiu Popa <pcmanticore@gmail.com>
 

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2014-2015 Bruno Daniel <bruno.daniel@blue-yonder.com>
 # Copyright (c) 2015-2017 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2016-2018 Ashley Whetter <ashley@awhetter.co.uk>

--- a/pylint/extensions/docstyle.py
+++ b/pylint/extensions/docstyle.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016-2017 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2016 Łukasz Rogalski <rogalski.91@gmail.com>
 # Copyright (c) 2016 Luis Escobar <lescobar@vauxoo.com>

--- a/pylint/extensions/emptystring.py
+++ b/pylint/extensions/emptystring.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016 Alexander Todorov <atodorov@otb.bg>
 # Copyright (c) 2017 Claudiu Popa <pcmanticore@gmail.com>
 

--- a/pylint/extensions/mccabe.py
+++ b/pylint/extensions/mccabe.py
@@ -17,13 +17,13 @@ from pylint.interfaces import HIGH, IAstroidChecker
 
 class PathGraph(Mccabe_PathGraph):
     def __init__(self, node):
-        super(PathGraph, self).__init__(name="", entity="", lineno=1)
+        super().__init__(name="", entity="", lineno=1)
         self.root = node
 
 
 class PathGraphingAstVisitor(Mccabe_PathGraphingAstVisitor):
     def __init__(self):
-        super(PathGraphingAstVisitor, self).__init__()
+        super().__init__()
         self._bottom_counter = 0
 
     def default(self, node, *args):

--- a/pylint/extensions/overlapping_exceptions.py
+++ b/pylint/extensions/overlapping_exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/pylint/extensions/redefined_variable_type.py
+++ b/pylint/extensions/redefined_variable_type.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016-2017 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2016 Glenn Matthews <glmatthe@cisco.com>
 # Copyright (c) 2018 Sushobhit <31987769+sushobhit27@users.noreply.github.com>

--- a/pylint/interfaces.py
+++ b/pylint/interfaces.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2009-2010, 2012-2013 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2013-2014 Google, Inc.
 # Copyright (c) 2014 Michal Nowikowski <godfryd@gmail.com>

--- a/pylint/lint.py
+++ b/pylint/lint.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006-2015 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2008 Fabrice Douchant <Fabrice.Douchant@logilab.fr>
 # Copyright (c) 2009 Vincent
@@ -553,7 +552,7 @@ class PyLinter(
         )
         MessagesHandlerMixIn.__init__(self)
         reporters.ReportsHandlerMixIn.__init__(self)
-        super(PyLinter, self).__init__(
+        super().__init__(
             usage=__doc__,
             version=full_version,
             config_file=pylintrc or next(config.find_default_config_files(), None),

--- a/pylint/message/__init__.py
+++ b/pylint/message/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2009 Vincent
 # Copyright (c) 2009 Mads Kiilerich <mads@kiilerich.com>

--- a/pylint/message/message.py
+++ b/pylint/message/message.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
@@ -35,8 +33,7 @@ class MessagesHandlerMixIn:
 
     def _checker_messages(self, checker):
         for known_checker in self._checkers[checker.lower()]:
-            for msgid in known_checker.msgs:
-                yield msgid
+            yield from known_checker.msgs
 
     @classmethod
     def clear_by_id_managed_msgs(cls):

--- a/pylint/message/message_id_store.py
+++ b/pylint/message/message_id_store.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/pylint/pyreverse/diadefslib.py
+++ b/pylint/pyreverse/diadefslib.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006, 2008-2010, 2013-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2014 Brett Cannon <brett@python.org>
 # Copyright (c) 2014 Arun Persaud <arun@nubati.net>

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2015-2018 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2017 Łukasz Rogalski <rogalski.91@gmail.com>
 # Copyright (c) 2018 ssolanki <sushobhitsolanki@gmail.com>

--- a/pylint/pyreverse/utils.py
+++ b/pylint/pyreverse/utils.py
@@ -32,7 +32,7 @@ def get_default_options():
         rcfile = os.path.join(home, RCFILE)
         try:
             options = open(rcfile).read().split()
-        except IOError:
+        except OSError:
             pass  # ignore if no config file found
     return options
 

--- a/pylint/pyreverse/vcgutils.py
+++ b/pylint/pyreverse/vcgutils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2015-2017 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2015 Florian Bruhin <me@the-compiler.org>
 # Copyright (c) 2018 ssolanki <sushobhitsolanki@gmail.com>

--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2008-2010, 2013-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2014 Arun Persaud <arun@nubati.net>
 # Copyright (c) 2015-2017 Claudiu Popa <pcmanticore@gmail.com>

--- a/pylint/reporters/__init__.py
+++ b/pylint/reporters/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006, 2010, 2012-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2012-2014 Google, Inc.
 # Copyright (c) 2012 FELD Boris <lothiraldan@gmail.com>

--- a/pylint/reporters/base_reporter.py
+++ b/pylint/reporters/base_reporter.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/pylint/reporters/collecting_reporter.py
+++ b/pylint/reporters/collecting_reporter.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/pylint/reporters/reports_handler_mix_in.py
+++ b/pylint/reporters/reports_handler_mix_in.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/pylint/reporters/ureports/nodes.py
+++ b/pylint/reporters/ureports/nodes.py
@@ -62,7 +62,7 @@ class BaseLayout(VNode):
     """
 
     def __init__(self, children=(), **kwargs):
-        super(BaseLayout, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         for child in children:
             if isinstance(child, VNode):
                 self.append(child)
@@ -97,7 +97,7 @@ class Text(VNode):
     """
 
     def __init__(self, data, escaped=True, **kwargs):
-        super(Text, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         # if isinstance(data, unicode):
         #    data = data.encode('ascii')
         assert isinstance(data, str), data.__class__
@@ -129,7 +129,7 @@ class Section(BaseLayout):
     """
 
     def __init__(self, title=None, description=None, **kwargs):
-        super(Section, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if description:
             self.insert(0, Paragraph([Text(description)]))
         if title:
@@ -138,7 +138,7 @@ class Section(BaseLayout):
 
 class EvaluationSection(Section):
     def __init__(self, message, **kwargs):
-        super(EvaluationSection, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         title = Paragraph()
         title.append(Text("-" * len(message)))
         self.append(title)
@@ -180,7 +180,7 @@ class Table(BaseLayout):
     """
 
     def __init__(self, cols, title=None, rheaders=0, cheaders=0, **kwargs):
-        super(Table, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         assert isinstance(cols, int)
         self.cols = cols
         self.title = title

--- a/pylint/reporters/ureports/text_writer.py
+++ b/pylint/reporters/ureports/text_writer.py
@@ -18,7 +18,7 @@ class TextWriter(BaseWriter):
     """
 
     def begin_format(self):
-        super(TextWriter, self).begin_format()
+        super().begin_format()
         self.list_level = 0
 
     def visit_section(self, layout):

--- a/pylint/testutils.py
+++ b/pylint/testutils.py
@@ -21,10 +21,10 @@
 
 """functional/non regression tests for pylint"""
 import collections
+import configparser
 import contextlib
 import csv
 import functools
-import io
 import operator
 import platform
 import re
@@ -38,8 +38,6 @@ from os.path import abspath, basename, dirname, exists, join, splitext
 
 import astroid
 import pytest
-import six
-from six.moves import configparser
 
 from pylint import checkers, interfaces
 from pylint.lint import PyLinter
@@ -161,7 +159,7 @@ class Message(
     def __eq__(self, other):
         if isinstance(other, Message):
             if self.confidence and other.confidence:
-                return super(Message, self).__eq__(other)
+                return super().__eq__(other)
             return self[:-1] == other[:-1]
         return NotImplemented  # pragma: no cover
 
@@ -483,7 +481,7 @@ def multiset_difference(left_op, right_op):
     missing = left_op.copy()
     missing.subtract(right_op)
     unexpected = {}
-    for key, value in list(six.iteritems(missing)):
+    for key, value in list(missing.items()):
         if value <= 0:
             missing.pop(key)
             if value < 0:
@@ -559,8 +557,8 @@ class LintModuleTest:
         if self._test_file.base == "invalid_encoded_data":
             return open(self._test_file.source)
         if "latin1" in self._test_file.base:
-            return io.open(self._test_file.source, encoding="latin1")
-        return io.open(self._test_file.source, encoding="utf8")
+            return open(self._test_file.source, encoding="latin1")
+        return open(self._test_file.source, encoding="utf8")
 
     def _get_expected(self):
         with self._open_source_file() as fobj:

--- a/pylint/utils/__init__.py
+++ b/pylint/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2009 Vincent
 # Copyright (c) 2009 Mads Kiilerich <mads@kiilerich.com>

--- a/pylint/utils/ast_walker.py
+++ b/pylint/utils/ast_walker.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/pylint/utils/file_state.py
+++ b/pylint/utils/file_state.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/pylint/utils/pragma_parser.py
+++ b/pylint/utils/pragma_parser.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
@@ -72,7 +70,7 @@ class PragmaParserError(Exception):
         """
         self.message = message
         self.token = token
-        super(PragmaParserError, self).__init__(self.message)
+        super().__init__(self.message)
 
 
 class UnRecognizedOptionError(PragmaParserError):

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,10 @@
 
 """Generic Setup script, takes package info from __pkginfo__.py file.
 """
-from distutils.command.build_py import build_py
 import os
-from os.path import exists, isdir, join
 import sys
+from distutils.command.build_py import build_py
+from os.path import exists, isdir, join
 
 __docformat__ = "restructuredtext en"
 
@@ -61,8 +61,8 @@ else:
     long_description = ""
 
 
-needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
-pytest_runner = ['pytest-runner'] if needs_pytest else []
+needs_pytest = {"pytest", "test", "ptr"}.intersection(sys.argv)
+pytest_runner = ["pytest-runner"] if needs_pytest else []
 
 
 def ensure_scripts(linux_scripts):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # pylint: disable=W0404,W0622,W0613
 # Copyright (c) 2006, 2009-2010, 2012-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2010 Julien Jehannet <julien.jehannet@logilab.fr>
@@ -62,7 +61,7 @@ else:
     long_description = ""
 
 
-needs_pytest = set(['pytest', 'test', 'ptr']).intersection(sys.argv)
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 

--- a/tests/extensions/test_broad_try_clause.py
+++ b/tests/extensions/test_broad_try_clause.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019 Tyler N. Thieding <python@thieding.com>
 
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html

--- a/tests/extensions/test_check_return_docs.py
+++ b/tests/extensions/test_check_return_docs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016-2017 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2016 Derek Gustafson <degustaf@gmail.com>
 # Copyright (c) 2016 Glenn Matthews <glenn@e-dad.net>

--- a/tests/extensions/test_comparetozero.py
+++ b/tests/extensions/test_comparetozero.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016 Alexander Todorov <atodorov@otb.bg>
 # Copyright (c) 2016 Łukasz Rogalski <rogalski.91@gmail.com>
 # Copyright (c) 2017 Claudiu Popa <pcmanticore@gmail.com>

--- a/tests/extensions/test_emptystring.py
+++ b/tests/extensions/test_emptystring.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016 Łukasz Rogalski <rogalski.91@gmail.com>
 # Copyright (c) 2016 Alexander Todorov <atodorov@otb.bg>
 # Copyright (c) 2017 Claudiu Popa <pcmanticore@gmail.com>

--- a/tests/message/generic_fixtures.py
+++ b/tests/message/generic_fixtures.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/tests/message/unittest_message.py
+++ b/tests/message/unittest_message.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/tests/message/unittest_message_definition.py
+++ b/tests/message/unittest_message_definition.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
@@ -46,7 +44,7 @@ class FalseChecker(BaseChecker):
     }
 
 
-class TestMessagesDefinition(object):
+class TestMessagesDefinition:
     def assert_with_fail_msg(self, msg, expected=True):
         fail_msg = "With minversion='{}' and maxversion='{}',".format(
             msg.minversion, msg.maxversion

--- a/tests/message/unittest_message_definition_store.py
+++ b/tests/message/unittest_message_definition_store.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
@@ -174,7 +172,7 @@ def test_get_msg_display_string(store):
     assert store.get_msg_display_string("E1234") == "'duplicate-keyword-arg'"
 
 
-class TestMessageDefinitionStore(object):
+class TestMessageDefinitionStore:
     def _compare_messages(self, desc, msg, checkerref=False):
         assert desc == msg.format_help(checkerref=checkerref)
 

--- a/tests/message/unittest_message_id_store.py
+++ b/tests/message/unittest_message_id_store.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -39,7 +39,7 @@ def exception_str(self, ex):  # pylint: disable=unused-argument
     return "in %s\n:: %s" % (ex.file, ", ".join(ex.args))
 
 
-class LintTestUsingModule(object):
+class LintTestUsingModule:
     INPUT_DIR = None
     DEFAULT_PACKAGE = "input"
     package = DEFAULT_PACKAGE
@@ -87,7 +87,7 @@ class LintTestUsingModule(object):
 
     def _get_expected(self):
         if self._has_output() and self.output:
-            with open(self.output, "r") as fobj:
+            with open(self.output) as fobj:
                 return fobj.read().strip() + "\n"
         else:
             return ""
@@ -101,7 +101,7 @@ class LintTestUpdate(LintTestUsingModule):
         if self._has_output():
             try:
                 expected = self._get_expected()
-            except IOError:
+            except OSError:
                 expected = ""
             if got != expected:
                 with open(self.output, "w") as fobj:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2014-2017 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2014 Google, Inc.
 # Copyright (c) 2014 Michal Nowikowski <godfryd@gmail.com>
@@ -45,8 +44,8 @@ UPDATE = False
 class LintModuleOutputUpdate(testutils.LintModuleTest):
     def _open_expected_file(self):
         try:
-            return super(LintModuleOutputUpdate, self)._open_expected_file()
-        except IOError:
+            return super()._open_expected_file()
+        except OSError:
             return io.StringIO()
 
     def _check_output_text(self, expected_messages, expected_lines, received_lines):

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2014-2018 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2014 Vlad Temian <vladtemian@gmail.com>
@@ -97,7 +96,7 @@ class MultiReporter(BaseReporter):
             rep.linter = value
 
 
-class TestRunTC(object):
+class TestRunTC:
     def _runtest(self, args, reporter=None, out=None, code=None):
         if out is None:
             out = StringIO()

--- a/tests/unittest_checker_base.py
+++ b/tests/unittest_checker_base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2013-2015 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2013-2014 Google, Inc.
 # Copyright (c) 2015-2018 Claudiu Popa <pcmanticore@gmail.com>

--- a/tests/unittest_checker_format.py
+++ b/tests/unittest_checker_format.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2009-2011, 2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2012 FELD Boris <lothiraldan@gmail.com>
 # Copyright (c) 2013-2014 Google, Inc.

--- a/tests/unittest_checker_imports.py
+++ b/tests/unittest_checker_imports.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2015-2017 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2015 Dmitry Pribysh <dmand@yandex.ru>
 # Copyright (c) 2015 Cezar <celnazli@bitdefender.com>

--- a/tests/unittest_checker_python3.py
+++ b/tests/unittest_checker_python3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2014-2018 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2014-2015 Brett Cannon <brett@python.org>
 # Copyright (c) 2015 Ionel Cristian Maries <contact@ionelmc.ro>

--- a/tests/unittest_checker_spelling.py
+++ b/tests/unittest_checker_spelling.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2014-2017 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2014 Michal Nowikowski <godfryd@gmail.com>
 # Copyright (c) 2015 Ionel Cristian Maries <contact@ionelmc.ro>

--- a/tests/unittest_checker_typecheck.py
+++ b/tests/unittest_checker_typecheck.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2014 Google, Inc.
 # Copyright (c) 2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2014 Holger Peters <email@holger-peters.de>

--- a/tests/unittest_checker_variables.py
+++ b/tests/unittest_checker_variables.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2014-2017 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2014 Google, Inc.
 # Copyright (c) 2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
@@ -126,7 +125,7 @@ class TestVariablesCheckerWithTearDown(CheckerTestCase):
     CHECKER_CLASS = variables.VariablesChecker
 
     def setup_method(self):
-        super(TestVariablesCheckerWithTearDown, self).setup_method()
+        super().setup_method()
         self._to_consume_backup = self.checker._to_consume
         self.checker._to_consume = []
 

--- a/tests/unittest_checkers_utils.py
+++ b/tests/unittest_checkers_utils.py
@@ -167,7 +167,7 @@ def test_parse_format_method_string():
     ]
     for fmt, count in samples:
         keys, num_args, pos_args = utils.parse_format_method_string(fmt)
-        keyword_args = len(set(k for k, l in keys if not isinstance(k, int)))
+        keyword_args = len({k for k, l in keys if not isinstance(k, int)})
         assert keyword_args + num_args + pos_args == count
 
 

--- a/tests/unittest_config.py
+++ b/tests/unittest_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2015 Aru Sahni <arusahni@gmail.com>
 # Copyright (c) 2016-2018 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2016 Derek Gustafson <degustaf@gmail.com>

--- a/tests/unittest_lint.py
+++ b/tests/unittest_lint.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2006-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2009 Charles Hebert <charles.hebert@logilab.fr>
 # Copyright (c) 2011-2014 Google, Inc.
@@ -297,7 +296,7 @@ def test_enable_message_category(init_linter):
 
 
 def test_message_state_scope(init_linter):
-    class FakeConfig(object):
+    class FakeConfig:
         confidence = ["HIGH"]
 
     linter = init_linter
@@ -709,7 +708,7 @@ def test_pylintrc_parentdir_no_package():
                 assert config.find_pylintrc() == expected
 
 
-class TestPreprocessOptions(object):
+class TestPreprocessOptions:
     def _callback(self, name, value):
         self.args.append((name, value))
 
@@ -744,7 +743,7 @@ class _CustomPyLinter(PyLinter):
         if os.path.basename(path) == "wrong.py":
             return False
 
-        return super(_CustomPyLinter, self).should_analyze_file(
+        return super().should_analyze_file(
             modname, path, is_argument=is_argument
         )
 

--- a/tests/unittest_pyreverse_diadefs.py
+++ b/tests/unittest_pyreverse_diadefs.py
@@ -85,7 +85,7 @@ def test_option_values(HANDLER, PROJECT):
     # or class diagrams
 
 
-class TestDefaultDiadefGenerator(object):
+class TestDefaultDiadefGenerator:
     def test_known_values1(self, HANDLER, PROJECT):
         dd = DefaultDiadefGenerator(Linker(PROJECT), HANDLER).visit(PROJECT)
         assert len(dd) == 2

--- a/tests/unittest_pyreverse_writer.py
+++ b/tests/unittest_pyreverse_writer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2008, 2010, 2013 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2014-2017 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2014 Google, Inc.
@@ -42,7 +41,7 @@ _DEFAULTS = {
 }
 
 
-class Config(object):
+class Config:
     """config object for tests"""
 
     def __init__(self):

--- a/tests/utils/unittest_ast_walker.py
+++ b/tests/utils/unittest_ast_walker.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
@@ -11,15 +9,15 @@ from pylint.checkers.utils import check_messages
 from pylint.utils import ASTWalker
 
 
-class TestASTWalker(object):
-    class MockLinter(object):
+class TestASTWalker:
+    class MockLinter:
         def __init__(self, msgs):
             self._msgs = msgs
 
         def is_message_enabled(self, msgid):
             return self._msgs.get(msgid, True)
 
-    class Checker(object):
+    class Checker:
         def __init__(self):
             self.called = set()
 
@@ -50,7 +48,7 @@ class TestASTWalker(object):
         assert {"module", "assignname"} == checker.called
 
     def test_deprecated_methods(self):
-        class Checker(object):
+        class Checker:
             def __init__(self):
                 self.called = False
 

--- a/tests/utils/unittest_utils.py
+++ b/tests/utils/unittest_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2013-2014 Google, Inc.
 # Copyright (c) 2013-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2014 Arun Persaud <arun@nubati.net>

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,8 @@ deps =
     black==19.10b0
     isort==4.3.21
 commands =
-    black --check pylint
-    isort -rc pylint/ --check-only
+    black --check pylint setup.py
+    isort -rc pylint/ setup.py --check-only
 changedir = {toxinidir}
 
 [testenv:mypy]


### PR DESCRIPTION
entirely automated using [pyupgrade](https://github.com/asottile/pyupgrade)

I used this pre-commit configuration:

```yaml
repos:
-   repo: https://github.com/asottile/pyupgrade
    rev: v2.1.0
    hooks:
    -   id: pyupgrade
        args: [--py3-plus, --keep-percent-format]
        exclude: ^tests/(extensions/data/|functional/|input/|regrtest_data/)
```

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does. (**N/A**)
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`. (**N/A**)
- [x] Write a good description on what the PR does.

## Description

(above)

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |
