### PR TITLE
Fix class scope issues in undefined-variable checker #511 #1976 #3494

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -379,3 +379,5 @@ contributors:
 * Matthew Beckers (mattlbeck): contributor
 
 * Yang Yang: contributor
+
+* Andrew J. Simmons (anjsimmo): contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in Pylint 2.5.0?
 
 Release date: TBA
 
+* Fix a false negative for ``undefined-variable`` when using class attribute in comprehension.
+
+  Close #3494
+
 * Fix a false positive for ``undefined-variable`` when using class attribute in decorator or as type hint.
 
   Close #511

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in Pylint 2.5.0?
 
 Release date: TBA
 
+* Fix a false positive for ``undefined-variable`` when using class attribute in decorator
+
+  Close #511
+
 * Remove HTML quoting of messages in JSON output.
 
   Close #2769

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,9 +7,10 @@ What's New in Pylint 2.5.0?
 
 Release date: TBA
 
-* Fix a false positive for ``undefined-variable`` when using class attribute in decorator
+* Fix a false positive for ``undefined-variable`` when using class attribute in decorator or as type hint.
 
   Close #511
+  Close #1976
 
 * Remove HTML quoting of messages in JSON output.
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1261,6 +1261,10 @@ class VariablesChecker(BaseChecker):
                 )
                 or frame.args.parent_of(node)
                 or (frame.decorators and frame.decorators.parent_of(node))
+                or (
+                    frame.returns
+                    and (node is frame.returns or frame.returns.parent_of(node))
+                )
             )
         return in_annotation_or_default_or_decorator
 

--- a/tests/functional/c/class_scope.py
+++ b/tests/functional/c/class_scope.py
@@ -7,10 +7,11 @@ class Well(object):
     """well"""
     attr = 42
     get_attr = lambda arg=attr: arg * 24
-    # +1: [used-before-assignment]
+    # +1: [undefined-variable, used-before-assignment]
     get_attr_bad = lambda arg=revattr: revattr * 42
     revattr = 24
     bad_lambda = lambda: get_attr_bad # [undefined-variable]
+    bad_gen = list(attr + i for i in range(10)) # [undefined-variable]
 
     class Data(object):
         """base hidden class"""

--- a/tests/functional/c/class_scope.txt
+++ b/tests/functional/c/class_scope.txt
@@ -1,4 +1,6 @@
+undefined-variable:11:Well.<lambda>:Undefined variable 'revattr'
 used-before-assignment:11:Well.<lambda>:Using variable 'revattr' before assignment
 undefined-variable:13:Well.<lambda>:Undefined variable 'get_attr_bad'
-undefined-variable:19:Well.Sub:Undefined variable 'Data'
-undefined-variable:22:Well.func:Undefined variable 'Sub'
+undefined-variable:14:Well:Undefined variable 'attr'
+undefined-variable:20:Well.Sub:Undefined variable 'Data'
+undefined-variable:23:Well.func:Undefined variable 'Sub'

--- a/tests/unittest_checker_variables.py
+++ b/tests/unittest_checker_variables.py
@@ -145,6 +145,23 @@ class TestVariablesChecker(CheckerTestCase):
         with self.assertNoMessages():
             self.walk(module)
 
+    def test_return_type_annotation(self):
+        """ Make sure class attributes in scope for return type annotations.
+
+        https://github.com/PyCQA/pylint/issues/1976
+        """
+        module = astroid.parse(
+            """
+        class MyObject:
+            class MyType:
+                pass
+            def my_method(self) -> MyType:
+                pass
+        """
+        )
+        with self.assertNoMessages():
+            self.walk(module)
+
 
 class TestVariablesCheckerWithTearDown(CheckerTestCase):
 

--- a/tests/unittest_checker_variables.py
+++ b/tests/unittest_checker_variables.py
@@ -119,6 +119,32 @@ class TestVariablesChecker(CheckerTestCase):
         with self.assertAddsMessages(msg):
             self.checker.visit_global(node)
 
+    def test_listcomp_in_decorator(self):
+        """ Make sure class attributes in scope for listcomp in decorator.
+
+        https://github.com/PyCQA/pylint/issues/511
+        """
+        module = astroid.parse(
+            """
+        def dec(inp):
+            def inner(func):
+                print(inp)
+                return func
+            return inner
+
+
+        class Cls:
+
+            DATA = "foo"
+
+            @dec([x for x in DATA])
+            def fun(self):
+                pass
+        """
+        )
+        with self.assertNoMessages():
+            self.walk(module)
+
 
 class TestVariablesCheckerWithTearDown(CheckerTestCase):
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

The  `_ignore_class_scope` method within the variable checker determines whether to search attributes in the class scope. This in turn uses `_defined_in_function_definition` to distinguish function arguments and annotations from the contents of the function (which form their own scope). However, `_defined_in_function_definition` was previously missing checks to search decorators (#511) and return type annotations (#1976), leading to false positives. These two checks were an easy fix.

While implementing the solution, it became apparent that Pylint wasn't checking whether variables inside list/set/dict comprehensions and generator expressions could actually access class scope. This led to false negatives where Python would raise a `NameError`, but Pylint wasn't providing any warning (#3494). A new function `_in_lambda_or_comprehension_body` was added that begins with a variable node, then searches up its parent chain, checking for lambda expressions and comprehensions along the way that would cause class attributes to go out of scope. Only the lambda arguments, and comprehension iters are allowed to pass through.

`tests/functional/c/class_scope.py` was changed to note that `lambda arg=revattr: revattr * 42`  uses `revattr` as both an argument, as well as an  `undefined-variable` in the body. An additional line was also added to test the scope issues were addressed for generator expressions.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

Closes #511
Closes #1976 
Closes #3494 
