### PR TITLE
Rename pylint.Run do_exit parameter to exit 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,12 @@ Release date: TBA
 
   Close #3527
 
+* Revert pylint.Run's `exit` parameter to ``do_exit``
+
+  This has been inadvertently changed several releases ago to ``do_exit``.
+
+  Close #3533
+
 What's New in Pylint 2.5.0?
 ===========================
 

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -66,7 +66,9 @@ group are mutually exclusive.",
     def _return_one(*args):  # pylint: disable=unused-argument
         return 1
 
-    def __init__(self, args, reporter=None, do_exit=True):
+    def __init__(
+        self, args, reporter=None, exit=True
+    ):  # pylint: disable=redefined-builtin
         self._rcfile = None
         self._plugins = []
         self.verbose = None
@@ -337,7 +339,7 @@ group are mutually exclusive.",
 
         linter.check(args)
         score_value = linter.generate_reports()
-        if do_exit:
+        if exit:
             if linter.config.exit_zero:
                 sys.exit(0)
             else:

--- a/tests/benchmark/test_baseline_benchmarks.py
+++ b/tests/benchmark/test_baseline_benchmarks.py
@@ -286,7 +286,7 @@ class TestEstablishBaselineBenchmarks:
         # Just 1 file, but all Checkers/Extensions
         fileinfos = [self.empty_filepath]
 
-        runner = benchmark(Run, fileinfos, reporter=Reporter(), do_exit=False)
+        runner = benchmark(Run, fileinfos, reporter=Reporter(), exit=False)
         assert runner.linter.config.jobs == 1
         print("len(runner.linter._checkers)", len(runner.linter._checkers))
         assert len(runner.linter._checkers) > 1, "Should have more than 'master'"

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -518,7 +518,7 @@ def test_load_plugin_command_line():
 
     run = Run(
         ["--load-plugins", "dummy_plugin", join(REGRTEST_DATA_DIR, "empty.py")],
-        do_exit=False,
+        exit=False,
     )
     assert (
         len([ch.name for ch in run.linter.get_checkers() if ch.name == "dummy_plugin"])
@@ -534,7 +534,7 @@ def test_load_plugin_config_file():
     config_path = join(REGRTEST_DATA_DIR, "dummy_plugin.rc")
 
     run = Run(
-        ["--rcfile", config_path, join(REGRTEST_DATA_DIR, "empty.py")], do_exit=False,
+        ["--rcfile", config_path, join(REGRTEST_DATA_DIR, "empty.py")], exit=False,
     )
     assert (
         len([ch.name for ch in run.linter.get_checkers() if ch.name == "dummy_plugin"])
@@ -556,7 +556,7 @@ def test_load_plugin_configuration():
             "foo,bar",
             join(REGRTEST_DATA_DIR, "empty.py"),
         ],
-        do_exit=False,
+        exit=False,
     )
     assert run.linter.config.black_list == ["foo", "bar", "bin"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
    isort
    pytest
 commands =
-    pylint -rn --rcfile={toxinidir}/pylintrc --load-plugins=pylint.extensions.docparams, pylint.extensions.mccabe {envsitepackagesdir}/pylint
+    pylint -rn --rcfile={toxinidir}/pylintrc --load-plugins=pylint.extensions.docparams, pylint.extensions.mccabe {toxinidir}/pylint
     # This would be greatly simplified by a solution for https://github.com/PyCQA/pylint/issues/352
     pylint -rn --rcfile={toxinidir}/tests/.test_pylintrc --load-plugins=pylint.extensions.docparams, pylint.extensions.mccabe \
     {toxinidir}/tests/message/ {toxinidir}/tests/extensions/ {toxinidir}/tests/utils/ {toxinidir}/tests/acceptance/ {toxinidir}/tests/conftest.py \


### PR DESCRIPTION

## Description

---

**Fix a crash in `method-hidden` lookup for unknown base classes** (90d42153)

The patch replaces `mro()` with `ancestors()` as the former is not
fully capable of generating the complete linearization when
dealing with ambiguous inferences.

Close #3527

---

**Revert pylint.Run's `exit` parameter to ``do_exit``** (a02b1892)

This has been inadvertently changed several releases ago to ``do_exit``.

---

**Lint pylint from toxinidir, not the installed one** (357922e9)

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

Close #3533