### PR TITLE
Enforce linting and auto-formatting in pylint's own tests

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,5 +3,5 @@ multi_line_output=3
 line_length=88
 known_third_party=astroid, sphinx, isort, pytest, mccabe, six,
 include_trailing_comma=True
-skip_glob=tests/functional/**,tests/input/**,tests/extensions/data/**,tests/regrtest_data/**,tests/data/**
+skip_glob=tests/functional/**,tests/input/**,tests/extensions/data/**,tests/regrtest_data/**,tests/data/**,astroid/**,venv/**
 project=pylint

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -35,5 +35,4 @@ disable=
     wildcard-import,
     singleton-comparison,
     fixme,
-    pointless-string-statement,
     super-init-not-called,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -21,7 +21,6 @@ disable=
     abstract-method,
     function-redefined,
     unused-import,
-    unnecessary-pass,
     too-many-public-methods,
     unused-argument,
     unused-wildcard-import,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -24,7 +24,6 @@ disable=
     too-many-public-methods,
     unused-argument,
     undefined-loop-variable,
-    unused-variable,
     no-member,
     missing-type-doc,
     bare-except,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -1,0 +1,40 @@
+# The idea is to use this file and remove disabled rule until we're able to merge with the pylintrc used for pylint
+# itself once the change required to fix are small enough
+
+[master]
+ignore=functional,input,data,regrtest_data
+
+[MESSAGES CONTROL]
+disable=
+    attribute-defined-outside-init,
+    duplicate-code,
+    invalid-name,
+    missing-docstring,
+    protected-access,
+    too-few-public-methods,
+    # handled by black
+    format,
+    redefined-outer-name,
+    misplaced-comparison-constant,
+    import-outside-toplevel,
+    no-self-use,
+    abstract-method,
+    function-redefined,
+    unused-import,
+    unnecessary-pass,
+    too-many-public-methods,
+    unused-argument,
+    unused-wildcard-import,
+    undefined-loop-variable,
+    unused-variable,
+    no-member,
+    missing-type-doc,
+    bare-except,
+    too-many-ancestors,
+    implicit-str-concat,
+    wildcard-import,
+    singleton-comparison,
+    pointless-statement,
+    fixme,
+    pointless-string-statement,
+    super-init-not-called,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -23,7 +23,6 @@ disable=
     unused-import,
     too-many-public-methods,
     unused-argument,
-    unused-wildcard-import,
     undefined-loop-variable,
     unused-variable,
     no-member,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -34,7 +34,6 @@ disable=
     implicit-str-concat,
     wildcard-import,
     singleton-comparison,
-    pointless-statement,
     fixme,
     pointless-string-statement,
     super-init-not-called,

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -1830,7 +1830,7 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a property having missing return documentation in
         a Sphinx style docstring
         """
-        property_node, node = astroid.extract_node(
+        _, node = astroid.extract_node(
             """
         class Foo(object):
             @property
@@ -1872,7 +1872,7 @@ class TestParamDocChecker(CheckerTestCase):
         """Example of a property having return documentation in
         a Google style docstring
         """
-        property_node, node = astroid.extract_node(
+        _, node = astroid.extract_node(
             """
         class Foo(object):
             @property

--- a/tests/extensions/test_check_raise_docs.py
+++ b/tests/extensions/test_check_raise_docs.py
@@ -561,7 +561,6 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         with self.assertNoMessages():
             self.checker.visit_raise(raise_node)
-        pass
 
     def test_find_numpy_attr_raises_substr_exc(self):
         raise_node = astroid.extract_node(

--- a/tests/message/unittest_message_definition.py
+++ b/tests/message/unittest_message_definition.py
@@ -20,8 +20,8 @@ from pylint.message import MessageDefinition
     ],
 )
 def test_create_invalid_message_type(msgid, expected):
-    checker_mock = mock.Mock(name='Checker')
-    checker_mock.name = 'checker'
+    checker_mock = mock.Mock(name="Checker")
+    checker_mock.name = "checker"
 
     with pytest.raises(InvalidMessageError) as invalid_message_error:
         MessageDefinition.check_msgid(msgid)

--- a/tests/message/unittest_message_definition_store.py
+++ b/tests/message/unittest_message_definition_store.py
@@ -140,7 +140,7 @@ def test_register_error_new_id_duplicate_of_new(empty_store):
     empty_store.register_messages_from_checker(CheckerOne())
     test_register_error(
         empty_store,
-        {"W1234": ("message two", "msg-symbol-two", "another msg description.")},
+        CheckerTwo.msgs,
         "Message id 'W1234' cannot have both 'msg-symbol-one' and 'msg-symbol-two' as symbolic name.",
     )
 

--- a/tests/message/unittest_message_id_store.py
+++ b/tests/message/unittest_message_id_store.py
@@ -43,7 +43,7 @@ def test_get_message_ids_not_existing(empty_msgid_store):
 
 def test_register_message_definitions(empty_msgid_store, message_definitions):
     number_of_msgid = len(message_definitions)
-    for i, message_definition in enumerate(message_definitions):
+    for message_definition in message_definitions:
         empty_msgid_store.register_message_definition(message_definition)
         if message_definition.old_names:
             number_of_msgid += len(message_definition.old_names)
@@ -64,9 +64,9 @@ def test_add_msgid_and_symbol(empty_msgid_store):
     assert empty_msgid_store.get_symbol("E1235") == "new-sckiil"
     assert empty_msgid_store.get_msgid("old-sckiil") == "C1235"
     assert empty_msgid_store.get_msgid("new-sckiil") == "E1235"
-    with pytest.raises(KeyError) as e:
+    with pytest.raises(KeyError):
         empty_msgid_store.get_symbol("C1234")
-    with pytest.raises(KeyError) as e:
+    with pytest.raises(KeyError):
         empty_msgid_store.get_msgid("not-exist")
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,8 @@
 import unittest.mock
 
-import pylint.lint
 import pytest
+
+import pylint.lint
 
 
 def test_can_read_toml(tmp_path):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -64,7 +64,7 @@ class LintModuleOutputUpdate(testutils.LintModuleTest):
 def get_tests():
     input_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "functional")
     suite = []
-    for dirpath, dirnames, filenames in os.walk(input_dir):
+    for dirpath, _, filenames in os.walk(input_dir):
         if dirpath.endswith("__pycache__"):
             continue
         for filename in filenames:

--- a/tests/test_pragma_parser.py
+++ b/tests/test_pragma_parser.py
@@ -46,49 +46,39 @@ def test_missing_assignment():
     comment = "#pylint: disable missing-docstring"
     match = OPTION_PO.search(comment)
     with pytest.raises(InvalidPragmaError):
-        for pragma_repr in parse_pragma(match.group(2)):
-            pass
+        list(parse_pragma(match.group(2)))
 
 
 def test_missing_keyword():
     comment = "#pylint: = missing-docstring"
     match = OPTION_PO.search(comment)
     with pytest.raises(InvalidPragmaError):
-        for pragma_repr in parse_pragma(match.group(2)):
-            pass
+        list(parse_pragma(match.group(2)))
 
 
 def test_unsupported_assignment():
     comment = "#pylint: disable-all = missing-docstring"
     match = OPTION_PO.search(comment)
     with pytest.raises(UnRecognizedOptionError):
-        for pragma_repr in parse_pragma(match.group(2)):
-            pass
+        list(parse_pragma(match.group(2)))
 
 
 def test_unknown_keyword_with_messages():
     comment = "#pylint: unknown-keyword = missing-docstring"
     match = OPTION_PO.search(comment)
     with pytest.raises(UnRecognizedOptionError):
-        for pragma_repr in parse_pragma(match.group(2)):
-            pass
+        list(parse_pragma(match.group(2)))
 
 
 def test_unknown_keyword_without_messages():
     comment = "#pylint: unknown-keyword"
     match = OPTION_PO.search(comment)
     with pytest.raises(UnRecognizedOptionError):
-        for pragma_repr in parse_pragma(match.group(2)):
-            pass
+        list(parse_pragma(match.group(2)))
 
 
 def test_missing_message():
     comment = "#pylint: disable = "
     match = OPTION_PO.search(comment)
     with pytest.raises(InvalidPragmaError):
-        for pragma_repr in parse_pragma(match.group(2)):
-            pass
-
-
-if __name__ == "__main__":
-    test_missing_message()
+        list(parse_pragma(match.group(2)))

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -22,11 +22,13 @@
 import configparser
 import contextlib
 import json
+import os
 import platform
 import re
 import subprocess
-import tempfile
+import sys
 import textwrap
+import warnings
 from io import StringIO
 from os.path import abspath, dirname, join
 from unittest import mock
@@ -36,7 +38,8 @@ import pytest
 from pylint.constants import MAIN_CHECKER_NAME
 from pylint.lint import Run
 from pylint.reporters import JSONReporter
-from pylint.reporters.text import *
+from pylint.reporters.text import BaseReporter, ColorizedTextReporter, TextReporter
+from pylint.utils import utils
 
 HERE = abspath(dirname(__file__))
 CLEAN_PATH = re.escape(dirname(dirname(__file__)) + "/")

--- a/tests/unittest_checker_format.py
+++ b/tests/unittest_checker_format.py
@@ -28,7 +28,7 @@ import tokenize
 import astroid
 
 from pylint import lint, reporters
-from pylint.checkers.format import *
+from pylint.checkers.format import FormatChecker
 from pylint.testutils import CheckerTestCase, Message, _tokenize_str, set_config
 
 

--- a/tests/unittest_lint.py
+++ b/tests/unittest_lint.py
@@ -743,9 +743,7 @@ class _CustomPyLinter(PyLinter):
         if os.path.basename(path) == "wrong.py":
             return False
 
-        return super().should_analyze_file(
-            modname, path, is_argument=is_argument
-        )
+        return super().should_analyze_file(modname, path, is_argument=is_argument)
 
 
 def test_custom_should_analyze_file():

--- a/tests/unittest_pyreverse_diadefs.py
+++ b/tests/unittest_pyreverse_diadefs.py
@@ -79,10 +79,11 @@ def test_option_values(HANDLER, PROJECT):
         assert (2, 1) == hndl._get_levels()
         assert False == hndl.module_names
 
-    # def test_default_values():
-    """test efault values for package or class diagrams"""
-    # TODO : should test difference between default values for package
-    # or class diagrams
+
+def test_default_values():
+    """test default values for package or class diagrams"""
+    pass
+    # TODO : should test difference between default values for package or class diagrams
 
 
 class TestDefaultDiadefGenerator:

--- a/tests/unittest_pyreverse_diadefs.py
+++ b/tests/unittest_pyreverse_diadefs.py
@@ -82,7 +82,6 @@ def test_option_values(HANDLER, PROJECT):
 
 def test_default_values():
     """test default values for package or class diagrams"""
-    pass
     # TODO : should test difference between default values for package or class diagrams
 
 

--- a/tests/unittest_pyreverse_diadefs.py
+++ b/tests/unittest_pyreverse_diadefs.py
@@ -19,7 +19,12 @@ from pathlib import Path
 import astroid
 import pytest
 
-from pylint.pyreverse.diadefslib import *
+from pylint.pyreverse.diadefslib import (
+    ClassDiadefGenerator,
+    DefaultDiadefGenerator,
+    DiaDefGenerator,
+    DiadefsHandler,
+)
 from pylint.pyreverse.inspector import Linker
 from unittest_pyreverse_writer import Config, get_project
 

--- a/tests/unittest_reporting.py
+++ b/tests/unittest_reporting.py
@@ -77,5 +77,6 @@ def test_display_results_is_renamed():
             return None
 
     reporter = CustomReporter()
-    with pytest.raises(AttributeError):
-        reporter.display_results
+    with pytest.raises(AttributeError) as exc:
+        reporter.display_results()
+    assert "no attribute 'display_results'" in str(exc)

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     black==19.10b0
     isort==4.3.21
 commands =
-    black --check pylint setup.py
+    black --check . --exclude="tests/functional/|tests/input|tests/extensions/data|tests/regrtest_data/|tests/data/|venv|astroid|.tox"
     isort -rc pylint/ setup.py --check-only
 changedir = {toxinidir}
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,24 @@ deps =
    git+https://github.com/pycqa/astroid@master
    isort
    pytest
-
-commands = pylint -rn --rcfile={toxinidir}/pylintrc --load-plugins=pylint.extensions.docparams, pylint.extensions.mccabe {envsitepackagesdir}/pylint
-
+commands =
+    pylint -rn --rcfile={toxinidir}/pylintrc --load-plugins=pylint.extensions.docparams, pylint.extensions.mccabe {envsitepackagesdir}/pylint
+    # This would be greatly simplified by a solution for https://github.com/PyCQA/pylint/issues/352
+    pylint -rn --rcfile={toxinidir}/tests/.test_pylintrc --load-plugins=pylint.extensions.docparams, pylint.extensions.mccabe \
+    {toxinidir}/tests/message/ {toxinidir}/tests/extensions/ {toxinidir}/tests/utils/ {toxinidir}/tests/acceptance/ {toxinidir}/tests/conftest.py \
+    {toxinidir}/tests/test_config.py {toxinidir}/tests/test_func.py {toxinidir}/tests/test_functional.py \
+    {toxinidir}/tests/test_import_graph.py {toxinidir}/tests/test_pragma_parser.py {toxinidir}/tests/test_pylint_runners.py \
+    {toxinidir}/tests/test_regr.py {toxinidir}/tests/test_self.py {toxinidir}/tests/unittest_checker_base.py \
+    {toxinidir}/tests/unittest_checker_classes.py {toxinidir}/tests/unittest_checker_exceptions.py \
+    {toxinidir}/tests/unittest_checker_format.py {toxinidir}/tests/unittest_checker_imports.py \
+    {toxinidir}/tests/unittest_checker_logging.py {toxinidir}/tests/unittest_checker_misc.py \
+    {toxinidir}/tests/unittest_checker_python3.py {toxinidir}/tests/unittest_checker_similar.py \
+    {toxinidir}/tests/unittest_checker_spelling.py {toxinidir}/tests/unittest_checker_stdlib.py \
+    {toxinidir}/tests/unittest_checker_strings.py {toxinidir}/tests/unittest_checkers_utils.py \
+    {toxinidir}/tests/unittest_checker_typecheck.py {toxinidir}/tests/unittest_checker_variables.py \
+    {toxinidir}/tests/unittest_config.py {toxinidir}/tests/unittest_lint.py {toxinidir}/tests/unittest_pyreverse_diadefs.py \
+    {toxinidir}/tests/unittest_pyreverse_inspector.py {toxinidir}/tests/unittest_pyreverse_writer.py \
+    {toxinidir}/tests/unittest_reporters_json.py {toxinidir}/tests/unittest_reporting.py
 
 [testenv:formatting]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     isort==4.3.21
 commands =
     black --check . --exclude="tests/functional/|tests/input|tests/extensions/data|tests/regrtest_data/|tests/data/|venv|astroid|.tox"
-    isort -rc pylint/ setup.py --check-only
+    isort -rc . --check-only
 changedir = {toxinidir}
 
 [testenv:mypy]


### PR DESCRIPTION
## Description

Permit to lint pylint's own test, and fix some of the old problem found. It was not done previousely or at least not enforced in CI. There is a lot of work to get up to speed by removing old issue. In order to not have to do everything at once we created a new pylintrc file specific for tests so this can be done progressively. 

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |

## Related Issue

Discussed in #3479 with @doublethefish . There is a lot of `redefined-outer-name` in the tests.
