### PR TITLE
Handle class decorators during typing checks.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -427,3 +427,5 @@ contributors:
 * Takashi Hirashima: contributor
 
 * Joffrey Mander: contributor
+
+* Julien Palard: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@
 Pylint's ChangeLog
 ------------------
 
+* Handle class decorators applied to function.
+
+  Closes #3882
+
 * Add check for empty comments
 
 * Fix minor documentation issue in contribute.rst

--- a/doc/development_guide/contribute.rst
+++ b/doc/development_guide/contribute.rst
@@ -110,7 +110,10 @@ your patch gets accepted.
   (`What's New` section). For the release document we usually write some more details,
   and it is also a good place to offer examples on how the new change is supposed to work.
 
-- Add yourself to the `CONTRIBUTORS` file, if you are not already there.
+- Add a short entry in :file:`doc/whatsnew/VERSION.rst`.
+
+- Add yourself to the `CONTRIBUTORS` file, flag youself appropriately
+  (if in doubt, you're a ``contributor``).
 
 - Write a comprehensive commit message
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1724,7 +1724,7 @@ accessed. Python regular expressions are accepted.",
         if inferred is None or inferred is astroid.Uninferable:
             return
 
-        if inferred.decorators:
+        if getattr(inferred, "decorators", None):
             first_decorator = helpers.safe_infer(inferred.decorators.nodes[0])
             if isinstance(first_decorator, astroid.ClassDef):
                 inferred = first_decorator.instantiate_class()

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -65,7 +65,7 @@ import astroid
 import astroid.arguments
 import astroid.context
 import astroid.nodes
-from astroid import bases, decorators, exceptions, modutils, objects
+from astroid import bases, decorators, exceptions, helpers, modutils, objects
 from astroid.interpreter import dunder_lookup
 
 from pylint.checkers import BaseChecker, utils
@@ -1720,8 +1720,17 @@ accessed. Python regular expressions are accepted.",
             return
 
         inferred = safe_infer(node.value)
+
         if inferred is None or inferred is astroid.Uninferable:
             return
+
+        if inferred.decorators:
+            first_decorator = helpers.safe_infer(inferred.decorators.nodes[0])
+            if isinstance(first_decorator, astroid.ClassDef):
+                inferred = first_decorator.instantiate_class()
+            else:
+                return  # It would be better to handle function
+                # decorators, but let's start slow.
 
         if not supported_protocol(inferred):
             self.add_message(msg, args=node.value.as_string(), node=node.value)

--- a/tests/checkers/unittest_typecheck.py
+++ b/tests/checkers/unittest_typecheck.py
@@ -300,7 +300,8 @@ class TestTypeChecker(CheckerTestCase):
             def __getitem__(self, item):
                 return item
         """
-        self.typing_option_object_is_subscriptable(decorators)
+        for generic in "Optional", "List", "ClassVar", "Final", "Literal":
+            self.typing_objects_are_subscriptable(generic)
 
         self.decorated_by_a_subscriptable_class(decorators)
         self.decorated_by_an_unsubscriptable_class(decorators)
@@ -308,12 +309,14 @@ class TestTypeChecker(CheckerTestCase):
         self.decorated_by_subscriptable_then_unsubscriptable_class(decorators)
         self.decorated_by_unsubscriptable_then_subscriptable_class(decorators)
 
-    def typing_option_object_is_subscriptable(self, decorators):
+    def typing_objects_are_subscriptable(self, generic):
         module = astroid.parse(
             """
         import typing
-        test = typing.Optional[int]
-        """
+        test = typing.{}[int]
+        """.format(
+                generic
+            )
         )
         subscript = module.body[-1].value
         with self.assertNoMessages():


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

I'm trying myself at fixing #3882, by handling the specific case where a decorator is a class. I bet this could be handled elsewere to be made more generic, but as a first contribution I'm starting slow.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #3882
