### PR TITLE
Implement reusable Method Deprecation checker.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,10 @@ Pylint's ChangeLog
 What's New in Pylint 2.7.0?
 ===========================
 
+* Introduce DeprecationMixin for reusable deprecation checks.
+
+  Closes #4049
+
 * Fix false positive for ``builtin-not-iterating`` when ``map`` receives iterable
 
   Closes #4078

--- a/doc/how_tos/custom_checkers.rst
+++ b/doc/how_tos/custom_checkers.rst
@@ -4,8 +4,10 @@ How to Write a Checker
 ======================
 You can find some simple examples in the distribution
 (`custom.py <https://github.com/PyCQA/pylint/blob/master/examples/custom.py>`_
+,
+`custom_raw.py <https://github.com/PyCQA/pylint/blob/master/examples/custom_raw.py>`_
 and
-`custom_raw.py <https://github.com/PyCQA/pylint/blob/master/examples/custom_raw.py>`_).
+`deprecation_checker.py <https://github.com/PyCQA/pylint/blob/master/examples/deprecation_checker.py>`_).
 
 .. TODO Create custom_token.py
 

--- a/examples/deprecation_checker.py
+++ b/examples/deprecation_checker.py
@@ -1,0 +1,89 @@
+"""
+Example checker detecting deprecated functions/methods. Following example searches for usages of
+deprecated function `deprecated_function` and deprecated method `MyClass.deprecated_method`
+from module mymodule:
+
+.. code-block:: console
+    $ cat mymodule.py
+    def deprecated_function():
+        pass
+
+    class MyClass:
+        def deprecated_method(self):
+            pass
+
+    $ cat mymain.py
+    from mymodule import deprecated_function, MyClass
+
+    deprecated_function()
+    MyClass().deprecated_method()
+
+    $ pylint --load-plugins=deprecation_checker mymain.py
+    ************* Module mymain
+    mymain.py:3:0: W1505: Using deprecated method deprecated_function() (deprecated-method)
+    mymain.py:4:0: W1505: Using deprecated method deprecated_method() (deprecated-method)
+
+    ------------------------------------------------------------------
+    Your code has been rated at 3.33/10 (previous run: 3.33/10, +0.00)
+"""
+
+import astroid
+
+from pylint.checkers import BaseChecker, DeprecatedMixin, utils
+from pylint.interfaces import IAstroidChecker
+
+
+class DeprecationChecker(BaseChecker, DeprecatedMixin):
+    """Class implementing deprecation checker."""
+
+    __implements__ = (IAstroidChecker,)
+    # The name defines a custom section of the config for this checker.
+    name = "deprecated"
+    # This class variable declares the messages (ie the warnings and errors)
+    # that the checker can emit.
+    msgs = {
+        # Each message has a code, a message that the user will see,
+        # a unique symbol that identifies the message,
+        # and a detailed help message
+        # that will be included in the documentation.
+        "W1505": (
+            "Using deprecated method %s()",
+            "deprecated-method",
+            "The method is marked as deprecated and will be removed in the future.",
+        ),
+    }
+
+    @utils.check_messages(
+        "deprecated-method",
+    )
+    def visit_call(self, node):
+        """Called when a :class:`.astroid.node_classes.Call` node is visited.
+
+        See :mod:`astroid` for the description of available nodes.
+
+        :param node: The node to check.
+        :type node: astroid.node_classes.Call
+        """
+        try:
+            for inferred in node.func.infer():
+                # Calling entry point for deprecation check logic.
+                self.check_deprecated_method(node, inferred)
+        except astroid.InferenceError:
+            return
+
+    def deprecated_methods(self):
+        """Callback method called by DeprecatedMixin for every method/function found in the code.
+
+        Returns:
+            collections.abc.Container of deprecated function/method names.
+        """
+        return {"mymodule.deprecated_function", "mymodule.MyClass.deprecated_method"}
+
+
+def register(linter):
+    """This required method auto registers the checker.
+
+    :param linter: The linter to register the checker to.
+    :type linter: pylint.lint.PyLinter
+    """
+    linter.register_checker(DeprecationChecker(linter))

--- a/examples/deprecation_checker.py
+++ b/examples/deprecation_checker.py
@@ -33,25 +33,17 @@ from pylint.checkers import BaseChecker, DeprecatedMixin, utils
 from pylint.interfaces import IAstroidChecker
 
 
-class DeprecationChecker(BaseChecker, DeprecatedMixin):
+class DeprecationChecker(DeprecatedMixin, BaseChecker):
     """Class implementing deprecation checker."""
+
+    # DeprecationMixin class is Mixin class implementing logic for searching deprecated methods and functions.
+    # The list of deprecated methods/functions is defined by implemeting class via deprecated_methods callback.
+    # DeprecatedMixin class is overriding attrigutes of BaseChecker hence must be specified *before* BaseChecker
+    # in list of base classes.
 
     __implements__ = (IAstroidChecker,)
     # The name defines a custom section of the config for this checker.
     name = "deprecated"
-    # This class variable declares the messages (ie the warnings and errors)
-    # that the checker can emit.
-    msgs = {
-        # Each message has a code, a message that the user will see,
-        # a unique symbol that identifies the message,
-        # and a detailed help message
-        # that will be included in the documentation.
-        "W1505": (
-            "Using deprecated method %s()",
-            "deprecated-method",
-            "The method is marked as deprecated and will be removed in the future.",
-        ),
-    }
 
     @utils.check_messages(
         "deprecated-method",

--- a/pylint/checkers/__init__.py
+++ b/pylint/checkers/__init__.py
@@ -44,6 +44,7 @@ messages nor reports. XXX not true, emit a 07 report !
 """
 
 from pylint.checkers.base_checker import BaseChecker, BaseTokenChecker
+from pylint.checkers.deprecated import DeprecatedMixin
 from pylint.checkers.mapreduce_checker import MapReduceMixin
 from pylint.utils import register_plugins
 
@@ -71,5 +72,6 @@ __all__ = [
     "BaseTokenChecker",
     "initialize",
     "MapReduceMixin",
+    "DeprecatedMixin",
     "register_plugins",
 ]

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -1,0 +1,49 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/COPYING
+
+"""Checker mixin for deprecated functionality."""
+
+import abc
+
+import astroid
+
+ACCEPTABLE_NODES = (
+    astroid.BoundMethod,
+    astroid.UnboundMethod,
+    astroid.FunctionDef,
+)
+
+
+class DeprecatedMixin(metaclass=abc.ABCMeta):
+    """A mixin implementing logic for checking deprecated symbols.
+    A class imlementing mixin must define "deprecated-method" Message.
+    """
+
+    @abc.abstractmethod
+    def deprecated_methods(self):
+        """Callback returning the deprecated methods/functions.
+
+        Returns:
+            collections.abc.Container of deprecated function/method names.
+        """
+
+    def check_deprecated_method(self, node, inferred):
+        """Executes the checker for the given node. This method should
+        be called from the checker implementing this mixin.
+        """
+
+        # Reject nodes which aren't of interest to us.
+        if not isinstance(inferred, ACCEPTABLE_NODES):
+            return
+
+        if isinstance(node.func, astroid.Attribute):
+            func_name = node.func.attrname
+        elif isinstance(node.func, astroid.Name):
+            func_name = node.func.name
+        else:
+            # Not interested in other nodes.
+            return
+
+        qname = inferred.qname()
+        if any(name in self.deprecated_methods() for name in (qname, func_name)):
+            self.add_message("deprecated-method", node=node, args=(func_name,))

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -4,6 +4,7 @@
 """Checker mixin for deprecated functionality."""
 
 import abc
+from typing import Any
 
 import astroid
 
@@ -18,6 +19,14 @@ class DeprecatedMixin(metaclass=abc.ABCMeta):
     """A mixin implementing logic for checking deprecated symbols.
     A class imlementing mixin must define "deprecated-method" Message.
     """
+
+    msgs: Any = {
+        "W1505": (
+            "Using deprecated method %s()",
+            "deprecated-method",
+            "The method is marked as deprecated and will be removed in the future.",
+        ),
+    }
 
     @abc.abstractmethod
     def deprecated_methods(self):

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -80,7 +80,7 @@ def _check_mode_str(mode):
     return True
 
 
-class StdlibChecker(BaseChecker, DeprecatedMixin):
+class StdlibChecker(DeprecatedMixin, BaseChecker):
     __implements__ = (IAstroidChecker,)
     name = "stdlib"
 

--- a/tests/checkers/unittest_deprecated.py
+++ b/tests/checkers/unittest_deprecated.py
@@ -1,0 +1,99 @@
+import astroid
+
+from pylint.checkers import BaseChecker, DeprecatedMixin, utils
+from pylint.interfaces import UNDEFINED, IAstroidChecker
+from pylint.testutils import CheckerTestCase, Message
+
+
+class _DeprecatedChecker(BaseChecker, DeprecatedMixin):
+    __implements__ = (IAstroidChecker,)
+    name = "deprecated"
+
+    msgs = {
+        "W1505": (
+            "Using deprecated method %s()",
+            "deprecated-method",
+            "The method is marked as deprecated and will be removed in "
+            "a future version of Python. Consider looking for an "
+            "alternative in the documentation.",
+        )
+    }
+
+    @utils.check_messages(
+        "deprecated-method",
+    )
+    def visit_call(self, node):
+        """Visit a Call node."""
+        try:
+            for inferred in node.func.infer():
+                self.check_deprecated_method(node, inferred)
+        except astroid.InferenceError:
+            return
+
+    def deprecated_methods(self):
+        return {"deprecated_func", ".Deprecated.deprecated_method"}
+
+
+class TestDeprecatedChecker(CheckerTestCase):
+    CHECKER_CLASS = _DeprecatedChecker
+
+    def test_deprecated_function(self):
+        # Tests detecting deprecated function
+        node = astroid.extract_node(
+            """
+        def deprecated_func():
+            pass
+
+        deprecated_func()
+        """
+        )
+        with self.assertAddsMessages(
+            Message(
+                msg_id="deprecated-method",
+                args=("deprecated_func",),
+                node=node,
+                confidence=UNDEFINED,
+            )
+        ):
+            self.checker.visit_call(node)
+
+    def test_deprecated_method(self):
+        # Tests detecting deprecated method
+        node = astroid.extract_node(
+            """
+        class Deprecated:
+            def deprecated_method():
+                pass
+
+        d = Deprecated()
+        d.deprecated_method()
+        """
+        )
+        with self.assertAddsMessages(
+            Message(
+                msg_id="deprecated-method",
+                args=("deprecated_method",),
+                node=node,
+                confidence=UNDEFINED,
+            )
+        ):
+            self.checker.visit_call(node)
+
+    def test_no_message(self):
+        # Tests not raising error when no deprecated functions/methods are present.
+        node = astroid.extract_node(
+            """
+        class MyClass:
+            def mymethod():
+                pass
+
+        MyClass().mymethod()
+
+        def myfunc():
+            pass
+
+        myfunc()
+        """
+        )
+        with self.assertNoMessages():
+            self.checker.visit_call(node)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

This PR is moving deprecated check logic to separate mixin class `DeprecatedMixin`. This enables plugins to implement their own deprecation checks. The most visible use case can be pylint-django. Here is the example of simple plugin:
```python
"""
Simple DeprecatedChecker marking test.deprecated_func as deprecated.
"""
import astroid

from pylint.checkers import BaseChecker, DeprecatedMixin, utils
from pylint.interfaces import IAstroidChecker


class DeprecatedChecker(BaseChecker, DeprecatedMixin):
    __implements__ = (IAstroidChecker,)
    name = "deprecated"

    msgs = {
        "W1505": (
            "Using deprecated method %s()",
            "deprecated-method",
            "The method is marked as deprecated and will be removed in "
            "a future version of Python. Consider looking for an "
            "alternative in the documentation.",
        )
      }

    @utils.check_messages(
        "deprecated-method",
    )
    def visit_call(self, node):
        """Visit a Call node."""
        try:
            for inferred in node.func.infer():
                self.check_deprecated_method(node, inferred)
        except astroid.InferenceError:
            return

    def deprecated_methods(self):
        return {'test.deprecated_func'}


def register(linter):
    linter.register_checker(DeprecatedChecker(linter))
```

Current desing has multiple design choices which can be discussed:
1. Implementing Deprecated checker requires writing new checker instead of configuring existing one.
2. Using `DeprecatedMixin` requires to define `deprecated-method` msg in Checker class. This can be cumbersome, but it is backwards compatible and it conforms rule that each checker has it's own isolated set of IDs.

Current state of PR is mainly a starting point for final implementation. The following parts needs to be done:
- [x] Implementing/adjusting unittests
- [ ] Documentation

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
|    | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|    | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related Issue
Closes #4049
<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->