### PR TITLE
Fix a regression where the score was not reported with multiple jobs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,10 @@ Release date: TBA
 
   Close #3604
 
+* Fix a regression where the score was not reported with multiple jobs
+
+  Close #3547
+
 
 What's New in Pylint 2.5.2?
 ===========================

--- a/pylint/lint/check_parallel.py
+++ b/pylint/lint/check_parallel.py
@@ -71,6 +71,7 @@ def _worker_check_single_file(file_item):
     msgs = [_get_new_args(m) for m in _worker_linter.reporter.messages]
     return (
         _worker_linter.current_name,
+        _worker_linter.file_state.base_name,
         msgs,
         _worker_linter.stats,
         _worker_linter.msg_status,
@@ -97,9 +98,10 @@ def check_parallel(linter, jobs, files, arguments=None):
 
         all_stats = []
 
-        for module, messages, stats, msg_status in pool.imap_unordered(
+        for module, base_name, messages, stats, msg_status in pool.imap_unordered(
             _worker_check_single_file, files
         ):
+            linter.file_state.base_name = base_name
             linter.set_current_module(module)
             for msg in messages:
                 msg = Message(*msg)

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -778,3 +778,8 @@ class TestRunTC:
                 ],
                 code=0,
             )
+
+    def test_jobs_score(self):
+        path = join(HERE, "regrtest_data", "unused_variable.py")
+        expected = "Your code has been rated at 7.50/10"
+        self._test_output([path, "--jobs=2", "-ry"], expected_output=expected)


### PR DESCRIPTION
## Description
The linter depends on `FileState.base_name` to be set for emitting
the reports. This has been removed inadvertently in
21dc87531296256c3bccda660229b0c60a7bb129 during refactoring of
the multiprocessing implementation.

Close #3547

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
