### PR TITLE
Fix changelog entries for 'super-with-arguments' check

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,8 +18,6 @@ Release date: TBA
 
   Close #2984 #3573
 
-* Add `super-with-arguments` check for flagging instances of Python 2 style super calls.
-
 
 What's New in Pylint 2.5.2?
 ===========================
@@ -29,6 +27,10 @@ Release date: 2020-05-05
 * ``pylint.Run`` accepts ``do_exit`` as a deprecated parameter
 
   Close #3590
+
+* Add `super-with-arguments` check for flagging instances of Python 2 style super calls.
+
+	Close #3541
 
 
 What's New in Pylint 2.5.1?

--- a/doc/whatsnew/2.6.rst
+++ b/doc/whatsnew/2.6.rst
@@ -13,8 +13,6 @@ Summary -- Release highlights
 New checkers
 ============
 
-* Add `super-with-arguments` check for flagging instances of Python 2 style super calls.
-
 Other Changes
 =============
 


### PR DESCRIPTION
## Description

The `super-with-arguments` change was under the 2.6 banner but it was released in its final form in 2.5.2. This changeset corrects that.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

