### PR TITLE
Add unimport to pre commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,21 @@
 repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.1.0
+  hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+- repo: https://github.com/hakancelik96/unimport
+  rev: 9a45494aba8d9f873d8d6104d60b824cba71ee05
+  hooks:
+    - id: unimport
+      args: [-r, --exclude=tests/functional/|tests/input/|tests/regrtest_data/]
+- repo: https://github.com/PyCQA/isort
+  rev: 5.5.2
+  hooks:
+      - id: isort
 -   repo: https://github.com/ambv/black
     rev: 20.8b1
     hooks:
     - id: black
       args: [--safe, --quiet]
       exclude: tests/functional/|tests/input|tests/extensions/data|tests/regrtest_data/|tests/data/
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
-    hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
--   repo: https://github.com/PyCQA/isort
-    rev: 5.5.2
-    hooks:
-    -   id: isort

--- a/doc/exts/pylint_features.py
+++ b/doc/exts/pylint_features.py
@@ -5,7 +5,6 @@
 """Script used to generate the features file before building the actual documentation."""
 
 import os
-import sys
 
 import sphinx
 
@@ -19,7 +18,6 @@ def builder_inited(app):
     )
     linter = PyLinter()
     linter.load_default_plugins()
-
     features = os.path.join(base_path, "doc", "technical_reference", "features.rst")
     with open(features, "w") as stream:
         stream.write("Pylint features\n")

--- a/pylint/__init__.py
+++ b/pylint/__init__.py
@@ -42,3 +42,6 @@ def run_symilar():
     from pylint.checkers.similar import Run as SimilarRun
 
     SimilarRun(sys.argv[1:])
+
+
+__all__ = ["__version__"]

--- a/pylint/checkers/__init__.py
+++ b/pylint/checkers/__init__.py
@@ -64,4 +64,4 @@ def initialize(linter):
     register_plugins(linter, __path__[0])
 
 
-__all__ = ("BaseChecker", "BaseTokenChecker", "initialize")
+__all__ = ["BaseChecker", "BaseTokenChecker", "initialize", "register_plugins"]

--- a/pylint/config/__init__.py
+++ b/pylint/config/__init__.py
@@ -46,9 +46,14 @@ from pylint.config.option_parser import OptionParser
 from pylint.config.options_provider_mixin import OptionsProviderMixIn, UnsupportedAction
 
 __all__ = [
-    "UnsupportedAction",
     "ConfigurationMixIn",
+    "find_default_config_files",
+    "_ManHelpFormatter",
+    "Option",
     "OptionsManagerMixIn",
+    "OptionParser",
+    "OptionsProviderMixIn",
+    "UnsupportedAction",
 ]
 
 USER_HOME = os.path.expanduser("~")

--- a/pylint/lint/__init__.py
+++ b/pylint/lint/__init__.py
@@ -87,5 +87,18 @@ from pylint.lint.utils import (
     preprocess_options,
 )
 
+__all__ = [
+    "check_parallel",
+    "PyLinter",
+    "report_messages_by_module_stats",
+    "report_messages_stats",
+    "report_total_messages_stats",
+    "Run",
+    "ArgumentPreprocessingError",
+    "_patch_sys_path",
+    "fix_import_path",
+    "preprocess_options",
+]
+
 if __name__ == "__main__":
     Run(sys.argv[1:])

--- a/pylint/utils/__init__.py
+++ b/pylint/utils/__init__.py
@@ -67,3 +67,27 @@ from pylint.utils.utils import (
     safe_decode,
     tokenize_module,
 )
+
+__all__ = [
+    "ASTWalker",
+    "HAS_ISORT_5",
+    "IsortDriver",
+    "_basename_in_blacklist_re",
+    "_check_csv",
+    "_format_option_value",
+    "_splitstrip",
+    "_unquote",
+    "decoding_stream",
+    "deprecated_option",
+    "expand_modules",
+    "FileState",
+    "format_section",
+    "get_global_option",
+    "get_module_and_frameid",
+    "get_rst_section",
+    "get_rst_title",
+    "normalize_text",
+    "register_plugins",
+    "safe_decode",
+    "tokenize_module",
+]


### PR DESCRIPTION

## Description

Add unimport to pre-commit in order to fix unused import automatically.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

