### PR TITLE
Fix multiple false positives with assignment expressions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,10 @@ Pylint's ChangeLog
 
   Closes #4065
 
+* Fix multiple false positives with assignment expressions
+
+  Closes #3347, #3953, #3865, #3275
+
 What's New in Pylint 2.6.1?
 ===========================
 Release date: TBA

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1407,6 +1407,36 @@ class VariablesChecker(BaseChecker):
                     # Single statement function, with the statement on the
                     # same line as the function definition
                     maybee0601 = False
+                elif (
+                    isinstance(defstmt, astroid.Assign)
+                    and isinstance(defstmt.value, astroid.IfExp)
+                    and frame is defframe
+                    and defframe.parent_of(node)
+                    and stmt is defstmt
+                ):
+                    # Single statement if, with assingment expression on same
+                    # line as assigment
+                    # x = b if (b := True) else False
+                    maybee0601 = False
+                elif (
+                    isinstance(  # pylint: disable=too-many-boolean-expressions
+                        defnode, astroid.NamedExpr
+                    )
+                    and frame is defframe
+                    and defframe.parent_of(stmt)
+                    and stmt is defstmt
+                    and (
+                        (
+                            defnode.lineno == node.lineno
+                            and defnode.col_offset < node.col_offset
+                        )
+                        or (defnode.lineno < node.lineno)
+                    )
+                ):
+                    # Expressions, with assignment expressions
+                    # Use only after assignment
+                    # b = (c := 2) and c
+                    maybee0601 = False
 
             # Look for type checking definitions inside a type checking guard.
             if isinstance(defstmt, (astroid.Import, astroid.ImportFrom)):

--- a/tests/functional/a/assignment_expression.py
+++ b/tests/functional/a/assignment_expression.py
@@ -1,0 +1,58 @@
+"""Test assignment expressions"""
+# pylint: disable=missing-docstring,unused-argument,unused-import,invalid-name,blacklisted-name,unused-variable
+import re
+
+if (a := True):
+    x = a
+else:
+    x = False
+
+x = b if (b := True) else False
+
+a = ["a   ", "b   ", "c   "]
+c = [text for el in a if (text := el.strip()) == "b"]
+
+
+# https://github.com/PyCQA/pylint/issues/3347
+s = 'foo' if (fval := lambda: 1) is None else fval
+
+
+# https://github.com/PyCQA/pylint/issues/3953
+assert (n := 2) == 1, f"Expected 1, but got {n}"
+dict({1: (o := 2)}, data=o)
+assert (p := 2) == 1, \
+    p
+
+FOO_PATT = re.compile("")
+foo = m.group("foo") if (m := FOO_PATT.match("")) else False
+
+
+# https://github.com/PyCQA/pylint/issues/3865
+if (c := lambda: 2) and c():
+    print("ok")
+
+def func():
+    print((d := lambda: 2) and d)
+
+
+# https://github.com/PyCQA/pylint/issues/3275
+values = (
+    e := 1,
+    f := e,
+)
+print(values)
+
+function = lambda: (
+    h := 1,
+    i := h,
+)
+print(function())
+
+
+# check wrong usage
+assert err_a, (err_a := 2)  # [used-before-assignment]
+print(err_b and (err_b := 2))  # [used-before-assignment]
+values = (
+    err_c := err_d,  # [used-before-assignment]
+    err_d := 2,
+)

--- a/tests/functional/a/assignment_expression.rc
+++ b/tests/functional/a/assignment_expression.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.8

--- a/tests/functional/a/assignment_expression.txt
+++ b/tests/functional/a/assignment_expression.txt
@@ -1,0 +1,3 @@
+used-before-assignment:53:7::Using variable 'err_a' before assignment
+used-before-assignment:54:6::Using variable 'err_b' before assignment
+used-before-assignment:56:13::Using variable 'err_d' before assignment


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Fix multiple false positive that occurred together with assignment expressions. Addressed issues:
```py
# used-before-assignment
x = b if (b := True) else False  # b

assert (n := 2) == 1, f"Expected 1, but got {n}"  # n

dict({1: (o := 2)}, data=o)  # o

if (c := lambda: 2) and c():  # c
    print("ok")

values = (
    e := 1,
    f := e,  # e
)


# undefined-variable
function = lambda: (
    h := 1,
    i := h,  # h
)
```



## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->

Closes: #3347
Closes: #3953
Closes: #3865
Closes: #3275
