### PR TITLE
Fix crash when the user ask for --version and pylintrc is malformed

### DIFF
--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -25,6 +25,7 @@
 # pylint: disable=redefined-builtin,invalid-name
 """pylint packaging information"""
 
+
 from os.path import join
 
 # For an official release, use dev_version = None

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -55,9 +55,9 @@ def _patch_optparse():
 class OptionsManagerMixIn:
     """Handle configuration from both a configuration file and command line options"""
 
-    def __init__(self, usage, config_file=None, version=None):
+    def __init__(self, usage, config_file=None):
         self.config_file = config_file
-        self.reset_parsers(usage, version=version)
+        self.reset_parsers(usage)
         # list of registered options providers
         self.options_providers = []
         # dictionary associating option name to checker
@@ -68,13 +68,13 @@ class OptionsManagerMixIn:
         # verbosity
         self._maxlevel = 0
 
-    def reset_parsers(self, usage="", version=None):
+    def reset_parsers(self, usage=""):
         # configuration file parser
         self.cfgfile_parser = configparser.ConfigParser(
             inline_comment_prefixes=("#", ";")
         )
         # command line parser
-        self.cmdline_parser = OptionParser(Option, usage=usage, version=version)
+        self.cmdline_parser = OptionParser(Option, usage=usage)
         self.cmdline_parser.options_manager = self
         self._optik_option_attrs = set(self.cmdline_parser.option_class.ATTRS)
 

--- a/pylint/config/option_parser.py
+++ b/pylint/config/option_parser.py
@@ -4,6 +4,7 @@
 import optparse
 
 from pylint.config.option import Option
+from pylint.constants import full_version
 
 
 def _level_options(group, outputlevel):
@@ -17,7 +18,9 @@ def _level_options(group, outputlevel):
 
 class OptionParser(optparse.OptionParser):
     def __init__(self, option_class, *args, **kwargs):
-        optparse.OptionParser.__init__(self, option_class=Option, *args, **kwargs)
+        optparse.OptionParser.__init__(
+            self, option_class=Option, *args, version=full_version, **kwargs
+        )
 
     def format_option_help(self, formatter=None):
         if formatter is None:

--- a/pylint/config/option_parser.py
+++ b/pylint/config/option_parser.py
@@ -4,7 +4,6 @@
 import optparse
 
 from pylint.config.option import Option
-from pylint.constants import full_version
 
 
 def _level_options(group, outputlevel):
@@ -18,9 +17,7 @@ def _level_options(group, outputlevel):
 
 class OptionParser(optparse.OptionParser):
     def __init__(self, option_class, *args, **kwargs):
-        optparse.OptionParser.__init__(
-            self, option_class=Option, *args, version=full_version, **kwargs
-        )
+        optparse.OptionParser.__init__(self, option_class=Option, *args, **kwargs)
 
     def format_option_help(self, formatter=None):
         if formatter is None:

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -2,6 +2,11 @@
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
 import re
+import sys
+
+from astroid.__pkginfo__ import version as astroid_version
+
+from pylint.__pkginfo__ import version as pylint_version
 
 # Allow stopping after the first semicolon/hash encountered,
 # so that an option can be continued with the reasons
@@ -39,3 +44,10 @@ MAIN_CHECKER_NAME = "master"
 class WarningScope:
     LINE = "line-based-msg"
     NODE = "node-based-msg"
+
+
+full_version = "pylint %s\nastroid %s\nPython %s" % (
+    pylint_version,
+    astroid_version,
+    sys.version,
+)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -14,11 +14,9 @@ from io import TextIOWrapper
 
 import astroid
 from astroid import modutils
-from astroid.__pkginfo__ import version as astroid_version
 from astroid.builder import AstroidBuilder
 
 from pylint import checkers, config, exceptions, interfaces, reporters
-from pylint.__pkginfo__ import version
 from pylint.constants import MAIN_CHECKER_NAME, MSG_TYPES
 from pylint.lint.check_parallel import check_parallel
 from pylint.lint.report_functions import (
@@ -448,16 +446,10 @@ class PyLinter(
             "disable-msg": self.disable,
             "enable-msg": self.enable,
         }
-        full_version = "pylint %s\nastroid %s\nPython %s" % (
-            version,
-            astroid_version,
-            sys.version,
-        )
         MessagesHandlerMixIn.__init__(self)
         reporters.ReportsHandlerMixIn.__init__(self)
         super().__init__(
             usage=__doc__,
-            version=full_version,
             config_file=pylintrc or next(config.find_default_config_files(), None),
         )
         checkers.BaseTokenChecker.__init__(self)

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -6,6 +6,7 @@ import sys
 import warnings
 
 from pylint import __pkginfo__, config, extensions, interfaces
+from pylint.constants import full_version
 from pylint.lint.pylinter import PyLinter
 from pylint.lint.utils import ArgumentPreprocessingError, preprocess_options
 from pylint.utils import utils
@@ -73,6 +74,10 @@ group are mutually exclusive.",
     def __init__(
         self, args, reporter=None, exit=True, do_exit=UNUSED_PARAM_SENTINEL,
     ):  # pylint: disable=redefined-builtin
+        def display_version(_, __):
+            print(full_version)
+            sys.exit(0)
+
         self._rcfile = None
         self._plugins = []
         self.verbose = None
@@ -81,6 +86,7 @@ group are mutually exclusive.",
                 args,
                 {
                     # option: (callback, takearg)
+                    "version": (display_version, False),
                     "init-hook": (cb_init_hook, True),
                     "rcfile": (self.cb_set_rcfile, True),
                     "load-plugins": (self.cb_add_plugins, True),

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -74,11 +74,8 @@ group are mutually exclusive.",
     def __init__(
         self, args, reporter=None, exit=True, do_exit=UNUSED_PARAM_SENTINEL,
     ):  # pylint: disable=redefined-builtin
-        def display_version(_, __):
-            print(full_version)
-            sys.exit(0)
-
         self._rcfile = None
+        self._version_asked = False
         self._plugins = []
         self.verbose = None
         try:
@@ -86,7 +83,7 @@ group are mutually exclusive.",
                 args,
                 {
                     # option: (callback, takearg)
-                    "version": (display_version, False),
+                    "version": (self.version_asked, False),
                     "init-hook": (cb_init_hook, True),
                     "rcfile": (self.cb_set_rcfile, True),
                     "load-plugins": (self.cb_add_plugins, True),
@@ -257,6 +254,9 @@ group are mutually exclusive.",
             pylintrc=self._rcfile,
         )
         # register standard checkers
+        if self._version_asked:
+            print(full_version)
+            sys.exit(0)
         linter.load_default_plugins()
         # load command line plugins
         linter.load_plugin_modules(self._plugins)
@@ -363,6 +363,10 @@ group are mutually exclusive.",
                 if score_value and score_value > linter.config.fail_under:
                     sys.exit(0)
                 sys.exit(self.linter.msg_status)
+
+    def version_asked(self, _, __):
+        """callback for version (i.e. before option parsing)"""
+        self._version_asked = True
 
     def cb_set_rcfile(self, name, value):
         """callback for option preprocessing (i.e. before option parsing)"""


### PR DESCRIPTION
## Description

This fix #3576 albeit in a hacky way (?) I refactored a little the version that was stored in every checker apparently. What could be the reason to do that? Also, I wonder why the BaseChecker inherit from OptionProviderMixin? Couldn't we parse the option once and give each checker it's own options so we can instantiate a checker without using sys args and optparse?

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :hammer: Refactoring  |


## Related Issue

Closes #3576 

