### PR TITLE
empty-comment line number bug fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 ------------------
 Pylint's ChangeLog
 ------------------
+* Bug fix for empty-comment message line number.
+
+  Closes #4009
+
 * Only emit `bad-reversed-sequence` on dictionaries if below py3.8
 
   Closes #3940

--- a/pylint/extensions/empty_comment.py
+++ b/pylint/extensions/empty_comment.py
@@ -49,7 +49,7 @@ class CommentChecker(BaseChecker):
                 line = line.rstrip()
                 if line.endswith(b"#"):
                     if not is_line_commented(line[:-1]):
-                        self.add_message("empty-comment", line=line_num)
+                        self.add_message("empty-comment", line=line_num + 1)
 
 
 def register(linter):

--- a/tests/extensions/test_empty_comment.py
+++ b/tests/extensions/test_empty_comment.py
@@ -28,7 +28,7 @@ def test_comment_base_case(linter):
     for msg in msgs:
         assert msg.symbol == "empty-comment"
         assert msg.msg == "Line with empty comment"
-    assert msgs[0].line == 1
-    assert msgs[1].line == 2
-    assert msgs[2].line == 4
-    assert msgs[3].line == 6
+    assert msgs[0].line == 2
+    assert msgs[1].line == 3
+    assert msgs[2].line == 5
+    assert msgs[3].line == 7


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [X] Add yourself to CONTRIBUTORS if you are a new contributor.
- [X] Add a ChangeLog entry describing what your PR does.
- [X] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [X] Write a good description on what the PR does.

## Description
Fixed empty-comment wrong line number in its message. Was 1 line behind the actual line number.
Fixed implementation and unittest.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue
#4009 
<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #4009 
-->
