### PR TITLE
Fix a crash caused by not guarding against `InferenceError` when calling `infer_call_result`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in Pylint 2.5.4?
 
 Release date: TBA
 
+* Fix a crash caused by not guarding against `InferenceError` when calling `infer_call_result`
+
+  Close #3690
+
 
 What's New in Pylint 2.5.3?
 ===========================

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1134,10 +1134,13 @@ class BasicChecker(_BasicChecker):
             # If the constant node is a FunctionDef or Lambda then
             #  it may be a illicit function call due to missing parentheses
             call_inferred = None
-            if isinstance(inferred, astroid.FunctionDef):
-                call_inferred = inferred.infer_call_result()
-            elif isinstance(inferred, astroid.Lambda):
-                call_inferred = inferred.infer_call_result(node)
+            try:
+                if isinstance(inferred, astroid.FunctionDef):
+                    call_inferred = inferred.infer_call_result()
+                elif isinstance(inferred, astroid.Lambda):
+                    call_inferred = inferred.infer_call_result(node)
+            except astroid.InferenceError:
+                call_inferred = None
             if call_inferred:
                 try:
                     for inf_call in call_inferred:

--- a/tests/functional/r/regression_infer_call_result_3690.py
+++ b/tests/functional/r/regression_infer_call_result_3690.py
@@ -1,0 +1,11 @@
+# pylint: disable-msg=missing-docstring,too-few-public-methods,using-constant-test
+
+class Class:
+    @property
+    @classmethod
+    def func(cls):
+        pass
+
+
+if Class.func:
+    pass


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description

`infer_call_result` can raise `InferenceError` and should be handler in all call sites. This was not happening with this particular check.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Close #3690
