### PR TITLE
`continue-in-finally` no longer emitted on Python 3.8 where it's now valid

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,10 @@ Release date: TBA
 
   Close #3600
 
+* `continue-in-finally` no longer emitted on Python 3.8 where it's now valid
+
+  Close #3612
+
 
 What's New in Pylint 2.5.2?
 ===========================

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -541,6 +541,7 @@ class BasicErrorChecker(_BasicChecker):
             "continue-in-finally",
             "Emitted when the `continue` keyword is found "
             "inside a finally clause, which is a SyntaxError.",
+            {"maxversion": (3, 8)},
         ),
         "E0117": (
             "nonlocal name %s found without binding",

--- a/tests/functional/c/continue_in_finally.rc
+++ b/tests/functional/c/continue_in_finally.rc
@@ -1,0 +1,2 @@
+[testoptions]
+max_pyver=3.8


### PR DESCRIPTION
Close #3612
