### PR TITLE
Fix a crash in parallel mode when the module's filepath is not set

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Pylint's ChangeLog
 
 What's New in Pylint 2.6.0?
 ===========================
+
 Release date: TBA
 
 * bad-continuation and bad-whitespace have been removed, black or another formatter can help you with this better than Pylint
@@ -34,6 +35,10 @@ Release date: TBA
 
 * Fix `pre-commit` config that could lead to undetected duplicate lines of code
 
+* Fix a crash in parallel mode when the module's filepath is not set
+
+  Close #3564
+
 
 What's New in Pylint 2.5.4?
 ===========================
@@ -41,6 +46,10 @@ What's New in Pylint 2.5.4?
 * Fix a crash caused by not guarding against `InferenceError` when calling `infer_call_result`
 
   Close #3690
+
+* Fix a crash in parallel mode when the module's filepath is not set
+
+  Close #3564
 
 
 What's New in Pylint 2.5.3?

--- a/pylint/lint/check_parallel.py
+++ b/pylint/lint/check_parallel.py
@@ -71,6 +71,7 @@ def _worker_check_single_file(file_item):
     msgs = [_get_new_args(m) for m in _worker_linter.reporter.messages]
     return (
         _worker_linter.current_name,
+        filepath,
         _worker_linter.file_state.base_name,
         msgs,
         _worker_linter.stats,
@@ -98,11 +99,16 @@ def check_parallel(linter, jobs, files, arguments=None):
 
         all_stats = []
 
-        for module, base_name, messages, stats, msg_status in pool.imap_unordered(
-            _worker_check_single_file, files
-        ):
+        for (
+            module,
+            file_path,
+            base_name,
+            messages,
+            stats,
+            msg_status,
+        ) in pool.imap_unordered(_worker_check_single_file, files):
             linter.file_state.base_name = base_name
-            linter.set_current_module(module)
+            linter.set_current_module(module, file_path)
             for msg in messages:
                 msg = Message(*msg)
                 linter.reporter.handle_message(msg)

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -791,3 +791,11 @@ class TestRunTC:
             [path, "--disable=all", "--enable=duplicate-code"],
             expected_output=expected_output,
         )
+
+    def test_regression_parallel_mode_without_filepath(self):
+        # Test that parallel mode properly passes filepath
+        # https://github.com/PyCQA/pylint/issues/3564
+        path = join(
+            HERE, "regrtest_data", "regression_missing_init_3564", "subdirectory/"
+        )
+        self._test_output([path, "-j2"], expected_output="No such file or directory")


### PR DESCRIPTION

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description
This has been like this since the parallel refactoring done in https://github.com/PyCQA/pylint/commit/8babeffde54a696e7ba84d69f8fc1f871e432950

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Close #3564