### PR TITLE
Fix score option for JSON export

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,16 @@
 Pylint's ChangeLog
 ------------------
 
+What's New in Pylint 3.0.0?
+===========================
+
+* Fix the score option not being honored when exporting to JSON
+
+  The default setting was to have a score, but it did not work. Now it will give a score at the end of the json:
+
+  Close #3504
+
+
 What's New in Pylint 2.8.0?
 ===========================
 Release date: TBA

--- a/doc/whatsnew/3.0.rst
+++ b/doc/whatsnew/3.0.rst
@@ -1,0 +1,24 @@
+**************************
+ What's New in Pylint 3.0
+**************************
+
+:Release: 3.0
+:Date: TBA
+
+
+Summary -- Release highlights
+=============================
+
+
+New checkers
+============
+
+
+Other Changes
+=============
+
+*  The score option for JSON export has been fixed
+
+  The default setting is to have a score, but it did not work before.
+  If a score appeared in your json, and you want to go back what you
+  had before, you must change the score option to "--score=n"

--- a/doc/whatsnew/index.rst
+++ b/doc/whatsnew/index.rst
@@ -9,6 +9,7 @@ High level descriptions of the most important changes between major Pylint versi
 .. toctree::
    :maxdepth: 1
 
+   3.0.rst
    2.8.rst
    2.7.rst
    2.6.rst

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1111,13 +1111,9 @@ class PyLinter(
             self.stats[msg_cat] = 0
 
     def generate_reports(self):
-        """close the whole package /module, it's time to make reports !
+        """Close the whole package /module, it's time to make reports !
 
-        if persistent run, pickle results for later comparison
-        """
-        # Display whatever messages are left on the reporter.
-        self.reporter.display_messages(report_nodes.Section())
-
+        if persistent run, pickle results for later comparison."""
         if self.file_state.base_name is not None:
             # load previous results if any
             previous_stats = config.load_results(self.file_state.base_name)
@@ -1136,6 +1132,8 @@ class PyLinter(
         else:
             self.reporter.on_close(self.stats, {})
             score_value = None
+        # Display whatever messages are left on the reporter.
+        self.reporter.display_messages(report_nodes.Section())
         return score_value
 
     def _report_evaluation(self):

--- a/pylint/reporters/json_reporter.py
+++ b/pylint/reporters/json_reporter.py
@@ -11,11 +11,13 @@
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
 """JSON reporter"""
+import io
 import json
 import sys
 
 from pylint.interfaces import IReporter
 from pylint.reporters.base_reporter import BaseReporter
+from pylint.reporters.ureports.text_writer import TextWriter
 
 
 class JSONReporter(BaseReporter):
@@ -50,7 +52,11 @@ class JSONReporter(BaseReporter):
         print(json.dumps(self.messages, indent=4), file=self.out)
 
     def display_reports(self, layout):
-        """Don't do anything in this reporter."""
+        output = io.StringIO()
+        TextWriter().format(layout, output)
+        score = output.getvalue().split("Your")[1]
+        score = score.split(r"/10")[0]
+        self.messages.append({"score": f"Your{score}/10"})
 
     def _display(self, layout):
         """Do nothing."""

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -415,7 +415,7 @@ class TestRunTC:
         self._runtest([module], code=4, reporter=JSONReporter(out))
         output = json.loads(out.getvalue())
         assert isinstance(output, list)
-        assert len(output) == 1
+        assert len(output) == 2
         assert isinstance(output[0], dict)
         expected = {
             "symbol": "unused-variable",
@@ -426,10 +426,13 @@ class TestRunTC:
             "line": 4,
             "type": "warning",
         }
+
         message = output[0]
         for key, value in expected.items():
             assert key in message
             assert message[key] == value
+        expected = {"score": "Your code has been rated at 7.50/10"}
+        assert output[-1] == expected
 
     def test_information_category_disabled_by_default(self):
         expected = "Your code has been rated at 10.00/10"

--- a/tests/unittest_reporters_json.py
+++ b/tests/unittest_reporters_json.py
@@ -21,7 +21,7 @@ from pylint.lint import PyLinter
 from pylint.reporters import JSONReporter
 from pylint.reporters.ureports.nodes import EvaluationSection
 
-expected_score_message = "Expected score message"
+expected_score_message = "Your code has been rated at 7.50/10"
 expected_result = [
     [
         ("column", 0),
@@ -35,6 +35,14 @@ expected_result = [
         ("type", "convention"),
     ]
 ]
+
+
+def test_simple_json_output_with_score():
+    report = get_linter_result(score=True)
+    assert len(report) == 2
+    report_result = [sorted(report[0].items(), key=lambda item: item[0])]
+    assert report_result == expected_result
+    assert report[1] == {"score": expected_score_message}
 
 
 def test_simple_json_output_no_score():
@@ -56,7 +64,10 @@ def get_linter_result(score):
     linter.add_message("line-too-long", line=1, args=(1, 2))
     # we call those methods because we didn't actually run the checkers
     if score:
-        reporter.display_reports(EvaluationSection(expected_score_message))
+        generated_msg = "-------------------------------------\r\n{}\r\n".format(
+            expected_score_message
+        )
+        reporter.display_reports(EvaluationSection(generated_msg))
     reporter.display_messages(None)
     report_result = json.loads(output.getvalue())
     return report_result


### PR DESCRIPTION
## Steps

- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.

## Description

This fix #3504, but I wonder... It looks like the fabled bug that will break countless integration by being fixed. `--score=y` is the default setting, and JSON is probably a prime candidate for automation. Is it reasonable to fix it and ask everyone to change their option to `-s n`? I'm pretty sure no one read the pylint's changelog and even if they do we can't know how many poeple have a working continuous integration that iwll be broken by this.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #3504 

