### PR TITLE
Fix false positive for `not-async-context-manager` when `contextlib.asynccontextmanager` is used

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,10 @@ What's New in Pylint 2.6.1?
 ===========================
 Release date: TBA
 
+* Fix false positive for `not-async-context-manager` when `contextlib.asynccontextmanager` is used
+
+  Close #3862
+
 * Fix linter multiprocessing pool shutdown (triggered warnings when runned in parallels with other pytest plugins)
 
   Closes #3779

--- a/pylint/checkers/async.py
+++ b/pylint/checkers/async.py
@@ -58,7 +58,12 @@ class AsyncChecker(checkers.BaseChecker):
             if inferred is None or inferred is astroid.Uninferable:
                 continue
 
-            if isinstance(inferred, bases.AsyncGenerator):
+            if isinstance(inferred, astroid.AsyncFunctionDef):
+                # Check if we are dealing with a function decorated
+                # with contextlib.asynccontextmanager.
+                if decorated_with(inferred, self._async_generators):
+                    continue
+            elif isinstance(inferred, bases.AsyncGenerator):
                 # Check if we are dealing with a function decorated
                 # with contextlib.asynccontextmanager.
                 if decorated_with(inferred.parent, self._async_generators):
@@ -79,7 +84,6 @@ class AsyncChecker(checkers.BaseChecker):
                                 continue
                 else:
                     continue
-
             self.add_message(
                 "not-async-context-manager", node=node, args=(inferred.name,)
             )

--- a/tests/functional/n/not_async_context_manager_py37.py
+++ b/tests/functional/n/not_async_context_manager_py37.py
@@ -10,3 +10,14 @@ async def context_manager(value):
 
 async with context_manager(42) as ans:
     assert ans == 42
+
+
+def async_context_manager():
+    @asynccontextmanager
+    async def wrapper():
+        pass
+    return wrapper
+
+async def func():
+    async with async_context_manager():
+        pass


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

Close #3862
