### PR TITLE
Fix false-negative cases for trailing-comma-tuple

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -377,3 +377,5 @@ contributors:
 * Slavfox: contributor
 
 * Matthew Beckers (mattlbeck): contributor
+
+* Yang Yang: contributor

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -95,7 +95,7 @@ def _is_trailing_comma(tokens, index):
         """Get the index denoting the start of the current line"""
         for subindex, token in enumerate(reversed(tokens[:index])):
             # See Lib/tokenize.py and Lib/token.py in cpython for more info
-            if token.type in (tokenize.NEWLINE, tokenize.NL):
+            if token.type == tokenize.NEWLINE:
                 return index - subindex
         return 0
 

--- a/tests/functional/t/trailing_comma_tuple.py
+++ b/tests/functional/t/trailing_comma_tuple.py
@@ -1,5 +1,5 @@
 """Check trailing comma one element tuples."""
-# pylint: disable=bad-whitespace, missing-docstring
+# pylint: disable=bad-whitespace, missing-docstring, bad-continuation
 AAA = 1, # [trailing-comma-tuple]
 BBB = "aaaa", # [trailing-comma-tuple]
 CCC="aaa", # [trailing-comma-tuple]
@@ -36,3 +36,15 @@ def some_func(first, second):
 
 def some_other_func():
     yield 'hello',  # [trailing-comma-tuple]
+
+GGG = ["aaa"
+], # [trailing-comma-tuple]
+
+HHH = ["aaa"
+]
+
+III = some_func(0,
+    0), # [trailing-comma-tuple]
+
+JJJ = some_func(0,
+    0)

--- a/tests/functional/t/trailing_comma_tuple.txt
+++ b/tests/functional/t/trailing_comma_tuple.txt
@@ -5,3 +5,5 @@ trailing-comma-tuple:6::Disallow trailing comma tuple
 trailing-comma-tuple:31::Disallow trailing comma tuple
 trailing-comma-tuple:34::Disallow trailing comma tuple
 trailing-comma-tuple:38::Disallow trailing comma tuple
+trailing-comma-tuple:41::Disallow trailing comma tuple
+trailing-comma-tuple:47::Disallow trailing comma tuple


### PR DESCRIPTION


<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

This change addresses #2007.

The current logic for detecting trailing-comma-tuple violations fails to detect positive cases that span multiple lines because its look-back mechanism stops at the last NL or NEWLINE token when it should in fact stop at the last NEWLINE token only.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #2007 
