### PR TITLE
lint multiprocessing pool shutdown

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -425,3 +425,5 @@ contributors:
 * Giuseppe Valente: contributor
 
 * Takashi Hirashima: contributor
+
+* Joffrey Mander: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,10 @@ What's New in Pylint 2.6.1?
 ===========================
 Release date: TBA
 
+* Fix linter multiprocessing pool shutdown (triggered warnings when runned in parallels with other pytest plugins)
+
+  Closes #3779
+
 * Fix a false-positive emission of `no-self-use` and `unused-argument` for methods
   of generic structural types (`Protocol[T]`)
 
@@ -23,7 +27,7 @@ Release date: TBA
 * Fix bug that lead to duplicate messages when using ``--jobs 2`` or more.
 
   Close #3584
- 
+
 * Adds option ``check-protected-access-in-special-methods`` in the ClassChecker to activate/deactivate
   ``protected-access`` message emission for single underscore prefixed attribute in special methods.
 

--- a/doc/whatsnew/2.6.rst
+++ b/doc/whatsnew/2.6.rst
@@ -29,6 +29,8 @@ New checkers
 Other Changes
 =============
 
+* Fix linter multiprocessing pool shutdown which triggered warnings when runned in parallels with other pytest plugins.
+
 * Enums are now required to be named in UPPER_CASE by ``invalid-name``.
 
 * Fix bug that lead to duplicate messages when using ``--jobs 2`` or more.


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Shutdown multiprocessing pool properly (base on pytest-cov recommandation [here](https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html#if-you-use-multiprocessing-pool));fixing the triggered warnings from parallel runs of pytest plugins (pytest-cov and pytest-pylint in this case (see issue #3779))

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #3779 
<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
