### PR TITLE
Less false positives for len-as-conditions (pandas's DataFrame, numpy's Array)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -286,11 +286,7 @@ contributors:
 
 * Michael Scott Cuthbert: contributor
 
-* Pierre Sassoulas : contributor
-    - Made C0412 (ungrouped import) compatible with isort
-    - Made multiple message with the same old name possible
-    - Made Pylint a little faster by refactoring the message store
-    - Broke down "missing-docstrings" between "module", "class" and "function"
+* Pierre Sassoulas : maintainer, contributor
 
 * Nathan Marrow
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -103,6 +103,10 @@ Release date: TBA
 
   Close #3735
 
+* `len-as-conditions` is now triggered only for classes that are inheriting directly from list, dict, or set and not implementing the `__bool__` function, or from generators like range or list/dict/set comprehension. This should reduce the false positives for other classes, like pandas's DataFrame or numpy's Array.
+
+  Close #1879
+
 What's New in Pylint 2.6.0?
 ===========================
 

--- a/doc/whatsnew/2.6.rst
+++ b/doc/whatsnew/2.6.rst
@@ -56,3 +56,5 @@ Other Changes
 * Fix vulnerable regular expressions in ``pyreverse``. The ambiguities of vulnerable regular expressions are removed, making the repaired regular expressions safer and faster matching.
 
 .. _the migration guide in isort documentation: https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/#known_standard_library
+
+* `len-as-conditions` is now triggered only for classes that are inheriting directly from list, dict, or set and not implementing the `__bool__` function, or from generators like range or list/dict/set comprehension. This should reduce the false positive for other classes, like pandas's DataFrame or numpy's Array.

--- a/pylint/checkers/refactoring/len_checker.py
+++ b/pylint/checkers/refactoring/len_checker.py
@@ -99,6 +99,7 @@ class LenChecker(checkers.BaseChecker):
 
     @staticmethod
     def base_classes_of_node(instance: astroid.nodes.ClassDef) -> List[astroid.Name]:
+        """Return all the classes names that a ClassDef inherit from including 'object'."""
         mother_classes = [instance.name]
         base_classes = instance.bases
         while base_classes and "object" not in mother_classes:

--- a/pylint/checkers/refactoring/len_checker.py
+++ b/pylint/checkers/refactoring/len_checker.py
@@ -67,11 +67,18 @@ class LenChecker(checkers.BaseChecker):
             # this len() call is part of a test condition
             if utils.is_test_condition(node, parent):
                 instance = next(node.args[0].infer())
+                try:
+                    instance = next(node.args[0].infer())
+                except astroid.InferenceError:
+                    self.add_message("len-as-condition", node=node)
+                    return
                 mother_classes = self.base_classes_of_node(instance)
                 affected_by_pep8 = any(
-                    t in mother_classes for t in ["str", "tuple", "range", "list"]
+                    t in mother_classes for t in ["str", "tuple", "list", "set"]
                 )
-                if affected_by_pep8 and not self.instance_has_bool(instance):
+                if "range" in mother_classes or (
+                    affected_by_pep8 and not self.instance_has_bool(instance)
+                ):
                     self.add_message("len-as-condition", node=node)
 
     @staticmethod

--- a/pylint/checkers/refactoring/len_checker.py
+++ b/pylint/checkers/refactoring/len_checker.py
@@ -85,7 +85,12 @@ class LenChecker(checkers.BaseChecker):
 
     @staticmethod
     def instance_has_bool(class_def: astroid.ClassDef) -> bool:
-        return any(hasattr(f, "name") and f.name == "__bool__" for f in class_def.body)
+        try:
+            class_def.getattr("__bool__")
+            return True
+        except astroid.AttributeInferenceError:
+            ...
+        return False
 
     @utils.check_messages("len-as-condition")
     def visit_unaryop(self, node):

--- a/pylint/checkers/refactoring/len_checker.py
+++ b/pylint/checkers/refactoring/len_checker.py
@@ -102,14 +102,7 @@ class LenChecker(checkers.BaseChecker):
     @staticmethod
     def base_classes_of_node(instance: astroid.nodes.ClassDef) -> List[astroid.Name]:
         """Return all the classes names that a ClassDef inherit from including 'object'."""
-        mother_classes = [instance.name]
-        base_classes = instance.bases
-        while base_classes and "object" not in mother_classes:
-            new_instances = []
-            for base_class in base_classes:
-                mother_classes.append(base_class.name)
-                inferred_class = next(base_class.infer())
-                if inferred_class.bases:
-                    new_instances += inferred_class.bases
-            base_classes = new_instances
-        return mother_classes
+        try:
+            return [instance.name] + [x.name for x in instance.ancestors()]
+        except TypeError:
+            return [instance.name]

--- a/pylint/checkers/refactoring/len_checker.py
+++ b/pylint/checkers/refactoring/len_checker.py
@@ -2,6 +2,8 @@
 
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+from typing import List
+
 import astroid
 
 from pylint import checkers, interfaces
@@ -78,3 +80,17 @@ class LenChecker(checkers.BaseChecker):
             and utils.is_call_of_name(node.operand, "len")
         ):
             self.add_message("len-as-condition", node=node)
+
+    @staticmethod
+    def base_classes_of_node(instance: astroid.nodes.ClassDef) -> List[astroid.Name]:
+        mother_classes = [instance.name]
+        base_classes = instance.bases
+        while base_classes and "object" not in mother_classes:
+            new_instances = []
+            for base_class in base_classes:
+                mother_classes.append(base_class.name)
+                inferred_class = next(base_class.infer())
+                if inferred_class.bases:
+                    new_instances += inferred_class.bases
+            base_classes = new_instances
+        return mother_classes

--- a/pylint/checkers/refactoring/len_checker.py
+++ b/pylint/checkers/refactoring/len_checker.py
@@ -70,6 +70,8 @@ class LenChecker(checkers.BaseChecker):
                 try:
                     instance = next(node.args[0].infer())
                 except astroid.InferenceError:
+                    # Inference error happens for list comprehension, dict comprehension,
+                    # set comprehension and generators (like range)
                     self.add_message("len-as-condition", node=node)
                     return
                 mother_classes = self.base_classes_of_node(instance)

--- a/tests/checkers/unittest_refactoring.py
+++ b/tests/checkers/unittest_refactoring.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+import astroid
+
+from pylint.checkers.refactoring import LenChecker
+
+
+def test_class_tree_detection():
+    module = astroid.parse(
+        """
+class ClassWithBool(list):
+    def __bool__(self):
+        return True
+
+class ClassWithoutBool(dict):
+    pass
+
+class ChildClassWithBool(ClassWithBool):
+    pass
+
+class ChildClassWithoutBool(ClassWithoutBool):
+    pass
+"""
+    )
+    with_bool, without_bool, child_with_bool, child_without_bool = module.body
+    assert LenChecker().base_classes_of_node(with_bool) == [
+        "ClassWithBool",
+        "list",
+        "object",
+    ]
+    assert LenChecker().base_classes_of_node(without_bool) == [
+        "ClassWithoutBool",
+        "dict",
+        "object",
+    ]
+    assert LenChecker().base_classes_of_node(child_with_bool) == [
+        "ChildClassWithBool",
+        "ClassWithBool",
+        "list",
+        "object",
+    ]
+    assert LenChecker().base_classes_of_node(child_without_bool) == [
+        "ChildClassWithoutBool",
+        "ClassWithoutBool",
+        "dict",
+        "object",
+    ]

--- a/tests/functional/l/len_checks.py
+++ b/tests/functional/l/len_checks.py
@@ -7,7 +7,7 @@ if len('TEST'):  # [len-as-condition]
 if not len('TEST'):  # [len-as-condition]
     pass
 
-z = False
+z = []
 if z and len(['T', 'E', 'S', 'T']):  # [len-as-condition]
     pass
 
@@ -102,3 +102,46 @@ def github_issue_1331_v4(*args):
 
 b = bool(len(z)) # [len-as-condition]
 c = bool(len('TEST') or 42) # [len-as-condition]
+
+
+def github_issue_1879():
+
+    class ClassWithBool(list):
+        def __bool__(self):
+            return True
+
+    class ClassWithoutBool(list):
+        pass
+
+    class ChildClassWithBool(ClassWithBool):
+        pass
+
+    class ChildClassWithoutBool(ClassWithoutBool):
+        pass
+
+    assert len(ClassWithBool())
+    # We could expect to not have a len-as-condition for ChildClassWithBool,
+    # but I don't think the required analysis is worth it.
+    assert len(ChildClassWithBool()) # [len-as-condition]
+    assert len(ClassWithoutBool())  # [len-as-condition]
+    assert len(ChildClassWithoutBool())  # [len-as-condition]
+    # assert len(range(0)) != 0
+
+    # pylint: disable=import-outside-toplevel
+    import numpy
+    numpy_array = numpy.array([0])
+    if len(numpy_array) > 0:
+        print('numpy_array')
+    if len(numpy_array):
+        print('numpy_array')
+    if numpy_array:
+        print('b')
+
+    import pandas as pd
+    pandas_df = pd.DataFrame()
+    if len(pandas_df):
+        print("this works, but pylint tells me not to use len() without comparison")
+    if len(pandas_df) > 0:
+        print("this works and pylint likes it, but it's not the solution intended by PEP-8")
+    if pandas_df:
+        print("this does not work (truth value of dataframe is ambiguous)")

--- a/tests/functional/l/len_checks.py
+++ b/tests/functional/l/len_checks.py
@@ -149,3 +149,16 @@ def github_issue_1879():
         print("this works and pylint likes it, but it's not the solution intended by PEP-8")
     if pandas_df:
         print("this does not work (truth value of dataframe is ambiguous)")
+
+    def function_returning_list(r):
+        if r==1:
+            return [1]
+        return [2]
+
+    def function_returning_int(r):
+        if r==1:
+            return 1
+        return 2
+
+    assert len(function_returning_list(z)) # [len-as-condition]
+    assert len(function_returning_int(z))

--- a/tests/functional/l/len_checks.py
+++ b/tests/functional/l/len_checks.py
@@ -120,9 +120,7 @@ def github_issue_1879():
         pass
 
     assert len(ClassWithBool())
-    # We could expect to not have a len-as-condition for ChildClassWithBool,
-    # but I don't think the required analysis is worth it.
-    assert len(ChildClassWithBool()) # [len-as-condition]
+    assert len(ChildClassWithBool())
     assert len(ClassWithoutBool())  # [len-as-condition]
     assert len(ChildClassWithoutBool())  # [len-as-condition]
     assert len(range(0))  # [len-as-condition]

--- a/tests/functional/l/len_checks.py
+++ b/tests/functional/l/len_checks.py
@@ -158,5 +158,18 @@ def github_issue_1879():
             return 1
         return 2
 
-    assert len(function_returning_list(z)) # [len-as-condition]
+    def function_returning_generator(r):
+        for i in [r, 1, 2, 3]:
+            yield i
+
+    def function_returning_comprehension(r):
+        return [x+1 for x in [r, 1, 2, 3]]
+
+    def function_returning_function(r):
+        return function_returning_generator(r)
+
+    assert len(function_returning_list(z))  # [len-as-condition]
     assert len(function_returning_int(z))
+    assert len(function_returning_generator(z))  # [len-as-condition]
+    assert len(function_returning_comprehension(z))  # [len-as-condition]
+    assert len(function_returning_function(z))  # [len-as-condition]

--- a/tests/functional/l/len_checks.py
+++ b/tests/functional/l/len_checks.py
@@ -158,18 +158,20 @@ def github_issue_1879():
             return 1
         return 2
 
-    def function_returning_generator(r):
-        for i in [r, 1, 2, 3]:
-            yield i
+    # def function_returning_generator(r):
+    #     for i in [r, 1, 2, 3]:
+    #         yield i
 
-    def function_returning_comprehension(r):
-        return [x+1 for x in [r, 1, 2, 3]]
+    # def function_returning_comprehension(r):
+    #     return [x+1 for x in [r, 1, 2, 3]]
 
-    def function_returning_function(r):
-        return function_returning_generator(r)
+    # def function_returning_function(r):
+    #     return function_returning_generator(r)
 
     assert len(function_returning_list(z))  # [len-as-condition]
     assert len(function_returning_int(z))
-    assert len(function_returning_generator(z))  # [len-as-condition]
-    assert len(function_returning_comprehension(z))  # [len-as-condition]
-    assert len(function_returning_function(z))  # [len-as-condition]
+    # This should raise a len-as-conditions once astroid can infer it
+    # See https://github.com/PyCQA/pylint/pull/3821#issuecomment-743771514
+    # assert len(function_returning_generator(z))
+    # assert len(function_returning_comprehension(z))
+    # assert len(function_returning_function(z))

--- a/tests/functional/l/len_checks.py
+++ b/tests/functional/l/len_checks.py
@@ -125,7 +125,11 @@ def github_issue_1879():
     assert len(ChildClassWithBool()) # [len-as-condition]
     assert len(ClassWithoutBool())  # [len-as-condition]
     assert len(ChildClassWithoutBool())  # [len-as-condition]
-    # assert len(range(0)) != 0
+    assert len(range(0))  # [len-as-condition]
+    assert len([t + 1 for t in []])  # [len-as-condition]
+    assert len(u + 1 for u in [])  # [len-as-condition]
+    assert len({"1":(v + 1) for v in {}})  # [len-as-condition]
+    assert len(set((w + 1) for w in set()))  # [len-as-condition]
 
     # pylint: disable=import-outside-toplevel
     import numpy

--- a/tests/functional/l/len_checks.txt
+++ b/tests/functional/l/len_checks.txt
@@ -13,6 +13,7 @@ len-as-condition:98:github_issue_1331_v3:Do not use `len(SEQUENCE)` without comp
 len-as-condition:101:github_issue_1331_v4:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:103::Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:104::Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
+len-as-condition:124:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:125:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:126:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:127:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
@@ -20,5 +21,4 @@ len-as-condition:128:github_issue_1879:Do not use `len(SEQUENCE)` without compar
 len-as-condition:129:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:130:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:131:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
-len-as-condition:132:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
-len-as-condition:163:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
+len-as-condition:161:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty

--- a/tests/functional/l/len_checks.txt
+++ b/tests/functional/l/len_checks.txt
@@ -16,3 +16,8 @@ len-as-condition:104::Do not use `len(SEQUENCE)` without comparison to determine
 len-as-condition:125:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:126:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:127:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
+len-as-condition:128:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
+len-as-condition:129:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
+len-as-condition:130:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
+len-as-condition:131:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
+len-as-condition:132:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty

--- a/tests/functional/l/len_checks.txt
+++ b/tests/functional/l/len_checks.txt
@@ -22,3 +22,5 @@ len-as-condition:129:github_issue_1879:Do not use `len(SEQUENCE)` without compar
 len-as-condition:130:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:131:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:161:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
+len-as-condition:170:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
+len-as-condition:171:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty

--- a/tests/functional/l/len_checks.txt
+++ b/tests/functional/l/len_checks.txt
@@ -20,7 +20,4 @@ len-as-condition:127:github_issue_1879:Do not use `len(SEQUENCE)` without compar
 len-as-condition:128:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:129:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:130:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
-len-as-condition:131:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
-len-as-condition:161:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
-len-as-condition:170:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:171:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty

--- a/tests/functional/l/len_checks.txt
+++ b/tests/functional/l/len_checks.txt
@@ -13,3 +13,6 @@ len-as-condition:98:github_issue_1331_v3:Do not use `len(SEQUENCE)` without comp
 len-as-condition:101:github_issue_1331_v4:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:103::Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:104::Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
+len-as-condition:125:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
+len-as-condition:126:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
+len-as-condition:127:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty

--- a/tests/functional/l/len_checks.txt
+++ b/tests/functional/l/len_checks.txt
@@ -21,3 +21,4 @@ len-as-condition:129:github_issue_1879:Do not use `len(SEQUENCE)` without compar
 len-as-condition:130:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:131:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:132:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
+len-as-condition:163:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty


### PR DESCRIPTION
## Description

`len-as-conditions` is now triggered only for classes that are inheriting directly from list, dict, or set and not implementing the `__bool__` function, or from generators like range or list/dict/set comprehension. This should reduce the false positive for other classes, like pandas's DataFrame or numpy's Array. See discussion in related issue.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

#1879 
