### PR TITLE
Only emit `bad-reversed-sequence` on dictionaries if below py3.8 (#3940)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 ------------------
 Pylint's ChangeLog
 ------------------
+* Only emit `bad-reversed-sequence` on dictionaries if below py3.8
+
+  Closes #3940
 
 * Handle class decorators applied to function.
 

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1524,14 +1524,11 @@ class BasicChecker(_BasicChecker):
                 return
 
             if isinstance(argument, astroid.Instance):
-                if argument._proxied.name == "dict" and utils.is_builtin_object(
-                    argument._proxied
-                ):
-                    self.add_message("bad-reversed-sequence", node=node)
-                    return
                 if any(
                     ancestor.name == "dict" and utils.is_builtin_object(ancestor)
-                    for ancestor in argument._proxied.ancestors()
+                    for ancestor in itertools.chain(
+                        (argument._proxied,), argument._proxied.ancestors()
+                    )
                 ):
                     # Mappings aren't accepted by reversed(), unless
                     # they provide explicitly a __reversed__ method.

--- a/tests/functional/b/bad_reversed_sequence.py
+++ b/tests/functional/b/bad_reversed_sequence.py
@@ -44,7 +44,6 @@ def test(path):
     seq = reversed([1, 2, 3])
     seq = reversed((1, 2, 3))
     seq = reversed(set()) # [bad-reversed-sequence]
-    seq = reversed({'a': 1, 'b': 2}) # [bad-reversed-sequence]
     seq = reversed(iter([1, 2, 3])) # [bad-reversed-sequence]
     seq = reversed(GoodReversed())
     seq = reversed(SecondGoodReversed())

--- a/tests/functional/b/bad_reversed_sequence.txt
+++ b/tests/functional/b/bad_reversed_sequence.txt
@@ -2,7 +2,9 @@ bad-reversed-sequence:43:test:The first reversed() argument is not a sequence
 bad-reversed-sequence:46:test:The first reversed() argument is not a sequence
 bad-reversed-sequence:47:test:The first reversed() argument is not a sequence
 bad-reversed-sequence:48:test:The first reversed() argument is not a sequence
+bad-reversed-sequence:50:test:The first reversed() argument is not a sequence
 bad-reversed-sequence:51:test:The first reversed() argument is not a sequence
 bad-reversed-sequence:52:test:The first reversed() argument is not a sequence
+bad-reversed-sequence:53:test:The first reversed() argument is not a sequence
 bad-reversed-sequence:54:test:The first reversed() argument is not a sequence
 bad-reversed-sequence:55:test:The first reversed() argument is not a sequence

--- a/tests/functional/b/bad_reversed_sequence_py37.py
+++ b/tests/functional/b/bad_reversed_sequence_py37.py
@@ -1,0 +1,2 @@
+""" Dictionaries are reversible starting on python 3.8"""
+reversed({'a': 1, 'b': 2}) # [bad-reversed-sequence]

--- a/tests/functional/b/bad_reversed_sequence_py37.rc
+++ b/tests/functional/b/bad_reversed_sequence_py37.rc
@@ -1,0 +1,2 @@
+[testoptions]
+max_pyver=3.8

--- a/tests/functional/b/bad_reversed_sequence_py37.txt
+++ b/tests/functional/b/bad_reversed_sequence_py37.txt
@@ -1,0 +1,1 @@
+bad-reversed-sequence:2::The first reversed() argument is not a sequence

--- a/tests/functional/b/bad_reversed_sequence_py38.py
+++ b/tests/functional/b/bad_reversed_sequence_py38.py
@@ -1,0 +1,2 @@
+""" Dictionaries are reversible starting on python 3.8"""
+reversed({'a': 1, 'b': 2})

--- a/tests/functional/b/bad_reversed_sequence_py38.rc
+++ b/tests/functional/b/bad_reversed_sequence_py38.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.8


### PR DESCRIPTION

## Description
Only emit `bad-reversed-sequence` on dictionaries if below py3.8

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

Closes #3940
