### PR TITLE
Disable design by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ debian/pylint
 .eggs/
 .pytest_cache/
 .mypy_cache/
+.vscode
+venv/

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -183,7 +183,7 @@ tricks like: ::
 pylint does have some messages disabled by default, either because
 they are prone to false positives or that they are opinionated enough
 for not being included as default messages. The disabled messages are 
-from the Python 3 porting check and design checker, which are disabled 
+from the Python 3 porting checker and design checker, which are disabled 
 by default. The Python 3 porting checker needs special activation with 
 the ``--py3k`` flag. The design checker can be enabled with
 ``--enabled=design``.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -182,9 +182,12 @@ tricks like: ::
 
 pylint does have some messages disabled by default, either because
 they are prone to false positives or that they are opinionated enough
-for not being included as default messages. But most of the disabled
-messages are from the Python 3 porting checker, which is disabled by
-default. It needs special activation with the ``--py3k`` flag.
+for not being included as default messages. The disabled messages are 
+from the Python 3 porting check and design checker, which are disabled 
+by default. The Python 3 porting checker needs special activation with 
+the ``--py3k`` flag. The design checker can be enabled with
+``--enabled=design``.
+
 
 4.8 I am using another popular linter alongside pylint. Which messages should I disable to avoid duplicates?
 ------------------------------------------------------------------------------------------------------------

--- a/doc/whatsnew/2.7.rst
+++ b/doc/whatsnew/2.7.rst
@@ -20,3 +20,5 @@ Other Changes
 * Fix bug that lead to duplicate messages when using ``--jobs 2`` or more.
 
   Close #3584
+
+* The `design` checker has been disabled by default, users can still explicitly enable the checker by specifying ``--enabled=design`` at the command line or including ``enable=design`` under the "MESSAGES CONTROL" section in their config files.

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -160,6 +160,7 @@ class MisdesignChecker(BaseChecker):
     """
 
     __implements__ = (IAstroidChecker,)
+    enabled = False
 
     # configuration section name
     name = "design"

--- a/pylint/testutils.py
+++ b/pylint/testutils.py
@@ -504,6 +504,7 @@ class LintModuleTest:
         self._linter.set_reporter(_test_reporter)
         self._linter.config.persistent = 0
         checkers.initialize(self._linter)
+        self._linter.enable("design")
         self._linter.disable("I")
         try:
             self._linter.read_config_file(test_file.option_file)

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -584,6 +584,15 @@ def test_python3_checker_disabled(linter):
     assert "python3" in checker_names
 
 
+def test_design_checker_disabled(linter):
+    checker_names = [c.name for c in linter.prepare_checkers()]
+    assert "design" not in checker_names
+
+    linter.set_option("enable", "design")
+    checker_names = [c.name for c in linter.prepare_checkers()]
+    assert "design" in checker_names
+
+
 def test_full_documentation(linter):
     out = StringIO()
     linter.print_full_documentation(out)

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -71,6 +71,7 @@ class LintTestUsingModule:
         assert self._get_expected().strip() + "\n" == got.strip() + "\n"
 
     def _test(self, tocheck):
+        self.linter.enable("design")
         if INFO_TEST_RGX.match(self.module):
             self.linter.enable("I")
         else:


### PR DESCRIPTION
## Description

This PR disables the design checker by default.  The only time I have seen these messages be used effectively, has been when the arbitrary default parameters are configured to a team/individual's liking. It follows that if a user is savvy enough to configure the design parameters, they are savvy enough to enable the checker. However, for someone who is looking for a pip-and-play option, these messages can be a nuisance.

The design checker in my opinion should not be removed from pylint because they can be powerful when configured, but without proper configuration (which is highly individualistic), they should be disabled.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related Issue

Starts to address #3512 
