### PR TITLE
Fix a crash in `consider-using-enumerate` when encountering `range()` without arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -91,6 +91,10 @@ Release date: TBA
 
 * Removed incorrect deprecation of ``inspect.getfullargspec``
 
+* Fix a crash in `consider-using-enumerate` when encountering `range()` without arguments
+
+  Close #3735
+
 What's New in Pylint 2.6.0?
 ===========================
 

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -67,6 +67,8 @@ class RecommendationChecker(checkers.BaseChecker):
             return
         if not self._is_builtin(node.iter.func, "range"):
             return
+        if not node.iter.args:
+            return
         is_constant_zero = (
             isinstance(node.iter.args[0], astroid.Const)
             and node.iter.args[0].value == 0

--- a/tests/functional/c/consider_using_enumerate.py
+++ b/tests/functional/c/consider_using_enumerate.py
@@ -66,3 +66,8 @@ class Good(object):
         # Should not suggest enumerate on self
         for i in range(len(self)):
             yield self[i]
+
+
+def does_not_crash_on_range_without_args():
+    for elem in range():
+        print(elem)


### PR DESCRIPTION

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

Close #3735
