### PR TITLE
Allow linting directories without `__init__.py`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,10 @@ Release date: TBA
 
   Close #3524
 
+* Allow linting directories without `__init__.py` which was a regression in 2.5.
+
+  Close #3528
+
 What's New in Pylint 2.5.0?
 ===========================
 

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -142,7 +142,7 @@ def expand_modules(files_or_modules, black_list, black_list_re):
             continue
 
         module_path = get_python_path(something)
-        additional_search_path = [module_path] + path
+        additional_search_path = [".", module_path] + path
         if os.path.exists(something):
             # this is a file or a directory
             try:

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -763,3 +763,18 @@ class TestRunTC:
                 ],
                 code=0,
             )
+
+    def test_can_list_directories_without_dunder_init(self, tmpdir):
+        test_directory = tmpdir / "test_directory"
+        test_directory.mkdir()
+        spam_module = test_directory / "spam.py"
+        spam_module.write("'Empty'")
+
+        with tmpdir.as_cwd():
+            self._runtest(
+                [
+                    "--disable=missing-docstring, missing-final-newline",
+                    "test_directory",
+                ],
+                code=0,
+            )


### PR DESCRIPTION
## Description

This was a regression in 2.5 caused by https://github.com/PyCQA/pylint/commit/a6d7ffc4679b0ad2258cf6c31c6dfbeeb2b331ef. 

Close #3528


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

