### PR TITLE
Fix TypedDict inherit-non-class false-positive Python 3.9+

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -43,6 +43,10 @@ Pylint's ChangeLog
 
   Closes #3347, #3953, #3865, #3275
 
+* Fix TypedDict inherit-non-class false-positive Python 3.9+
+
+  Closes #1927
+
 What's New in Pylint 2.6.1?
 ===========================
 Release date: TBA

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -831,6 +831,11 @@ a metaclass class method.",
                 "%s.type" % (BUILTINS,)
             ):
                 continue
+            if (
+                isinstance(ancestor, astroid.FunctionDef)
+                and ancestor.name == "TypedDict"
+            ):
+                continue
 
             if not isinstance(ancestor, astroid.ClassDef) or _is_invalid_base_class(
                 ancestor

--- a/tests/functional/t/typedDict.py
+++ b/tests/functional/t/typedDict.py
@@ -1,0 +1,18 @@
+"""Test typing.TypedDict"""
+# pylint: disable=invalid-name,missing-class-docstring,too-few-public-methods
+import typing
+from typing import TypedDict
+
+
+class CustomTD(TypedDict):
+    var: int
+
+class CustomTD2(typing.TypedDict, total=False):
+    var2: str
+
+class CustomTD3(CustomTD2):
+    var3: int
+
+CustomTD4 = TypedDict("CustomTD4", var4=bool)
+
+CustomTD5 = TypedDict("CustomTD5", {"var5": bool})

--- a/tests/functional/t/typedDict.rc
+++ b/tests/functional/t/typedDict.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.8


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
In Python 3.9 `typing.TypedDict` changed from a class to function with some metaclass magic.
This caused a `inherit-non-class` error for valid code.

**Source code**
[Python 3.8 - typing.py](https://github.com/python/cpython/blob/c370596a23167749b8127d1d2e20e039865aa695/Lib/typing.py#L1760-L1763)
[Python 3.9 - typing.py](https://github.com/python/cpython/blob/48d16b4b0fb0d0558bdbc1aee850650a671ecc77/Lib/typing.py#L1940-L1998)

**Documentation**
https://docs.python.org/3/library/typing.html#typing.TypedDict

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

Closes #1927