### PR TITLE
Add missing test dependency pytest-benchmark to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ def install(**kwargs):
         test_suite="test",
         python_requires=">=3.5.*",
         setup_requires=pytest_runner,
-        tests_require=["pytest"],
+        tests_require=["pytest", "pytest-benchmark"],
         project_urls=project_urls,
         **kwargs
     )


### PR DESCRIPTION
The test suite certainly exits with failure when running ``python setup.py test`` without this.

Mentioned in #3702 but does not close the issue

Or we can skip the benchmark tests if the plugin is not installed. What do you think?

Sample error:

```
file /home/user/code/pylint/tests/benchmark/test_baseline_benchmarks.py, line 208
      def test_baseline_lots_of_files_j10_empty_checker(self, benchmark):
E       fixture 'benchmark' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, checker, disable, doctest_namespace, enable, linter, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, register, reporter, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

```