### PR TITLE
Fix module without __init__.py parse error for 2.5.0

### DIFF
--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -175,7 +175,7 @@ def fake_path():
 
 def test_no_args(fake_path):
     with lint.fix_import_path([]):
-        assert sys.path == fake_path
+        assert sys.path == ["."] + fake_path
     assert sys.path == fake_path
 
 
@@ -185,7 +185,7 @@ def test_no_args(fake_path):
 def test_one_arg(fake_path, case):
     with tempdir() as chroot:
         create_files(["a/b/__init__.py"])
-        expected = [join(chroot, "a")] + fake_path
+        expected = [join(chroot, "a")] + ["."] + fake_path
 
         assert sys.path == fake_path
         with lint.fix_import_path(case):
@@ -205,7 +205,7 @@ def test_one_arg(fake_path, case):
 def test_two_similar_args(fake_path, case):
     with tempdir() as chroot:
         create_files(["a/b/__init__.py", "a/c/__init__.py"])
-        expected = [join(chroot, "a")] + fake_path
+        expected = [join(chroot, "a")] + ["."] + fake_path
 
         assert sys.path == fake_path
         with lint.fix_import_path(case):
@@ -224,10 +224,14 @@ def test_two_similar_args(fake_path, case):
 def test_more_args(fake_path, case):
     with tempdir() as chroot:
         create_files(["a/b/c/__init__.py", "a/d/__init__.py", "a/e/f.py"])
-        expected = [
-            join(chroot, suffix)
-            for suffix in [sep.join(("a", "b")), "a", sep.join(("a", "e"))]
-        ] + fake_path
+        expected = (
+            [
+                join(chroot, suffix)
+                for suffix in [sep.join(("a", "b")), "a", sep.join(("a", "e"))]
+            ]
+            + ["."]
+            + fake_path
+        )
 
         assert sys.path == fake_path
         with lint.fix_import_path(case):


### PR DESCRIPTION
## Description

This is a naive revert of https://github.com/PyCQA/pylint/commit/a6d7ffc4679b0ad2258cf6c31c6dfbeeb2b331ef there probably is a better way to do it. In particular it probably need a refactor to use what replaced `_get_python_path` since then.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Would close #3528 
