### PR TITLE
Brought back logging-fstring-interpolation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -262,6 +262,13 @@ Release date: TBA
   Close #1482
   Close #1553
 
+* Multiple types of string formatting are allowed in logging functions.
+
+  The `logging-fstring-interpolation` message has been brought back to allow
+  multiple types of string formatting to be used.
+
+  Close #3361
+
 What's New in Pylint 2.4.4?
 ===========================
 Release date: 2019-11-13

--- a/doc/whatsnew/2.5.rst
+++ b/doc/whatsnew/2.5.rst
@@ -92,3 +92,11 @@ Other Changes
   This command lists all extensions present in ``pylint.extensions``.
 
 * Various false positives have been fixed which you can read more about in the Changelog files.
+
+* Multiple types of string formatting are allowed in logging functions.
+
+The `logging-fstring-interpolation` message has been brought back to allow
+multiple types of string formatting to be used.
+The type of formatting to use is chosen through enabling and disabling messages
+rather than through the logging-format-style option.
+The fstr value of the logging-format-style option is not valid.

--- a/tests/functional/l/logging_format_interpolation.txt
+++ b/tests/functional/l/logging_format_interpolation.txt
@@ -1,5 +1,5 @@
-logging-format-interpolation:16::Use % formatting in logging functions and pass the % parameters as arguments
-logging-format-interpolation:17::Use % formatting in logging functions and pass the % parameters as arguments
-logging-format-interpolation:18::Use % formatting in logging functions and pass the % parameters as arguments
-logging-format-interpolation:19::Use % formatting in logging functions and pass the % parameters as arguments
-logging-format-interpolation:20::Use % formatting in logging functions and pass the % parameters as arguments
+logging-format-interpolation:16::Use lazy % formatting in logging functions
+logging-format-interpolation:17::Use lazy % formatting in logging functions
+logging-format-interpolation:18::Use lazy % formatting in logging functions
+logging-format-interpolation:19::Use lazy % formatting in logging functions
+logging-format-interpolation:20::Use lazy % formatting in logging functions

--- a/tests/functional/l/logging_format_interpolation_py36.py
+++ b/tests/functional/l/logging_format_interpolation_py36.py
@@ -1,5 +1,5 @@
-"""Test logging-format-interpolation for Python 3.6"""
+"""Test logging-fstring-interpolation for Python 3.6"""
 import logging as renamed_logging
 
 
-renamed_logging.info(f'Read {renamed_logging} from globals')  # [logging-format-interpolation]
+renamed_logging.info(f'Read {renamed_logging} from globals')  # [logging-fstring-interpolation]

--- a/tests/functional/l/logging_format_interpolation_py36.txt
+++ b/tests/functional/l/logging_format_interpolation_py36.txt
@@ -1,1 +1,1 @@
-logging-format-interpolation:5::Use % formatting in logging functions and pass the % parameters as arguments
+logging-fstring-interpolation:5::Use lazy % formatting in logging functions

--- a/tests/functional/l/logging_fstring_interpolation_py36.py
+++ b/tests/functional/l/logging_fstring_interpolation_py36.py
@@ -1,4 +1,4 @@
-"""Test logging-format-interpolation for Python 3.6"""
+"""Test logging-fstring-interpolation for Python 3.6"""
 # pylint: disable=invalid-name
 
 from datetime import datetime
@@ -14,8 +14,8 @@ pi = 3.14159265
 may_14 = datetime(year=2018, month=5, day=14)
 
 # Statements that should be flagged:
-renamed_logging.debug(f'{local_var_1} {local_var_2}') # [logging-format-interpolation]
-renamed_logging.log(renamed_logging.DEBUG, f'msg: {local_var_2}') # [logging-format-interpolation]
-renamed_logging.log(renamed_logging.DEBUG, f'pi: {pi:.3f}') # [logging-format-interpolation]
-renamed_logging.info(f"{local_var_2.upper()}") # [logging-format-interpolation]
-renamed_logging.info(f"{may_14:'%b %d: %Y'}") # [logging-format-interpolation]
+renamed_logging.debug(f'{local_var_1} {local_var_2}') # [logging-fstring-interpolation]
+renamed_logging.log(renamed_logging.DEBUG, f'msg: {local_var_2}') # [logging-fstring-interpolation]
+renamed_logging.log(renamed_logging.DEBUG, f'pi: {pi:.3f}') # [logging-fstring-interpolation]
+renamed_logging.info(f"{local_var_2.upper()}") # [logging-fstring-interpolation]
+renamed_logging.info(f"{may_14:'%b %d: %Y'}") # [logging-fstring-interpolation]

--- a/tests/functional/l/logging_fstring_interpolation_py36.txt
+++ b/tests/functional/l/logging_fstring_interpolation_py36.txt
@@ -1,5 +1,5 @@
-logging-format-interpolation:17::Use % formatting in logging functions and pass the % parameters as arguments
-logging-format-interpolation:18::Use % formatting in logging functions and pass the % parameters as arguments
-logging-format-interpolation:19::Use % formatting in logging functions and pass the % parameters as arguments
-logging-format-interpolation:20::Use % formatting in logging functions and pass the % parameters as arguments
-logging-format-interpolation:21::Use % formatting in logging functions and pass the % parameters as arguments
+logging-fstring-interpolation:17::Use lazy % formatting in logging functions
+logging-fstring-interpolation:18::Use lazy % formatting in logging functions
+logging-fstring-interpolation:19::Use lazy % formatting in logging functions
+logging-fstring-interpolation:20::Use lazy % formatting in logging functions
+logging-fstring-interpolation:21::Use lazy % formatting in logging functions

--- a/tests/functional/l/logging_not_lazy.txt
+++ b/tests/functional/l/logging_not_lazy.txt
@@ -1,6 +1,6 @@
-logging-not-lazy:10::Specify string format arguments as logging function parameters
-logging-not-lazy:11::Specify string format arguments as logging function parameters
-logging-not-lazy:12::Specify string format arguments as logging function parameters
-logging-not-lazy:13::Specify string format arguments as logging function parameters
-logging-not-lazy:14::Specify string format arguments as logging function parameters
-logging-not-lazy:15::Specify string format arguments as logging function parameters
+logging-not-lazy:10::Use lazy % formatting in logging functions
+logging-not-lazy:11::Use lazy % formatting in logging functions
+logging-not-lazy:12::Use lazy % formatting in logging functions
+logging-not-lazy:13::Use lazy % formatting in logging functions
+logging-not-lazy:14::Use lazy % formatting in logging functions
+logging-not-lazy:15::Use lazy % formatting in logging functions

--- a/tests/messages/func_bug113231.txt
+++ b/tests/messages/func_bug113231.txt
@@ -1,2 +1,2 @@
-W: 20: Specify string format arguments as logging function parameters
-W: 21: Specify string format arguments as logging function parameters
+W: 20: Use lazy % formatting in logging functions
+W: 21: Use lazy % formatting in logging functions

--- a/tests/messages/func_logging_not_lazy_with_logger.txt
+++ b/tests/messages/func_logging_not_lazy_with_logger.txt
@@ -1,4 +1,4 @@
-W:  8: Specify string format arguments as logging function parameters
-W:  9: Specify string format arguments as logging function parameters
-W: 11: Specify string format arguments as logging function parameters
-W: 13: Specify string format arguments as logging function parameters
+W:  8: Use lazy % formatting in logging functions
+W:  9: Use lazy % formatting in logging functions
+W: 11: Use lazy % formatting in logging functions
+W: 13: Use lazy % formatting in logging functions

--- a/tests/unittest_checker_logging.py
+++ b/tests/unittest_checker_logging.py
@@ -30,7 +30,7 @@ class TestLoggingModuleDetection(CheckerTestCase):
         )
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
-        with self.assertAddsMessages(Message("logging-not-lazy", node=stmts[1])):
+        with self.assertAddsMessages(Message("logging-not-lazy", node=stmts[1], args=("lazy %",))):
             self.checker.visit_call(stmts[1])
 
     def test_dont_crash_on_invalid_format_string(self):
@@ -51,7 +51,7 @@ class TestLoggingModuleDetection(CheckerTestCase):
         )
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
-        with self.assertAddsMessages(Message("logging-not-lazy", node=stmts[1])):
+        with self.assertAddsMessages(Message("logging-not-lazy", node=stmts[1], args=("lazy %",))):
             self.checker.visit_call(stmts[1])
 
     @set_config(logging_modules=["logging", "my.logging"])
@@ -64,7 +64,7 @@ class TestLoggingModuleDetection(CheckerTestCase):
         )
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
-        with self.assertAddsMessages(Message("logging-not-lazy", node=stmts[1])):
+        with self.assertAddsMessages(Message("logging-not-lazy", node=stmts[1], args=("lazy %",))):
             self.checker.visit_call(stmts[1])
 
     def _assert_logging_format_no_messages(self, stmt):
@@ -140,42 +140,6 @@ class TestLoggingModuleDetection(CheckerTestCase):
     @pytest.mark.skipif(sys.version_info < (3, 6), reason="F-string require >=3.6")
     @set_config(logging_format_style="new")
     def test_fstr_not_new_format_style_matching_arguments(self):
-        msg = "logging-format-interpolation"
-        args = ("{", "")
+        msg = "logging-fstring-interpolation"
+        args = ("lazy %",)
         self._assert_logging_format_message(msg, "(f'{named}')", args)
-
-    @set_config(logging_format_style="fstr")
-    def test_modulo_not_fstr_format_style_matching_arguments(self):
-        msg = "logging-format-interpolation"
-        args = ("f-string", "")
-        with_too_many = False
-        self._assert_logging_format_message(msg, "('%s', 1)", args, with_too_many)
-        self._assert_logging_format_message(
-            msg, "('%(named)s', {'named': 1})", args, with_too_many
-        )
-        self._assert_logging_format_message(
-            msg, "('%s %(named)s', 1, {'named': 1})", args, with_too_many
-        )
-
-    @set_config(logging_format_style="fstr")
-    def test_brace_not_fstr_format_style_matching_arguments(self):
-        msg = "logging-format-interpolation"
-        args = ("f-string", "")
-        with_too_many = False
-        self._assert_logging_format_message(msg, "('{}', 1)", args, with_too_many)
-        self._assert_logging_format_message(msg, "('{0}', 1)", args, with_too_many)
-        self._assert_logging_format_message(
-            msg, "('{named}', {'named': 1})", args, with_too_many
-        )
-        self._assert_logging_format_message(
-            msg, "('{} {named}', 1, {'named': 1})", args, with_too_many
-        )
-        self._assert_logging_format_message(
-            msg, "('{0} {named}', 1, {'named': 1})", args, with_too_many
-        )
-
-    @pytest.mark.skipif(sys.version_info < (3, 6), reason="F-string require >=3.6")
-    @set_config(logging_format_style="fstr")
-    def test_fstr_format_style_matching_arguments(self):
-        self._assert_logging_format_no_messages("(f'constant string')")
-        self._assert_logging_format_no_messages("(f'{named}')")


### PR DESCRIPTION
## Steps

- [X] Add yourself to CONTRIBUTORS if you are a new contributor.
- [X] Add a ChangeLog entry describing what your PR does.
- [X] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [X] Write a good description on what the PR does.

## Description
The brings back the logging-fstring-interpolation message so that multiple types of log formatting can be used at once. To address the original issue (#2395) we need to disable `logging-fstring-interpolation` by default so that f-string formatting is allowed by default, but this currently isn't possible.

In #3361 I also noted that we should add a `logging-old-style-interpolation` message but `logging-not-lazy` takes care of that case already.

When I first implemented fstring formatting in logging functions I misunderstood what the `logging-format-style` option was for. It's actually for controlling whether you can pass a new or old style format string directly to the logging message (eg `log.info("{}", "blah")` or `log.info("%s", "blah")`), not what type of logging is valid overall. So this option needs to remain to allow the functionality to stay.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Closes #3361 