### PR TITLE
Allow numbers in checker names.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -385,3 +385,5 @@ contributors:
 * Damien Baty: contributor
 
 * Daniel R. Neal (danrneal): contributer
+
+* Jeremy Fleischman (jfly): contributer

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ What's New in Pylint 2.6.0?
 ===========================
 Release date: TBA
 
+* Fix a regression where disable comments that have checker names with numbers in them are not parsed correctly
+
+  Close #3666
+
 * bad-continuation and bad-whitespace have been removed, black or another formatter can help you with this better than Pylint
 
   Close #246, #289, #638, #747, #1148, #1179, #1943, #2041, #2301, #2304, #2944, #3565

--- a/pylint/utils/pragma_parser.py
+++ b/pylint/utils/pragma_parser.py
@@ -39,7 +39,7 @@ ALL_KEYWORDS = "|".join(
 
 TOKEN_SPECIFICATION = [
     ("KEYWORD", r"\b({:s})\b".format(ALL_KEYWORDS)),
-    ("MESSAGE_STRING", r"[A-Za-z\-\_]{2,}"),  #  Identifiers
+    ("MESSAGE_STRING", r"[0-9A-Za-z\-\_]{2,}"),  #  Identifiers
     ("ASSIGN", r"="),  #  Assignment operator
     ("MESSAGE_NUMBER", r"[CREIWF]{1}\d*"),
 ]

--- a/tests/test_pragma_parser.py
+++ b/tests/test_pragma_parser.py
@@ -16,6 +16,14 @@ def test_simple_pragma():
         assert pragma_repr.messages == ["missing-docstring"]
 
 
+def test_disable_checker_with_number_in_name():
+    comment = "#pylint: disable = j3-custom-checker"
+    match = OPTION_PO.search(comment)
+    for pragma_repr in parse_pragma(match.group(2)):
+        assert pragma_repr.action == "disable"
+        assert pragma_repr.messages == ["j3-custom-checker"]
+
+
 def test_simple_pragma_no_messages():
     comment = "#pylint: skip-file"
     match = OPTION_PO.search(comment)


### PR DESCRIPTION
This fixes https://github.com/PyCQA/pylint/issues/3666.

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [N/A] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Pylint used to allow just about anything in a checker name, but with https://github.com/PyCQA/pylint/commit/9bdae8b82fcc5b0592135cbf6bead7df360a6672, it got a lot stricter about naming (I believe unintentionally). This expands the `MESSAGE_STRING` regular expression to allow for numbers in checker names.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes https://github.com/PyCQA/pylint/issues/3666
