### PR TITLE
Corrects syntax error that prevent upload to pypi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 
 README for Pylint - https://pylint.pycqa.org/
-============================================
+=============================================
 
 .. image:: https://travis-ci.org/PyCQA/pylint.svg?branch=master
     :target: https://travis-ci.org/PyCQA/pylint


### PR DESCRIPTION
## Description

The title in README.rst had a too short underline. It prevents upload to pypi.
