### PR TITLE
Bug: fix vulnerable regexes to avoid potential ReDoS

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,11 @@ Pylint's ChangeLog
 
 What's New in Pylint 2.6.1?
 ===========================
+Release date: 2020-09-08
+
+* Fix vulnerable regular expressions in ``pyreverse``
+
+  Close #3811
 
 Release date: TBA
 

--- a/doc/whatsnew/2.6.rst
+++ b/doc/whatsnew/2.6.rst
@@ -36,4 +36,6 @@ Other Changes
 
 * Add support for both isort 4 and isort 5. If you have pinned isort 4 in your projet requirements, nothing changes. If you use isort 5, though, note that the `known-standard-library` option is not interpreted the same in isort 4 and isort 5 (see `the migration guide in isort documentation`_ for further details). For compatibility's sake for most pylint users, the `known-standard-library` option in pylint now maps to `extra-standard-library` in isort 5. If you really want what `known-standard-library` now means in isort 5, you must disable the `wrong-import-order` check in pylint and run isort manually with a proper isort configuration file.
 
+* Fix vulnerable regular expressions in ``pyreverse``. The ambiguities of vulnerable regular expressions are removed, making the repaired regular expressions safer and faster matching.
+
 .. _the migration guide in isort documentation: https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/#known_standard_library

--- a/pylint/pyreverse/utils.py
+++ b/pylint/pyreverse/utils.py
@@ -50,12 +50,13 @@ def insert_default_options():
 
 
 # astroid utilities ###########################################################
-
-SPECIAL = re.compile(r"^__[^\W_]+\w*__$")
-PRIVATE = re.compile(r"^__\w*[^\W_]+_?$")
+# fix SPECIAL and PRIVATE to avoid potential ReDoS
+SPECIAL = re.compile(r"^__([^\W_]_*)+__$")
+PRIVATE = re.compile(r"^__(_*[^\W_])+_?$")
 PROTECTED = re.compile(r"^_\w*$")
 
 
+gi
 def get_visibility(name):
     """return the visibility from a name: public, protected, private or special
     """

--- a/pylint/pyreverse/utils.py
+++ b/pylint/pyreverse/utils.py
@@ -56,7 +56,6 @@ PRIVATE = re.compile(r"^__(_*[^\W_])+_?$")
 PROTECTED = re.compile(r"^_\w*$")
 
 
-gi
 def get_visibility(name):
     """return the visibility from a name: public, protected, private or special
     """


### PR DESCRIPTION
The ambiguity of vulnerable regex is eliminated, so that when the fixed regex matches a string, there is only a unique path to match, thereby ensuring that the fixed regex is safer and faster to match.
This related issue addresses #3811