### PR TITLE
Allow configuring mixin classes

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -393,3 +393,5 @@ contributors:
 * Jochen Preusche (iilei): contributor
 
 * Ram Rachum (cool-RR)
+
+* D. Alphus (Alphadelta14): contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,7 @@ Release date: TBA
 
 * Add `raise-missing-from` check for exceptions that should have a cause.
 
+* Support configuring mixin class pattern via `mixin-class-rgx` when `ignore-mixin-members` is enabled.
 
 What's New in Pylint 2.5.4?
 ===========================

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -224,7 +224,7 @@ methods is doing nothing but raising NotImplementedError.
 
 To do so you have to set the ignore-mixin-members option to
 "yes" (this is the default value) and to name your mixin class with
-a name which ends with "mixin" (whatever case).
+a name which ends with "Mixin" (mixin-class-rgx default).
 
 
 6. Troubleshooting

--- a/pylint/checkers/async.py
+++ b/pylint/checkers/async.py
@@ -41,6 +41,9 @@ class AsyncChecker(checkers.BaseChecker):
         self._ignore_mixin_members = utils.get_global_option(
             self, "ignore-mixin-members"
         )
+        self._mixin_class_rgx = utils.get_global_option(
+            self, "mixin-class-rgx"
+        )
         self._async_generators = ["contextlib.asynccontextmanager"]
 
     @checker_utils.check_messages("yield-inside-async-function")
@@ -75,7 +78,7 @@ class AsyncChecker(checkers.BaseChecker):
                             continue
                         # Just ignore mixin classes.
                         if self._ignore_mixin_members:
-                            if inferred.name[-5:].lower() == "mixin":
+                            if self._mixin_class_rgx.match(inferred.name):
                                 continue
                 else:
                     continue

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -767,6 +767,10 @@ a metaclass class method.",
         return get_global_option(self, "dummy-variables-rgx", default=None)
 
     @decorators.cachedproperty
+    def _mixin_rgx(self):
+        return get_global_option(self, "mixin-class-rgx", default=True)
+
+    @decorators.cachedproperty
     def _ignore_mixin(self):
         return get_global_option(self, "ignore-mixin-members", default=True)
 
@@ -838,7 +842,7 @@ a metaclass class method.",
         access to existent members
         """
         # check access to existent members on non metaclass classes
-        if self._ignore_mixin and cnode.name[-5:].lower() == "mixin":
+        if self._ignore_mixin and self._mixin_rgx.match(cnode.name):
             # We are in a mixin class. No need to try to figure out if
             # something is missing, since it is most likely that it will
             # miss.


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
We support having a slightly different nomenclature for mixin classes, and I'm sure other people do in their projects, as well.
This allows updating the regex of the class name to not just strictly end in Mixin, but other variants, like Base.

`mixin-class-rgx=.*[Mm]ixin` is the Default.

`mixin-class-rgx=.*(MixinAPI|Base)` would allow for no-member to be skipped if a class is named ProjectMixinAPI or ProjectBase.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
