### PR TITLE
Add a warning in the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-.svn/
-.hg/
-.hgtags/
+# Do not add entries specific to your dev environment or development
+# preferences in this file. You can use the global .gitignore for that:
+# git config --global core.excludesFile '~/.gitignore'
 /log
 *.py[cod]
 /build
@@ -20,7 +20,6 @@ debian/pylint.substvars
 debian/pylint
 .coverage
 .coverage.*
-.idea
 .cache/
 .eggs/
 .pytest_cache/


### PR DESCRIPTION
## Description

Permit to avoid having to repeat that the gitignore global exists like in #4058 

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |
