### PR TITLE
[blacklisted-name] Allow emission on non-constants

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -439,3 +439,5 @@ contributors:
 * Logan Miller (komodo472): contributor
 
 * Matthew Suozzo: contributor
+
+* Rick Elrod (relrod): contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,13 @@
 ------------------
 Pylint's ChangeLog
 ------------------
+
+* Fix regression where `blacklisted-name` was no longer emitted for non-constants.
+
+* Fix bug where `non-ascii-name` was not emitted for non-constants.
+
+  Closes #3701
+
 * Bug fix for empty-comment message line number.
 
   Closes #4009

--- a/tests/functional/b/blacklisted_name.py
+++ b/tests/functional/b/blacklisted_name.py
@@ -2,3 +2,6 @@
 
 def baz(): # [blacklisted-name]
     pass
+
+foo = {}.keys()  # [blacklisted-name]
+foo = None  # [blacklisted-name]

--- a/tests/functional/b/blacklisted_name.txt
+++ b/tests/functional/b/blacklisted_name.txt
@@ -1,1 +1,3 @@
-blacklisted-name:3:0:baz:Black listed name "baz"
+blacklisted-name:3:0:baz:"Black listed name ""baz"""
+blacklisted-name:6:0::"Black listed name ""foo"""
+blacklisted-name:7:0::"Black listed name ""foo"""

--- a/tests/functional/n/non_ascii_name.py
+++ b/tests/functional/n/non_ascii_name.py
@@ -1,5 +1,6 @@
 """ Tests for non-ascii-name checker. """
 
+áéíóú = {}.keys() # [non-ascii-name]
 áéíóú = 4444 # [non-ascii-name]
 
 def úóíéá(): # [non-ascii-name]

--- a/tests/functional/n/non_ascii_name.txt
+++ b/tests/functional/n/non_ascii_name.txt
@@ -1,2 +1,3 @@
 non-ascii-name:3:0::"Constant name ""áéíóú"" contains a non-ASCII unicode character"
-non-ascii-name:5:0:úóíéá:"Function name ""úóíéá"" contains a non-ASCII unicode character"
+non-ascii-name:4:0::"Constant name ""áéíóú"" contains a non-ASCII unicode character"
+non-ascii-name:6:0:úóíéá:"Function name ""úóíéá"" contains a non-ASCII unicode character"


### PR DESCRIPTION
NOTE: CI is currently failing (independently of this change) due to [this PR](https://github.com/PyCQA/astroid/pull/884/) in `astroid`. I didn't try to debug it beyond bisecting it to that PR.

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

- Fix a regression introduced in
  3422e4adc718c60a467d66ab0dedf4a7032c4fc5 where blacklisted-name
  (emitted by _check_name()) would only be emitted for constants.
- The blacklisted-name check has been pulled out into its own helper
  function, and is now called instead of _check_name() when we are NOT
  at a constant.
- Fix a similar bug (not regression) for non-ascii-name in the same
  scenario.
- Changelog updated.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

- Fixes #3701


<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
