### PR TITLE
Fix old pylint issue in pylint's own tests files

### DIFF
--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -24,7 +24,6 @@ disable=
     unused-argument,
     undefined-loop-variable,
     no-member,
-    missing-type-doc,
     bare-except,
     too-many-ancestors,
     wildcard-import,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -15,7 +15,6 @@ disable=
     # handled by black
     format,
     redefined-outer-name,
-    misplaced-comparison-constant,
     import-outside-toplevel,
     no-self-use,
     abstract-method,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -25,4 +25,3 @@ disable=
     too-many-ancestors,
     singleton-comparison,
     fixme,
-    super-init-not-called,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -15,7 +15,6 @@ disable=
     # handled by black
     format,
     redefined-outer-name,
-    import-outside-toplevel,
     abstract-method,
     function-redefined,
     unused-import,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -15,7 +15,6 @@ disable=
     # handled by black
     format,
     redefined-outer-name,
-    abstract-method,
     function-redefined,
     undefined-loop-variable,
     fixme,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -17,7 +17,6 @@ disable=
     redefined-outer-name,
     abstract-method,
     function-redefined,
-    too-many-public-methods,
     unused-argument,
     undefined-loop-variable,
     too-many-ancestors,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -18,5 +18,4 @@ disable=
     abstract-method,
     function-redefined,
     undefined-loop-variable,
-    too-many-ancestors,
     fixme,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -23,7 +23,6 @@ disable=
     unused-argument,
     undefined-loop-variable,
     no-member,
-    bare-except,
     too-many-ancestors,
     singleton-comparison,
     fixme,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -17,7 +17,6 @@ disable=
     redefined-outer-name,
     abstract-method,
     function-redefined,
-    unused-import,
     too-many-public-methods,
     unused-argument,
     undefined-loop-variable,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -16,7 +16,6 @@ disable=
     format,
     redefined-outer-name,
     import-outside-toplevel,
-    no-self-use,
     abstract-method,
     function-redefined,
     unused-import,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -23,5 +23,4 @@ disable=
     unused-argument,
     undefined-loop-variable,
     too-many-ancestors,
-    singleton-comparison,
     fixme,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -22,7 +22,6 @@ disable=
     too-many-public-methods,
     unused-argument,
     undefined-loop-variable,
-    no-member,
     too-many-ancestors,
     singleton-comparison,
     fixme,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -15,6 +15,5 @@ disable=
     # handled by black
     format,
     redefined-outer-name,
-    function-redefined,
     undefined-loop-variable,
     fixme,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -25,7 +25,6 @@ disable=
     no-member,
     bare-except,
     too-many-ancestors,
-    wildcard-import,
     singleton-comparison,
     fixme,
     super-init-not-called,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -28,7 +28,6 @@ disable=
     missing-type-doc,
     bare-except,
     too-many-ancestors,
-    implicit-str-concat,
     wildcard-import,
     singleton-comparison,
     fixme,

--- a/tests/.test_pylintrc
+++ b/tests/.test_pylintrc
@@ -17,7 +17,6 @@ disable=
     redefined-outer-name,
     abstract-method,
     function-redefined,
-    unused-argument,
     undefined-loop-variable,
     too-many-ancestors,
     fixme,

--- a/tests/extensions/test_bad_builtin.py
+++ b/tests/extensions/test_bad_builtin.py
@@ -21,12 +21,12 @@ EXPECTED = [
 
 
 @pytest.fixture(scope="module")
-def checker(checker):
+def checker():
     return BadBuiltinChecker
 
 
 @pytest.fixture(scope="module")
-def disable(disable):
+def disable():
     return ["I"]
 
 

--- a/tests/extensions/test_broad_try_clause.py
+++ b/tests/extensions/test_broad_try_clause.py
@@ -22,6 +22,9 @@ class BroadTryClauseTestReporter(BaseReporter):
     def on_set_current_module(self, module, filepath):
         self.messages = []
 
+    def _display(self, layout):
+        pass
+
 
 class BroadTryClauseTC(unittest.TestCase):
     @classmethod

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -2113,7 +2113,7 @@ class TestParamDocChecker(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
-    def test_ignores_return_in_abstract_method_google(self):
+    def test_ignores_return_in_abstract_method_google_2(self):
         """Example of a method documenting the return type that an
         implementation should return.
         """
@@ -2132,7 +2132,7 @@ class TestParamDocChecker(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
-    def test_ignores_return_in_abstract_method_numpy(self):
+    def test_ignores_return_in_abstract_method_numpy_2(self):
         """Example of a method documenting the return type that an
         implementation should return.
         """

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -1609,7 +1609,7 @@ class TestParamDocChecker(CheckerTestCase):
 
             @foo.setter
             def foo(self, value):
-                raises AttributeError() #@
+                raise AttributeError() #@
         """
         )
         with self.assertAddsMessages(
@@ -1645,7 +1645,7 @@ class TestParamDocChecker(CheckerTestCase):
 
             @foo.setter
             def foo(self, value):
-                raises AttributeError() #@
+                raise AttributeError() #@
         """
         )
         with self.assertAddsMessages(

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -1690,7 +1690,7 @@ class TestParamDocChecker(CheckerTestCase):
         ):
             self.checker.visit_raise(node)
 
-    def test_finds_missing_raises_from_setter_google(self):
+    def test_finds_missing_raises_from_setter_google_2(self):
         """Example of a setter having missing raises documentation in
         its own Google style docstring of the property
         """
@@ -1726,7 +1726,7 @@ class TestParamDocChecker(CheckerTestCase):
         ):
             self.checker.visit_raise(node)
 
-    def test_finds_missing_raises_from_setter_numpy(self):
+    def test_finds_missing_raises_from_setter_numpy_2(self):
         """Example of a setter having missing raises documentation in
         its own Numpy style docstring of the property
         """

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -16,6 +16,9 @@
 """Unit tests for the pylint checkers in :mod:`pylint.extensions.check_docs`,
 in particular the parameter documentation checker `DocstringChecker`
 """
+
+# pylint: disable=too-many-public-methods
+
 import astroid
 import pytest
 

--- a/tests/extensions/test_check_mccabe.py
+++ b/tests/extensions/test_check_mccabe.py
@@ -5,8 +5,7 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
-"""Tests for the pylint checker in :mod:`pylint.extensions.check_mccabe
-"""
+"""Tests for the pylint checker in :mod:`pylint.extensions.check_mccabe"""
 
 import os.path as osp
 
@@ -33,17 +32,17 @@ EXPECTED_MSGS = [
 
 
 @pytest.fixture(scope="module")
-def enable(enable):
+def enable():
     return ["too-complex"]
 
 
 @pytest.fixture(scope="module")
-def disable(disable):
+def disable():
     return ["all"]
 
 
 @pytest.fixture(scope="module")
-def register(register):
+def register():
     return mccabe.register
 
 

--- a/tests/extensions/test_check_raise_docs.py
+++ b/tests/extensions/test_check_raise_docs.py
@@ -10,6 +10,9 @@
 """Unit tests for the raised exception documentation checking in the
 `DocstringChecker` in :mod:`pylint.extensions.check_docs`
 """
+
+# pylint: disable=too-many-public-methods
+
 import astroid
 
 from pylint.extensions.docparams import DocstringParameterChecker

--- a/tests/extensions/test_check_return_docs.py
+++ b/tests/extensions/test_check_return_docs.py
@@ -11,6 +11,9 @@
 """Unit tests for the return documentation checking in the
 `DocstringChecker` in :mod:`pylint.extensions.check_docs`
 """
+
+# pylint: disable=too-many-public-methods
+
 import astroid
 
 from pylint.extensions.docparams import DocstringParameterChecker

--- a/tests/extensions/test_check_yields_docs.py
+++ b/tests/extensions/test_check_yields_docs.py
@@ -9,6 +9,9 @@
 """Unit tests for the yield documentation checking in the
 `DocstringChecker` in :mod:`pylint.extensions.check_docs`
 """
+
+# pylint: disable=too-many-public-methods
+
 import astroid
 
 from pylint.extensions.docparams import DocstringParameterChecker

--- a/tests/extensions/test_comparetozero.py
+++ b/tests/extensions/test_comparetozero.py
@@ -24,6 +24,9 @@ class CompareToZeroTestReporter(BaseReporter):
     def on_set_current_module(self, module, filepath):
         self.messages = []
 
+    def _display(self, layout):
+        pass
+
 
 class CompareToZeroUsedTC(unittest.TestCase):
     @classmethod

--- a/tests/extensions/test_comparetozero.py
+++ b/tests/extensions/test_comparetozero.py
@@ -9,7 +9,6 @@
 """
 
 import os
-import os.path as osp
 import unittest
 
 from pylint import checkers
@@ -36,8 +35,8 @@ class CompareToZeroUsedTC(unittest.TestCase):
         cls._linter.disable("I")
 
     def test_comparetozero_message(self):
-        elif_test = osp.join(
-            osp.dirname(osp.abspath(__file__)), "data", "compare_to_zero.py"
+        elif_test = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "data", "compare_to_zero.py"
         )
         self._linter.check([elif_test])
         msgs = self._linter.reporter.messages

--- a/tests/extensions/test_docstyle.py
+++ b/tests/extensions/test_docstyle.py
@@ -36,7 +36,7 @@ EXPECTED_SYMBOLS = [
 
 
 @pytest.fixture(scope="module")
-def checker(checker):
+def checker():
     return DocStringStyleChecker
 
 

--- a/tests/extensions/test_elseif_used.py
+++ b/tests/extensions/test_elseif_used.py
@@ -16,7 +16,7 @@ from pylint.extensions.check_elif import ElseifUsedChecker
 
 
 @pytest.fixture(scope="module")
-def checker(checker):
+def checker():
     return ElseifUsedChecker
 
 

--- a/tests/extensions/test_emptystring.py
+++ b/tests/extensions/test_emptystring.py
@@ -17,12 +17,12 @@ from pylint.extensions.emptystring import CompareToEmptyStringChecker
 
 
 @pytest.fixture(scope="module")
-def checker(checker):
+def checker():
     return CompareToEmptyStringChecker
 
 
 @pytest.fixture(scope="module")
-def disable(disable):
+def disable():
     return ["I"]
 
 

--- a/tests/extensions/test_overlapping_exceptions.py
+++ b/tests/extensions/test_overlapping_exceptions.py
@@ -12,12 +12,12 @@ from pylint.extensions.overlapping_exceptions import OverlappingExceptionsChecke
 
 
 @pytest.fixture(scope="module")
-def checker(checker):
+def checker():
     return OverlappingExceptionsChecker
 
 
 @pytest.fixture(scope="module")
-def disable(disable):
+def disable():
     return ["I"]
 
 

--- a/tests/extensions/test_redefined.py
+++ b/tests/extensions/test_redefined.py
@@ -4,8 +4,7 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
-"""Tests for the pylint checker in :mod:`pylint.extensions.check_elif
-"""
+"""Tests for the pylint checker in :mod:`pylint.extensions.check_elif"""
 
 import os.path as osp
 
@@ -29,12 +28,12 @@ EXPECTED = [
 
 
 @pytest.fixture(scope="module")
-def checker(checker):
+def checker():
     return MultipleTypesChecker
 
 
 @pytest.fixture(scope="module")
-def disable(disable):
+def disable():
     return ["I"]
 
 

--- a/tests/message/conftest.py
+++ b/tests/message/conftest.py
@@ -1,5 +1,7 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+# pylint: disable=redefined-outer-name
+
 
 import pytest
 
@@ -24,7 +26,7 @@ def empty_store():
 
 @pytest.fixture
 def store():
-    store = MessageDefinitionStore()
+    store_ = MessageDefinitionStore()
 
     class Checker(BaseChecker):
         name = "achecker"
@@ -43,8 +45,8 @@ def store():
             ),
         }
 
-    store.register_messages_from_checker(Checker())
-    return store
+    store_.register_messages_from_checker(Checker())
+    return store_
 
 
 @pytest.fixture

--- a/tests/message/unittest_message.py
+++ b/tests/message/unittest_message.py
@@ -3,7 +3,10 @@
 
 from pylint.message import Message
 
-from .generic_fixtures import message_definitions, store
+from .generic_fixtures import (  # pylint: disable=unused-import
+    message_definitions,
+    store,
+)
 
 
 def test_new_message(message_definitions):

--- a/tests/message/unittest_message.py
+++ b/tests/message/unittest_message.py
@@ -3,11 +3,6 @@
 
 from pylint.message import Message
 
-from .generic_fixtures import (  # pylint: disable=unused-import
-    message_definitions,
-    store,
-)
-
 
 def test_new_message(message_definitions):
     def build_message(message_definition, location_value):

--- a/tests/message/unittest_message_definition.py
+++ b/tests/message/unittest_message_definition.py
@@ -45,7 +45,8 @@ class FalseChecker(BaseChecker):
 
 
 class TestMessagesDefinition:
-    def assert_with_fail_msg(self, msg, expected=True):
+    @staticmethod
+    def assert_with_fail_msg(msg, expected=True):
         fail_msg = "With minversion='{}' and maxversion='{}',".format(
             msg.minversion, msg.maxversion
         )
@@ -56,7 +57,8 @@ class TestMessagesDefinition:
         else:
             assert not msg.may_be_emitted(), fail_msg.format(" not ")
 
-    def get_message_definition(self):
+    @staticmethod
+    def get_message_definition():
         args = [
             FalseChecker(),
             "W1234",

--- a/tests/message/unittest_message_definition_store.py
+++ b/tests/message/unittest_message_definition_store.py
@@ -172,21 +172,23 @@ def test_get_msg_display_string(store):
     assert store.get_msg_display_string("E1234") == "'duplicate-keyword-arg'"
 
 
-class TestMessageDefinitionStore:
-    def _compare_messages(self, desc, msg, checkerref=False):
-        assert desc == msg.format_help(checkerref=checkerref)
+def test_check_message_id(store):
+    w1234 = store.get_message_definitions("W1234")[0]
+    w0001 = store.get_message_definitions("W0001")[0]
+    e1234 = store.get_message_definitions("E1234")[0]
+    old_symbol = store.get_message_definitions("old-symbol")[0]
+    assert isinstance(w1234, MessageDefinition)
+    assert isinstance(e1234, MessageDefinition)
+    assert w1234 == w0001
+    assert w1234 == old_symbol
+    with pytest.raises(UnknownMessageError):
+        store.get_message_definitions("YB12")
 
-    def test_check_message_id(self, store):
-        w1234 = store.get_message_definitions("W1234")[0]
-        w0001 = store.get_message_definitions("W0001")[0]
-        e1234 = store.get_message_definitions("E1234")[0]
-        old_symbol = store.get_message_definitions("old-symbol")[0]
-        assert isinstance(w1234, MessageDefinition)
-        assert isinstance(e1234, MessageDefinition)
-        assert w1234 == w0001
-        assert w1234 == old_symbol
-        with pytest.raises(UnknownMessageError):
-            store.get_message_definitions("YB12")
+
+class TestMessageDefinitionStore:
+    @staticmethod
+    def _compare_messages(desc, msg, checkerref=False):
+        assert desc == msg.format_help(checkerref=checkerref)
 
     def test_message_help(self, store):
         message_definition = store.get_message_definitions("W1234")[0]
@@ -222,16 +224,18 @@ class TestMessageDefinitionStore:
             checkerref=False,
         )
 
-    def test_list_messages(self, store):
-        output = StringIO()
-        with redirect_stdout(output):
-            store.list_messages()
-        # cursory examination of the output: we're mostly testing it completes
-        assert ":msg-symbol (W1234): *message*" in output.getvalue()
 
-    def test_renamed_message_register(self, store):
-        assert store.get_message_definitions("W0001")[0].symbol == "msg-symbol"
-        assert store.get_message_definitions("old-symbol")[0].symbol == "msg-symbol"
+def test_list_messages(store):
+    output = StringIO()
+    with redirect_stdout(output):
+        store.list_messages()
+    # cursory examination of the output: we're mostly testing it completes
+    assert ":msg-symbol (W1234): *message*" in output.getvalue()
+
+
+def test_renamed_message_register(store):
+    assert store.get_message_definitions("W0001")[0].symbol == "msg-symbol"
+    assert store.get_message_definitions("old-symbol")[0].symbol == "msg-symbol"
 
 
 def test_multiple_child_of_old_name(store):

--- a/tests/message/unittest_message_definition_store.py
+++ b/tests/message/unittest_message_definition_store.py
@@ -10,8 +10,6 @@ from pylint.checkers import BaseChecker
 from pylint.exceptions import InvalidMessageError, UnknownMessageError
 from pylint.message import MessageDefinition
 
-from .generic_fixtures import empty_store, store  # pylint: disable=unused-import
-
 
 @pytest.mark.parametrize(
     "messages,expected",

--- a/tests/message/unittest_message_definition_store.py
+++ b/tests/message/unittest_message_definition_store.py
@@ -10,7 +10,7 @@ from pylint.checkers import BaseChecker
 from pylint.exceptions import InvalidMessageError, UnknownMessageError
 from pylint.message import MessageDefinition
 
-from .generic_fixtures import empty_store, store
+from .generic_fixtures import empty_store, store  # pylint: disable=unused-import
 
 
 @pytest.mark.parametrize(

--- a/tests/message/unittest_message_definition_store.py
+++ b/tests/message/unittest_message_definition_store.py
@@ -230,8 +230,8 @@ class TestMessageDefinitionStore:
         assert ":msg-symbol (W1234): *message*" in output.getvalue()
 
     def test_renamed_message_register(self, store):
-        assert "msg-symbol" == store.get_message_definitions("W0001")[0].symbol
-        assert "msg-symbol" == store.get_message_definitions("old-symbol")[0].symbol
+        assert store.get_message_definitions("W0001")[0].symbol == "msg-symbol"
+        assert store.get_message_definitions("old-symbol")[0].symbol == "msg-symbol"
 
 
 def test_multiple_child_of_old_name(store):

--- a/tests/message/unittest_message_id_store.py
+++ b/tests/message/unittest_message_id_store.py
@@ -5,14 +5,6 @@ import pytest
 
 from pylint.exceptions import InvalidMessageError, UnknownMessageError
 
-from .generic_fixtures import (  # pylint: disable=unused-import
-    empty_msgid_store,
-    message_definitions,
-    msgid_store,
-    msgids,
-    store,
-)
-
 
 def test_len_str(msgid_store, msgids):
     assert len(msgid_store) == len(msgids)

--- a/tests/message/unittest_message_id_store.py
+++ b/tests/message/unittest_message_id_store.py
@@ -4,9 +4,8 @@
 import pytest
 
 from pylint.exceptions import InvalidMessageError, UnknownMessageError
-from pylint.message import MessageIdStore
 
-from .generic_fixtures import (
+from .generic_fixtures import (  # pylint: disable=unused-import
     empty_msgid_store,
     message_definitions,
     msgid_store,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,5 @@
 import unittest.mock
 
-import pytest
-
 import pylint.lint
 
 
@@ -13,7 +11,6 @@ def test_can_read_toml(tmp_path):
         "enable='missing-module-docstring'\n"
         "jobs=10\n"
     )
-
     linter = pylint.lint.PyLinter()
     linter.global_set_option = unittest.mock.MagicMock()
     linter.read_config_file(str(config_file))
@@ -31,7 +28,6 @@ def test_can_read_setup_cfg(tmp_path):
         "enable=missing-module-docstring\n"
         "jobs=10\n"
     )
-
     linter = pylint.lint.PyLinter()
     linter.global_set_option = unittest.mock.MagicMock()
     linter.read_config_file(str(config_file))

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -19,7 +19,7 @@ import sys
 
 import pytest
 
-from pylint import checkers, lint, reporters, testutils
+from pylint import testutils
 
 
 class test_dialect(csv.excel):

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -64,7 +64,7 @@ def remove_files():
     for fname in ("import.dot", "ext_import.dot", "int_import.dot"):
         try:
             os.remove(fname)
-        except:
+        except FileNotFoundError:
             pass
 
 

--- a/tests/test_regr.py
+++ b/tests/test_regr.py
@@ -33,12 +33,12 @@ except AttributeError:
 
 
 @pytest.fixture(scope="module")
-def reporter(reporter):
+def reporter():
     return testutils.TestReporter
 
 
 @pytest.fixture(scope="module")
-def disable(disable):
+def disable():
     return ["I"]
 
 

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -205,7 +205,7 @@ class TestRunTC:
         out = StringIO()
         with pytest.raises(IOError) as excinfo:
             self._run_pylint(["--rcfile=/tmp/norcfile.txt"], out=out)
-        assert "The config file /tmp/norcfile.txt doesn't exist!" == str(excinfo.value)
+        assert str(excinfo.value) == "The config file /tmp/norcfile.txt doesn't exist!"
 
     def test_help_message_option(self):
         self._runtest(["--help-msg", "W0101"], code=0)

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -115,7 +115,8 @@ class TestRunTC:
             msg = "%s. Below pylint output: \n%s" % (msg, output)
         assert pylint_code == code, msg
 
-    def _run_pylint(self, args, out, reporter=None):
+    @staticmethod
+    def _run_pylint(args, out, reporter=None):
         args = args + ["--persistent=no"]
         with _patch_streams(out):
             with pytest.raises(SystemExit) as cm:
@@ -668,7 +669,8 @@ class TestRunTC:
             code=0,
         )
 
-    def test_do_not_import_files_from_local_directory(self, tmpdir):
+    @staticmethod
+    def test_do_not_import_files_from_local_directory(tmpdir):
         p_astroid = tmpdir / "astroid.py"
         p_astroid.write("'Docstring'\nimport completely_unknown\n")
         p_hmac = tmpdir / "hmac.py"

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -19,6 +19,8 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
+# pylint: disable=too-many-public-methods
+
 import configparser
 import contextlib
 import json

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -70,6 +70,10 @@ def _configure_lc_ctype(lc_ctype):
 
 class MultiReporter(BaseReporter):
     def __init__(self, reporters):
+        # pylint: disable=super-init-not-called
+        # We don't call it because there is an attribute "linter" that is set inside the base class
+        # and we have another setter here using yet undefined attribute.
+        # I don't think fixing the init order in a test class used once is worth it.
         self._reporters = reporters
         self.path_strip_prefix = os.getcwd() + os.sep
 

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -87,7 +87,7 @@ class MultiReporter(BaseReporter):
         for rep in self._reporters:
             rep.handle_message(msg)
 
-    def display_reports(self, layout):
+    def _display(self, layout):
         pass
 
     @property

--- a/tests/unittest_checker_format.py
+++ b/tests/unittest_checker_format.py
@@ -417,7 +417,7 @@ class TestCheckSpace(CheckerTestCase):
             )
 
     def testOperatorSpacingGood(self):
-        good_cases = ["a = b\n" "a < b\n" "a\n< b\n"]
+        good_cases = ["a = b\n", "a < b\n", "a\n< b\n"]
         with self.assertNoMessages():
             for code in good_cases:
                 self.checker.process_tokens(_tokenize_str(code))

--- a/tests/unittest_checker_python3.py
+++ b/tests/unittest_checker_python3.py
@@ -15,6 +15,8 @@
 
 """Tests for the python3 checkers."""
 
+# pylint: disable=too-many-public-methods
+
 import astroid
 
 from pylint import testutils

--- a/tests/unittest_checker_similar.py
+++ b/tests/unittest_checker_similar.py
@@ -9,7 +9,6 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
-import sys
 from contextlib import redirect_stdout
 from io import StringIO
 from os.path import abspath, dirname, join

--- a/tests/unittest_checker_stdlib.py
+++ b/tests/unittest_checker_stdlib.py
@@ -36,7 +36,7 @@ class TestStdlibChecker(CheckerTestCase):
         # got to be the result of a function inference
         # beats me..)
 
-        def infer_func(node, context=None):
+        def infer_func(node, context=None):  # pylint: disable=unused-argument
             new_node = astroid.AssignAttr()
             new_node.parent = node
             yield new_node

--- a/tests/unittest_checker_strings.py
+++ b/tests/unittest_checker_strings.py
@@ -80,6 +80,7 @@ class TestStringChecker(CheckerTestCase):
             ):
                 self.checker.visit_binop(node)
 
-    def test_str_eval(self):
-        for token in TEST_TOKENS:
-            assert strings.str_eval(token) == "X"
+
+def test_str_eval():
+    for token in TEST_TOKENS:
+        assert strings.str_eval(token) == "X"

--- a/tests/unittest_checker_typecheck.py
+++ b/tests/unittest_checker_typecheck.py
@@ -12,27 +12,22 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
-"""Unittest for the type checker."""
 import astroid
 import pytest
 
 from pylint.checkers import typecheck
 from pylint.testutils import CheckerTestCase, Message, set_config
 
+try:
+    import coverage.tracer as _
 
-def c_extension_missing():
-    """Coverage module has C-extension, which we can reuse for test"""
-    try:
-        import coverage.tracer as _
-
-        return False
-    except ImportError:
-        _ = None
-        return True
-
+    C_EXTENTIONS_AVAILABLE = True
+except ImportError:
+    _ = None
+    C_EXTENTIONS_AVAILABLE = False
 
 needs_c_extension = pytest.mark.skipif(
-    c_extension_missing(), reason="Requires coverage (source of C-extension)"
+    not C_EXTENTIONS_AVAILABLE, reason="Requires coverage (source of C-extension)"
 )
 
 

--- a/tests/unittest_checker_variables.py
+++ b/tests/unittest_checker_variables.py
@@ -270,7 +270,8 @@ class TestVariablesCheckerWithTearDown(CheckerTestCase):
 class TestMissingSubmodule(CheckerTestCase):
     CHECKER_CLASS = variables.VariablesChecker
 
-    def test_package_all(self):
+    @staticmethod
+    def test_package_all():
         regr_data = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "regrtest_data"
         )

--- a/tests/unittest_checker_variables.py
+++ b/tests/unittest_checker_variables.py
@@ -129,7 +129,7 @@ class TestVariablesCheckerWithTearDown(CheckerTestCase):
         self._to_consume_backup = self.checker._to_consume
         self.checker._to_consume = []
 
-    def teardown_method(self, method):
+    def teardown_method(self):
         self.checker._to_consume = self._to_consume_backup
 
     @set_config(callbacks=("callback_", "_callback"))

--- a/tests/unittest_checkers_utils.py
+++ b/tests/unittest_checkers_utils.py
@@ -186,193 +186,207 @@ def test_inherit_from_std_ex_recursive_definition():
     assert not utils.inherit_from_std_ex(node)
 
 
-class TestGetNodeLastLineno:
-    def test_get_node_last_lineno_simple(self):
-        node = astroid.extract_node(
-            """
+def test_get_node_last_lineno_simple():
+    node = astroid.extract_node(
+        """
+        pass
+    """
+    )
+    assert utils.get_node_last_lineno(node) == 2
+
+
+def test_get_node_last_lineno_if_simple():
+    node = astroid.extract_node(
+        """
+        if True:
+            print(1)
             pass
         """
-        )
-        assert utils.get_node_last_lineno(node) == 2
+    )
+    assert utils.get_node_last_lineno(node) == 4
 
-    def test_get_node_last_lineno_if_simple(self):
-        node = astroid.extract_node(
-            """
-            if True:
-                print(1)
+
+def test_get_node_last_lineno_if_elseif_else():
+    node = astroid.extract_node(
+        """
+        if True:
+            print(1)
+        elif False:
+            print(2)
+        else:
+            print(3)
+        """
+    )
+    assert utils.get_node_last_lineno(node) == 7
+
+
+def test_get_node_last_lineno_while():
+    node = astroid.extract_node(
+        """
+        while True:
+            print(1)
+        """
+    )
+    assert utils.get_node_last_lineno(node) == 3
+
+
+def test_get_node_last_lineno_while_else():
+    node = astroid.extract_node(
+        """
+        while True:
+            print(1)
+        else:
+            print(2)
+        """
+    )
+    assert utils.get_node_last_lineno(node) == 5
+
+
+def test_get_node_last_lineno_for():
+    node = astroid.extract_node(
+        """
+        for x in range(0, 5):
+            print(1)
+        """
+    )
+    assert utils.get_node_last_lineno(node) == 3
+
+
+def test_get_node_last_lineno_for_else():
+    node = astroid.extract_node(
+        """
+        for x in range(0, 5):
+            print(1)
+        else:
+            print(2)
+        """
+    )
+    assert utils.get_node_last_lineno(node) == 5
+
+
+def test_get_node_last_lineno_try():
+    node = astroid.extract_node(
+        """
+        try:
+            print(1)
+        except ValueError:
+            print(2)
+        except Exception:
+            print(3)
+        """
+    )
+    assert utils.get_node_last_lineno(node) == 7
+
+
+def test_get_node_last_lineno_try_except_else():
+    node = astroid.extract_node(
+        """
+        try:
+            print(1)
+        except Exception:
+            print(2)
+            print(3)
+        else:
+            print(4)
+        """
+    )
+    assert utils.get_node_last_lineno(node) == 8
+
+
+def test_get_node_last_lineno_try_except_finally():
+    node = astroid.extract_node(
+        """
+        try:
+            print(1)
+        except Exception:
+            print(2)
+        finally:
+            print(4)
+        """
+    )
+    assert utils.get_node_last_lineno(node) == 7
+
+
+def test_get_node_last_lineno_try_except_else_finally():
+    node = astroid.extract_node(
+        """
+        try:
+            print(1)
+        except Exception:
+            print(2)
+        else:
+            print(3)
+        finally:
+            print(4)
+        """
+    )
+    assert utils.get_node_last_lineno(node) == 9
+
+
+def test_get_node_last_lineno_with():
+    node = astroid.extract_node(
+        """
+        with x as y:
+            print(1)
+            pass
+        """
+    )
+    assert utils.get_node_last_lineno(node) == 4
+
+
+def test_get_node_last_lineno_method():
+    node = astroid.extract_node(
+        """
+        def x(a, b):
+            print(a, b)
+            pass
+        """
+    )
+    assert utils.get_node_last_lineno(node) == 4
+
+
+def test_get_node_last_lineno_decorator():
+    node = astroid.extract_node(
+        """
+        @decor()
+        def x(a, b):
+            print(a, b)
+            pass
+        """
+    )
+    assert utils.get_node_last_lineno(node) == 5
+
+
+def test_get_node_last_lineno_class():
+    node = astroid.extract_node(
+        """
+        class C(object):
+            CONST = True
+
+            def x(self, b):
+                print(b)
+
+            def y(self):
                 pass
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 4
-
-    def test_get_node_last_lineno_if_elseif_else(self):
-        node = astroid.extract_node(
-            """
-            if True:
-                print(1)
-            elif False:
-                print(2)
-            else:
-                print(3)
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 7
-
-    def test_get_node_last_lineno_while(self):
-        node = astroid.extract_node(
-            """
-            while True:
-                print(1)
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 3
-
-    def test_get_node_last_lineno_while_else(self):
-        node = astroid.extract_node(
-            """
-            while True:
-                print(1)
-            else:
-                print(2)
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 5
-
-    def test_get_node_last_lineno_for(self):
-        node = astroid.extract_node(
-            """
-            for x in range(0, 5):
-                print(1)
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 3
-
-    def test_get_node_last_lineno_for_else(self):
-        node = astroid.extract_node(
-            """
-            for x in range(0, 5):
-                print(1)
-            else:
-                print(2)
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 5
-
-    def test_get_node_last_lineno_try(self):
-        node = astroid.extract_node(
-            """
-            try:
-                print(1)
-            except ValueError:
-                print(2)
-            except Exception:
-                print(3)
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 7
-
-    def test_get_node_last_lineno_try_except_else(self):
-        node = astroid.extract_node(
-            """
-            try:
-                print(1)
-            except Exception:
-                print(2)
-                print(3)
-            else:
-                print(4)
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 8
-
-    def test_get_node_last_lineno_try_except_finally(self):
-        node = astroid.extract_node(
-            """
-            try:
-                print(1)
-            except Exception:
-                print(2)
-            finally:
-                print(4)
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 7
-
-    def test_get_node_last_lineno_try_except_else_finally(self):
-        node = astroid.extract_node(
-            """
-            try:
-                print(1)
-            except Exception:
-                print(2)
-            else:
-                print(3)
-            finally:
-                print(4)
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 9
-
-    def test_get_node_last_lineno_with(self):
-        node = astroid.extract_node(
-            """
-            with x as y:
-                print(1)
                 pass
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 4
+        """
+    )
+    assert utils.get_node_last_lineno(node) == 10
 
-    def test_get_node_last_lineno_method(self):
-        node = astroid.extract_node(
-            """
-            def x(a, b):
-                print(a, b)
-                pass
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 4
 
-    def test_get_node_last_lineno_decorator(self):
-        node = astroid.extract_node(
-            """
-            @decor()
-            def x(a, b):
-                print(a, b)
-                pass
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 5
+def test_get_node_last_lineno_combined():
+    node = astroid.extract_node(
+        """
+        class C(object):
+            CONST = True
 
-    def test_get_node_last_lineno_class(self):
-        node = astroid.extract_node(
-            """
-            class C(object):
-                CONST = True
-
-                def x(self, b):
-                    print(b)
-
-                def y(self):
+            def y(self):
+                try:
                     pass
+                except:
                     pass
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 10
-
-    def test_get_node_last_lineno_combined(self):
-        node = astroid.extract_node(
-            """
-            class C(object):
-                CONST = True
-
-                def y(self):
-                    try:
-                        pass
-                    except:
-                        pass
-                    finally:
-                        pass
-            """
-        )
-        assert utils.get_node_last_lineno(node) == 11
+                finally:
+                    pass
+        """
+    )
+    assert utils.get_node_last_lineno(node) == 11

--- a/tests/unittest_checkers_utils.py
+++ b/tests/unittest_checkers_utils.py
@@ -53,7 +53,7 @@ def testGetArgumentFromCallExists(fn, kw):
 def testGetArgumentFromCall():
     node = astroid.extract_node("foo(a, not_this_one=1, this_one=2)")
     arg = utils.get_argument_from_call(node, position=2, keyword="this_one")
-    assert 2 == arg.value
+    assert arg.value == 2
 
     node = astroid.extract_node("foo(a)")
     with pytest.raises(utils.NoSuchArgumentError):

--- a/tests/unittest_lint.py
+++ b/tests/unittest_lint.py
@@ -359,16 +359,16 @@ def test_enable_message_block(init_linter):
     assert linter.is_message_enabled("E1101", 77)
 
     fs = linter.file_state
-    assert 17 == fs._suppression_mapping["W0613", 18]
-    assert 30 == fs._suppression_mapping["E1101", 33]
+    assert fs._suppression_mapping["W0613", 18] == 17
+    assert fs._suppression_mapping["E1101", 33] == 30
     assert ("E1101", 46) not in fs._suppression_mapping
-    assert 1 == fs._suppression_mapping["C0302", 18]
-    assert 1 == fs._suppression_mapping["C0302", 50]
+    assert fs._suppression_mapping["C0302", 18] == 1
+    assert fs._suppression_mapping["C0302", 50] == 1
     # This is tricky. While the disable in line 106 is disabling
     # both 108 and 110, this is usually not what the user wanted.
     # Therefore, we report the closest previous disable comment.
-    assert 106 == fs._suppression_mapping["E1101", 108]
-    assert 109 == fs._suppression_mapping["E1101", 110]
+    assert fs._suppression_mapping["E1101", 108] == 106
+    assert fs._suppression_mapping["E1101", 110] == 109
 
 
 def test_enable_by_symbol(init_linter):

--- a/tests/unittest_lint.py
+++ b/tests/unittest_lint.py
@@ -119,8 +119,8 @@ def tempdir():
 def create_files(paths, chroot="."):
     """Creates directories and files found in <path>.
 
-    :param paths: list of relative paths to files or directories
-    :param chroot: the root directory in which paths will be created
+    :param list paths: list of relative paths to files or directories
+    :param str chroot: the root directory in which paths will be created
 
     >>> from os.path import isdir, isfile
     >>> isdir('/tmp/a')

--- a/tests/unittest_lint.py
+++ b/tests/unittest_lint.py
@@ -743,6 +743,7 @@ class TestPreprocessOptions:
 
 
 class _CustomPyLinter(PyLinter):
+    # pylint: disable=too-many-ancestors
     def should_analyze_file(self, modname, path, is_argument=False):
         if os.path.basename(path) == "wrong.py":
             return False

--- a/tests/unittest_lint.py
+++ b/tests/unittest_lint.py
@@ -227,12 +227,12 @@ def test_more_args(fake_path, case):
 
 
 @pytest.fixture(scope="module")
-def disable(disable):
+def disable():
     return ["I"]
 
 
 @pytest.fixture(scope="module")
-def reporter(reporter):
+def reporter():
     return testutils.TestReporter
 
 

--- a/tests/unittest_lint.py
+++ b/tests/unittest_lint.py
@@ -725,13 +725,15 @@ class TestPreprocessOptions:
         preprocess_options(["--qu", "ux"], {"qu": (self._callback, True)})
         assert [("qu", "ux")] == self.args
 
-    def test_error_missing_expected_value(self):
+    @staticmethod
+    def test_error_missing_expected_value():
         with pytest.raises(ArgumentPreprocessingError):
             preprocess_options(["--foo", "--bar", "--qu=ux"], {"bar": (None, True)})
         with pytest.raises(ArgumentPreprocessingError):
             preprocess_options(["--foo", "--bar"], {"bar": (None, True)})
 
-    def test_error_unexpected_value(self):
+    @staticmethod
+    def test_error_unexpected_value():
         with pytest.raises(ArgumentPreprocessingError):
             preprocess_options(
                 ["--foo", "--bar=spam", "--qu=ux"], {"bar": (None, False)}

--- a/tests/unittest_lint.py
+++ b/tests/unittest_lint.py
@@ -636,7 +636,7 @@ def test_pylint_home():
         finally:
             try:
                 os.remove(pylintd)
-            except:
+            except FileNotFoundError:
                 pass
     finally:
         del os.environ["PYLINTHOME"]

--- a/tests/unittest_lint.py
+++ b/tests/unittest_lint.py
@@ -52,6 +52,8 @@ from pylint.reporters import text
 from pylint.utils import FileState, tokenize_module
 
 if os.name == "java":
+    # pylint: disable=no-member
+    # os._name is valid see https://www.programcreek.com/python/example/3842/os._name
     if os._name == "nt":
         HOME = "USERPROFILE"
     else:

--- a/tests/unittest_pyreverse_diadefs.py
+++ b/tests/unittest_pyreverse_diadefs.py
@@ -60,17 +60,17 @@ def test_option_values(HANDLER, PROJECT):
     cl_config = Config()
     cl_config.classes = ["Specialization"]
     cl_h = DiaDefGenerator(Linker(PROJECT), DiadefsHandler(cl_config))
-    assert (0, 0) == df_h._get_levels()
-    assert False == df_h.module_names
-    assert (-1, -1) == cl_h._get_levels()
-    assert True == cl_h.module_names
+    assert df_h._get_levels() == (0, 0)
+    assert df_h.module_names == False
+    assert cl_h._get_levels() == (-1, -1)
+    assert cl_h.module_names
     for hndl in [df_h, cl_h]:
         hndl.config.all_ancestors = True
         hndl.config.all_associated = True
         hndl.config.module_names = True
         hndl._set_default_options()
-        assert (-1, -1) == hndl._get_levels()
-        assert True == hndl.module_names
+        assert hndl._get_levels() == (-1, -1)
+        assert hndl.module_names
     handler = DiadefsHandler(Config())
     df_h = DiaDefGenerator(Linker(PROJECT), handler)
     cl_config = Config()
@@ -81,8 +81,8 @@ def test_option_values(HANDLER, PROJECT):
         hndl.config.show_associated = 1
         hndl.config.module_names = False
         hndl._set_default_options()
-        assert (2, 1) == hndl._get_levels()
-        assert False == hndl.module_names
+        assert hndl._get_levels() == (2, 1)
+        assert not hndl.module_names
 
 
 def test_default_values():

--- a/tests/unittest_pyreverse_diadefs.py
+++ b/tests/unittest_pyreverse_diadefs.py
@@ -91,31 +91,6 @@ def test_default_values():
 
 
 class TestDefaultDiadefGenerator:
-    def test_known_values1(self, HANDLER, PROJECT):
-        dd = DefaultDiadefGenerator(Linker(PROJECT), HANDLER).visit(PROJECT)
-        assert len(dd) == 2
-        keys = [d.TYPE for d in dd]
-        assert keys == ["package", "class"]
-        pd = dd[0]
-        assert pd.title == "packages No Name"
-        modules = sorted(
-            [(isinstance(m.node, astroid.Module), m.title) for m in pd.objects]
-        )
-        assert modules == [
-            (True, "data"),
-            (True, "data.clientmodule_test"),
-            (True, "data.suppliermodule_test"),
-        ]
-        cd = dd[1]
-        assert cd.title == "classes No Name"
-        classes = _process_classes(cd.objects)
-        assert classes == [
-            (True, "Ancestor"),
-            (True, "DoNothing"),
-            (True, "Interface"),
-            (True, "Specialization"),
-        ]
-
     _should_rels = [
         ("association", "DoNothing", "Ancestor"),
         ("association", "DoNothing", "Specialization"),
@@ -142,19 +117,46 @@ class TestDefaultDiadefGenerator:
         relations = _process_relations(cd.relationships)
         assert relations == self._should_rels
 
-    def test_known_values2(self, HANDLER):
-        project = get_project("data.clientmodule_test")
-        dd = DefaultDiadefGenerator(Linker(project), HANDLER).visit(project)
-        assert len(dd) == 1
-        keys = [d.TYPE for d in dd]
-        assert keys == ["class"]
-        cd = dd[0]
-        assert cd.title == "classes No Name"
-        classes = _process_classes(cd.objects)
-        assert classes == [(True, "Ancestor"), (True, "Specialization")]
-
 
 def test_known_values1(HANDLER, PROJECT):
+    dd = DefaultDiadefGenerator(Linker(PROJECT), HANDLER).visit(PROJECT)
+    assert len(dd) == 2
+    keys = [d.TYPE for d in dd]
+    assert keys == ["package", "class"]
+    pd = dd[0]
+    assert pd.title == "packages No Name"
+    modules = sorted(
+        [(isinstance(m.node, astroid.Module), m.title) for m in pd.objects]
+    )
+    assert modules == [
+        (True, "data"),
+        (True, "data.clientmodule_test"),
+        (True, "data.suppliermodule_test"),
+    ]
+    cd = dd[1]
+    assert cd.title == "classes No Name"
+    classes = _process_classes(cd.objects)
+    assert classes == [
+        (True, "Ancestor"),
+        (True, "DoNothing"),
+        (True, "Interface"),
+        (True, "Specialization"),
+    ]
+
+
+def test_known_values2(HANDLER):
+    project = get_project("data.clientmodule_test")
+    dd = DefaultDiadefGenerator(Linker(project), HANDLER).visit(project)
+    assert len(dd) == 1
+    keys = [d.TYPE for d in dd]
+    assert keys == ["class"]
+    cd = dd[0]
+    assert cd.title == "classes No Name"
+    classes = _process_classes(cd.objects)
+    assert classes == [(True, "Ancestor"), (True, "Specialization")]
+
+
+def test_known_values3(HANDLER, PROJECT):
     HANDLER.config.classes = ["Specialization"]
     cdg = ClassDiadefGenerator(Linker(PROJECT), HANDLER)
     special = "data.clientmodule_test.Specialization"
@@ -168,7 +170,7 @@ def test_known_values1(HANDLER, PROJECT):
     ]
 
 
-def test_known_values2(HANDLER, PROJECT):
+def test_known_values4(HANDLER, PROJECT):
     HANDLER.config.classes = ["Specialization"]
     HANDLER.config.module_names = False
     cd = ClassDiadefGenerator(Linker(PROJECT), HANDLER).class_diagram(

--- a/tests/unittest_pyreverse_diadefs.py
+++ b/tests/unittest_pyreverse_diadefs.py
@@ -61,7 +61,7 @@ def test_option_values(HANDLER, PROJECT):
     cl_config.classes = ["Specialization"]
     cl_h = DiaDefGenerator(Linker(PROJECT), DiadefsHandler(cl_config))
     assert df_h._get_levels() == (0, 0)
-    assert df_h.module_names == False
+    assert not df_h.module_names
     assert cl_h._get_levels() == (-1, -1)
     assert cl_h.module_names
     for hndl in [df_h, cl_h]:

--- a/tests/unittest_pyreverse_writer.py
+++ b/tests/unittest_pyreverse_writer.py
@@ -90,7 +90,7 @@ def setup():
     for fname in DOT_FILES:
         try:
             os.remove(fname)
-        except:
+        except FileNotFoundError:
             continue
 
 

--- a/tests/unittest_reporting.py
+++ b/tests/unittest_reporting.py
@@ -78,5 +78,6 @@ def test_display_results_is_renamed():
 
     reporter = CustomReporter()
     with pytest.raises(AttributeError) as exc:
+        # pylint: disable=no-member
         reporter.display_results()
     assert "no attribute 'display_results'" in str(exc)

--- a/tests/unittest_reporting.py
+++ b/tests/unittest_reporting.py
@@ -21,12 +21,12 @@ from pylint.reporters.text import ParseableTextReporter, TextReporter
 
 
 @pytest.fixture(scope="module")
-def reporter(reporter):
+def reporter():
     return TextReporter
 
 
 @pytest.fixture(scope="module")
-def disable(disable):
+def disable():
     return ["I"]
 
 

--- a/tests/utils/unittest_ast_walker.py
+++ b/tests/utils/unittest_ast_walker.py
@@ -22,7 +22,7 @@ class TestASTWalker:
             self.called = set()
 
         @check_messages("first-message")
-        def visit_module(self, module):
+        def visit_module(self, module):  # pylint: disable=unused-argument
             self.called.add("module")
 
         @check_messages("second-message")
@@ -30,7 +30,7 @@ class TestASTWalker:
             raise NotImplementedError
 
         @check_messages("second-message", "third-message")
-        def visit_assignname(self, module):
+        def visit_assignname(self, module):  # pylint: disable=unused-argument
             self.called.add("assignname")
 
         @check_messages("second-message")
@@ -53,7 +53,7 @@ class TestASTWalker:
                 self.called = False
 
             @check_messages("first-message")
-            def visit_assname(self, node):
+            def visit_assname(self, node):  # pylint: disable=unused-argument
                 self.called = True
 
         linter = self.MockLinter({"first-message": True})


### PR DESCRIPTION
## Description
 
Following what was done in #3490 we remove disables in the test configuration progressively. Soon we'll be able to use the default pylint configuration. Major one to fix still is `redefined-outer-name` for which we must use proper pytest fixture import with `conftest.py`. Not an expert on that. Also maybe fix #3493.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :hammer: Refactoring  |
