### PR TITLE
Bug pylint 3873

### DIFF
--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1332,8 +1332,11 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         if isinstance(node, astroid.If):
             return self._is_if_node_return_ended(node)
         if isinstance(node, astroid.TryExcept):
-            handlers = {_child for _child in node.get_children()
-                         if isinstance(_child, astroid.ExceptHandler)}
+            handlers = {
+                _child
+                for _child in node.get_children()
+                if isinstance(_child, astroid.ExceptHandler)
+            }
             all_but_handler = set(node.get_children()) - handlers
             return any(
                 self._is_node_return_ended(_child) for _child in all_but_handler

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1332,9 +1332,12 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         if isinstance(node, astroid.If):
             return self._is_if_node_return_ended(node)
         if isinstance(node, astroid.TryExcept):
-            return all(
-                self._is_node_return_ended(_child) for _child in node.get_children()
-            )
+            handlers = {_child for _child in node.get_children()
+                         if isinstance(_child, astroid.ExceptHandler)}
+            all_but_handler = set(node.get_children()) - handlers
+            return any(
+                self._is_node_return_ended(_child) for _child in all_but_handler
+            ) and all(self._is_node_return_ended(_child) for _child in handlers)
         # recurses on the children of the node
         return any(self._is_node_return_ended(_child) for _child in node.get_children())
 

--- a/tests/functional/i/inconsistent_returns.py
+++ b/tests/functional/i/inconsistent_returns.py
@@ -308,3 +308,30 @@ def bug_3468_counter_example_2(bar):
         return bar.baz
     except AttributeError:
         return None
+
+def nothing_to_do():
+    pass
+
+def bug_pylint_3873():
+    try:
+        nothing_to_do()
+        return True
+    except IndexError:
+        return False
+
+def bug_pylint_3873_1():  # [inconsistent-return-statements]
+    try:
+        nothing_to_do()
+        return True
+    except IndexError:
+        pass
+    except ValueError:
+        return False
+
+def bug_pylint_3873_2():
+    try:
+        nothing_to_do()
+        return True
+    except IndexError:
+        nothing_to_do()
+    return False

--- a/tests/functional/i/inconsistent_returns.txt
+++ b/tests/functional/i/inconsistent_returns.txt
@@ -13,3 +13,4 @@ inconsistent-return-statements:255:bug_1794_inner_func_in_if_counter_example_3:E
 inconsistent-return-statements:262:bug_1794_inner_func_in_if_counter_example_3._inner2:Either all return statements in a function should return an expression, or none of them should.
 inconsistent-return-statements:267:bug_3468:Either all return statements in a function should return an expression, or none of them should.
 inconsistent-return-statements:277:bug_3468_variant:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:322:bug_pylint_3873_1:Either all return statements in a function should return an expression, or none of them should.


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
This PR is a fix for #3873 and should allow `astroid` CI to be free from linting errors.
A try/except node is now considered as return ended if at least one of its non-except-handling children is return ended and if all the except-handling children are return ended.
3 unit tests have been added.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #3873 
