### PR TITLE
Fix false positive for signature-differs

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -433,3 +433,5 @@ contributors:
 * Raphael Gaschignard: contributor
 
 * Sorin Sbarnea: contributor
+
+* Gergely Kalmár: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -83,6 +83,10 @@ Release date: TBA
 
 * Removed incorrect deprecation of ``inspect.getfullargspec``
 
+* Fix ``signature-differs`` false positive for functions with variadics
+
+  Close #3737
+
 What's New in Pylint 2.6.0?
 ===========================
 

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -1724,7 +1724,10 @@ a metaclass class method.",
             self.add_message(
                 "arguments-differ", args=(class_type, method1.name), node=method1
             )
-        elif len(method1.args.defaults) < len(refmethod.args.defaults):
+        elif (
+            len(method1.args.defaults) < len(refmethod.args.defaults)
+            and not method1.args.vararg
+        ):
             self.add_message(
                 "signature-differs", args=(class_type, method1.name), node=method1
             )

--- a/tests/functional/s/signature_differs.py
+++ b/tests/functional/s/signature_differs.py
@@ -20,3 +20,13 @@ class Cdef(Abcd):
 
     def abcd(self, aaa, bbbb=None): # [signature-differs]
         return aaa, bbbb
+
+
+class Ghij(Abcd):
+    def __init__(self, aaa):
+        Abcd.__init__(self)
+        self.aaa = aaa
+
+    def abcd(self, *args, **kwargs):
+        """Test that a method with variadics does not trigger the warning"""
+        return super().abcd(*args, **kwargs)


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
We make sure to only raise signature-differs warnings for functions that do not have variadic arguments.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #3737
