### PR TITLE
Set default pre-commit hook config: single process

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,3 +3,4 @@
     entry: pylint
     language: python
     types: [python]
+    require_serial: true

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -389,3 +389,5 @@ contributors:
 * Jeremy Fleischman (jfly): contributer
 
 * Shiv Venkatasubrahmanyam
+
+* Jochen Preusche (iilei): contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,7 @@ Release date: TBA
 
 * Fix a bug with `ignore-docstrings` ignoring all lines in a module
 
+* Fix `pre-commit` config that could lead to undetected duplicate lines of code
 
 What's New in Pylint 2.5.3?
 ===========================


### PR DESCRIPTION
The default pre-commit behaviour might lead to falsely succeeding lint-runs.
E.g. due to duplicate lines of code spread across multiple files -- if affected
files get spread across multiple runs, duplicates can not be detected.

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
