### PR TITLE
Fix #2498: add generated-members match against the qualified name

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -383,3 +383,5 @@ contributors:
 * Andrew J. Simmons (anjsimmo): contributor
 
 * Damien Baty: contributor
+
+* Gauthier Sebaux: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,10 @@ Release date: TBA
 
 * Add `super-with-arguments` check for flagging instances of Python 2 style super calls.
 
+* `generated-members` now matches the qualified name of members
+
+  Close #2498
+
 
 What's New in Pylint 2.5.3?
 ===========================

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -916,13 +916,6 @@ accessed. Python regular expressions are accepted.",
 
         function/method, super call and metaclasses are ignored
         """
-        for pattern in self.config.generated_members:
-            # attribute is marked as generated, stop here
-            if re.match(pattern, node.attrname):
-                return
-            if re.match(pattern, node.as_string()):
-                return
-
         try:
             inferred = list(node.expr.infer())
         except exceptions.InferenceError:
@@ -950,6 +943,24 @@ accessed. Python regular expressions are accepted.",
             if _is_owner_ignored(
                 owner, name, self.config.ignored_classes, self.config.ignored_modules
             ):
+                continue
+
+            # ignore pattern added to generated-members
+            ignored = False
+            for pattern in self.config.generated_members:
+                # attribute is marked as generated, stop here
+                if re.match(pattern, node.attrname):
+                    ignored = True
+                    break
+                if re.match(pattern, node.as_string()):
+                    ignored = True
+                    break
+                if re.match(pattern, "%s.%s" % (owner.pytype(), node.attrname)):
+                    ignored = True
+                    break
+
+            # continue the outer loop if a pattern matched
+            if ignored:
                 continue
 
             try:


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [X] Add yourself to CONTRIBUTORS if you are a new contributor.
- [X] Add a ChangeLog entry describing what your PR does.
- [X] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [X] Write a good description on what the PR does.

## Description

This PR fix #2498: previously, `generated-members` only matched against the node string (e.g. `service.files`) or against the node attribute name (e.g. `files`).

With this change, the qualified name can also be matched (e.g. `googleapiclient.discovery.Resource.files`)

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

Closes #2498
<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
