### PR TITLE
Rename old-style-super and move it to refactoring out of the Python 3 porting checker

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,17 +8,18 @@ Release date: TBA
 
 * bad-continuation and bad-whitespace have been removed, black or another formatter can help you with this better than Pylint
 
-    Close #246, #289, #638, #747, #1148, #1179, #1943, #2041, #2301, #2304, #2944, #3565
+  Close #246, #289, #638, #747, #1148, #1179, #1943, #2041, #2301, #2304, #2944, #3565
 
 * The no-space-check option has been removed. It's no longer possible to consider empty line like a `trailing-whitespace` by using clever options
 
-    Close #1368
+  Close #1368
 
 * mixed-indentation has been removed, it is no longer useful since TabError is included directly in python3
 
-* Add `old-style-super` check for flagging instances of Python 2 style super calls.
+  Close #2984 #3573
 
-   Close #2984 #3573
+* Add `super-with-arguments` check for flagging instances of Python 2 style super calls.
+
 
 What's New in Pylint 2.5.1?
 ===========================

--- a/doc/whatsnew/2.6.rst
+++ b/doc/whatsnew/2.6.rst
@@ -13,7 +13,7 @@ Summary -- Release highlights
 New checkers
 ============
 
-* Add `old-style-super` check for flagging instances of Python 2 style super calls.
+* Add `super-with-arguments` check for flagging instances of Python 2 style super calls.
 
 Other Changes
 =============

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -598,12 +598,6 @@ class Python3Checker(checkers.BaseChecker):
             "variables will be deleted outside of the "
             "comprehension.",
         ),
-        "C1601": (
-            "Consider using Python 3 style super() without arguments",
-            "old-style-super",
-            "Emitted when calling the super builtin with the current class "
-            "and instance. On Python 3 these arguments are the default.",
-        ),
     }
 
     _bad_builtins = frozenset(
@@ -1245,20 +1239,6 @@ class Python3Checker(checkers.BaseChecker):
                         if kwarg.arg == "encoding":
                             self._validate_encoding(kwarg.value, node)
                             break
-                elif node.func.name == "super":
-                    if len(node.args) != 2:
-                        return
-                    if (
-                        not isinstance(node.args[1], astroid.Name)
-                        or node.args[1].name != "self"
-                    ):
-                        return
-                    if (
-                        not isinstance(node.args[1], astroid.Name)
-                        or node.args[0].name != node.scope().parent.name
-                    ):
-                        return
-                    self.add_message("old-style-super", node=node)
 
     def _validate_encoding(self, encoding, node):
         if isinstance(encoding, astroid.Const):

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -751,15 +751,18 @@ class RefactoringChecker(checkers.BaseTokenChecker):
     def _check_super_with_arguments(self, node):
         if not isinstance(node.func, astroid.Name) or node.func.name != "super":
             return
-        if len(node.args) != 2:
-            return
-        if not isinstance(node.args[1], astroid.Name) or node.args[1].name != "self":
-            return
+
+        # pylint: disable=too-many-boolean-expressions
         if (
-            not isinstance(node.args[1], astroid.Name)
+            len(node.args) != 2
+            or not isinstance(node.args[1], astroid.Name)
+            or node.args[1].name != "self"
+            or not isinstance(node.args[0], astroid.Name)
+            or not isinstance(node.args[1], astroid.Name)
             or node.args[0].name != node_frame_class(node).name
         ):
             return
+
         self.add_message("super-with-arguments", node=node)
 
     def _check_raising_stopiteration_in_generator_next_call(self, node):

--- a/pylint/checkers/refactoring.py
+++ b/pylint/checkers/refactoring.py
@@ -45,6 +45,7 @@ from astroid import decorators
 from pylint import checkers, interfaces
 from pylint import utils as lint_utils
 from pylint.checkers import utils
+from pylint.checkers.utils import node_frame_class
 
 KNOWN_INFINITE_ITERATORS = {"itertools.count"}
 BUILTIN_EXIT_FUNCS = frozenset(("quit", "exit"))
@@ -308,6 +309,12 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             "As such, it will warn when it encounters an else "
             "following a chain of ifs, all of them containing a "
             "continue statement.",
+        ),
+        "R1725": (
+            "Consider using Python 3 style super() without arguments",
+            "super-with-arguments",
+            "Emitted when calling the super() builtin with the current class "
+            "and instance. On Python 3 these arguments are the default and they can be omitted.",
         ),
     }
     options = (
@@ -715,11 +722,13 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         "consider-using-dict-comprehension",
         "consider-using-set-comprehension",
         "consider-using-sys-exit",
+        "super-with-arguments",
     )
     def visit_call(self, node):
         self._check_raising_stopiteration_in_generator_next_call(node)
         self._check_consider_using_comprehension_constructor(node)
         self._check_quit_exit_call(node)
+        self._check_super_with_arguments(node)
 
     @staticmethod
     def _has_exit_in_scope(scope):
@@ -738,6 +747,20 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             ):
                 return
             self.add_message("consider-using-sys-exit", node=node)
+
+    def _check_super_with_arguments(self, node):
+        if not isinstance(node.func, astroid.Name) or node.func.name != "super":
+            return
+        if len(node.args) != 2:
+            return
+        if not isinstance(node.args[1], astroid.Name) or node.args[1].name != "self":
+            return
+        if (
+            not isinstance(node.args[1], astroid.Name)
+            or node.args[0].name != node_frame_class(node).name
+        ):
+            return
+        self.add_message("super-with-arguments", node=node)
 
     def _check_raising_stopiteration_in_generator_next_call(self, node):
         """Check if a StopIteration exception is raised by the call to next function

--- a/tests/checkers/unittest_python3.py
+++ b/tests/checkers/unittest_python3.py
@@ -1153,37 +1153,3 @@ class TestPython3Checker(testutils.CheckerTestCase):
         message = testutils.Message("next-method-defined", node=node)
         with self.assertAddsMessages(message):
             self.checker.visit_functiondef(node)
-
-    def test_old_style_super(self):
-        node = astroid.extract_node(
-            """
-            class Foo(object):
-                def __init__():
-                    super(Foo, self).__init__()  #@
-            """
-        ).func.expr
-        message = testutils.Message("old-style-super", node=node)
-        with self.assertAddsMessages(message):
-            self.checker.visit_call(node)
-
-    def test_super_non_default_args(self):
-        node = astroid.extract_node(
-            """
-            class Foo(object):
-                def __init__():
-                    super(Bar, self).__init__()  #@
-            """
-        ).func.expr
-        with self.assertNoMessages():
-            self.checker.visit_call(node)
-
-    def test_new_style_super(self):
-        node = astroid.extract_node(
-            """
-            class Foo(object):
-                def __init__():
-                    super().__init__()  #@
-            """
-        ).func.expr
-        with self.assertNoMessages():
-            self.checker.visit_call(node)

--- a/tests/functional/a/access_to_protected_members.py
+++ b/tests/functional/a/access_to_protected_members.py
@@ -33,7 +33,7 @@ class Subclass(MyClass):
 
     def __init__(self):
         MyClass._protected = 5
-        super(Subclass, self)._private_method()
+        super()._private_method()
 
 INST = Subclass()
 INST.attr = 1

--- a/tests/functional/a/arguments_differ.py
+++ b/tests/functional/a/arguments_differ.py
@@ -93,7 +93,7 @@ class Sub(Super):
 
     # pylint: disable=unused-argument
     def __init__(self, arg):
-        super(Sub, self).__init__()
+        super().__init__()
 
     def __private(self, arg):
         pass
@@ -142,7 +142,7 @@ class PropertySetter(Property):
 class StaticmethodChild2(Staticmethod):
 
     def func(self, data):
-        super(StaticmethodChild2, self).func(data)
+        super().func(data)
 
 
 class SuperClass(object):
@@ -158,7 +158,7 @@ class MyClass(SuperClass):
         """
         Acceptable use of vararg in subclass because it does not violate LSP.
         """
-        super(MyClass, self).impl(*args, **kwargs)
+        super().impl(*args, **kwargs)
 
 
 class FirstHasArgs(object):
@@ -185,7 +185,7 @@ class PositionalChild(Positional):
         """
         Acceptable use of vararg in subclass because it does not violate LSP.
         """
-        super(PositionalChild, self).test(args[0], args[1])
+        super().test(args[0], args[1])
 
 class Mixed(object):
 
@@ -199,7 +199,7 @@ class MixedChild1(Mixed):
         """
         Acceptable use of vararg in subclass because it does not violate LSP.
         """
-        super(MixedChild1, self).mixed(first, *args, **kwargs)
+        super().mixed(first, *args, **kwargs)
 
 
 class MixedChild2(Mixed):
@@ -208,7 +208,7 @@ class MixedChild2(Mixed):
         """
         Acceptable use of vararg in subclass because it does not violate LSP.
         """
-        super(MixedChild2, self).mixed(first, *args, third, **kwargs)
+        super().mixed(first, *args, third, **kwargs)
 
 
 class HasSpecialMethod(object):

--- a/tests/functional/a/assigning_non_slot.py
+++ b/tests/functional/a/assigning_non_slot.py
@@ -34,7 +34,7 @@ class Bad3(Bad):
         self.component = 42
         self.member = 24
         self.missing = 42 # [assigning-non-slot]
-        super(Bad3, self).__init__()
+        super().__init__()
 
 class Good(Empty):
     """ missing not in slots, but Empty doesn't

--- a/tests/functional/d/deprecated_methods_py3.py
+++ b/tests/functional/d/deprecated_methods_py3.py
@@ -32,7 +32,7 @@ class SuperCrash(unittest.TestCase):
 
     def __init__(self):
         # should not crash.
-        super(SuperCrash, self)()
+        super()()
 
 xml.etree.ElementTree.iterparse(None)
 

--- a/tests/functional/d/deprecated_methods_py38.py
+++ b/tests/functional/d/deprecated_methods_py38.py
@@ -27,7 +27,7 @@ class SuperCrash(unittest.TestCase):
 
     def __init__(self):
         # should not crash.
-        super(SuperCrash, self)()
+        super()()
 
 xml.etree.ElementTree.iterparse(None)
 

--- a/tests/functional/i/init_not_called.py
+++ b/tests/functional/i/init_not_called.py
@@ -28,13 +28,13 @@ class ZZZZ(AAAA, BBBB, CCCC):
 class NewStyleA(object):
     """new style class"""
     def __init__(self):
-        super(NewStyleA, self).__init__()
+        super().__init__()
         print('init', self)
 
 class NewStyleB(NewStyleA):
     """derived new style class"""
     def __init__(self):
-        super(NewStyleB, self).__init__()
+        super().__init__()
 
 class NoInit(object):
     """No __init__ defined"""

--- a/tests/functional/m/member_checks.py
+++ b/tests/functional/m/member_checks.py
@@ -62,7 +62,7 @@ class Client(object):
         none = None
         print(none.whatever)
         # No misssing in the parents.
-        super(Client, self).misssing() # [no-member]
+        super().misssing() # [no-member]
 
 
 class Mixin(object):
@@ -129,7 +129,7 @@ except AttributeError:
 class SuperChecks(str, str): # pylint: disable=duplicate-bases
     """Don't fail when the MRO is invalid."""
     def test(self):
-        super(SuperChecks, self).lalala()
+        super().lalala()
 
 type(Client()).ala # [no-member]
 type({}).bala # [no-member]

--- a/tests/functional/m/member_checks_hints.py
+++ b/tests/functional/m/member_checks_hints.py
@@ -16,7 +16,7 @@ class Parent(object):
 class Child(Parent):
 
     def __init__(self):
-        super(Child, self).__init__()
+        super().__init__()
 
         self._similar # [no-member]
         self._really_similar # [no-member]

--- a/tests/functional/m/member_checks_no_hints.py
+++ b/tests/functional/m/member_checks_no_hints.py
@@ -16,7 +16,7 @@ class Parent(object):
 class Child(Parent):
 
     def __init__(self):
-        super(Child, self).__init__()
+        super().__init__()
 
         self._similar # [no-member]
         self._really_similar # [no-member]

--- a/tests/functional/m/method_hidden.py
+++ b/tests/functional/m/method_hidden.py
@@ -87,6 +87,6 @@ except ImportError:
 
 
 class JsonEncoder(js.JSONEncoder):
-    # pylint: disable=useless-super-delegation
+    # pylint: disable=useless-super-delegation,super-with-arguments
     def default(self, o):
         return super(JsonEncoder, self).default(o)

--- a/tests/functional/n/name_styles.py
+++ b/tests/functional/n/name_styles.py
@@ -59,7 +59,7 @@ class DerivedFromCorrect(CorrectClassName):
     zz = 'Now a good class attribute'
 
     def __init__(self):
-        super(DerivedFromCorrect, self).__init__()
+        super().__init__()
         self._Bad_AtTR_name = None  # Ignored
 
     def BadMethodName(self):

--- a/tests/functional/r/regression_property_no_member_844.py
+++ b/tests/functional/r/regression_property_no_member_844.py
@@ -12,7 +12,7 @@ class Parent:
 class Child(Parent):
     @Parent.thing.getter
     def thing(self):
-        return super(Child, self).thing + '!'
+        return super().thing + '!'
 
 
 print(Child().thing)

--- a/tests/functional/s/super_checks.py
+++ b/tests/functional/s/super_checks.py
@@ -1,6 +1,6 @@
 # pylint: disable=too-few-public-methods,import-error, no-absolute-import,missing-docstring, useless-object-inheritance
 # pylint: disable=useless-super-delegation,wrong-import-position,invalid-name, wrong-import-order
-
+# pylint: disable=super-with-arguments
 from unknown import Missing
 
 class Aaaa:

--- a/tests/functional/s/super_style.txt
+++ b/tests/functional/s/super_style.txt
@@ -1,1 +1,0 @@
-old-style-super:7:Bar.__init__:Consider using Python 3 style super() without arguments

--- a/tests/functional/s/super_with_arguments.py
+++ b/tests/functional/s/super_with_arguments.py
@@ -4,7 +4,7 @@ class Foo:
 
 class Bar(Foo):
     def __init__(self):
-        super(Bar, self).__init__()  # [old-style-super]
+        super(Bar, self).__init__()  # [super-with-arguments]
 
 
 class Baz(Foo):
@@ -15,3 +15,8 @@ class Baz(Foo):
 class Qux(Foo):
     def __init__(self):
         super(Bar, self).__init__()
+
+
+class NotSuperCall(Foo):
+    def __init__(self):
+        super.test(Bar, self).__init__()

--- a/tests/functional/s/super_with_arguments.py
+++ b/tests/functional/s/super_with_arguments.py
@@ -20,3 +20,8 @@ class Qux(Foo):
 class NotSuperCall(Foo):
     def __init__(self):
         super.test(Bar, self).__init__()
+
+
+class InvalidSuperCall(Foo):
+    def __init__(self):
+        super(InvalidSuperCall.__class__, self).__init__()

--- a/tests/functional/s/super_with_arguments.rc
+++ b/tests/functional/s/super_with_arguments.rc
@@ -1,3 +1,3 @@
 [Messages Control]
 disable=all
-enable=old-style-super
+enable=super-with-arguments

--- a/tests/functional/s/super_with_arguments.txt
+++ b/tests/functional/s/super_with_arguments.txt
@@ -1,0 +1,1 @@
+super-with-arguments:7:Bar.__init__:Consider using Python 3 style super() without arguments

--- a/tests/functional/u/useless_super_delegation.py
+++ b/tests/functional/u/useless_super_delegation.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-docstring, no-member, no-self-use, bad-super-call
 # pylint: disable=too-few-public-methods, unused-argument, invalid-name, too-many-public-methods
 # pylint: disable=line-too-long, useless-object-inheritance, arguments-out-of-order
-
+# pylint: disable=super-with-arguments
 
 def not_a_method(param, param2):
     return super(None, None).not_a_method(param, param2)
@@ -50,16 +50,16 @@ class Base(SuperBase):
         pass
 
     def with_default_arg_ter(self, first, default_arg="has_been_changed"):
-        super(Base, self).with_default_arg_ter(first, default_arg)
+        super().with_default_arg_ter(first, default_arg)
 
     def with_default_arg_quad(self, first, default_arg="has_been_changed"):
-        super(Base, self).with_default_arg_quad(first, default_arg)
+        super().with_default_arg_quad(first, default_arg)
 
 class NotUselessSuper(Base):
 
     def multiple_statements(self):
         first = 42 * 24
-        return super(NotUselessSuper, self).multiple_statements() + first
+        return super().multiple_statements() + first
 
     def not_a_call(self):
         return 1 + 2
@@ -68,7 +68,7 @@ class NotUselessSuper(Base):
         return type(self).__class__
 
     def not_super_attribute_access(self):
-        return super(NotUselessSuper, self)
+        return super()
 
     def invalid_super_call(self):
         return super(NotUselessSuper, 1).invalid_super_call()
@@ -77,7 +77,7 @@ class NotUselessSuper(Base):
         return super(2, 3, 4, 5).other_invalid_super_call()
 
     def different_name(self):
-        return super(NotUselessSuper, self).something()
+        return super().something()
 
     def different_super_mro_pointer(self):
         return super(Base, self).different_super_mro_pointer()

--- a/tests/functional/u/useless_super_delegation_py3.py
+++ b/tests/functional/u/useless_super_delegation_py3.py
@@ -4,10 +4,10 @@
 class NotUselessSuper(object):
 
     def not_passing_keyword_only(self, first, *, second):
-        return super(NotUselessSuper, self).not_passing_keyword_only(first)
+        return super().not_passing_keyword_only(first)
 
     def passing_keyword_only_with_modifications(self, first, *, second):
-        return super(NotUselessSuper, self).passing_keyword_only_with_modifications(
+        return super().passing_keyword_only_with_modifications(
             first, second + 1)
 
 
@@ -19,7 +19,7 @@ class AlsoNotUselessSuper(NotUselessSuper):
 class UselessSuper(object):
 
     def useless(self, *, first): # [useless-super-delegation]
-        super(UselessSuper, self).useless(first=first)
+        super().useless(first=first)
 
 
 class Egg():

--- a/tests/functional/u/useless_super_delegation_py35.py
+++ b/tests/functional/u/useless_super_delegation_py35.py
@@ -3,10 +3,10 @@
 class NotUselessSuper(object):
 
     def not_passing_all_params(self, first, *args, second=None, **kwargs):
-        return super(NotUselessSuper, self).not_passing_all_params(*args, second, **kwargs)
+        return super().not_passing_all_params(*args, second, **kwargs)
 
 
 class UselessSuper(object):
 
     def useless(self, first, *, second=None, **kwargs): # [useless-super-delegation]
-        return super(UselessSuper, self).useless(first, second=second, **kwargs)
+        return super().useless(first, second=second, **kwargs)


### PR DESCRIPTION
## Description

---

**Rename the new old-style super with super-with-arguments** (0c54e7e9)

Also move it from the Python 3 checker to the refactoring one, as it's a
better fit for it.

---

**Address the super violations in the codebase** (f2197e5f)


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |
