### PR TITLE
Pruning

### DIFF
--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -171,7 +171,6 @@ class EncodingChecker(BaseChecker):
                     except PragmaParserError:
                         # Printing useful information dealing with this error is done in the lint package
                         pass
-                    values = [_val.upper() for _val in values]
                     if set(values) & set(self.config.notes):
                         continue
                 except ValueError:

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -1,7 +1,6 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
-import re
 import sys
 
 from astroid.__pkginfo__ import version as astroid_version

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -8,11 +8,6 @@ from astroid.__pkginfo__ import version as astroid_version
 
 from pylint.__pkginfo__ import version as pylint_version
 
-# Allow stopping after the first semicolon/hash encountered,
-# so that an option can be continued with the reasons
-# why it is active or disabled.
-OPTION_RGX = re.compile(r"\s*#.*\bpylint:\s*([^;#]+)[;#]{0,1}")
-
 PY_EXTS = (".py", ".pyc", ".pyo", ".pyw", ".so", ".dll")
 
 MSG_STATE_CONFIDENCE = 2


### PR DESCRIPTION
This changeset prunes some unnecessary code (probably leftover from past refactors):

* A unnecessary conversion to uppercase in `misc.py` on a value that is simply tested for existence and then discarded
* A duplicate definition of `OPTION_RGX` in `constants.py`