### PR TITLE
Factorize code formatting in one place

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,4 @@ repos:
         entry: pylint
         language: system
         types: [python]
-        exclude: *fixtures
+        exclude: tests/functional/|tests/input|tests/extensions/data|tests/regrtest_data/|tests/data/|doc/

--- a/bin/pylint
+++ b/bin/pylint
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# pylint: disable=import-self
 from pylint import run_pylint
 
 run_pylint()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-#!/usr/bin/env python
-# pylint: disable=W0404,W0622,W0613
 # Copyright (c) 2006, 2009-2010, 2012-2014 LOGILAB S.A. (Paris, FRANCE) <contact@logilab.fr>
 # Copyright (c) 2010 Julien Jehannet <julien.jehannet@logilab.fr>
 # Copyright (c) 2012 FELD Boris <lothiraldan@gmail.com>
@@ -26,15 +23,14 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
-"""Generic Setup script, takes package info from __pkginfo__.py file.
-"""
+"""Generic Setup script, takes package info from __pkginfo__.py file."""
+
+# pylint: disable=import-outside-toplevel,arguments-differ,ungrouped-imports,exec-used
+
 import os
 import sys
 from distutils.command.build_py import build_py
 from os.path import exists, isdir, join
-
-__docformat__ = "restructuredtext en"
-
 
 try:
     from setuptools import setup
@@ -50,6 +46,7 @@ except ImportError:
     easy_install_lib = None
 
 
+__docformat__ = "restructuredtext en"
 base_dir = os.path.dirname(__file__)
 
 __pkginfo__ = {}

--- a/tox.ini
+++ b/tox.ini
@@ -36,11 +36,11 @@ commands =
 [testenv:formatting]
 basepython = python3
 deps =
-    black==20.8b1
-    isort==5.5.2
+    pre-commit
+    sphinx
+    pytest
 commands =
-    black --diff --check . --exclude="tests/functional/|tests/input|tests/extensions/data|tests/regrtest_data/|tests/data/|venv|astroid|.tox"
-    isort . --check-only
+    pre-commit run --all-files
 changedir = {toxinidir}
 
 [testenv:mypy]


### PR DESCRIPTION
## Description

This put all the formatting in pre-commit so we can't have change in tox that make pre-commit not work anymore and inversely.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :hammer: Refactoring  |
