### PR TITLE
Fix crash when specified config file doesn't exist

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -397,3 +397,5 @@ contributors:
 * Pieter Engelbrecht
 
 * Ethan Leba: contributor
+
+* Matěj Grabovský: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,8 @@ Release date: TBA
 
   Close #3773
 
+* Fix a crash when a specified config file does not exist
+
 What's New in Pylint 2.6.0?
 ===========================
 

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -295,7 +295,12 @@ group are mutually exclusive.",
         # read configuration
         linter.disable("I")
         linter.enable("c-extension-no-member")
-        linter.read_config_file(verbose=self.verbose)
+        try:
+            linter.read_config_file(verbose=self.verbose)
+        except OSError as ex:
+            print(ex, file=sys.stderr)
+            sys.exit(32)
+
         config_parser = linter.cfgfile_parser
         # run init hook, if present, before loading plugins
         if config_parser.has_option("MASTER", "init-hook"):

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -217,11 +217,8 @@ class TestRunTC:
         output = out.getvalue()
         assert "profile" not in output
 
-    def test_inexisting_rcfile(self):
-        out = StringIO()
-        with pytest.raises(IOError) as excinfo:
-            self._run_pylint(["--rcfile=/tmp/norcfile.txt"], out=out)
-        assert str(excinfo.value) == "The config file /tmp/norcfile.txt doesn't exist!"
+    def test_nonexistent_config_file(self):
+        self._runtest(["--rcfile=/tmp/this_file_does_not_exist"], code=32)
 
     def test_help_message_option(self):
         self._runtest(["--help-msg", "W0101"], code=0)


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Previously, pylint would crash if called with a nonexistent config file, such as `pylint --rcfile=does_not_exist`. This change catches the exception raised by `OptionsManagerMixIn.read_config_file()` and reports it properly, exiting with the code 32.

I also changed a test case which only checked if the crash occurred.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Downstream bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1831554
