### PR TITLE
Fix #2498: add generated-members match against the qualified name

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -439,3 +439,5 @@ contributors:
 * Logan Miller (komodo472): contributor
 
 * Matthew Suozzo: contributor
+
+* Gauthier Sebaux: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -120,6 +120,10 @@ Release date: TBA
 
   Close #3314
 
+* `generated-members` now matches the qualified name of members
+
+  Close #2498
+
 What's New in Pylint 2.6.0?
 ===========================
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -916,13 +916,6 @@ accessed. Python regular expressions are accepted.",
 
         function/method, super call and metaclasses are ignored
         """
-        for pattern in self.config.generated_members:
-            # attribute is marked as generated, stop here
-            if re.match(pattern, node.attrname):
-                return
-            if re.match(pattern, node.as_string()):
-                return
-
         try:
             inferred = list(node.expr.infer())
         except exceptions.InferenceError:
@@ -950,6 +943,24 @@ accessed. Python regular expressions are accepted.",
             if _is_owner_ignored(
                 owner, name, self.config.ignored_classes, self.config.ignored_modules
             ):
+                continue
+
+            # ignore pattern added to generated-members
+            ignored = False
+            for pattern in self.config.generated_members:
+                # attribute is marked as generated, stop here
+                if re.match(pattern, node.attrname):
+                    ignored = True
+                    break
+                if re.match(pattern, node.as_string()):
+                    ignored = True
+                    break
+                if re.match(pattern, "%s.%s" % (owner.pytype(), node.attrname)):
+                    ignored = True
+                    break
+
+            # continue the outer loop if a pattern matched
+            if ignored:
                 continue
 
             try:

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -60,6 +60,7 @@ import types
 from collections import deque
 from collections.abc import Sequence
 from functools import singledispatch
+from typing import Pattern, Tuple
 
 import astroid
 import astroid.arguments
@@ -852,17 +853,20 @@ accessed. Python regular expressions are accepted.",
     def _suggestion_mode(self):
         return get_global_option(self, "suggestion-mode", default=True)
 
-    def open(self):
-        # do this in open since config not fully initialized in __init__
+    @decorators.cachedproperty
+    def _compiled_generated_members(self) -> Tuple[Pattern, ...]:
+        # do this lazily since config not fully initialized in __init__
         # generated_members may contain regular expressions
         # (surrounded by quote `"` and followed by a comma `,`)
         # REQUEST,aq_parent,"[a-zA-Z]+_set{1,2}"' =>
         # ('REQUEST', 'aq_parent', '[a-zA-Z]+_set{1,2}')
-        if isinstance(self.config.generated_members, str):
-            gen = shlex.shlex(self.config.generated_members)
+        generated_members = self.config.generated_members
+        if isinstance(generated_members, str):
+            gen = shlex.shlex(generated_members)
             gen.whitespace += ","
             gen.wordchars += r"[]-+\.*?()|"
-            self.config.generated_members = tuple(tok.strip('"') for tok in gen)
+            generated_members = tuple(tok.strip('"') for tok in gen)
+        return tuple(re.compile(exp) for exp in generated_members)
 
     @check_messages("keyword-arg-before-vararg")
     def visit_functiondef(self, node):
@@ -916,6 +920,13 @@ accessed. Python regular expressions are accepted.",
 
         function/method, super call and metaclasses are ignored
         """
+        if any(
+            pattern.match(name)
+            for name in (node.attrname, node.as_string())
+            for pattern in self._compiled_generated_members
+        ):
+            return
+
         try:
             inferred = list(node.expr.infer())
         except exceptions.InferenceError:
@@ -945,23 +956,11 @@ accessed. Python regular expressions are accepted.",
             ):
                 continue
 
-            # ignore pattern added to generated-members
-            ignored = False
-            for pattern in self.config.generated_members:
-                # attribute is marked as generated, stop here
-                if re.match(pattern, node.attrname):
-                    ignored = True
-                    break
-                if re.match(pattern, node.as_string()):
-                    ignored = True
-                    break
-                if re.match(pattern, "%s.%s" % (owner.pytype(), node.attrname)):
-                    ignored = True
-                    break
-
-            # continue the outer loop if a pattern matched
-            if ignored:
-                continue
+            qualname = "{}.{}".format(owner.pytype(), node.attrname)
+            if any(
+                pattern.match(qualname) for pattern in self._compiled_generated_members
+            ):
+                return
 
             try:
                 if not [

--- a/tests/functional/g/generated_members.py
+++ b/tests/functional/g/generated_members.py
@@ -9,6 +9,8 @@ class Klass(object):
 
 print(Klass().DoesNotExist)
 print(Klass().aBC_set1)
+print(Klass().ham.does.not_.exist)
+print(Klass().spam.does.not_.exist)  # [no-member]
 node_classes.Tuple.does.not_.exist
 checkers.base.doesnotexist()
 

--- a/tests/functional/g/generated_members.rc
+++ b/tests/functional/g/generated_members.rc
@@ -2,4 +2,10 @@
 disable=too-few-public-methods,print-statement
 
 [typecheck]
-generated-members=DoesNotExist,"[a-zA-Z]+_set{1,2}",node_classes.Tuple.*,checkers.*?base,(session|SESSION).rollback
+generated-members=
+    \Afunctional\.g\.generated_members\.Klass\.ham\Z,
+    DoesNotExist,
+    "[a-zA-Z]+_set{1,2}",
+    node_classes.Tuple.*,
+    checkers.*?base,
+    (session|SESSION).rollback

--- a/tests/functional/g/generated_members.txt
+++ b/tests/functional/g/generated_members.txt
@@ -1,0 +1,1 @@
+no-member:13:6::Instance of 'Klass' has no 'spam' member:INFERENCE

--- a/tests/functional/g/generated_members.txt
+++ b/tests/functional/g/generated_members.txt
@@ -1,1 +1,1 @@
-no-member:13:6::Instance of 'Klass' has no 'spam' member:INFERENCE
+no-member:13:15::Instance of 'Klass' has no 'spam' member:INFERENCE


### PR DESCRIPTION
## Description
A continuation of https://github.com/PyCQA/pylint/pull/3634
This PR fix #2498: previously, `generated-members` only matched against the node string (e.g. `service.files`) or against the node attribute name (e.g. `files`).

With this change, the qualified name can also be matched (e.g. `googleapiclient.discovery.Resource.files`)
## Type of Changes
	Type
✓ 	bug Bug fix
## Related Issue

Closes #2498
