### PR TITLE
Burst testutils/utils into files with semantic names

### DIFF
--- a/pylint/testutils/__init__.py
+++ b/pylint/testutils/__init__.py
@@ -44,13 +44,8 @@ __all__ = [
 
 from pylint.testutils.constants import UPDATE_OPTION
 from pylint.testutils.functional_test_file import FunctionalTestFile
+from pylint.testutils.get_test_info import _get_tests_info
 from pylint.testutils.lint_module_test import LintModuleTest
 from pylint.testutils.output_line import Message
 from pylint.testutils.reporter_for_tests import GenericTestReporter, MinimalTestReporter
-from pylint.testutils.utils import (
-    CheckerTestCase,
-    _get_tests_info,
-    _tokenize_str,
-    linter,
-    set_config,
-)
+from pylint.testutils.utils import CheckerTestCase, _tokenize_str, linter, set_config

--- a/pylint/testutils/__init__.py
+++ b/pylint/testutils/__init__.py
@@ -42,11 +42,13 @@ __all__ = [
     "UPDATE_OPTION",
 ]
 
+from pylint.testutils.checker_test_case import CheckerTestCase
 from pylint.testutils.constants import UPDATE_OPTION
 from pylint.testutils.decorator import set_config
 from pylint.testutils.functional_test_file import FunctionalTestFile
 from pylint.testutils.get_test_info import _get_tests_info
+from pylint.testutils.global_test_linter import linter
 from pylint.testutils.lint_module_test import LintModuleTest
 from pylint.testutils.output_line import Message
 from pylint.testutils.reporter_for_tests import GenericTestReporter, MinimalTestReporter
-from pylint.testutils.utils import CheckerTestCase, _tokenize_str, linter
+from pylint.testutils.tokenize_str import _tokenize_str

--- a/pylint/testutils/__init__.py
+++ b/pylint/testutils/__init__.py
@@ -42,13 +42,13 @@ __all__ = [
     "UPDATE_OPTION",
 ]
 
+from pylint.testutils.output_line import Message
 from pylint.testutils.reporter_for_tests import GenericTestReporter, MinimalTestReporter
 from pylint.testutils.utils import (
     UPDATE_OPTION,
     CheckerTestCase,
     FunctionalTestFile,
     LintModuleTest,
-    Message,
     _get_tests_info,
     _tokenize_str,
     linter,

--- a/pylint/testutils/__init__.py
+++ b/pylint/testutils/__init__.py
@@ -43,9 +43,10 @@ __all__ = [
 ]
 
 from pylint.testutils.constants import UPDATE_OPTION
+from pylint.testutils.decorator import set_config
 from pylint.testutils.functional_test_file import FunctionalTestFile
 from pylint.testutils.get_test_info import _get_tests_info
 from pylint.testutils.lint_module_test import LintModuleTest
 from pylint.testutils.output_line import Message
 from pylint.testutils.reporter_for_tests import GenericTestReporter, MinimalTestReporter
-from pylint.testutils.utils import CheckerTestCase, _tokenize_str, linter, set_config
+from pylint.testutils.utils import CheckerTestCase, _tokenize_str, linter

--- a/pylint/testutils/__init__.py
+++ b/pylint/testutils/__init__.py
@@ -42,13 +42,13 @@ __all__ = [
     "UPDATE_OPTION",
 ]
 
+from pylint.testutils.constants import UPDATE_OPTION
+from pylint.testutils.functional_test_file import FunctionalTestFile
+from pylint.testutils.lint_module_test import LintModuleTest
 from pylint.testutils.output_line import Message
 from pylint.testutils.reporter_for_tests import GenericTestReporter, MinimalTestReporter
 from pylint.testutils.utils import (
-    UPDATE_OPTION,
     CheckerTestCase,
-    FunctionalTestFile,
-    LintModuleTest,
     _get_tests_info,
     _tokenize_str,
     linter,

--- a/pylint/testutils/checker_test_case.py
+++ b/pylint/testutils/checker_test_case.py
@@ -1,49 +1,11 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
-"""functional/non regression tests for pylint"""
 import contextlib
-import tokenize
-from io import StringIO
 
 from pylint.testutils.global_test_linter import linter
-from pylint.testutils.output_line import Message
+from pylint.testutils.unittest_linter import UnittestLinter
 from pylint.utils import ASTWalker
-
-
-class UnittestLinter:
-    """A fake linter class to capture checker messages."""
-
-    # pylint: disable=unused-argument, no-self-use
-
-    def __init__(self):
-        self._messages = []
-        self.stats = {}
-
-    def release_messages(self):
-        try:
-            return self._messages
-        finally:
-            self._messages = []
-
-    def add_message(
-        self, msg_id, line=None, node=None, args=None, confidence=None, col_offset=None
-    ):
-        # Do not test col_offset for now since changing Message breaks everything
-        self._messages.append(Message(msg_id, line, node, args, confidence))
-
-    @staticmethod
-    def is_message_enabled(*unused_args, **unused_kwargs):
-        return True
-
-    def add_stats(self, **kwargs):
-        for name, value in kwargs.items():
-            self.stats[name] = value
-        return self.stats
-
-    @property
-    def options_providers(self):
-        return linter.options_providers
 
 
 class CheckerTestCase:
@@ -86,7 +48,3 @@ class CheckerTestCase:
         walker = ASTWalker(linter)
         walker.add_checker(self.checker)
         walker.walk(node)
-
-
-def _tokenize_str(code):
-    return list(tokenize.generate_tokens(StringIO(code).readline))

--- a/pylint/testutils/constants.py
+++ b/pylint/testutils/constants.py
@@ -1,0 +1,26 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+import operator
+import re
+import sys
+from os.path import abspath, dirname
+
+SYS_VERS_STR = "%d%d%d" % sys.version_info[:3]
+TITLE_UNDERLINES = ["", "=", "-", "."]
+PREFIX = abspath(dirname(__file__))
+UPDATE_OPTION = "--update-functional-output"
+# Common sub-expressions.
+_MESSAGE = {"msg": r"[a-z][a-z\-]+"}
+# Matches a #,
+#  - followed by a comparison operator and a Python version (optional),
+#  - followed by a line number with a +/- (optional),
+#  - followed by a list of bracketed message symbols.
+# Used to extract expected messages from testdata files.
+_EXPECTED_RE = re.compile(
+    r"\s*#\s*(?:(?P<line>[+-]?[0-9]+):)?"
+    r"(?:(?P<op>[><=]+) *(?P<version>[0-9.]+):)?"
+    r"\s*\[(?P<msgs>%(msg)s(?:,\s*%(msg)s)*)]" % _MESSAGE
+)
+
+_OPERATORS = {">": operator.gt, "<": operator.lt, ">=": operator.ge, "<=": operator.le}

--- a/pylint/testutils/decorator.py
+++ b/pylint/testutils/decorator.py
@@ -1,0 +1,24 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+import functools
+
+from pylint.testutils.utils import CheckerTestCase
+
+
+def set_config(**kwargs):
+    """Decorator for setting config values on a checker."""
+
+    def _wrapper(fun):
+        @functools.wraps(fun)
+        def _forward(self):
+            for key, value in kwargs.items():
+                setattr(self.checker.config, key, value)
+            if isinstance(self, CheckerTestCase):
+                # reopen checker in case, it may be interested in configuration change
+                self.checker.open()
+            fun(self)
+
+        return _forward
+
+    return _wrapper

--- a/pylint/testutils/decorator.py
+++ b/pylint/testutils/decorator.py
@@ -3,7 +3,7 @@
 
 import functools
 
-from pylint.testutils.utils import CheckerTestCase
+from pylint.testutils.checker_test_case import CheckerTestCase
 
 
 def set_config(**kwargs):

--- a/pylint/testutils/functional_test_file.py
+++ b/pylint/testutils/functional_test_file.py
@@ -1,7 +1,6 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
-"""functional/non regression tests for pylint"""
 import configparser
 from os.path import basename, exists, join
 

--- a/pylint/testutils/functional_test_file.py
+++ b/pylint/testutils/functional_test_file.py
@@ -1,0 +1,74 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+"""functional/non regression tests for pylint"""
+import configparser
+from os.path import basename, exists, join
+
+
+def parse_python_version(ver_str):
+    return tuple(int(digit) for digit in ver_str.split("."))
+
+
+class NoFileError(Exception):
+    pass
+
+
+class FunctionalTestFile:
+    """A single functional test case file with options."""
+
+    _CONVERTERS = {
+        "min_pyver": parse_python_version,
+        "max_pyver": parse_python_version,
+        "requires": lambda s: s.split(","),
+    }
+
+    def __init__(self, directory, filename):
+        self._directory = directory
+        self.base = filename.replace(".py", "")
+        self.options = {
+            "min_pyver": (2, 5),
+            "max_pyver": (4, 0),
+            "requires": [],
+            "except_implementations": [],
+            "exclude_platforms": [],
+        }
+        self._parse_options()
+
+    def __repr__(self):
+        return "FunctionalTest:{}".format(self.base)
+
+    def _parse_options(self):
+        cp = configparser.ConfigParser()
+        cp.add_section("testoptions")
+        try:
+            cp.read(self.option_file)
+        except NoFileError:
+            pass
+
+        for name, value in cp.items("testoptions"):
+            conv = self._CONVERTERS.get(name, lambda v: v)
+            self.options[name] = conv(value)
+
+    @property
+    def option_file(self):
+        return self._file_type(".rc")
+
+    @property
+    def module(self):
+        package = basename(self._directory)
+        return ".".join([package, self.base])
+
+    @property
+    def expected_output(self):
+        return self._file_type(".txt", check_exists=False)
+
+    @property
+    def source(self):
+        return self._file_type(".py")
+
+    def _file_type(self, ext, check_exists=True):
+        name = join(self._directory, self.base + ext)
+        if not check_exists or exists(name):
+            return name
+        raise NoFileError("Cannot find '{}'.".format(name))

--- a/pylint/testutils/get_test_info.py
+++ b/pylint/testutils/get_test_info.py
@@ -1,0 +1,45 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+from glob import glob
+from os.path import basename, join, splitext
+
+from pylint.testutils.constants import SYS_VERS_STR
+
+
+def _get_tests_info(input_dir, msg_dir, prefix, suffix):
+    """get python input examples and output messages
+
+    We use following conventions for input files and messages:
+    for different inputs:
+        test for python  >= x.y    ->  input   =  <name>_pyxy.py
+        test for python  <  x.y    ->  input   =  <name>_py_xy.py
+    for one input and different messages:
+        message for python >=  x.y ->  message =  <name>_pyxy.txt
+        lower versions             ->  message with highest num
+    """
+    result = []
+    for fname in glob(join(input_dir, prefix + "*" + suffix)):
+        infile = basename(fname)
+        fbase = splitext(infile)[0]
+        # filter input files :
+        pyrestr = fbase.rsplit("_py", 1)[-1]  # like _26 or 26
+        if pyrestr.isdigit():  # '24', '25'...
+            if SYS_VERS_STR < pyrestr:
+                continue
+        if pyrestr.startswith("_") and pyrestr[1:].isdigit():
+            # skip test for higher python versions
+            if SYS_VERS_STR >= pyrestr[1:]:
+                continue
+        messages = glob(join(msg_dir, fbase + "*.txt"))
+        # the last one will be without ext, i.e. for all or upper versions:
+        if messages:
+            for outfile in sorted(messages, reverse=True):
+                py_rest = outfile.rsplit("_py", 1)[-1][:-4]
+                if py_rest.isdigit() and SYS_VERS_STR >= py_rest:
+                    break
+        else:
+            # This will provide an error message indicating the missing filename.
+            outfile = join(msg_dir, fbase + ".txt")
+        result.append((infile, outfile))
+    return result

--- a/pylint/testutils/global_test_linter.py
+++ b/pylint/testutils/global_test_linter.py
@@ -1,0 +1,20 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+
+from pylint import checkers
+from pylint.lint import PyLinter
+from pylint.testutils.reporter_for_tests import GenericTestReporter
+
+
+def create_test_linter():
+    test_reporter = GenericTestReporter()
+    linter_ = PyLinter()
+    linter_.set_reporter(test_reporter)
+    linter_.config.persistent = 0
+    checkers.initialize(linter_)
+    return linter_
+
+
+# Can't be renamed to a constant (easily), it breaks countless tests
+linter = create_test_linter()

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -1,0 +1,214 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+import collections
+import csv
+import itertools
+import platform
+import sys
+from typing import Tuple
+
+import pytest
+
+from pylint import checkers
+from pylint.lint import PyLinter
+from pylint.testutils.constants import _EXPECTED_RE, _OPERATORS, UPDATE_OPTION
+from pylint.testutils.functional_test_file import (
+    FunctionalTestFile,
+    NoFileError,
+    parse_python_version,
+)
+from pylint.testutils.output_line import OutputLine
+from pylint.testutils.reporter_for_tests import FunctionalTestReporter
+
+
+class LintModuleTest:
+    maxDiff = None
+
+    def __init__(self, test_file: FunctionalTestFile):
+        _test_reporter = FunctionalTestReporter()
+        self._linter = PyLinter()
+        self._linter.set_reporter(_test_reporter)
+        self._linter.config.persistent = 0
+        checkers.initialize(self._linter)
+        self._linter.disable("I")
+        try:
+            self._linter.read_config_file(test_file.option_file)
+            self._linter.load_config_file()
+        except NoFileError:
+            pass
+        self._test_file = test_file
+
+    def setUp(self):
+        if self._should_be_skipped_due_to_version():
+            pytest.skip(
+                "Test cannot run with Python %s." % (sys.version.split(" ")[0],)
+            )
+        missing = []
+        for req in self._test_file.options["requires"]:
+            try:
+                __import__(req)
+            except ImportError:
+                missing.append(req)
+        if missing:
+            pytest.skip("Requires %s to be present." % (",".join(missing),))
+        if self._test_file.options["except_implementations"]:
+            implementations = [
+                item.strip()
+                for item in self._test_file.options["except_implementations"].split(",")
+            ]
+            implementation = platform.python_implementation()
+            if implementation in implementations:
+                pytest.skip(
+                    "Test cannot run with Python implementation %r" % (implementation,)
+                )
+        if self._test_file.options["exclude_platforms"]:
+            platforms = [
+                item.strip()
+                for item in self._test_file.options["exclude_platforms"].split(",")
+            ]
+            if sys.platform.lower() in platforms:
+                pytest.skip("Test cannot run on platform %r" % (sys.platform,))
+
+    def _should_be_skipped_due_to_version(self):
+        return (
+            sys.version_info < self._test_file.options["min_pyver"]
+            or sys.version_info > self._test_file.options["max_pyver"]
+        )
+
+    def __str__(self):
+        return "%s (%s.%s)" % (
+            self._test_file.base,
+            self.__class__.__module__,
+            self.__class__.__name__,
+        )
+
+    @staticmethod
+    def get_expected_messages(stream):
+        """Parses a file and get expected messages.
+
+        :param stream: File-like input stream.
+        :type stream: enumerable
+        :returns: A dict mapping line,msg-symbol tuples to the count on this line.
+        :rtype: dict
+        """
+        messages = collections.Counter()
+        for i, line in enumerate(stream):
+            match = _EXPECTED_RE.search(line)
+            if match is None:
+                continue
+            line = match.group("line")
+            if line is None:
+                line = i + 1
+            elif line.startswith("+") or line.startswith("-"):
+                line = i + 1 + int(line)
+            else:
+                line = int(line)
+
+            version = match.group("version")
+            op = match.group("op")
+            if version:
+                required = parse_python_version(version)
+                if not _OPERATORS[op](sys.version_info, required):
+                    continue
+
+            for msg_id in match.group("msgs").split(","):
+                messages[line, msg_id.strip()] += 1
+        return messages
+
+    @staticmethod
+    def multiset_difference(expected_entries: set, actual_entries: set) -> Tuple[set]:
+        """Takes two multisets and compares them.
+
+        A multiset is a dict with the cardinality of the key as the value."""
+        missing = expected_entries.copy()
+        missing.subtract(actual_entries)
+        unexpected = {}
+        for key, value in list(missing.items()):
+            if value <= 0:
+                missing.pop(key)
+                if value < 0:
+                    unexpected[key] = -value
+        return missing, unexpected
+
+    def _open_expected_file(self):
+        return open(self._test_file.expected_output)
+
+    def _open_source_file(self):
+        if self._test_file.base == "invalid_encoded_data":
+            return open(self._test_file.source)
+        if "latin1" in self._test_file.base:
+            return open(self._test_file.source, encoding="latin1")
+        return open(self._test_file.source, encoding="utf8")
+
+    def _get_expected(self):
+        with self._open_source_file() as fobj:
+            expected_msgs = self.get_expected_messages(fobj)
+
+        if expected_msgs:
+            with self._open_expected_file() as fobj:
+                expected_output_lines = [
+                    OutputLine.from_csv(row) for row in csv.reader(fobj, "test")
+                ]
+        else:
+            expected_output_lines = []
+        return expected_msgs, expected_output_lines
+
+    def _get_actual(self):
+        messages = self._linter.reporter.messages
+        messages.sort(key=lambda m: (m.line, m.symbol, m.msg))
+        received_msgs = collections.Counter()
+        received_output_lines = []
+        for msg in messages:
+            assert (
+                msg.symbol != "fatal"
+            ), "Pylint analysis failed because of '{}'".format(msg.msg)
+            received_msgs[msg.line, msg.symbol] += 1
+            received_output_lines.append(OutputLine.from_msg(msg))
+        return received_msgs, received_output_lines
+
+    def _runTest(self):
+        modules_to_check = [self._test_file.source]
+        self._linter.check(modules_to_check)
+        expected_messages, expected_output = self._get_expected()
+        actual_messages, actual_output = self._get_actual()
+
+        if expected_messages != actual_messages:
+            msg = ['Wrong results for file "%s":' % (self._test_file.base)]
+            missing, unexpected = self.multiset_difference(
+                expected_messages, actual_messages
+            )
+            if missing:
+                msg.append("\nExpected in testdata:")
+                msg.extend(" %3d: %s" % msg for msg in sorted(missing))
+            if unexpected:
+                msg.append("\nUnexpected in testdata:")
+                msg.extend(" %3d: %s" % msg for msg in sorted(unexpected))
+            pytest.fail("\n".join(msg))
+        self._check_output_text(expected_messages, expected_output, actual_output)
+
+    @classmethod
+    def _split_lines(cls, expected_messages, lines):
+        emitted, omitted = [], []
+        for msg in lines:
+            if (msg[1], msg[0]) in expected_messages:
+                emitted.append(msg)
+            else:
+                omitted.append(msg)
+        return emitted, omitted
+
+    def _check_output_text(self, expected_messages, expected_lines, received_lines):
+        expected_lines = self._split_lines(expected_messages, expected_lines)[0]
+        for exp, rec in itertools.zip_longest(expected_lines, received_lines):
+            assert exp == rec, (
+                "Wrong output for '{_file}.txt':\n"
+                "You can update the expected output automatically with: '"
+                'python tests/test_functional.py {update_option} -k "test_functional[{_file}]"\'\n\n'
+                "Expected : {expected}\n"
+                "Received : {received}".format(
+                    update_option=UPDATE_OPTION,
+                    expected=exp,
+                    received=rec,
+                    _file=self._test_file.base,
+                )
+            )

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -1,0 +1,50 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+import collections
+
+from pylint import interfaces
+
+
+class Message(
+    collections.namedtuple("Message", ["msg_id", "line", "node", "args", "confidence"])
+):
+    def __new__(cls, msg_id, line=None, node=None, args=None, confidence=None):
+        return tuple.__new__(cls, (msg_id, line, node, args, confidence))
+
+    def __eq__(self, other):
+        if isinstance(other, Message):
+            if self.confidence and other.confidence:
+                return super().__eq__(other)
+            return self[:-1] == other[:-1]
+        return NotImplemented  # pragma: no cover
+
+    __hash__ = None
+
+
+class OutputLine(
+    collections.namedtuple(
+        "OutputLine", ["symbol", "lineno", "object", "msg", "confidence"]
+    )
+):
+    @classmethod
+    def from_msg(cls, msg):
+        return cls(
+            msg.symbol,
+            msg.line,
+            msg.obj or "",
+            msg.msg.replace("\r\n", "\n"),
+            msg.confidence.name
+            if msg.confidence != interfaces.UNDEFINED
+            else interfaces.HIGH.name,
+        )
+
+    @classmethod
+    def from_csv(cls, row):
+        confidence = row[4] if len(row) == 5 else interfaces.HIGH.name
+        return cls(row[0], int(row[1]), row[2], row[3], confidence)
+
+    def to_csv(self):
+        if self.confidence == interfaces.HIGH.name:
+            return self[:-1]
+        return self

--- a/pylint/testutils/tokenize_str.py
+++ b/pylint/testutils/tokenize_str.py
@@ -1,0 +1,9 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+import tokenize
+from io import StringIO
+
+
+def _tokenize_str(code):
+    return list(tokenize.generate_tokens(StringIO(code).readline))

--- a/pylint/testutils/unittest_linter.py
+++ b/pylint/testutils/unittest_linter.py
@@ -1,0 +1,40 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+from pylint.testutils.global_test_linter import linter
+from pylint.testutils.output_line import Message
+
+
+class UnittestLinter:
+    """A fake linter class to capture checker messages."""
+
+    # pylint: disable=unused-argument, no-self-use
+
+    def __init__(self):
+        self._messages = []
+        self.stats = {}
+
+    def release_messages(self):
+        try:
+            return self._messages
+        finally:
+            self._messages = []
+
+    def add_message(
+        self, msg_id, line=None, node=None, args=None, confidence=None, col_offset=None
+    ):
+        # Do not test col_offset for now since changing Message breaks everything
+        self._messages.append(Message(msg_id, line, node, args, confidence))
+
+    @staticmethod
+    def is_message_enabled(*unused_args, **unused_kwargs):
+        return True
+
+    def add_stats(self, **kwargs):
+        for name, value in kwargs.items():
+            self.stats[name] = value
+        return self.stats
+
+    @property
+    def options_providers(self):
+        return linter.options_providers

--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -9,11 +9,9 @@ from glob import glob
 from io import StringIO
 from os.path import basename, join, splitext
 
-from pylint import checkers
-from pylint.lint import PyLinter
 from pylint.testutils.constants import SYS_VERS_STR
+from pylint.testutils.global_test_linter import linter
 from pylint.testutils.output_line import Message
-from pylint.testutils.reporter_for_tests import GenericTestReporter
 from pylint.utils import ASTWalker
 
 
@@ -148,14 +146,6 @@ class CheckerTestCase:
         walker = ASTWalker(linter)
         walker.add_checker(self.checker)
         walker.walk(node)
-
-
-# Init
-test_reporter = GenericTestReporter()
-linter = PyLinter()
-linter.set_reporter(test_reporter)
-linter.config.persistent = 0
-checkers.initialize(linter)
 
 
 def _tokenize_str(code):

--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -397,7 +397,7 @@ def multiset_difference(expected_entries: set, actual_entries: set) -> Tuple[set
 class LintModuleTest:
     maxDiff = None
 
-    def __init__(self, test_file):
+    def __init__(self, test_file: FunctionalTestFile):
         _test_reporter = FunctionalTestReporter()
         self._linter = PyLinter()
         self._linter.set_reporter(_test_reporter)

--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -20,7 +20,7 @@ from typing import Tuple
 import astroid
 import pytest
 
-from pylint import checkers, interfaces
+from pylint import checkers
 from pylint.lint import PyLinter
 from pylint.testutils.constants import (
     _EXPECTED_RE,
@@ -33,6 +33,7 @@ from pylint.testutils.functional_test_file import (
     NoFileError,
     parse_python_version,
 )
+from pylint.testutils.output_line import Message, OutputLine
 from pylint.testutils.reporter_for_tests import (
     FunctionalTestReporter,
     GenericTestReporter,
@@ -76,22 +77,6 @@ def _get_tests_info(input_dir, msg_dir, prefix, suffix):
             outfile = join(msg_dir, fbase + ".txt")
         result.append((infile, outfile))
     return result
-
-
-class Message(
-    collections.namedtuple("Message", ["msg_id", "line", "node", "args", "confidence"])
-):
-    def __new__(cls, msg_id, line=None, node=None, args=None, confidence=None):
-        return tuple.__new__(cls, (msg_id, line, node, args, confidence))
-
-    def __eq__(self, other):
-        if isinstance(other, Message):
-            if self.confidence and other.confidence:
-                return super().__eq__(other)
-            return self[:-1] == other[:-1]
-        return NotImplemented  # pragma: no cover
-
-    __hash__ = None
 
 
 class UnittestLinter:
@@ -229,35 +214,6 @@ def _create_file_backed_module(code):
         module = astroid.parse(code)
         module.file = temp
         yield module
-
-
-class OutputLine(
-    collections.namedtuple(
-        "OutputLine", ["symbol", "lineno", "object", "msg", "confidence"]
-    )
-):
-    @classmethod
-    def from_msg(cls, msg):
-        return cls(
-            msg.symbol,
-            msg.line,
-            msg.obj or "",
-            msg.msg.replace("\r\n", "\n"),
-            msg.confidence.name
-            if msg.confidence != interfaces.UNDEFINED
-            else interfaces.HIGH.name,
-        )
-
-    @classmethod
-    def from_csv(cls, row):
-        confidence = row[4] if len(row) == 5 else interfaces.HIGH.name
-        return cls(row[0], int(row[1]), row[2], row[3], confidence)
-
-    def to_csv(self):
-        if self.confidence == interfaces.HIGH.name:
-            return self[:-1]
-
-        return self
 
 
 def parse_expected_output(stream):

--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -4,14 +4,10 @@
 """functional/non regression tests for pylint"""
 import contextlib
 import functools
-import tempfile
 import tokenize
 from glob import glob
 from io import StringIO
-from os import close, remove, write
 from os.path import basename, join, splitext
-
-import astroid
 
 from pylint import checkers
 from pylint.lint import PyLinter
@@ -164,33 +160,3 @@ checkers.initialize(linter)
 
 def _tokenize_str(code):
     return list(tokenize.generate_tokens(StringIO(code).readline))
-
-
-@contextlib.contextmanager
-def _create_tempfile(content=None):
-    """Create a new temporary file.
-
-    If *content* parameter is given, then it will be written
-    in the temporary file, before passing it back.
-    This is a context manager and should be used with a *with* statement.
-    """
-    # Can't use tempfile.NamedTemporaryFile here
-    # because on Windows the file must be closed before writing to it,
-    # see https://bugs.python.org/issue14243
-    file_handle, tmp = tempfile.mkstemp()
-    if content:
-        write(file_handle, bytes(content, "ascii"))
-    try:
-        yield tmp
-    finally:
-        close(file_handle)
-        remove(tmp)
-
-
-@contextlib.contextmanager
-def _create_file_backed_module(code):
-    """Create an astroid module for the given code, backed by a real file."""
-    with _create_tempfile() as temp:
-        module = astroid.parse(code)
-        module.file = temp
-        yield module

--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -18,6 +18,7 @@ from glob import glob
 from io import StringIO
 from os import close, remove, write
 from os.path import abspath, basename, dirname, exists, join, splitext
+from typing import Tuple
 
 import astroid
 import pytest
@@ -378,21 +379,12 @@ def get_expected_messages(stream):
     return messages
 
 
-def multiset_difference(left_op, right_op):
+def multiset_difference(expected_entries: set, actual_entries: set) -> Tuple[set]:
     """Takes two multisets and compares them.
 
-    A multiset is a dict with the cardinality of the key as the value.
-
-    :param left_op: The expected entries.
-    :type left_op: set
-    :param right_op: Actual entries.
-    :type right_op: set
-
-    :returns: The two multisets of missing and unexpected messages.
-    :rtype: tuple
-    """
-    missing = left_op.copy()
-    missing.subtract(right_op)
+    A multiset is a dict with the cardinality of the key as the value."""
+    missing = expected_entries.copy()
+    missing.subtract(actual_entries)
     unexpected = {}
     for key, value in list(missing.items()):
         if value <= 0:

--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -476,7 +476,7 @@ class LintModuleTest:
             expected_output_lines = []
         return expected_msgs, expected_output_lines
 
-    def _get_received(self):
+    def _get_actual(self):
         messages = self._linter.reporter.messages
         messages.sort(key=lambda m: (m.line, m.symbol, m.msg))
         received_msgs = collections.Counter()
@@ -492,13 +492,13 @@ class LintModuleTest:
     def _runTest(self):
         modules_to_check = [self._test_file.source]
         self._linter.check(modules_to_check)
-        expected_messages, expected_text = self._get_expected()
-        received_messages, received_text = self._get_received()
+        expected_messages, expected_output = self._get_expected()
+        actual_messages, actual_output = self._get_actual()
 
-        if expected_messages != received_messages:
+        if expected_messages != actual_messages:
             msg = ['Wrong results for file "%s":' % (self._test_file.base)]
             missing, unexpected = multiset_difference(
-                expected_messages, received_messages
+                expected_messages, actual_messages
             )
             if missing:
                 msg.append("\nExpected in testdata:")
@@ -507,7 +507,7 @@ class LintModuleTest:
                 msg.append("\nUnexpected in testdata:")
                 msg.extend(" %3d: %s" % msg for msg in sorted(unexpected))
             pytest.fail("\n".join(msg))
-        self._check_output_text(expected_messages, expected_text, received_text)
+        self._check_output_text(expected_messages, expected_output, actual_output)
 
     @classmethod
     def _split_lines(cls, expected_messages, lines):

--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -2,42 +2,22 @@
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
 """functional/non regression tests for pylint"""
-import collections
 import contextlib
-import csv
 import functools
-import itertools
-import platform
-import sys
 import tempfile
 import tokenize
 from glob import glob
 from io import StringIO
 from os import close, remove, write
 from os.path import basename, join, splitext
-from typing import Tuple
 
 import astroid
-import pytest
 
 from pylint import checkers
 from pylint.lint import PyLinter
-from pylint.testutils.constants import (
-    _EXPECTED_RE,
-    _OPERATORS,
-    SYS_VERS_STR,
-    UPDATE_OPTION,
-)
-from pylint.testutils.functional_test_file import (
-    FunctionalTestFile,
-    NoFileError,
-    parse_python_version,
-)
-from pylint.testutils.output_line import Message, OutputLine
-from pylint.testutils.reporter_for_tests import (
-    FunctionalTestReporter,
-    GenericTestReporter,
-)
+from pylint.testutils.constants import SYS_VERS_STR
+from pylint.testutils.output_line import Message
+from pylint.testutils.reporter_for_tests import GenericTestReporter
 from pylint.utils import ASTWalker
 
 
@@ -214,197 +194,3 @@ def _create_file_backed_module(code):
         module = astroid.parse(code)
         module.file = temp
         yield module
-
-
-def parse_expected_output(stream):
-    return [OutputLine.from_csv(row) for row in csv.reader(stream, "test")]
-
-
-def get_expected_messages(stream):
-    """Parses a file and get expected messages.
-
-    :param stream: File-like input stream.
-    :type stream: enumerable
-    :returns: A dict mapping line,msg-symbol tuples to the count on this line.
-    :rtype: dict
-    """
-    messages = collections.Counter()
-    for i, line in enumerate(stream):
-        match = _EXPECTED_RE.search(line)
-        if match is None:
-            continue
-        line = match.group("line")
-        if line is None:
-            line = i + 1
-        elif line.startswith("+") or line.startswith("-"):
-            line = i + 1 + int(line)
-        else:
-            line = int(line)
-
-        version = match.group("version")
-        op = match.group("op")
-        if version:
-            required = parse_python_version(version)
-            if not _OPERATORS[op](sys.version_info, required):
-                continue
-
-        for msg_id in match.group("msgs").split(","):
-            messages[line, msg_id.strip()] += 1
-    return messages
-
-
-def multiset_difference(expected_entries: set, actual_entries: set) -> Tuple[set]:
-    """Takes two multisets and compares them.
-
-    A multiset is a dict with the cardinality of the key as the value."""
-    missing = expected_entries.copy()
-    missing.subtract(actual_entries)
-    unexpected = {}
-    for key, value in list(missing.items()):
-        if value <= 0:
-            missing.pop(key)
-            if value < 0:
-                unexpected[key] = -value
-    return missing, unexpected
-
-
-class LintModuleTest:
-    maxDiff = None
-
-    def __init__(self, test_file: FunctionalTestFile):
-        _test_reporter = FunctionalTestReporter()
-        self._linter = PyLinter()
-        self._linter.set_reporter(_test_reporter)
-        self._linter.config.persistent = 0
-        checkers.initialize(self._linter)
-        self._linter.disable("I")
-        try:
-            self._linter.read_config_file(test_file.option_file)
-            self._linter.load_config_file()
-        except NoFileError:
-            pass
-        self._test_file = test_file
-
-    def setUp(self):
-        if self._should_be_skipped_due_to_version():
-            pytest.skip(
-                "Test cannot run with Python %s." % (sys.version.split(" ")[0],)
-            )
-        missing = []
-        for req in self._test_file.options["requires"]:
-            try:
-                __import__(req)
-            except ImportError:
-                missing.append(req)
-        if missing:
-            pytest.skip("Requires %s to be present." % (",".join(missing),))
-        if self._test_file.options["except_implementations"]:
-            implementations = [
-                item.strip()
-                for item in self._test_file.options["except_implementations"].split(",")
-            ]
-            implementation = platform.python_implementation()
-            if implementation in implementations:
-                pytest.skip(
-                    "Test cannot run with Python implementation %r" % (implementation,)
-                )
-        if self._test_file.options["exclude_platforms"]:
-            platforms = [
-                item.strip()
-                for item in self._test_file.options["exclude_platforms"].split(",")
-            ]
-            if sys.platform.lower() in platforms:
-                pytest.skip("Test cannot run on platform %r" % (sys.platform,))
-
-    def _should_be_skipped_due_to_version(self):
-        return (
-            sys.version_info < self._test_file.options["min_pyver"]
-            or sys.version_info > self._test_file.options["max_pyver"]
-        )
-
-    def __str__(self):
-        return "%s (%s.%s)" % (
-            self._test_file.base,
-            self.__class__.__module__,
-            self.__class__.__name__,
-        )
-
-    def _open_expected_file(self):
-        return open(self._test_file.expected_output)
-
-    def _open_source_file(self):
-        if self._test_file.base == "invalid_encoded_data":
-            return open(self._test_file.source)
-        if "latin1" in self._test_file.base:
-            return open(self._test_file.source, encoding="latin1")
-        return open(self._test_file.source, encoding="utf8")
-
-    def _get_expected(self):
-        with self._open_source_file() as fobj:
-            expected_msgs = get_expected_messages(fobj)
-
-        if expected_msgs:
-            with self._open_expected_file() as fobj:
-                expected_output_lines = parse_expected_output(fobj)
-        else:
-            expected_output_lines = []
-        return expected_msgs, expected_output_lines
-
-    def _get_actual(self):
-        messages = self._linter.reporter.messages
-        messages.sort(key=lambda m: (m.line, m.symbol, m.msg))
-        received_msgs = collections.Counter()
-        received_output_lines = []
-        for msg in messages:
-            assert (
-                msg.symbol != "fatal"
-            ), "Pylint analysis failed because of '{}'".format(msg.msg)
-            received_msgs[msg.line, msg.symbol] += 1
-            received_output_lines.append(OutputLine.from_msg(msg))
-        return received_msgs, received_output_lines
-
-    def _runTest(self):
-        modules_to_check = [self._test_file.source]
-        self._linter.check(modules_to_check)
-        expected_messages, expected_output = self._get_expected()
-        actual_messages, actual_output = self._get_actual()
-
-        if expected_messages != actual_messages:
-            msg = ['Wrong results for file "%s":' % (self._test_file.base)]
-            missing, unexpected = multiset_difference(
-                expected_messages, actual_messages
-            )
-            if missing:
-                msg.append("\nExpected in testdata:")
-                msg.extend(" %3d: %s" % msg for msg in sorted(missing))
-            if unexpected:
-                msg.append("\nUnexpected in testdata:")
-                msg.extend(" %3d: %s" % msg for msg in sorted(unexpected))
-            pytest.fail("\n".join(msg))
-        self._check_output_text(expected_messages, expected_output, actual_output)
-
-    @classmethod
-    def _split_lines(cls, expected_messages, lines):
-        emitted, omitted = [], []
-        for msg in lines:
-            if (msg[1], msg[0]) in expected_messages:
-                emitted.append(msg)
-            else:
-                omitted.append(msg)
-        return emitted, omitted
-
-    def _check_output_text(self, expected_messages, expected_lines, received_lines):
-        expected_lines = self._split_lines(expected_messages, expected_lines)[0]
-        for exp, rec in itertools.zip_longest(expected_lines, received_lines):
-            assert exp == rec, (
-                "Wrong output for '{_file}.txt':\n"
-                "You can update the expected output automatically with: '"
-                'python tests/test_functional.py {update_option} -k "test_functional[{_file}]"\'\n\n'
-                "Expected : {expected}\n"
-                "Received : {received}".format(
-                    update_option=UPDATE_OPTION,
-                    expected=exp,
-                    received=rec,
-                    _file=self._test_file.base,
-                )
-            )

--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -5,52 +5,11 @@
 import contextlib
 import functools
 import tokenize
-from glob import glob
 from io import StringIO
-from os.path import basename, join, splitext
 
-from pylint.testutils.constants import SYS_VERS_STR
 from pylint.testutils.global_test_linter import linter
 from pylint.testutils.output_line import Message
 from pylint.utils import ASTWalker
-
-
-def _get_tests_info(input_dir, msg_dir, prefix, suffix):
-    """get python input examples and output messages
-
-    We use following conventions for input files and messages:
-    for different inputs:
-        test for python  >= x.y    ->  input   =  <name>_pyxy.py
-        test for python  <  x.y    ->  input   =  <name>_py_xy.py
-    for one input and different messages:
-        message for python >=  x.y ->  message =  <name>_pyxy.txt
-        lower versions             ->  message with highest num
-    """
-    result = []
-    for fname in glob(join(input_dir, prefix + "*" + suffix)):
-        infile = basename(fname)
-        fbase = splitext(infile)[0]
-        # filter input files :
-        pyrestr = fbase.rsplit("_py", 1)[-1]  # like _26 or 26
-        if pyrestr.isdigit():  # '24', '25'...
-            if SYS_VERS_STR < pyrestr:
-                continue
-        if pyrestr.startswith("_") and pyrestr[1:].isdigit():
-            # skip test for higher python versions
-            if SYS_VERS_STR >= pyrestr[1:]:
-                continue
-        messages = glob(join(msg_dir, fbase + "*.txt"))
-        # the last one will be without ext, i.e. for all or upper versions:
-        if messages:
-            for outfile in sorted(messages, reverse=True):
-                py_rest = outfile.rsplit("_py", 1)[-1][:-4]
-                if py_rest.isdigit() and SYS_VERS_STR >= py_rest:
-                    break
-        else:
-            # This will provide an error message indicating the missing filename.
-            outfile = join(msg_dir, fbase + ".txt")
-        result.append((infile, outfile))
-    return result
 
 
 class UnittestLinter:

--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -3,7 +3,6 @@
 
 """functional/non regression tests for pylint"""
 import contextlib
-import functools
 import tokenize
 from io import StringIO
 
@@ -45,24 +44,6 @@ class UnittestLinter:
     @property
     def options_providers(self):
         return linter.options_providers
-
-
-def set_config(**kwargs):
-    """Decorator for setting config values on a checker."""
-
-    def _wrapper(fun):
-        @functools.wraps(fun)
-        def _forward(self):
-            for key, value in kwargs.items():
-                setattr(self.checker.config, key, value)
-            if isinstance(self, CheckerTestCase):
-                # reopen checker in case, it may be interested in configuration change
-                self.checker.open()
-            fun(self)
-
-        return _forward
-
-    return _wrapper
 
 
 class CheckerTestCase:

--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -7,16 +7,14 @@ import contextlib
 import csv
 import functools
 import itertools
-import operator
 import platform
-import re
 import sys
 import tempfile
 import tokenize
 from glob import glob
 from io import StringIO
 from os import close, remove, write
-from os.path import abspath, basename, dirname, join, splitext
+from os.path import basename, join, splitext
 from typing import Tuple
 
 import astroid
@@ -24,6 +22,12 @@ import pytest
 
 from pylint import checkers, interfaces
 from pylint.lint import PyLinter
+from pylint.testutils.constants import (
+    _EXPECTED_RE,
+    _OPERATORS,
+    SYS_VERS_STR,
+    UPDATE_OPTION,
+)
 from pylint.testutils.functional_test_file import (
     FunctionalTestFile,
     NoFileError,
@@ -34,11 +38,6 @@ from pylint.testutils.reporter_for_tests import (
     GenericTestReporter,
 )
 from pylint.utils import ASTWalker
-
-SYS_VERS_STR = "%d%d%d" % sys.version_info[:3]
-TITLE_UNDERLINES = ["", "=", "-", "."]
-PREFIX = abspath(dirname(__file__))
-UPDATE_OPTION = "--update-functional-output"
 
 
 def _get_tests_info(input_dir, msg_dir, prefix, suffix):
@@ -259,22 +258,6 @@ class OutputLine(
             return self[:-1]
 
         return self
-
-
-# Common sub-expressions.
-_MESSAGE = {"msg": r"[a-z][a-z\-]+"}
-# Matches a #,
-#  - followed by a comparison operator and a Python version (optional),
-#  - followed by a line number with a +/- (optional),
-#  - followed by a list of bracketed message symbols.
-# Used to extract expected messages from testdata files.
-_EXPECTED_RE = re.compile(
-    r"\s*#\s*(?:(?P<line>[+-]?[0-9]+):)?"
-    r"(?:(?P<op>[><=]+) *(?P<version>[0-9.]+):)?"
-    r"\s*\[(?P<msgs>%(msg)s(?:,\s*%(msg)s)*)]" % _MESSAGE
-)
-
-_OPERATORS = {">": operator.gt, "<": operator.lt, ">=": operator.ge, "<=": operator.le}
 
 
 def parse_expected_output(stream):

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -25,8 +25,6 @@ import pytest
 
 from pylint.testutils import _get_tests_info, linter
 
-SYS_VERS_STR = "%d%d%d" % sys.version_info[:3]
-
 # Configure paths
 INPUT_DIR = join(dirname(abspath(__file__)), "input")
 MSG_DIR = join(dirname(abspath(__file__)), "messages")


### PR DESCRIPTION
## Description

In order to be able to make better test utility we  first start to make the testutils package more manageable. This permit to not have too much noise in #3918 .

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Related Issue

#3918 
