### PR TITLE
``missing-kwoa`` is no longer emitted when dealing with overload functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,10 @@ Release date: TBA
 
   Close #1368
 
+* ``missing-kwoa`` is no longer emitted when dealing with overload functions
+
+  Close #3655
+
 * mixed-indentation has been removed, it is no longer useful since TabError is included directly in python3
 
   Close #2984 #3573

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1413,7 +1413,12 @@ accessed. Python regular expressions are accepted.",
 
         for name in kwparams:
             defval, assigned = kwparams[name]
-            if defval is None and not assigned and not has_no_context_keywords_variadic:
+            if (
+                defval is None
+                and not assigned
+                and not has_no_context_keywords_variadic
+                and not overload_function
+            ):
                 self.add_message("missing-kwoa", node=node, args=(name, callable_name))
 
     def _check_invalid_sequence_index(self, subscript: astroid.Subscript):

--- a/tests/functional/m/missing_kwoa_py3.py
+++ b/tests/functional/m/missing_kwoa_py3.py
@@ -1,4 +1,6 @@
-# pylint: disable=missing-docstring,unused-argument
+# pylint: disable=missing-docstring,unused-argument,too-few-public-methods
+import typing
+
 
 def target(pos, *, keyword):
     return pos + keyword
@@ -34,3 +36,38 @@ def other_function(**kwargs):
 
 
 other_function(param=2)
+
+
+class Parent:
+
+    @typing.overload
+    def __init__( self, *, first, second, third):
+        pass
+
+    @typing.overload
+    def __init__(self, *, first, second):
+        pass
+
+    @typing.overload
+    def __init__(self, *, first):
+        pass
+
+    def __init__(
+            self,
+            *,
+            first,
+            second: typing.Optional[str] = None,
+            third: typing.Optional[str] = None):
+        self._first = first
+        self._second = second
+        self._third = third
+
+
+class Child(Parent):
+    def __init__(
+            self,
+            *,
+            first,
+            second):
+        super().__init__(first=first, second=second)
+        self._first = first + second

--- a/tests/functional/m/missing_kwoa_py3.txt
+++ b/tests/functional/m/missing_kwoa_py3.txt
@@ -1,3 +1,3 @@
-missing-kwoa:19:not_forwarding_kwargs:Missing mandatory keyword argument 'keyword' in function call
-missing-kwoa:25::Missing mandatory keyword argument 'keyword' in function call
-too-many-function-args:25::Too many positional arguments for function call
+missing-kwoa:21:not_forwarding_kwargs:Missing mandatory keyword argument 'keyword' in function call
+missing-kwoa:27::Missing mandatory keyword argument 'keyword' in function call
+too-many-function-args:27::Too many positional arguments for function call


### PR DESCRIPTION
Close #3655
