### PR TITLE
Don't HTML-escape JSON messages

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,9 @@ What's New in Pylint 2.5.0?
 
 Release date: TBA
 
+* Remove HTML quoting of messages in JSON output.
+
+  Close #2769
 
 * Adjust the `invalid-name` rule to work with non-ASCII identifiers and add the `non-ascii-name` rule.
 

--- a/pylint/reporters/json_reporter.py
+++ b/pylint/reporters/json_reporter.py
@@ -7,7 +7,6 @@
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
 """JSON reporter"""
-import html
 import json
 import sys
 
@@ -37,7 +36,7 @@ class JSONReporter(BaseReporter):
                 "column": msg.column,
                 "path": msg.path,
                 "symbol": msg.symbol,
-                "message": html.escape(msg.msg or "", quote=False),
+                "message": msg.msg or "",
                 "message-id": msg.msg_id,
             }
         )

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -347,6 +347,7 @@ class TestRunTC:
             assert key in message
             assert message[key] == value
         assert "invalid syntax" in message["message"].lower()
+        assert "<unknown>" in message["message"].lower()
 
     def test_json_report_when_file_is_missing(self):
         out = StringIO()


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.

## Description

The JSON module already escapes special characters as needed, so no need to HTML-escape them.  The only thing that this could break would be code that directly interpolates error messages into HTML code.  This would be a bug of that code, arguably.

This was already reported in #2769 and partially addressed by
6b1adc668727ebfbd84763b14b65676cc11febec, but that commit still quotes angle
brackets ('<' and '>').

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #2769.
