### PR TITLE
Extends mypy check, add pre-commit configuration and fix legacy fail

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,15 @@ repos:
         language: system
         types: [python]
         exclude: tests/functional/|tests/input|tests/extensions/data|tests/regrtest_data/|tests/data/|doc/
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.800
+    hooks:
+    -   id: mypy
+        name: mypy
+        entry: mypy
+        language: python
+        "types": [python]
+        args: ["--ignore-missing-imports", "--scripts-are-modules"]
+        require_serial: true
+        additional_dependencies: []
+        exclude: tests/functional/|tests/input|tests/extensions/data|tests/regrtest_data/|tests/data/|doc/|bin/

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -189,7 +189,7 @@ class Docstring:
         re.X | re.S,
     )
 
-    supports_yields = None
+    supports_yields: bool = False
     """True if the docstring supports a "yield" section.
 
     False if the docstring uses the returns section to document generators.

--- a/pylint/testutils/checker_test_case.py
+++ b/pylint/testutils/checker_test_case.py
@@ -2,6 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
 import contextlib
+from typing import Dict
 
 from pylint.testutils.global_test_linter import linter
 from pylint.testutils.unittest_linter import UnittestLinter
@@ -12,7 +13,7 @@ class CheckerTestCase:
     """A base testcase class for unit testing individual checker classes."""
 
     CHECKER_CLASS = None
-    CONFIG = {}
+    CONFIG: Dict = {}
 
     def setup_method(self):
         self.linter = UnittestLinter()

--- a/pylint/testutils/checker_test_case.py
+++ b/pylint/testutils/checker_test_case.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
 import contextlib
-from typing import Dict
+from typing import Dict, Optional, Type
 
 from pylint.testutils.global_test_linter import linter
 from pylint.testutils.unittest_linter import UnittestLinter
@@ -12,7 +12,7 @@ from pylint.utils import ASTWalker
 class CheckerTestCase:
     """A base testcase class for unit testing individual checker classes."""
 
-    CHECKER_CLASS = None
+    CHECKER_CLASS: Optional[Type] = None
     CONFIG: Dict = {}
 
     def setup_method(self):

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -7,7 +7,7 @@ import platform
 import sys
 from collections import Counter
 from io import StringIO
-from typing import Tuple
+from typing import Dict, Tuple
 
 import pytest
 
@@ -110,7 +110,9 @@ class LintModuleTest:
         return messages
 
     @staticmethod
-    def multiset_difference(expected_entries: set, actual_entries: set) -> Tuple[set]:
+    def multiset_difference(
+        expected_entries: Counter, actual_entries: Counter
+    ) -> Tuple[Counter, Dict[str, int]]:
         """Takes two multisets and compares them.
 
         A multiset is a dict with the cardinality of the key as the value."""

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -21,7 +21,8 @@ class Message(
             return self[:-1] == other[:-1]
         return NotImplemented  # pragma: no cover
 
-    __hash__ = None
+    def __hash__(self):
+        return None
 
 
 class MalformedOutputLineException(Exception):

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ import os
 import sys
 from distutils.command.build_py import build_py
 from os.path import exists, isdir, join
+from typing import Any, Dict
 
 try:
     from setuptools import setup
@@ -49,7 +50,7 @@ except ImportError:
 __docformat__ = "restructuredtext en"
 base_dir = os.path.dirname(__file__)
 
-__pkginfo__ = {}
+__pkginfo__: Dict[str, Any] = {}
 with open(os.path.join(base_dir, "pylint", "__pkginfo__.py")) as pkginfo_fp:
     exec(pkginfo_fp.read(), __pkginfo__)
 scripts = __pkginfo__.get("scripts", [])

--- a/tests/checkers/unittest_base.py
+++ b/tests/checkers/unittest_base.py
@@ -25,6 +25,7 @@
 import re
 import sys
 import unittest
+from typing import Dict, Type
 
 import astroid
 
@@ -33,7 +34,7 @@ from pylint.testutils import CheckerTestCase, Message, set_config
 
 
 class TestDocstring(CheckerTestCase):
-    CHECKER_CLASS = base.DocStringChecker
+    CHECKER_CLASS: Type = base.DocStringChecker
 
     def test_missing_docstring_module(self):
         module = astroid.parse("something")
@@ -135,8 +136,8 @@ class TestDocstring(CheckerTestCase):
 
 
 class TestNameChecker(CheckerTestCase):
-    CHECKER_CLASS = base.NameChecker
-    CONFIG = {"bad_names": set()}
+    CHECKER_CLASS: Type = base.NameChecker
+    CONFIG: Dict = {"bad_names": set()}
 
     @set_config(
         attr_rgx=re.compile("[A-Z]+"),

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -63,7 +63,7 @@ from pylint.utils import FileState, tokenize_module
 if os.name == "java":
     # pylint: disable=no-member
     # os._name is valid see https://www.programcreek.com/python/example/3842/os._name
-    if os._name == "nt":
+    if os.name == "nt":
         HOME = "USERPROFILE"
     else:
         HOME = "HOME"

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -72,11 +72,6 @@ elif sys.platform == "win32":
 else:
     HOME = "HOME"
 
-try:
-    PYPY_VERSION_INFO = sys.pypy_version_info
-except AttributeError:
-    PYPY_VERSION_INFO = None
-
 
 @contextmanager
 def fake_home():
@@ -653,11 +648,6 @@ def test_pylint_home():
         del os.environ["PYLINTHOME"]
 
 
-@pytest.mark.skipif(
-    PYPY_VERSION_INFO,
-    reason="TOX runs this test from within the repo and finds "
-    "the project's pylintrc.",
-)
 @pytest.mark.usefixtures("pop_pylintrc")
 def test_pylintrc():
     with fake_home():

--- a/tests/test_regr.py
+++ b/tests/test_regr.py
@@ -30,11 +30,6 @@ from pylint import testutils
 REGR_DATA = join(dirname(abspath(__file__)), "regrtest_data")
 sys.path.insert(1, REGR_DATA)
 
-try:
-    PYPY_VERSION_INFO = sys.pypy_version_info
-except AttributeError:
-    PYPY_VERSION_INFO = None
-
 
 @pytest.fixture(scope="module")
 def reporter():

--- a/tox.ini
+++ b/tox.ini
@@ -46,11 +46,10 @@ changedir = {toxinidir}
 [testenv:mypy]
 basepython = python3
 deps =
-    typed-ast>=1.4
-    mypy>=0.7,<1.0
+    pre-commit
 
 commands =
-    python -m mypy {toxinidir}/pylint/checkers --ignore-missing-imports {posargs:}
+    pre-commit run mypy --all-files
 
 [testenv]
 deps =


### PR DESCRIPTION

## Description

This  MR make the tox mypy test be applied on the whole code, use pre-commit to do it so it's done automatically on commit and fix all issues encountered with mypy in the existing code.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :hammer: Refactoring  |
