### PR TITLE
Add new old-style-super check to flag instances of super with default arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,8 @@ Release date: TBA
 
 * mixed-indentation has been removed, it is no longer useful since TabError is included directly in python3
 
+* Add `old-style-super` check for flagging instances of Python 2 style super calls.
+
    Close #2984 #3573
 
 What's New in Pylint 2.5.1?

--- a/doc/whatsnew/2.6.rst
+++ b/doc/whatsnew/2.6.rst
@@ -13,6 +13,8 @@ Summary -- Release highlights
 New checkers
 ============
 
+* Add `old-style-super` check for flagging instances of Python 2 style super calls.
+
 Other Changes
 =============
 

--- a/tests/checkers/unittest_python3.py
+++ b/tests/checkers/unittest_python3.py
@@ -1153,3 +1153,37 @@ class TestPython3Checker(testutils.CheckerTestCase):
         message = testutils.Message("next-method-defined", node=node)
         with self.assertAddsMessages(message):
             self.checker.visit_functiondef(node)
+
+    def test_old_style_super(self):
+        node = astroid.extract_node(
+            """
+            class Foo(object):
+                def __init__():
+                    super(Foo, self).__init__()  #@
+            """
+        ).func.expr
+        message = testutils.Message("old-style-super", node=node)
+        with self.assertAddsMessages(message):
+            self.checker.visit_call(node)
+
+    def test_super_non_default_args(self):
+        node = astroid.extract_node(
+            """
+            class Foo(object):
+                def __init__():
+                    super(Bar, self).__init__()  #@
+            """
+        ).func.expr
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
+
+    def test_new_style_super(self):
+        node = astroid.extract_node(
+            """
+            class Foo(object):
+                def __init__():
+                    super().__init__()  #@
+            """
+        ).func.expr
+        with self.assertNoMessages():
+            self.checker.visit_call(node)

--- a/tests/functional/s/super_style.py
+++ b/tests/functional/s/super_style.py
@@ -1,0 +1,17 @@
+class Foo:
+    pass
+
+
+class Bar(Foo):
+    def __init__(self):
+        super(Bar, self).__init__()  # [old-style-super]
+
+
+class Baz(Foo):
+    def __init__(self):
+        super().__init__()
+
+
+class Qux(Foo):
+    def __init__(self):
+        super(Bar, self).__init__()

--- a/tests/functional/s/super_style.rc
+++ b/tests/functional/s/super_style.rc
@@ -1,0 +1,3 @@
+[Messages Control]
+disable=all
+enable=old-style-super

--- a/tests/functional/s/super_style.txt
+++ b/tests/functional/s/super_style.txt
@@ -1,0 +1,1 @@
+old-style-super:7:Bar.__init__:Consider using Python 3 style super() without arguments


### PR DESCRIPTION
##  Description

Adds a check that flags instances of super with the default arguments, which are no longer needed in Python 3.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Related Issue

Closes #3541 
