### PR TITLE
Fix a crash in `method-hidden` lookup for unknown base classes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,15 @@
 Pylint's ChangeLog
 ------------------
 
+What's New in Pylint 2.5.1?
+===========================
+
+Release date: TBA
+
+* Fix a crash in `method-hidden` lookup for unknown base classes
+
+  Close #3527
+
 What's New in Pylint 2.5.0?
 ===========================
 

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -988,15 +988,10 @@ a metaclass class method.",
                 return
 
             # If a subclass defined the method then it's not our fault.
-            try:
-                mro = klass.mro()
-            except (InconsistentMroError, DuplicateBasesError):
-                pass
-            else:
-                for subklass in mro[1 : mro.index(overridden_frame) + 1]:
-                    for obj in subklass.lookup(node.name)[1]:
-                        if isinstance(obj, astroid.FunctionDef):
-                            return
+            for ancestor in klass.ancestors():
+                for obj in ancestor.lookup(node.name)[1]:
+                    if isinstance(obj, astroid.FunctionDef):
+                        return
             args = (overridden.root().name, overridden.fromlineno)
             self.add_message("method-hidden", args=args, node=node)
         except astroid.NotFoundError:

--- a/tests/functional/m/method_hidden.py
+++ b/tests/functional/m/method_hidden.py
@@ -79,3 +79,14 @@ class One:
 class Two(One):
     def one(self):
         pass
+
+try:
+    import unknown as js
+except ImportError:
+    import json as js
+
+
+class JsonEncoder(js.JSONEncoder):
+    # pylint: disable=useless-super-delegation
+    def default(self, o):
+        return super(JsonEncoder, self).default(o)


### PR DESCRIPTION
The patch replaces `mro()` with `ancestors()` as the former is not
fully capable of generating the complete linearization when
dealing with ambiguous inferences.

Close #3527
