### PR TITLE
Fix for py39 - unsubscriptable-object

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -423,3 +423,5 @@ contributors:
 * Joshua Cannon: contributor
 
 * Giuseppe Valente: contributor
+
+* cdce8p: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -19,7 +19,7 @@ Release date: TBA
 * Fix bug that lead to duplicate messages when using ``--jobs 2`` or more.
 
   Close #3584
- 
+
 * Adds option ``check-protected-access-in-special-methods`` in the ClassChecker to activate/deactivate
   ``protected-access`` message emission for single underscore prefixed attribute in special methods.
 
@@ -61,6 +61,8 @@ Release date: TBA
   Close #3798
 
 * Fix minor documentation issues
+
+* Fix false-positive ``unsubscriptable-object`` message for ``typing.Union`` and ``typing.Optional``. Closes #3882
 
 What's New in Pylint 2.6.0?
 ===========================

--- a/doc/whatsnew/2.6.rst
+++ b/doc/whatsnew/2.6.rst
@@ -52,3 +52,5 @@ Other Changes
 * Fix vulnerable regular expressions in ``pyreverse``. The ambiguities of vulnerable regular expressions are removed, making the repaired regular expressions safer and faster matching.
 
 .. _the migration guide in isort documentation: https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/#known_standard_library
+
+* Fix false-positive ``unsubscriptable-object`` message for ``typing.Union`` and ``typing.Optional``. Closes #3882

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1076,6 +1076,9 @@ def _supports_protocol(
             return True
         if protocol_callback(value):
             return True
+    if isinstance(value, astroid.FunctionDef):
+        if value.name in ("Optional", "Union"):
+            return True
 
     if (
         isinstance(value, _bases.Proxy)


### PR DESCRIPTION
## Description
This PR fixes an issue where `typing.Optional` and `typing.Union` where falsely flagged with `unsubscriptable-object`.

This error seems to be the result of a changed inference value:
```
# py38
Instance of typing._SpecialForm

# py39
FunctionDef.Union(...)
FunctionDef.Optional(...)
```

Since I'm new to pylint, this might not be the best place to fix it and I saw that #3894 also addresses this issue in a different spot. Please let me know if I should change something or if you like to continue with the other PR.

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

Closes: #3882
This PR partially addresses #3895
