### PR TITLE
Better assert message when dealing with functional tests messages

### DIFF
--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -215,18 +215,8 @@ class LintModuleTest:
                 error_msg += "{}\n".format(line)
         return error_msg
 
-    @classmethod
-    def _split_lines(cls, expected_messages, lines):
-        emitted, omitted = [], []
-        for msg in lines:
-            if (msg[1], msg[0]) in expected_messages:
-                emitted.append(msg)
-            else:
-                omitted.append(msg)
-        return emitted, omitted
-
-    def _check_output_text(self, expected_messages, expected_lines, received_lines):
+    def _check_output_text(self, _, expected_output, actual_output):
         """This is a function because we want to be able to update the text in LintModuleOutputUpdate"""
-        expected_lines = self._split_lines(expected_messages, expected_lines)[0]
-        error_msg = self.error_msg_for_unequal_output(expected_lines, received_lines)
-        assert expected_lines == received_lines, error_msg
+        assert expected_output == actual_output, self.error_msg_for_unequal_output(
+            expected_output, actual_output
+        )

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -175,12 +175,9 @@ class LintModuleTest:
         self._linter.check(modules_to_check)
         expected_messages, expected_output = self._get_expected()
         actual_messages, actual_output = self._get_actual()
-
-        if expected_messages != actual_messages:
-            error_msg = self.error_msg_for_unequal_messages(
-                actual_messages, expected_messages
-            )
-            pytest.fail(error_msg)
+        assert (
+            expected_messages == actual_messages
+        ), self.error_msg_for_unequal_messages(actual_messages, expected_messages)
         self._check_output_text(expected_messages, expected_output, actual_output)
 
     def error_msg_for_unequal_messages(self, actual_messages, expected_messages):

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -173,21 +173,29 @@ class LintModuleTest:
     def _runTest(self):
         modules_to_check = [self._test_file.source]
         self._linter.check(modules_to_check)
-        expected_messages, expected_text = self._get_expected()
-        received_messages, received_text = self._get_actual()
-        if expected_messages != received_messages:
-            msg = ['Wrong results for file "%s":' % (self._test_file.base)]
-            missing, unexpected = self.multiset_difference(
-                expected_messages, received_messages
+        expected_messages, expected_output = self._get_expected()
+        actual_messages, actual_output = self._get_actual()
+
+        if expected_messages != actual_messages:
+            error_msg = self.error_msg_for_unequal_messages(
+                actual_messages, expected_messages
             )
-            if missing:
-                msg.append("\nExpected in testdata:")
-                msg.extend(" %3d: %s" % msg for msg in sorted(missing))
-            if unexpected:
-                msg.append("\nUnexpected in testdata:")
-                msg.extend(" %3d: %s" % msg for msg in sorted(unexpected))
-            pytest.fail("\n".join(msg))
-        self._check_output_text(expected_messages, expected_text, received_text)
+            pytest.fail(error_msg)
+        self._check_output_text(expected_messages, expected_output, actual_output)
+
+    def error_msg_for_unequal_messages(self, actual_messages, expected_messages):
+        msg = ['Wrong results for file "%s":' % (self._test_file.base)]
+        missing, unexpected = self.multiset_difference(
+            expected_messages, actual_messages
+        )
+        if missing:
+            msg.append("\nExpected in testdata:")
+            msg.extend(" %3d: %s" % msg for msg in sorted(missing))
+        if unexpected:
+            msg.append("\nUnexpected in testdata:")
+            msg.extend(" %3d: %s" % msg for msg in sorted(unexpected))
+        error_msg = "\n".join(msg)
+        return error_msg
 
     @classmethod
     def _split_lines(cls, expected_messages, lines):

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -3,6 +3,7 @@
 
 import collections
 import csv
+import operator
 import platform
 import sys
 from io import StringIO
@@ -205,13 +206,14 @@ class LintModuleTest:
                 _file=self._test_file.base,
             )
         )
+        sort_by_line_number = operator.attrgetter("lineno")
         if missing:
             error_msg += "\n- Missing lines:\n"
-            for line in missing:
+            for line in sorted(missing, key=sort_by_line_number):
                 error_msg += "{}\n".format(line)
         if unexpected:
             error_msg += "\n- Unexpected lines:\n"
-            for line in unexpected:
+            for line in sorted(unexpected, key=sort_by_line_number):
                 error_msg += "{}\n".format(line)
         return error_msg
 

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -194,18 +194,7 @@ class LintModuleTest:
         error_msg = "\n".join(msg)
         return error_msg
 
-    @classmethod
-    def _split_lines(cls, expected_messages, lines):
-        emitted, omitted = [], []
-        for msg in lines:
-            if (msg[1], msg[0]) in expected_messages:
-                emitted.append(msg)
-            else:
-                omitted.append(msg)
-        return emitted, omitted
-
-    def _check_output_text(self, expected_messages, expected_lines, received_lines):
-        expected_lines = self._split_lines(expected_messages, expected_lines)[0]
+    def error_msg_for_unequal_output(self, expected_lines, received_lines) -> str:
         missing = set(expected_lines) - set(received_lines)
         unexpected = set(received_lines) - set(expected_lines)
         error_msg = (
@@ -224,4 +213,20 @@ class LintModuleTest:
             error_msg += "\n- Unexpected lines:\n"
             for line in unexpected:
                 error_msg += "{}\n".format(line)
+        return error_msg
+
+    @classmethod
+    def _split_lines(cls, expected_messages, lines):
+        emitted, omitted = [], []
+        for msg in lines:
+            if (msg[1], msg[0]) in expected_messages:
+                emitted.append(msg)
+            else:
+                omitted.append(msg)
+        return emitted, omitted
+
+    def _check_output_text(self, expected_messages, expected_lines, received_lines):
+        """This is a function because we want to be able to update the text in LintModuleOutputUpdate"""
+        expected_lines = self._split_lines(expected_messages, expected_lines)[0]
+        error_msg = self.error_msg_for_unequal_output(expected_lines, received_lines)
         assert expected_lines == received_lines, error_msg

--- a/tests/functional/b/bad_reversed_sequence.txt
+++ b/tests/functional/b/bad_reversed_sequence.txt
@@ -1,10 +1,7 @@
 bad-reversed-sequence:43:test:The first reversed() argument is not a sequence
 bad-reversed-sequence:46:test:The first reversed() argument is not a sequence
 bad-reversed-sequence:47:test:The first reversed() argument is not a sequence
-bad-reversed-sequence:48:test:The first reversed() argument is not a sequence
 bad-reversed-sequence:50:test:The first reversed() argument is not a sequence
 bad-reversed-sequence:51:test:The first reversed() argument is not a sequence
-bad-reversed-sequence:52:test:The first reversed() argument is not a sequence
 bad-reversed-sequence:53:test:The first reversed() argument is not a sequence
 bad-reversed-sequence:54:test:The first reversed() argument is not a sequence
-bad-reversed-sequence:55:test:The first reversed() argument is not a sequence

--- a/tests/functional/c/comparison_with_callable.txt
+++ b/tests/functional/c/comparison_with_callable.txt
@@ -1,5 +1,4 @@
 comparison-with-callable:8::Comparing against a callable, did you omit the parenthesis?
 comparison-with-callable:11::Comparing against a callable, did you omit the parenthesis?
-comparison-with-callable:45::Comparing against a callable, did you omit the parenthesis?
 comparison-with-callable:48::Comparing against a callable, did you omit the parenthesis?
 comparison-with-callable:51::Comparing against a callable, did you omit the parenthesis?

--- a/tests/functional/i/init_not_called.txt
+++ b/tests/functional/i/init_not_called.txt
@@ -1,3 +1,2 @@
-no-init:18:CCCC:Class has no __init__ method
 super-init-not-called:25:ZZZZ.__init__:__init__ method from base class 'BBBB' is not called
 super-init-not-called:58:AssignedInit.__init__:__init__ method from base class 'NewStyleC' is not called

--- a/tests/functional/i/invalid_exceptions_raised.txt
+++ b/tests/functional/i/invalid_exceptions_raised.txt
@@ -1,7 +1,5 @@
-nonstandard-exception:38:bad_case0:"Exception doesn't inherit from standard ""Exception"" class"
 raising-non-exception:38:bad_case0:Raising a new style class which doesn't inherit from BaseException
 raising-non-exception:42:bad_case1:Raising a new style class which doesn't inherit from BaseException
-nonstandard-exception:48:bad_case2:"Exception doesn't inherit from standard ""Exception"" class"
 raising-non-exception:48:bad_case2:Raising a new style class which doesn't inherit from BaseException
 raising-non-exception:52:bad_case3:Raising a new style class which doesn't inherit from BaseException
 notimplemented-raised:56:bad_case4:NotImplemented raised - should raise NotImplementedError

--- a/tests/functional/i/invalid_sequence_index.txt
+++ b/tests/functional/i/invalid_sequence_index.txt
@@ -10,7 +10,6 @@ invalid-sequence-index:128:function19:Sequence index is not an int, slice, or in
 invalid-sequence-index:133:function20:Sequence index is not an int, slice, or instance with __index__
 invalid-sequence-index:144:function21:Sequence index is not an int, slice, or instance with __index__
 invalid-sequence-index:145:function21:Sequence index is not an int, slice, or instance with __index__
-invalid-sequence-index:159:function22:Sequence index is not an int, slice, or instance with __index__
 invalid-sequence-index:160:function22:Sequence index is not an int, slice, or instance with __index__
 invalid-sequence-index:162:function22:Sequence index is not an int, slice, or instance with __index__
 invalid-sequence-index:178:function23:Sequence index is not an int, slice, or instance with __index__

--- a/tests/functional/m/messages_managed_by_id.txt
+++ b/tests/functional/m/messages_managed_by_id.txt
@@ -1,6 +1,1 @@
-use-symbolic-message-instead:2::"Id 'C0111' is used to disable 'missing-docstring' message emission"
-use-symbolic-message-instead:3::"Id 'C0102' is used to disable 'blacklisted-name' message emission"
-use-symbolic-message-instead:6::"Id 'C0102' is used to disable 'blacklisted-name' message emission"
-use-symbolic-message-instead:6::"Id 'R1711' is used to disable 'useless-return' message emission"
-use-symbolic-message-instead:10::"Id 'C0111' is used to enable 'missing-docstring' message emission"
 missing-function-docstring:10:test_enabled_by_id_msg:"Missing function or method docstring"

--- a/tests/functional/n/namedtuple_member_inference.txt
+++ b/tests/functional/n/namedtuple_member_inference.txt
@@ -1,2 +1,1 @@
 no-member:17:test:Class 'Thing' has no 'x' member:INFERENCE
-no-member:23:test:Instance of 'Fantastic' has no 'foo' member:INFERENCE

--- a/tests/functional/s/super_checks.txt
+++ b/tests/functional/s/super_checks.txt
@@ -1,7 +1,6 @@
 no-member:10:Aaaa.hop:Super of 'Aaaa' has no 'hop' member:INFERENCE
 no-member:19:NewAaaa.hop:Super of 'NewAaaa' has no 'hop' member:INFERENCE
 bad-super-call:22:NewAaaa.__init__:Bad first argument 'Aaaa' given to super()
-missing-super-argument:27:Py3kAaaa.__init__:Missing argument to super()
 bad-super-call:32:Py3kWrongSuper.__init__:Bad first argument 'NewAaaa' given to super()
 bad-super-call:37:WrongNameRegression.__init__:Bad first argument 'Missing' given to super()
 bad-super-call:46:CrashSuper.__init__:Bad first argument 'NewAaaa' given to super()

--- a/tests/functional/u/unbalanced_tuple_unpacking.txt
+++ b/tests/functional/u/unbalanced_tuple_unpacking.txt
@@ -1,6 +1,5 @@
 unbalanced-tuple-unpacking:9:do_stuff:"Possible unbalanced tuple unpacking with sequence (1, 2, 3): left side has 2 label(s), right side has 3 value(s)"
 unbalanced-tuple-unpacking:14:do_stuff1:"Possible unbalanced tuple unpacking with sequence [1, 2, 3]: left side has 2 label(s), right side has 3 value(s)"
 unbalanced-tuple-unpacking:19:do_stuff2:"Possible unbalanced tuple unpacking with sequence (1, 2, 3): left side has 2 label(s), right side has 3 value(s)"
-unbalanced-tuple-unpacking:24:do_stuff3:"Possible unbalanced tuple unpacking with sequence (1, 2, 3): left side has 2 label(s), right side has 3 value(s)"
 unbalanced-tuple-unpacking:69:do_stuff9:"Possible unbalanced tuple unpacking with sequence defined at line 7 of functional.u.unpacking: left side has 2 label(s), right side has 3 value(s)"
 unbalanced-tuple-unpacking:81:UnbalancedUnpacking.test:"Possible unbalanced tuple unpacking with sequence defined at line 7 of functional.u.unpacking: left side has 2 label(s), right side has 3 value(s)"

--- a/tests/functional/u/unidiomatic_typecheck.txt
+++ b/tests/functional/u/unidiomatic_typecheck.txt
@@ -2,7 +2,6 @@ unidiomatic-typecheck:5:simple_positives:Using type() instead of isinstance() fo
 unidiomatic-typecheck:6:simple_positives:Using type() instead of isinstance() for a typecheck.
 unidiomatic-typecheck:7:simple_positives:Using type() instead of isinstance() for a typecheck.
 unidiomatic-typecheck:8:simple_positives:Using type() instead of isinstance() for a typecheck.
-unidiomatic-typecheck:9:simple_positives:Using type() instead of isinstance() for a typecheck.
 unidiomatic-typecheck:12:simple_inference_positives:Using type() instead of isinstance() for a typecheck.
 unidiomatic-typecheck:13:simple_inference_positives:Using type() instead of isinstance() for a typecheck.
 unidiomatic-typecheck:14:simple_inference_positives:Using type() instead of isinstance() for a typecheck.

--- a/tests/functional/u/useless-import-alias.txt
+++ b/tests/functional/u/useless-import-alias.txt
@@ -1,6 +1,4 @@
 useless-import-alias:2::Import alias does not rename original package
-useless-import-alias:4::Import alias does not rename original package
-useless-import-alias:6::Import alias does not rename original package
 useless-import-alias:10::Import alias does not rename original package
 useless-import-alias:13::Import alias does not rename original package
 useless-import-alias:14::Import alias does not rename original package

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -76,7 +76,6 @@ class LintModuleOutputUpdate(testutils.LintModuleTest):
             return
         emitted, remaining = self._split_lines(expected_messages, expected_output)
         if emitted != actual_output:
-
             remaining.extend(actual_output)
             remaining.sort(key=lambda m: (m[1], m[0], m[3]))
             warnings.warn(

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -61,13 +61,23 @@ class LintModuleOutputUpdate(testutils.LintModuleTest):
         except OSError:
             return io.StringIO()
 
-    def _check_output_text(self, expected_messages, expected_lines, received_lines):
+    @classmethod
+    def _split_lines(cls, expected_messages, lines):
+        emitted, omitted = [], []
+        for msg in lines:
+            if (msg[1], msg[0]) in expected_messages:
+                emitted.append(msg)
+            else:
+                omitted.append(msg)
+        return emitted, omitted
+
+    def _check_output_text(self, expected_messages, expected_output, actual_output):
         if not expected_messages:
             return
-        emitted, remaining = self._split_lines(expected_messages, expected_lines)
-        if emitted != received_lines:
+        emitted, remaining = self._split_lines(expected_messages, expected_output)
+        if emitted != actual_output:
 
-            remaining.extend(received_lines)
+            remaining.extend(actual_output)
             remaining.sort(key=lambda m: (m[1], m[0], m[3]))
             warnings.warn(
                 "Updated '{}' with the new content generated from '{}'".format(


### PR DESCRIPTION
Use sets here to show full diffs in functional tests

Co-authored-by: Ethan Leba <ethanleba5@gmail.com>

## Description

This change was hidden in #3821 and was not related to the MR that is taking some time because I must handle function and it's hard to do it properly. This was detrimental because tjhe error message was modified again in #3906 although a clearer error message already existed.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |



