### PR TITLE
bugfix: accepts aliases for __future__ annotations

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -411,3 +411,5 @@ contributors:
 * Josselin Feist: contributor
 
 * David Cain: contributor
+
+* Luigi Bertaco Cristofolini (luigibertaco): contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,10 @@ Release date: TBA
 
 * Fix AttributeError in checkers/refactoring.py
 
+* Fix a bug with postponed evaluation when using aliases for annotations.
+
+  Close #3798
+
 What's New in Pylint 2.6.0?
 ===========================
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1262,14 +1262,8 @@ def get_node_last_lineno(node: astroid.node_classes.NodeNG) -> int:
 
 def is_postponed_evaluation_enabled(node: astroid.node_classes.NodeNG) -> bool:
     """Check if the postponed evaluation of annotations is enabled"""
-    name = "annotations"
     module = node.root()
-    stmt = module.locals.get(name)
-    return (
-        stmt
-        and isinstance(stmt[0], astroid.ImportFrom)
-        and stmt[0].modname == "__future__"
-    )
+    return "annotations" in module.future_imports
 
 
 def is_subclass_of(child: astroid.ClassDef, parent: astroid.ClassDef) -> bool:

--- a/tests/functional/p/postponed_evaluation_activated_with_alias.py
+++ b/tests/functional/p/postponed_evaluation_activated_with_alias.py
@@ -1,0 +1,28 @@
+# pylint: disable=missing-docstring,no-self-use,unused-argument,pointless-statement
+# pylint: disable=too-few-public-methods,no-name-in-module
+from __future__ import annotations as __annotations__
+
+
+class Class:
+    @classmethod
+    def from_string(cls, source) -> Class:
+        ...
+
+    def validate_b(self, obj: OtherClass) -> bool:
+        ...
+
+
+class OtherClass:
+    ...
+
+
+class Example:
+    obj: Other
+
+
+class Other:
+    ...
+
+
+class ExampleSelf:
+    next: ExampleSelf

--- a/tests/functional/p/postponed_evaluation_activated_with_alias.py
+++ b/tests/functional/p/postponed_evaluation_activated_with_alias.py
@@ -3,9 +3,9 @@
 from __future__ import annotations as __annotations__
 
 
-class Class:
+class MyClass:
     @classmethod
-    def from_string(cls, source) -> Class:
+    def from_string(cls, source) -> MyClass:
         ...
 
     def validate_b(self, obj: OtherClass) -> bool:

--- a/tests/functional/p/postponed_evaluation_activated_with_alias.rc
+++ b/tests/functional/p/postponed_evaluation_activated_with_alias.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.7


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Fix a bug that causes an unrelated warning when renaming "annotations" from "__future__" with the `as` clause.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->
Closes #3798 