### PR TITLE
Add checker for empty comments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,10 @@
 Pylint's ChangeLog
 ------------------
 
+* Add check for empty comments
+
 * Fix minor documentation issue in contribute.rst
+
 
 What's New in Pylint 2.6.1?
 ===========================

--- a/doc/whatsnew/2.7.rst
+++ b/doc/whatsnew/2.7.rst
@@ -13,6 +13,7 @@ Summary -- Release highlights
 New checkers
 ============
 
+* Add `empty-comment` check for empty comments.
 
 Other Changes
 =============

--- a/pylint/extensions/empty_comment.py
+++ b/pylint/extensions/empty_comment.py
@@ -1,0 +1,56 @@
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IRawChecker
+
+
+def is_line_commented(line):
+    """ Checks if a `# symbol that is not part of a string was found in line"""
+
+    comment_idx = line.find(b"#")
+    if comment_idx == -1:
+        return False
+    if comment_part_of_string(line, comment_idx):
+        return is_line_commented(line[:comment_idx] + line[comment_idx + 1 :])
+    return True
+
+
+def comment_part_of_string(line, comment_idx):
+    """ checks if the symbol at comment_idx is part of a string """
+
+    if (
+        line[:comment_idx].count(b"'") % 2 == 1
+        and line[comment_idx:].count(b"'") % 2 == 1
+    ) or (
+        line[:comment_idx].count(b'"') % 2 == 1
+        and line[comment_idx:].count(b'"') % 2 == 1
+    ):
+        return True
+    return False
+
+
+class CommentChecker(BaseChecker):
+    __implements__ = IRawChecker
+
+    name = "refactoring"
+    msgs = {
+        "R2044": (
+            "Line with empty comment",
+            "empty-comment",
+            (
+                "Used when a # symbol appears on a line not followed by an actual comment"
+            ),
+        )
+    }
+    options = ()
+    priority = -1  # low priority
+
+    def process_module(self, node):
+        with node.stream() as stream:
+            for (line_num, line) in enumerate(stream):
+                line = line.rstrip()
+                if line.endswith(b"#"):
+                    if not is_line_commented(line[:-1]):
+                        self.add_message("empty-comment", line=line_num)
+
+
+def register(linter):
+    linter.register_checker(CommentChecker(linter))

--- a/tests/extensions/data/empty_comment.py
+++ b/tests/extensions/data/empty_comment.py
@@ -1,0 +1,9 @@
+"""empty-comment test-case"""
+A = 5  #
+#
+A = '#' + '1'
+print(A)  #
+print("A=", A)  # should not be an error#
+A = "#pe\0ace#love#"  #
+A = "peace#love"  # \0 peace'#'''' love#peace'''-'#love'-"peace#love"#
+#######

--- a/tests/extensions/test_empty_comment.py
+++ b/tests/extensions/test_empty_comment.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pytest
+
+import pylint.extensions.empty_comment as empty_comment
+
+
+@pytest.fixture(scope="module")
+def checker():
+    return empty_comment.CommentChecker
+
+
+@pytest.fixture(scope="module")
+def enable():
+    return ["empty-comment"]
+
+
+@pytest.fixture(scope="module")
+def disable():
+    return ["all"]
+
+
+def test_comment_base_case(linter):
+    comment_test = str(Path(__file__).parent.joinpath("data", "empty_comment.py"))
+    linter.check([comment_test])
+    msgs = linter.reporter.messages
+    assert len(msgs) == 4
+    for msg in msgs:
+        assert msg.symbol == "empty-comment"
+        assert msg.msg == "Line with empty comment"
+    assert msgs[0].line == 1
+    assert msgs[1].line == 2
+    assert msgs[2].line == 4
+    assert msgs[3].line == 6


### PR DESCRIPTION
# Steps
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x]  Add a ChangeLog entry.
- [x]  If it's a new feature or an important bug fix, add a What's New entry in doc/whatsnew/<current release.rst>.
- [x]  Write a good description on what the PR does.

# Description
 #### Added `comment_ending` plug-in for empty comments.
* Empty comments in your code can be confusing in large scale programs, especially when developers are replaced frequently. If a developer who didn't write the code see an empty comment s/he can think there is a missing a comment. I know that some developers put empty comments when they want to bookmark somewhere in the code, and this is a bad practice that should be avoided.
* This checker recognizes lines with empty comments, but also accurate enough not to raise False Positives (or else people would stop using this tool).
* Since a message is raised only with empty comments, I could not add a test at `tests/test_functional.py` folder, so I wrote a unittest instead.
# Type of Changes

IsDone | Type
------------ | -------------
|| 🐛 Bug fix
✓|✨ New feature
||🔨  Refactoring
||📜  Docs

# Related Issue
None