### PR TITLE
Fix regression about getfullargspec deprecation

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -431,3 +431,5 @@ contributors:
 * Julien Palard: contributor
 
 * Raphael Gaschignard: contributor
+
+* Sorin Sbarnea: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -81,6 +81,7 @@ Release date: TBA
 
 * Improve the performance of the line length check.
 
+* Removed incorrect deprecation of ``inspect.getfullargspec``
 
 What's New in Pylint 2.6.0?
 ===========================

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -245,7 +245,6 @@ class StdlibChecker(BaseChecker):
                 "fractions.gcd",
                 "inspect.formatargspec",
                 "inspect.getcallargs",
-                "inspect.getfullargspec",
                 "platform.linux_distribution",
                 "platform.dist",
             },


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Fixes regression introduced by
https://github.com/PyCQA/pylint/commit/9d4f2c082e4f17fb5165deb0c9e4a0fd329d5cbd which incorrectly added
getfullargspec as deprecated, which in fact was never deprecated, not even in the latest [3.9.0](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec)

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

Related: https://github.com/PyCQA/pylint/commit/9d4f2c082e4f17fb5165deb0c9e4a0fd329d5cbd
