### PR TITLE
``pylint.Run`` accepts ``do_exit`` as a deprecated parameter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,15 @@
 Pylint's ChangeLog
 ------------------
 
+What's New in Pylint 2.5.2?
+===========================
+
+Release date: TBA
+
+* ``pylint.Run`` accepts ``do_exit`` as a deprecated parameter
+
+  Close #3590
+
 What's New in Pylint 2.5.1?
 ===========================
 

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import warnings
 
 from pylint import __pkginfo__, config, extensions, interfaces
 from pylint.lint.pylinter import PyLinter
@@ -47,6 +48,9 @@ def cb_init_hook(optname, value):
     exec(value)  # pylint: disable=exec-used
 
 
+UNUSED_PARAM_SENTINEL = object()
+
+
 class Run:
     """helper class to use as main for pylint :
 
@@ -67,7 +71,7 @@ group are mutually exclusive.",
         return 1
 
     def __init__(
-        self, args, reporter=None, exit=True
+        self, args, reporter=None, exit=True, do_exit=UNUSED_PARAM_SENTINEL,
     ):  # pylint: disable=redefined-builtin
         self._rcfile = None
         self._plugins = []
@@ -339,6 +343,14 @@ group are mutually exclusive.",
 
         linter.check(args)
         score_value = linter.generate_reports()
+
+        if do_exit is not UNUSED_PARAM_SENTINEL:
+            warnings.warn(
+                "do_exit is deprecated and it is going to be removed in a future version.",
+                DeprecationWarning,
+            )
+            exit = do_exit
+
         if exit:
             if linter.config.exit_zero:
                 sys.exit(0)


### PR DESCRIPTION
We need to allow various third party libraries that depend on `pylint` to still use `do_exit` until they can move over to use `exit`. For now the `do_exit` parameter is marked as deprecated and will be removed in a future version.

Close #3590
