### PR TITLE
Temporary fix build for setuptools 50.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ before_install:
 - sudo apt-get -qq update
 - sudo apt-get install -y enchant
 install:
+# Temporary escape hatch for setuptools 50.0:
+# See https://github.com/pypa/setuptools/blob/17cb9d6bf249cefe653d3bdb712582409035a7db/CHANGES.rst#v5000
+- export SETUPTOOLS_USE_DISTUTILS=stdlib
 - pip install -U setuptools
 - pip install tox coverage coveralls
 - virtualenv --version


### PR DESCRIPTION
Not having this option is creating an error:
````
   SystemError: Parent module 'setuptools' not loaded,
   cannot perform relative import
````

See https://travis-ci.org/github/PyCQA/pylint/jobs/722843170:

It isn't clear what a permanent fix could be. See
https://github.com/pypa/setuptools/issues/2232 and
https://github.com/pypa/setuptools/blob/17cb9d6bf249cefe653d3bdb712582409035a7db/CHANGES.rst#v5000
for details.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
