### PR TITLE
 Add an faq detailing which messages to disable to avoid duplicates w/ other popular linters

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -383,3 +383,5 @@ contributors:
 * Andrew J. Simmons (anjsimmo): contributor
 
 * Damien Baty: contributor
+
+* Daniel R. Neal (danrneal): contributer

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,7 @@ Release date: TBA
 
 * Add `super-with-arguments` check for flagging instances of Python 2 style super calls.
 
+* Add an faq detailing which messages to disable to avoid duplicates w/ other popular linters
 
 What's New in Pylint 2.5.3?
 ===========================

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -154,6 +154,7 @@ No, starting from 0.25.3, you can use symbolic names for messages::
 
     # pylint: disable=fixme, line-too-long
 
+
 4.5 I have a callback function where I have no control over received arguments. How do I avoid getting unused argument warnings?
 ----------------------------------------------------------------------------------------------------------------------------------
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -189,7 +189,7 @@ default. It needs special activation with the ``--py3k`` flag.
 4.8 I am using another popular linter alongside pylint. Which messages should I disable to avoid duplicates?
 ------------------------------------------------------------------------------------------------------------
 
-pycodestyle: unneeded-not, line-too-long, unnecessary-semicolon, trailing-whitespace, missing-final-newline, bad-indentation, multiple-statements, bare-except
+pycodestyle_: unneeded-not, line-too-long, unnecessary-semicolon, trailing-whitespace, missing-final-newline, bad-indentation, multiple-statements, bare-except
 
 pyflakes_: undefined-variable, unused-import, unused-variable
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -154,7 +154,6 @@ No, starting from 0.25.3, you can use symbolic names for messages::
 
     # pylint: disable=fixme, line-too-long
 
-
 4.5 I have a callback function where I have no control over received arguments. How do I avoid getting unused argument warnings?
 ----------------------------------------------------------------------------------------------------------------------------------
 
@@ -185,6 +184,21 @@ they are prone to false positives or that they are opinionated enough
 for not being included as default messages. But most of the disabled
 messages are from the Python 3 porting checker, which is disabled by
 default. It needs special activation with the ``--py3k`` flag.
+
+4.8 I am using another popular linter alongside pylint. Which messages should I disable to avoid duplicates?
+-------------------------------------------------------------------------------------------
+
+pycodestyle: unneeded-not, line-too-long, unnecessary-semicolon, trailing-whitespace, missing-final-newline, bad-indentation, mixed-indentation, multiple-statements, bad-whitespace, bad-continuation, bare-except
+
+pyflakes: undefined-variable, unused-import, unused-variable
+
+mccabe: too-many-branches
+
+pydocstyle: missing-module-docstring, missing-class-docstring, missing-function-docstring
+
+pep8-naming: invalid-name, bad-classmethod-argument, bad-mcs-classmethod-argument, no-self-argument
+
+flake8-import-order: wrong-import-order
 
 5. Classes and Inheritance
 ==========================

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -189,17 +189,25 @@ default. It needs special activation with the ``--py3k`` flag.
 4.8 I am using another popular linter alongside pylint. Which messages should I disable to avoid duplicates?
 ------------------------------------------------------------------------------------------------------------
 
-pycodestyle: unneeded-not, line-too-long, unnecessary-semicolon, trailing-whitespace, missing-final-newline, bad-indentation, mixed-indentation, multiple-statements, bad-whitespace, bad-continuation, bare-except
+pycodestyle: unneeded-not, line-too-long, unnecessary-semicolon, trailing-whitespace, missing-final-newline, bad-indentation, multiple-statements, bare-except
 
-pyflakes: undefined-variable, unused-import, unused-variable
+pyflakes_: undefined-variable, unused-import, unused-variable
 
-mccabe: too-many-branches
+mccabe_: too-many-branches
 
-pydocstyle: missing-module-docstring, missing-class-docstring, missing-function-docstring
+pydocstyle_: missing-module-docstring, missing-class-docstring, missing-function-docstring
 
-pep8-naming: invalid-name, bad-classmethod-argument, bad-mcs-classmethod-argument, no-self-argument
+pep8-naming_: invalid-name, bad-classmethod-argument, bad-mcs-classmethod-argument, no-self-argument
 
-flake8-import-order: wrong-import-order
+flake8-import-order_: wrong-import-order
+
+.. _`pycodestyle`: https://github.com/PyCQA/pycodestyle
+.. _`pyflakes`: https://github.com/PyCQA/pyflakes
+.. _`mccabe`: https://github.com/PyCQA/mccabe
+.. _`pydocstyle`: https://github.com/PyCQA/pydocstyle
+.. _`pep8-naming`: https://github.com/PyCQA/pep8-naming
+.. _`flake8-import-order`: https://github.com/PyCQA/flake8-import-order
+
 
 5. Classes and Inheritance
 ==========================

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -187,7 +187,7 @@ messages are from the Python 3 porting checker, which is disabled by
 default. It needs special activation with the ``--py3k`` flag.
 
 4.8 I am using another popular linter alongside pylint. Which messages should I disable to avoid duplicates?
--------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------
 
 pycodestyle: unneeded-not, line-too-long, unnecessary-semicolon, trailing-whitespace, missing-final-newline, bad-indentation, mixed-indentation, multiple-statements, bad-whitespace, bad-continuation, bare-except
 


### PR DESCRIPTION
## Description

Add an FAQ detailing which messages to disable to avoid duplicates when using other popular linters alongside pylint.  Includes pycodestyle, pyflakes, mccabe, pep8-naming, and flake8-import-order.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

## Related Issue

Related: #3512, #3517 
This does not resolve them in any way.  It only adds instructions in the faq on how to configure pylint manually while using other linters