### PR TITLE
Handles failing file-delete when skipping import_graph tests

### DIFF
--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -23,7 +23,11 @@ from pylint.lint import PyLinter
 def dest():
     dest = "dependencies_graph.dot"
     yield dest
-    os.remove(dest)
+    try:
+        os.remove(dest)
+    except FileNotFoundError:
+        # file may not have been created if tests inside fixture skipped
+        pass
 
 
 def test_dependencies_graph(dest):


### PR DESCRIPTION
We skip these tests if/when we run benchmarking only

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] (n/a) Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] (n/a) Add a ChangeLog entry describing what your PR does.
- [ ] (n/a) If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Simply ignore a failure to delete a test-fixture file if it wasn't found on delete - it's likely the cause is the fact the test was skipped.

NB: we should run pylint on these test files. There is a lot of shadowed variables in this file.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
