### PR TITLE
`no-value-for-parameter` variadic detection has improved for assign statements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,10 @@ Release date: TBA
 
   Close #3533
 
+* ``no-value-for-parameter`` variadic detection has improved for assign statements
+
+  Close #3563
+
 What's New in Pylint 2.5.0?
 ===========================
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -564,9 +564,9 @@ def _no_context_variadic_keywords(node, scope):
 
     if isinstance(scope, astroid.Lambda) and not isinstance(scope, astroid.FunctionDef):
         variadics = list(node.keywords or []) + node.kwargs
-    elif isinstance(statement, (astroid.Return, astroid.Expr)) and isinstance(
-        statement.value, astroid.Call
-    ):
+    elif isinstance(
+        statement, (astroid.Return, astroid.Expr, astroid.Assign)
+    ) and isinstance(statement.value, astroid.Call):
         call = statement.value
         variadics = list(call.keywords or []) + call.kwargs
 
@@ -579,9 +579,9 @@ def _no_context_variadic_positional(node, scope):
         variadics = node.starargs + node.kwargs
     else:
         statement = node.statement()
-        if isinstance(statement, (astroid.Expr, astroid.Return)) and isinstance(
-            statement.value, astroid.Call
-        ):
+        if isinstance(
+            statement, (astroid.Expr, astroid.Return, astroid.Assign)
+        ) and isinstance(statement.value, astroid.Call):
             call = statement.value
             variadics = call.starargs + call.kwargs
 

--- a/tests/functional/r/regression_no_value_for_parameter.py
+++ b/tests/functional/r/regression_no_value_for_parameter.py
@@ -1,5 +1,8 @@
 # pylint: disable=missing-docstring,import-error
+import os
+
 from Unknown import Unknown
+
 
 class ConfigManager(Unknown):
 
@@ -13,3 +16,27 @@ class ConfigManager(Unknown):
 
     def items(self, sectname, raw=True):
         pass
+
+
+def func(*, key=None):
+    return key
+
+
+def varargs_good(*parts):
+    """All good"""
+    return os.path.join(*parts)
+
+
+def varargs_no_expr(*parts):
+    """False positive below this line"""
+    ret = os.path.join(*parts)
+    return ret
+
+
+def kwargs_good(**kwargs):
+    return func(**kwargs)
+
+
+def kwargs_no_expr(**kwargs):
+    ret = func(**kwargs)
+    return ret


### PR DESCRIPTION
## Description
The problem was caused by the exemption of variadics for `no-value-for-parameter` not being smart enough when deciding if a statement should be included or not. Previously only return statements or expressions were taking in consideration, but right hand side of assignments should also be exempted when dealing with variadics.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Close #3563