### PR TITLE
Add proper exclusion in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,9 @@ repos:
     rev: v2.1.0
     hooks:
     -   id: trailing-whitespace
+        exclude: "tests/functional/t/trailing_whitespaces.py"
     -   id: end-of-file-fixer
+        exclude: "tests/functional/m/missing_final_newline.py|tests/functional/t/trailing_newlines.py"
 -   repo: https://github.com/PyCQA/isort
     rev: 5.5.2
     hooks:
@@ -32,3 +34,4 @@ repos:
         entry: pylint
         language: system
         types: [python]
+        exclude: *fixtures

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands =
 
 [testenv]
 deps =
-   https://github.com/PyCQA/astroid/tarball/master#egg=astroid-master-2.0
+   https://github.com/PyCQA/astroid/tarball/master#egg=astroid
    coverage<5.0
    mccabe
    # isort 5 is not compatible with Python 3.5
@@ -80,7 +80,7 @@ changedir = {toxworkdir}
 
 [testenv:spelling]
 deps =
-   https://github.com/PyCQA/astroid/tarball/master#egg=astroid-master-2.0
+   https://github.com/PyCQA/astroid/tarball/master#egg=astroid
    pytest
    pytest-xdist
    pyenchant
@@ -136,7 +136,7 @@ commands =
 
 [testenv:benchmark]
 deps =
-   https://github.com/PyCQA/astroid/tarball/master#egg=astroid-master-2.0
+   https://github.com/PyCQA/astroid/tarball/master#egg=astroid
    coverage<5.0
    mccabe
    pytest
@@ -159,7 +159,7 @@ commands =
 
 [testenv:profile_against_external]
 deps =
-   https://github.com/PyCQA/astroid/tarball/master#egg=astroid-master-2.0
+   https://github.com/PyCQA/astroid/tarball/master#egg=astroid
    gprof2dot
    mccabe
    pytest


### PR DESCRIPTION
Permit to use `pre-commit run --all-files` as exec
during interactive rebasing.

Also fix a bug with appveyor that appeared on the master branch.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
