### PR TITLE
profile| Runs pylint against external code, generating profile-heatmaps

### DIFF
--- a/tests/profile/test_profile_against_externals.py
+++ b/tests/profile/test_profile_against_externals.py
@@ -71,8 +71,3 @@ def test_run(name, git_repo):
             % (len(filepaths), len(runner.linter.reporter.messages))
         )
         pprint.pprint(runner.linter.reporter.messages)
-
-        # one day: assert runner.linter.msg_status == 0, (
-        # one day:     "Expected no errors to be thrown: %s"
-        # one day:     % pprint.pformat(runner.linter.reporter.messages)
-        # one day: )

--- a/tox.ini
+++ b/tox.ini
@@ -157,4 +157,21 @@ commands =
                          --benchmark-group-by="group" \
                          {posargs:}
 
+[testenv:profile_against_external]
+deps =
+   https://github.com/PyCQA/astroid/tarball/master#egg=astroid-master-2.0
+   gprof2dot
+   mccabe
+   pytest
+   pytest-profiling
+   pytest-xdist
+
+setenv =
+  PYTEST_PROFILE_EXTERNAL = 1
+
+commands =
+    python -Wi -m pytest --exitfirst \
+                         --profile-svg \
+                         {toxinidir}/tests/profile/test_profile_against_externals.py
+
 changedir = {toxworkdir}


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [-] Add yourself to CONTRIBUTORS if you are a new contributor.
- [-] Add a ChangeLog entry describing what your PR does.
- [-] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Runs pylint against numpy and supports adding other external repos for testing.

Will generate a .svg in the .tox/prof. Here's an example:
https://pylint.s3.amazonaws.com/doublethefish/pylint/output.svg

Other considerations:
* Use https gitub uri so we do not need credentials
* Shallow clone so we don't pull more data than we need
* Ensure we skip external profiling unless explicitly wanted

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |


## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
