### PR TITLE
Fix the ambiguous python version specifier

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -399,3 +399,5 @@ contributors:
 * Ethan Leba: contributor
 
 * Matěj Grabovský: contributor
+
+* Frost Ming (frostming): contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,7 +11,7 @@ Release date: TBA
   is not returning explicitly while the other do.
 
   Closes #3468
-  
+
 * Fix ``useless-super-delegation`` false positive when default keyword argument is a dictionnary.
 
   Close #3773
@@ -74,6 +74,10 @@ Release date: 2020-08-20
 * Add `condition-evals-to-constant` check for conditionals using and/or that evaluate to a constant.
 
   Close #3407
+
+* Changed setup.py to work with [distlib](https://pypi.org/project/distlib)
+
+  Close #3555
 
 What's New in Pylint 2.5.4?
 ===========================

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ def install(**kwargs):
         cmdclass=cmdclass,
         extras_require=extras_require,
         test_suite="test",
-        python_requires=">=3.5",
+        python_requires="~=3.5",
         setup_requires=pytest_runner,
         tests_require=["pytest", "pytest-benchmark"],
         project_urls=project_urls,

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ def install(**kwargs):
         cmdclass=cmdclass,
         extras_require=extras_require,
         test_suite="test",
-        python_requires=">=3.5.*",
+        python_requires=">=3.5",
         setup_requires=pytest_runner,
         tests_require=["pytest", "pytest-benchmark"],
         project_urls=project_urls,


### PR DESCRIPTION
`>=3.5.*` can make some packaging tools confused.

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
