### PR TITLE
Avoid doing a regex search for line lengths unless necessary

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -427,3 +427,5 @@ contributors:
 * Takashi Hirashima: contributor
 
 * Joffrey Mander: contributor
+
+* Raphael Gaschignard: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -70,6 +70,9 @@ Release date: TBA
 
 * Fix minor documentation issues
 
+* Improve the performance of the line length check.
+
+
 What's New in Pylint 2.6.0?
 ===========================
 

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -725,20 +725,49 @@ class FormatChecker(BaseTokenChecker):
             - no trailing whitespace
             - less than a maximum number of characters
         """
-        # By default, check the line length
-        check_l_length = True
+        # we're first going to do a rough check whether any lines in this set
+        # go over the line limit. If none of them do, then we don't need to
+        # parse out the pylint options later on and can just assume that these
+        # lines are clean
+
+        # we'll also handle the line ending check here to avoid double-iteration
+        # unless the line lengths are suspect
+
+        max_chars = self.config.max_line_length
+
+        potential_line_length_warning = False
+
+        # hold onto the initial lineno for later
+        starting_lineno = lineno
+        for line in self.specific_splitlines(lines):
+            self.check_line_ending(line, lineno)
+            # this check is purposefully simple and doesn't rstrip
+            # since this is running on every line you're checking it's
+            # advantageous to avoid doing a lot of work
+            if len(line) > max_chars:
+                potential_line_length_warning = True
+            lineno += 1
+
+        # if there were no lines passing the max_chars config, we don't bother
+        # running the full line check (as we've met an even more strict condition)
+        if not potential_line_length_warning:
+            return
 
         # Line length check may be deactivated through `pylint: disable` comment
         mobj = OPTION_PO.search(lines)
         if mobj:
-            check_l_length = self.is_line_length_check_activated(mobj)
+            if not self.is_line_length_check_activated(mobj):
+                # the line length check is deactivated, we can stop here
+                return
             # The 'pylint: disable whatever' should not be taken into account for line length count
             lines = self.remove_pylint_option_from_lines(mobj)
 
+        # reset the lineno back to its original value
+        # (since we iterated over stuff earlier)
+        lineno = starting_lineno
+
         for line in self.specific_splitlines(lines):
-            if check_l_length:
-                self.check_line_length(line, lineno)
-            self.check_line_ending(line, lineno)
+            self.check_line_length(line, lineno)
             lineno += 1
 
     def check_indent_level(self, string, expected, line_num):


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

 Before this change, we would check a line for `pylint: disable`-style
 pragmas to determine whether to check the line length. The regex
 check itself is very costly (~5% of pylint's total runtime in one
 codebase), and is much more costly than the check itself.

 This refactors the pylint check to instead do an approximate line
 length check on everything, before using the regex to handle
 exceptional, false negative cases like pragmas being the cause for the line length
 overflow.

 This change, in one sample codebase, lowered the `check_lines`
 runtime from 5% of the total runtime to 0.35% of the total runtime.

**EDIT**: the control flow on this is a bit weird to avoid iterating over content twice in the common "passing" case, but I think here it's worth it 

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |
