### PR TITLE
Fix location metadata on backslash/unicode escape lints

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -435,3 +435,5 @@ contributors:
 * Batuhan Taskaya: contributor
 
 * Frank Harrison (doublethefish): contributor
+
+* Matthew Suozzo

--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,7 @@ Pylint's ChangeLog
 
   Closes #3992
 
+* Fix column metadata for anomalous backslash lints
 
 What's New in Pylint 2.6.1?
 ===========================

--- a/tests/functional/a/anomalous_backslash_escape.py
+++ b/tests/functional/a/anomalous_backslash_escape.py
@@ -1,0 +1,21 @@
+# pylint:disable=W0105, W0511
+"""Test for anomalous backslash escapes in strings"""
+
+BAD_ESCAPE = '\z'  # [anomalous-backslash-in-string]
+BAD_ESCAPE_NOT_FIRST = 'abc\z'  # [anomalous-backslash-in-string]
+BAD_ESCAPE_WITH_PREFIX = b'abc\z'  # [anomalous-backslash-in-string]
+BAD_ESCAPE_WITH_BACKSLASH = b'a\
+    \z'  # [anomalous-backslash-in-string]
+# +3:[anomalous-backslash-in-string]
+BAD_ESCAPE_BLOCK = b'''
+    abc
+    \z
+'''
+BAD_ESCAPE_PARENS = (b'abc'
+                     b'\z')  # [anomalous-backslash-in-string]
+GOOD_ESCAPE = '\b'
+
+# Valid raw strings
+BAD_ESCAPE_BUT_RAW = r'\z'
+
+# In a comment you can have whatever you want: \z

--- a/tests/functional/a/anomalous_backslash_escape.txt
+++ b/tests/functional/a/anomalous_backslash_escape.txt
@@ -1,0 +1,6 @@
+anomalous-backslash-in-string:4::"Anomalous backslash in string: '\z'. String constant might be missing an r prefix."
+anomalous-backslash-in-string:5::"Anomalous backslash in string: '\z'. String constant might be missing an r prefix."
+anomalous-backslash-in-string:6::"Anomalous backslash in string: '\z'. String constant might be missing an r prefix."
+anomalous-backslash-in-string:8::"Anomalous backslash in string: '\z'. String constant might be missing an r prefix."
+anomalous-backslash-in-string:12::"Anomalous backslash in string: '\z'. String constant might be missing an r prefix."
+anomalous-backslash-in-string:15::"Anomalous backslash in string: '\z'. String constant might be missing an r prefix."

--- a/tests/functional/e/excess_escapes.py
+++ b/tests/functional/e/excess_escapes.py
@@ -25,7 +25,8 @@ LITERAL_NEWLINE = '\
 ESCAPE_UNICODE = "\\\\n"
 
 # Bad docstring
-"""Even in a docstring # [anomalous-backslash-in-string]
+# +3:[anomalous-backslash-in-string]
+"""Even in a docstring
 
 You shouldn't have ambiguous text like: C:\Program Files\alpha
 """

--- a/tests/functional/e/excess_escapes.txt
+++ b/tests/functional/e/excess_escapes.txt
@@ -6,4 +6,4 @@ anomalous-backslash-in-string:16::"Anomalous backslash in string: '\o'. String c
 anomalous-backslash-in-string:16::"Anomalous backslash in string: '\o'. String constant might be missing an r prefix."
 anomalous-backslash-in-string:18::"Anomalous backslash in string: '\8'. String constant might be missing an r prefix."
 anomalous-backslash-in-string:18::"Anomalous backslash in string: '\9'. String constant might be missing an r prefix."
-anomalous-backslash-in-string:28::"Anomalous backslash in string: '\P'. String constant might be missing an r prefix."
+anomalous-backslash-in-string:31::"Anomalous backslash in string: '\P'. String constant might be missing an r prefix."


### PR DESCRIPTION
The existing logic does not account for the start-of-line to start-of-string offset in the column and does not adjust the line to reflect where the actual backslash occurs.

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [X] Add yourself to CONTRIBUTORS if you are a new contributor.
- [X] Add a ChangeLog entry describing what your PR does.
- [X] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [X] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|  | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
