### PR TITLE
Add allow-redefined-builtins option to variable checker

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -454,3 +454,5 @@ contributors:
 * Lefteris Karapetsas: contributor
 
 * Louis Sautier: contributor
+
+* Alexander Kapshuna: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,9 @@ Release date: TBA
 
   Closes #4149
 
+* Add `allowed-redefined-builtins` option for fine tuning `redefined-builtin` check.
+
+  Close #3263
 
 What's New in Pylint 2.7.2?
 ===========================
@@ -34,7 +37,6 @@ Release date: 2021-02-28
   Closes #3636
 
 * Workflow and packaging improvements
-
 
 What's New in Pylint 2.7.1?
 ===========================
@@ -297,7 +299,6 @@ What's New in Pylint 2.5.4?
 * Fix a crash in parallel mode when the module's filepath is not set
 
   Close #3564
-
 
 What's New in Pylint 2.5.3?
 ===========================

--- a/doc/whatsnew/2.7.rst
+++ b/doc/whatsnew/2.7.rst
@@ -54,3 +54,5 @@ Other Changes
 * `len-as-conditions` is now triggered only for classes that are inheriting directly from list, dict, or set and not implementing the `__bool__` function, or from generators like range or list/dict/set comprehension. This should reduce the false positive for other classes, like pandas's DataFrame or numpy's Array.
 
 * Fixes duplicate code detection for --jobs=2+
+
+* New option `allowed-redefined-builtins` defines variable names allowed to shadow builtins.

--- a/tests/functional/r/redefined_builtin_allowed.py
+++ b/tests/functional/r/redefined_builtin_allowed.py
@@ -1,0 +1,9 @@
+"""Tests for redefining builtins."""
+
+def function():
+    """Allow some redefines."""
+    dir = "path"  # allowed in config
+    dict = "wrong"  # [redefined-builtin]
+    print(dir, dict)
+
+list = "not in globals" # [redefined-builtin]

--- a/tests/functional/r/redefined_builtin_allowed.rc
+++ b/tests/functional/r/redefined_builtin_allowed.rc
@@ -1,0 +1,4 @@
+[messages control]
+disable = invalid-name
+[variables]
+allowed-redefined-builtins = dir, list

--- a/tests/functional/r/redefined_builtin_allowed.txt
+++ b/tests/functional/r/redefined_builtin_allowed.txt
@@ -1,0 +1,2 @@
+redefined-builtin:6:4:function:Redefining built-in 'dict'
+redefined-builtin:9:0::Redefining built-in 'list'


### PR DESCRIPTION

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [X] Write a good description on what the PR does.

## Description
Some builtins have little-to-no use in application code while being
convenient as variables names (e.g. id, dir). New option allows
to configure allowed to override names for redefined-builtin checker.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #3263 
