### PR TITLE
Allow package files to be properly discovered with multiple jobs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,10 @@ Release date: TBA
 
   Close #3563
 
+* Allow package files to be properly discovered with multiple jobs
+
+  Close #3524
+
 What's New in Pylint 2.5.0?
 ===========================
 

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -104,12 +104,12 @@ def _basename_in_blacklist_re(base_name, black_list_re):
     return False
 
 
-def _modpath_from_file(filename, is_namespace):
+def _modpath_from_file(filename, is_namespace, path=None):
     def _is_package_cb(path, parts):
         return modutils.check_modpath_has_init(path, parts) or is_namespace
 
     return modutils.modpath_from_file_with_callback(
-        filename, is_package_cb=_is_package_cb
+        filename, path=path, is_package_cb=_is_package_cb
     )
 
 
@@ -200,7 +200,6 @@ def expand_modules(files_or_modules, black_list, black_list_re):
             not (modname.endswith(".__init__") or modname == "__init__")
             and os.path.basename(filepath) == "__init__.py"
         )
-
         if has_init or is_namespace or is_directory:
             for subfilepath in modutils.get_module_files(
                 os.path.dirname(filepath), black_list, list_all=is_namespace
@@ -212,7 +211,9 @@ def expand_modules(files_or_modules, black_list, black_list_re):
                 ):
                     continue
 
-                modpath = _modpath_from_file(subfilepath, is_namespace)
+                modpath = _modpath_from_file(
+                    subfilepath, is_namespace, path=additional_search_path
+                )
                 submodname = ".".join(modpath)
                 result.append(
                     {

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -732,3 +732,34 @@ class TestRunTC:
                 ],
                 cwd=str(tmpdir),
             )
+
+    def test_allow_import_of_files_found_in_modules_during_parallel_check(self, tmpdir):
+        test_directory = tmpdir / "test_directory"
+        test_directory.mkdir()
+        spam_module = test_directory / "spam.py"
+        spam_module.write("'Empty'")
+
+        init_module = test_directory / "__init__.py"
+        init_module.write("'Empty'")
+
+        # For multiple jobs we could not find the `spam.py` file.
+        with tmpdir.as_cwd():
+            self._runtest(
+                [
+                    "-j2",
+                    "--disable=missing-docstring, missing-final-newline",
+                    "test_directory",
+                ],
+                code=0,
+            )
+
+        # A single job should be fine as well
+        with tmpdir.as_cwd():
+            self._runtest(
+                [
+                    "-j1",
+                    "--disable=missing-docstring, missing-final-newline",
+                    "test_directory",
+                ],
+                code=0,
+            )


### PR DESCRIPTION
## Description
`modutils.modpath_from_file_with_callback` can use an additional path to search other than `sys.path`. While we were passing this flag for `modutils.file_info_from_modpath` in the `expand_modules` function, we were not doing it for `modpath_from_file_with_callback` as well, which is used to grab the file paths from the current package to be linted.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue
Close #3524

