### PR TITLE
Improve `singleton-comparison` suggestion message

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,8 @@ Release date: TBA
 
 * Fix ``duplicate-code`` false positive when lines only contain whitespace and non-alphanumeric characters (e.g. parentheses, bracket, comman, etc.)
 
+* Improve lint message for `singleton-comparison` with bools
+
 What's New in Pylint 2.6.0?
 ===========================
 

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -16,7 +16,6 @@ from astroid import decorators
 from pylint import checkers, interfaces
 from pylint import utils as lint_utils
 from pylint.checkers import utils
-from pylint.checkers.refactoring.len_checker import _is_test_condition
 from pylint.checkers.utils import node_frame_class
 
 KNOWN_INFINITE_ITERATORS = {"itertools.count"}
@@ -1003,7 +1002,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
 
         Variables will not be simplified, even in the value can be inferred,
         and expressions like '3 + 4' will remain expanded."""
-        if not _is_test_condition(node):
+        if not utils.is_test_condition(node):
             return
 
         self._can_simplify_bool_op = False

--- a/tests/checkers/unittest_base.py
+++ b/tests/checkers/unittest_base.py
@@ -414,18 +414,32 @@ class TestComparison(CheckerTestCase):
 
     def test_comparison(self):
         node = astroid.extract_node("foo == True")
-        message = Message("singleton-comparison", node=node, args=(True, "just 'expr'"))
+        message = Message(
+            "singleton-comparison",
+            node=node,
+            args=(
+                "'foo == True'",
+                "'foo is True' if checking for the singleton value True, or 'bool(foo)' if testing for truthiness",
+            ),
+        )
         with self.assertAddsMessages(message):
             self.checker.visit_compare(node)
 
         node = astroid.extract_node("foo == False")
-        message = Message("singleton-comparison", node=node, args=(False, "'not expr'"))
+        message = Message(
+            "singleton-comparison",
+            node=node,
+            args=(
+                "'foo == False'",
+                "'foo is False' if checking for the singleton value False, or 'not foo' if testing for falsiness",
+            ),
+        )
         with self.assertAddsMessages(message):
             self.checker.visit_compare(node)
 
         node = astroid.extract_node("foo == None")
         message = Message(
-            "singleton-comparison", node=node, args=(None, "'expr is None'")
+            "singleton-comparison", node=node, args=("'foo == None'", "'foo is None'")
         )
         with self.assertAddsMessages(message):
             self.checker.visit_compare(node)
@@ -433,7 +447,14 @@ class TestComparison(CheckerTestCase):
         node = astroid.extract_node("True == foo")
         messages = (
             Message("misplaced-comparison-constant", node=node, args=("foo == True",)),
-            Message("singleton-comparison", node=node, args=(True, "just 'expr'")),
+            Message(
+                "singleton-comparison",
+                node=node,
+                args=(
+                    "'True == foo'",
+                    "'True is foo' if checking for the singleton value True, or 'bool(foo)' if testing for truthiness",
+                ),
+            ),
         )
         with self.assertAddsMessages(*messages):
             self.checker.visit_compare(node)
@@ -441,7 +462,14 @@ class TestComparison(CheckerTestCase):
         node = astroid.extract_node("False == foo")
         messages = (
             Message("misplaced-comparison-constant", node=node, args=("foo == False",)),
-            Message("singleton-comparison", node=node, args=(False, "'not expr'")),
+            Message(
+                "singleton-comparison",
+                node=node,
+                args=(
+                    "'False == foo'",
+                    "'False is foo' if checking for the singleton value False, or 'not foo' if testing for falsiness",
+                ),
+            ),
         )
         with self.assertAddsMessages(*messages):
             self.checker.visit_compare(node)
@@ -449,7 +477,11 @@ class TestComparison(CheckerTestCase):
         node = astroid.extract_node("None == foo")
         messages = (
             Message("misplaced-comparison-constant", node=node, args=("foo == None",)),
-            Message("singleton-comparison", node=node, args=(None, "'expr is None'")),
+            Message(
+                "singleton-comparison",
+                node=node,
+                args=("'None == foo'", "'None is foo'"),
+            ),
         )
         with self.assertAddsMessages(*messages):
             self.checker.visit_compare(node)

--- a/tests/functional/s/singleton_comparison.py
+++ b/tests/functional/s/singleton_comparison.py
@@ -12,4 +12,9 @@ i = None == x  # [singleton-comparison]
 
 j = x != True  # [singleton-comparison]
 j1 = x != False  # [singleton-comparison]
-j2 = x != None # [singleton-comparison]
+j2 = x != None  # [singleton-comparison]
+assert x == True  # [singleton-comparison]
+assert x != False  # [singleton-comparison]
+if x == True:  # [singleton-comparison]
+    pass
+z = bool(x == True)  # [singleton-comparison]

--- a/tests/functional/s/singleton_comparison.txt
+++ b/tests/functional/s/singleton_comparison.txt
@@ -1,8 +1,12 @@
-singleton-comparison:4::Comparison to None should be 'expr is None'
-singleton-comparison:5::Comparison to True should be just 'expr'
-singleton-comparison:6::Comparison to False should be 'not expr'
-singleton-comparison:7::Comparison to True should be just 'expr'
-singleton-comparison:11::Comparison to None should be 'expr is None'
-singleton-comparison:13::Comparison to True should be just 'not expr'
-singleton-comparison:14::Comparison to False should be 'expr'
-singleton-comparison:15::Comparison to None should be 'expr is not None'
+singleton-comparison:4::Comparison 'x == None' should be 'x is None'
+singleton-comparison:5::Comparison 'x == True' should be 'x is True' if checking for the singleton value True, or 'bool(x)' if testing for truthiness
+singleton-comparison:6::Comparison 'x == False' should be 'x is False' if checking for the singleton value False, or 'not x' if testing for falsiness
+singleton-comparison:7::Comparison 'True == True' should be 'True is True' if checking for the singleton value True, or 'bool(True)' if testing for truthiness
+singleton-comparison:11::Comparison 'None == x' should be 'None is x'
+singleton-comparison:13::Comparison 'x != True' should be 'x is not True' if checking for the singleton value True, or 'not x' if testing for falsiness
+singleton-comparison:14::Comparison 'x != False' should be 'x is not False' if checking for the singleton value False, or 'bool(x)' if testing for truthiness
+singleton-comparison:15::Comparison 'x != None' should be 'x is not None'
+singleton-comparison:16::Comparison 'x == True' should be 'x is True' if checking for the singleton value True, or 'x' if testing for truthiness
+singleton-comparison:17::Comparison 'x != False' should be 'x is not False' if checking for the singleton value False, or 'x' if testing for truthiness
+singleton-comparison:18::Comparison 'x == True' should be 'x is True' if checking for the singleton value True, or 'x' if testing for truthiness
+singleton-comparison:20::Comparison 'x == True' should be 'x is True' if checking for the singleton value True, or 'x' if testing for truthiness


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Description
Singleton-comparison will now suggest `is` for boolean constants, as well as a message for truthiness/falsiness in case the user intended this, whereas the message would only suggest checking truthiness/falsiness before. The message will now also display the actual code in question, instead of an `expr` stand-in.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|      | :sparkles: New feature |
|      | :hammer: Refactoring  |
|      | :scroll: Docs |
