### PR TITLE
[backport #3248]Fix problem with syntaxerrors in file from stdin

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,10 @@ Release data: TBA
 
   Close #3256
 
+* Handle SyntaxError in files passed via ``--from-stdin`` option
+
+  Pylint no longer outputs a traceback, if a file, read from stdin,
+  contains a syntaxerror.
 
 What's New in Pylint 2.4.4?
 ===========================

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -595,6 +595,19 @@ class TestRunTC(object):
         finally:
             os.chdir(curdir)
 
+    def test_stdin_syntaxerror(self):
+        expected_output = (
+            "************* Module a\n"
+            "a.py:1:4: E0001: invalid syntax (<unknown>, line 1) (syntax-error)"
+        )
+
+        with mock.patch("pylint.lint._read_stdin", return_value="for\n") as mock_stdin:
+            self._test_output(
+                ["--from-stdin", "a.py", "--disable=all", "--enable=syntax-error"],
+                expected_output=expected_output,
+            )
+            assert mock_stdin.call_count == 1
+
     def test_version(self):
         def check(lines):
             assert lines[0].startswith("pylint ")


### PR DESCRIPTION
This backports #3248 to the 2.4 branch. I've done this backport because it is not clear to me when 2.5 will finally be released. @cpitclaudel and me would like to merge https://github.com/flycheck/flycheck/pull/1546, but for that we need a release containing the fix of #3248.