### PR TITLE
profile| Adds (opt-inable) profile-heatmap generation output to tox test-runs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ setenv =
     COVERAGE_FILE = {toxinidir}/.coverage.{envname}
 
 commands =
-    python -Wignore -m coverage run -m pytest --profile-svg {toxinidir}/tests/ {posargs:}
+    python -Wignore -m coverage run -m pytest {toxinidir}/tests/ {posargs:}
 
     ; Transform absolute path to relative path
     ; for compatibility with coveralls.io and fix 'source not available' error.

--- a/tox.ini
+++ b/tox.ini
@@ -53,12 +53,13 @@ deps =
    mccabe
    pytest
    pytest-xdist
+   pytest-profiling
 
 setenv =
     COVERAGE_FILE = {toxinidir}/.coverage.{envname}
 
 commands =
-    python -Wignore -m coverage run -m pytest {toxinidir}/tests/ {posargs:}
+    python -Wignore -m coverage run -m pytest --profile-svg {toxinidir}/tests/ {posargs:}
 
     ; Transform absolute path to relative path
     ; for compatibility with coveralls.io and fix 'source not available' error.


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] (n/a) Add a ChangeLog entry describing what your PR does.
- [x] (n/a) If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Fairly straight-forward change enabling the creation heatgraphs for test-runs, when and as needed.

We can use `tox -epy38 -- --profile-svg` to enable this functionality now that we have the pytest-profiling dependency added to tox.

Partly addresses #1954. Split out from the original PR for #3473.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
