### PR TITLE
Fix exception causes all over the codebase

### DIFF
--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -396,8 +396,8 @@ def report_by_type_stats(sect, stats, _):
     for node_type in ("module", "class", "method", "function"):
         try:
             total = stats[node_type]
-        except KeyError:
-            raise exceptions.EmptyReportError()
+        except KeyError as e:
+            raise exceptions.EmptyReportError() from e
         nice_stats[node_type] = {}
         if total != 0:
             try:

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -536,9 +536,9 @@ def _determine_callable(callable_obj):
             try:
                 # Use the last definition of __init__.
                 callable_obj = callable_obj.local_attr("__init__")[-1]
-            except exceptions.NotFoundError:
+            except exceptions.NotFoundError as e:
                 # do nothing, covered by no-init.
-                raise ValueError
+                raise ValueError from e
         else:
             callable_obj = new
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -533,8 +533,8 @@ def parse_format_string(
 def split_format_field_names(format_string) -> Tuple[str, Iterable[Tuple[bool, str]]]:
     try:
         return _string.formatter_field_name_split(format_string)
-    except ValueError:
-        raise IncompleteFormatString()
+    except ValueError as e:
+        raise IncompleteFormatString() from e
 
 
 def collect_string_fields(format_string) -> Iterable[Optional[str]]:
@@ -566,7 +566,7 @@ def collect_string_fields(format_string) -> Iterable[Optional[str]]:
             yield ""
             yield "1"
             return
-        raise IncompleteFormatString(format_string)
+        raise IncompleteFormatString(format_string) from exc
 
 
 def parse_format_method_string(
@@ -591,8 +591,8 @@ def parse_format_method_string(
                 explicit_pos_args.add(str(keyname))
             try:
                 keyword_arguments.append((keyname, list(fielditerator)))
-            except ValueError:
-                raise IncompleteFormatString()
+            except ValueError as e:
+                raise IncompleteFormatString() from e
         else:
             implicit_pos_args_cnt += 1
     return keyword_arguments, implicit_pos_args_cnt, len(explicit_pos_args)

--- a/pylint/config/option.py
+++ b/pylint/config/option.py
@@ -86,10 +86,10 @@ def _call_validator(opttype, optdict, option, value):
     except TypeError:
         try:
             return VALIDATORS[opttype](value)
-        except Exception:
+        except Exception as e:
             raise optparse.OptionValueError(
                 "%s value (%r) should be of type %s" % (option, value, opttype)
-            )
+            ) from e
 
 
 def _validate(value, optdict, name=""):

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -509,8 +509,8 @@ class PyLinter(
         else:
             try:
                 reporter_class = self._load_reporter_class()
-            except (ImportError, AttributeError):
-                raise exceptions.InvalidReporterError(name)
+            except (ImportError, AttributeError) as e:
+                raise exceptions.InvalidReporterError(name) from e
             else:
                 self.set_reporter(reporter_class())
 

--- a/pylint/pyreverse/vcgutils.py
+++ b/pylint/pyreverse/vcgutils.py
@@ -198,12 +198,12 @@ class VCGPrinter:
         for key, value in args.items():
             try:
                 _type = attributes_dict[key]
-            except KeyError:
+            except KeyError as e:
                 raise Exception(
                     """no such attribute %s
 possible attributes are %s"""
                     % (key, attributes_dict.keys())
-                )
+                ) from e
 
             if not _type:
                 self._stream.write('%s%s:"%s"\n' % (self._indent, key, value))


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 