### PR TITLE
Experimental: Unify NamingSchemes.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -392,6 +392,8 @@ contributors:
 
 * Jochen Preusche (iilei): contributor
 
+* Buck Evan (bukzor, Google LLC): contributor
+
 * Ram Rachum (cool-RR)
 
 * Pieter Engelbrecht

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,14 @@ Pylint's ChangeLog
 
   Close #3834
 
+* The `invalid-name` checker has been re-worked for increased consistency. Some
+  names that previously passed unnoticed will be flagged. You may solve these
+  new issues three (or more) ways:
+
+   1. increase the length of names to be more descriptive (recommended)
+   2. add strange-but-useful names to the good-names configuration
+   3. override the default regexen, via pylintrc (not recommended)
+
 
 What's New in Pylint 2.6.1?
 ===========================

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 python_files=*test_*.py
-addopts=-m "not acceptance"
+addopts=-m "not acceptance" --tb=short
 markers =
    acceptance

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,14 @@ from pylint import checkers
 from pylint.lint import PyLinter
 from pylint.testutils import MinimalTestReporter
 
+TOP = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PYLINTRC = os.path.join(TOP, "pylintrc")
+
+
+@pytest.fixture(autouse=True)
+def pylintrc():
+    os.environ["PYLINTRC"] = PYLINTRC
+
 
 @pytest.fixture
 def linter(checker, register, enable, disable, reporter):
@@ -24,7 +32,7 @@ def linter(checker, register, enable, disable, reporter):
     if enable:
         for msg in enable:
             _linter.enable(msg)
-    os.environ.pop("PYLINTRC", None)
+    os.environ["PYLINTRC"] = PYLINTRC
     return _linter
 
 

--- a/tests/extensions/data/compare_to_zero.py
+++ b/tests/extensions/data/compare_to_zero.py
@@ -1,4 +1,4 @@
-# pylint: disable=literal-comparison,missing-docstring,misplaced-comparison-constant
+# pylint: disable=literal-comparison,missing-docstring,misplaced-comparison-constant,invalid-name
 
 X = 123
 Y = len('test')

--- a/tests/extensions/data/empty_string_comparison.py
+++ b/tests/extensions/data/empty_string_comparison.py
@@ -1,4 +1,4 @@
-# pylint: disable=literal-comparison,missing-docstring
+# pylint: disable=literal-comparison,missing-docstring,invalid-name
 
 X = ''
 Y = 'test'

--- a/tests/functional/a/arguments_differ.rc
+++ b/tests/functional/a/arguments_differ.rc
@@ -1,0 +1,2 @@
+[basics]
+good-names=___private3

--- a/tests/functional/l/line_too_long.py
+++ b/tests/functional/l/line_too_long.py
@@ -5,7 +5,7 @@
 """ that one is too long tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo loooooong"""
 
 # The next line is exactly 80 characters long.
-A = "--------------------------------------------------------------------------"
+_ = "--------------------------------------------------------------------------"
 
 # Do not trigger the line-too-long warning if the only token that makes the
 # line longer than 80 characters is a trailing pylint disable.

--- a/tests/functional/m/method_hidden.py
+++ b/tests/functional/m/method_hidden.py
@@ -28,12 +28,12 @@ class CustomProperty:
     def __init__(self, _):
         pass
 
-    def __get__(self, obj, __):
+    def __get__(self, obj, _):
         if not obj:
             return self
         return 5
 
-    def __set__(self, _, __):
+    def __set__(self, _key, _val):
         pass
 
 class Ddef:

--- a/tests/functional/n/namePresetCamelCase.txt
+++ b/tests/functional/n/namePresetCamelCase.txt
@@ -1,3 +1,3 @@
-invalid-name:3::"Constant name ""SOME_CONSTANT"" doesn't conform to camelCase naming style ('([^\\W\\dA-Z][^\\W_]*|__.*__)$' pattern)"
-invalid-name:10:MyClass:"Class name ""MyClass"" doesn't conform to camelCase naming style ('[^\\W\\dA-Z][^\\W_]+$' pattern)"
-invalid-name:22:say_hello:"Function name ""say_hello"" doesn't conform to camelCase naming style ('([^\\W\\dA-Z][^\\W_]{2,}|__[^\\W\\dA-Z_]\\w+__)$' pattern)"
+invalid-name:3::"Constant name ""SOME_CONSTANT"" doesn't conform to camelCase naming style ('^(_{0,2}[^\\W\\d_A-Z][^\\W_]{2,}|__[^\\W\\d_A-Z][^\\WA-Z]{2,}__)$' pattern)"
+invalid-name:10:MyClass:"Class name ""MyClass"" doesn't conform to camelCase naming style ('^(_{0,2}[^\\W\\d_A-Z][^\\W_]{2,})$' pattern)"
+invalid-name:22:say_hello:"Function name ""say_hello"" doesn't conform to camelCase naming style ('^(_{0,2}[^\\W\\d_A-Z][^\\W_]{2,}|__[^\\W\\d_A-Z][^\\WA-Z]{2,}__)$' pattern)"

--- a/tests/functional/n/name_good_bad_names_regex.txt
+++ b/tests/functional/n/name_good_bad_names_regex.txt
@@ -1,3 +1,3 @@
 blacklisted-name:5::"Black listed name ""explicit_bad_some_constant"""
-invalid-name:7::"Constant name ""snake_case_bad_SOME_CONSTANT"" doesn't conform to snake_case naming style ('([^\\W\\dA-Z][^\\WA-Z]*|__.*__)$' pattern)"
+invalid-name:7::"Constant name ""snake_case_bad_SOME_CONSTANT"" doesn't conform to snake_case naming style ('^(_{0,2}[^\\W\\d_A-Z][^\\WA-Z]{2,}|__[^\\W\\d_A-Z][^\\WA-Z]{2,}__)$' pattern)"
 blacklisted-name:19:blacklisted_2_snake_case:"Black listed name ""blacklisted_2_snake_case"""

--- a/tests/functional/n/name_preset_snake_case.txt
+++ b/tests/functional/n/name_preset_snake_case.txt
@@ -1,3 +1,3 @@
-invalid-name:3::"Constant name ""SOME_CONSTANT"" doesn't conform to snake_case naming style ('([^\\W\\dA-Z][^\\WA-Z]*|__.*__)$' pattern)"
-invalid-name:10:MyClass:"Class name ""MyClass"" doesn't conform to snake_case naming style ('[^\\W\\dA-Z][^\\WA-Z]+$' pattern)"
-invalid-name:22:sayHello:"Function name ""sayHello"" doesn't conform to snake_case naming style ('([^\\W\\dA-Z][^\\WA-Z]{2,}|_[^\\WA-Z]*|__[^\\WA-Z\\d_][^\\WA-Z]+__)$' pattern)"
+invalid-name:3::"Constant name ""SOME_CONSTANT"" doesn't conform to snake_case naming style ('^(_{0,2}[^\\W\\d_A-Z][^\\WA-Z]{2,}|__[^\\W\\d_A-Z][^\\WA-Z]{2,}__)$' pattern)"
+invalid-name:10:MyClass:"Class name ""MyClass"" doesn't conform to snake_case naming style ('^(_{0,2}[^\\W\\d_A-Z][^\\WA-Z]{2,})$' pattern)"
+invalid-name:22:sayHello:"Function name ""sayHello"" doesn't conform to snake_case naming style ('^(_{0,2}[^\\W\\d_A-Z][^\\WA-Z]{2,}|__[^\\W\\d_A-Z][^\\WA-Z]{2,}__)$' pattern)"

--- a/tests/functional/r/regression_2443_duplicate_bases.rc
+++ b/tests/functional/r/regression_2443_duplicate_bases.rc
@@ -1,2 +1,4 @@
 [testoptions]
 min_pyver=3.6
+[basics]
+good-names=IN

--- a/tests/functional/u/undefined_variable.rc
+++ b/tests/functional/u/undefined_variable.rc
@@ -1,0 +1,2 @@
+[basics]
+good-names=i,j,k,ex,Run,_,_dt

--- a/tests/functional/u/unnecessary_pass.py
+++ b/tests/functional/u/unnecessary_pass.py
@@ -1,9 +1,9 @@
 # pylint: disable=missing-docstring, too-few-public-methods
 
 try:
-    A = 2
+    _ = 2
 except ValueError:
-    A = 24
+    _ = 24
     pass # [unnecessary-pass]
 
 def docstring_only():

--- a/tests/functional/w/wrong_import_position11.py
+++ b/tests/functional/w/wrong_import_position11.py
@@ -1,4 +1,4 @@
 """Checks import position rule"""
 # pylint: disable=unused-import,pointless-string-statement
-A = 1
+_ = 1
 import os  # [wrong-import-position]

--- a/tests/functional/w/wrong_import_position13.py
+++ b/tests/functional/w/wrong_import_position13.py
@@ -1,4 +1,4 @@
 """Checks import position rule"""
 # pylint: disable=unused-import,no-name-in-module
-A = 1
+_ = 1
 from sys import x  # [wrong-import-position]

--- a/tests/input/func_excess_escapes.py
+++ b/tests/input/func_excess_escapes.py
@@ -4,7 +4,7 @@
 __revision__ = '$Id$'
 
 # Bad escape sequences, which probably don't do what you expect.
-A = "\[\]\\"
+_ = "\[\]\\"
 assert '\/' == '\\/'
 ESCAPE_BACKSLASH = '\`'
 

--- a/tests/input/func_typecheck_callfunc_assigment.py
+++ b/tests/input/func_typecheck_callfunc_assigment.py
@@ -15,7 +15,7 @@ def func_no_return():
     """function without return"""
     print('dougloup')
 
-A = func_no_return()
+_ = func_no_return()
 
 
 def func_return_none():
@@ -23,14 +23,14 @@ def func_return_none():
     print('dougloup')
     return None
 
-A = func_return_none()
+_ = func_return_none()
 
 
 def func_implicit_return_none():
     """Function returning None from bare return statement."""
     return
 
-A = func_implicit_return_none()
+_ = func_implicit_return_none()
 
 
 def func_return_none_and_smth():
@@ -40,13 +40,13 @@ def func_return_none_and_smth():
         return None
     return 3
 
-A = func_return_none_and_smth()
+_ = func_return_none_and_smth()
 
 def generator():
     """no problemo"""
     yield 2
 
-A = generator()
+_ = generator()
 
 class Abstract(object):
     """bla bla"""

--- a/tests/input/func_w0801.py
+++ b/tests/input/func_w0801.py
@@ -1,6 +1,7 @@
 """test code similarities
-by defaut docstring are not considered
+by default docstring are not considered
 """
+# pylint: disable=invalid-name
 __revision__ = 'id'
 A = 2
 B = 3

--- a/tests/input/w0801_same.py
+++ b/tests/input/w0801_same.py
@@ -1,6 +1,7 @@
 """test code similarities
-by defaut docstring are not considered
+by default docstring are not considered
 """
+# pylint: disable=invalid-name
 __revision__ = 'id'
 A = 2
 B = 3

--- a/tests/messages/func_w0801.txt
+++ b/tests/messages/func_w0801.txt
@@ -1,6 +1,6 @@
 R:  1: Similar lines in 2 files
-==input.func_w0801:3
-==input.w0801_same:3
+==input.func_w0801:4
+==input.w0801_same:4
 __revision__ = 'id'
 A = 2
 B = 3


### PR DESCRIPTION
## Description

The current default pylint naming schemes only differ on three parameters:

 1. characters allowed at beginning of name
 2. characters allowed elsewhere
 3. minimum length of name

Where this was not true was due to either bugs, oversight, or legacy
inertia; i's hard for me to tell the difference.  Many odd
discrepancies among the naming schemes have been rectified, and this
change will bother users by calling out some of their bizarre naming
conventions, but all such issues are valid.

For churn considerations, I've not (yet?) modified the names of the
naming scheme objects although they've transitioned from being classes
to objects, and there's a couple other bits of odd naming in here for
the same reason. My aim was chiefly to show that this was possible, and
spur consideration of the idea.

A further improvement would be to set a "minimum length" for names in
the configuration, which should be checked apart from "naming scheme"
issues. This would greatly reduce the need for users to read and
understand regular expressions, and will make messages more actionable,
but also separating that additional resonsibility would further simplify
and rectify the naming schemes.



## Type of Changes
|   | Type |
| ------------- | ------------- |
|    | :bug: Bug fix  |
|    | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
|    | :scroll: Docs |