### PR TITLE
tox| Uses -m coverage instead of path to site-packages

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ setenv =
     COVERAGE_FILE = {toxinidir}/.coverage.{envname}
 
 commands =
-    python -Wi {envsitepackagesdir}/coverage run -m pytest {toxinidir}/tests/ {posargs:}
+    python -Wignore -m coverage run -m pytest {toxinidir}/tests/ {posargs:}
 
     ; Transform absolute path to relative path
     ; for compatibility with coveralls.io and fix 'source not available' error.
@@ -74,8 +74,8 @@ deps =
     coveralls
 skip_install = true
 commands =
-    python {envsitepackagesdir}/coverage combine
-    python {envsitepackagesdir}/coverage report --rcfile={toxinidir}/.coveragerc -m
+    python -m coverage combine
+    python -m coverage report --rcfile={toxinidir}/.coveragerc -m
     - coveralls --rcfile={toxinidir}/.coveragerc
 changedir = {toxinidir}
 
@@ -86,7 +86,7 @@ deps =
     coverage<5
 skip_install = true
 commands =
-    python {envsitepackagesdir}/coverage erase
+    python -m coverage erase
 changedir = {toxinidir}
 
 [testenv:docs]


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [N/A] Add yourself to CONTRIBUTORS if you are a new contributor.
- [N/A] Add a ChangeLog entry describing what your PR does.
- [N/A] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Tox wasn't running locally without this, so we switch to using the coverage module invocation
instead of calling the site-package directly.

It's not clear why the site-package was being used directly, and if it passes on all platforms it might be worth applying.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
