### PR TITLE
Fix the changelog and whatsnew retroactively

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 ------------------
 Pylint's ChangeLog
 ------------------
+
+What's New in Pylint 2.7.0?
+===========================
+
 * Python 3.6+ is now required.
 
 * Bug fix for empty-comment message line number.
@@ -52,10 +56,6 @@ Pylint's ChangeLog
 * Fix issue with nested PEP 585 syntax
 
 * Fix issue with nested PEP 604 syntax
-
-What's New in Pylint 2.6.1?
-===========================
-Release date: TBA
 
 * Fix a crash in `undefined-variable` caused by chained attributes in metaclass
 
@@ -148,6 +148,26 @@ Release date: TBA
 
   Close #2498
 
+* Add check for bool function to `len-as-condition`
+
+* Add `simplifiable-condition` check for extraneous constants in conditionals using and/or.
+
+* Add `condition-evals-to-constant` check for conditionals using and/or that evaluate to a constant.
+
+  Close #3407
+
+* Changed setup.py to work with [distlib](https://pypi.org/project/distlib)
+
+  Close #3555
+
+What's New in Pylint 2.6.1?
+===========================
+
+* Astroid version has been set as < 2.5
+
+  Close #4093
+
+
 What's New in Pylint 2.6.0?
 ===========================
 
@@ -197,17 +217,6 @@ Release date: 2020-08-20
 
   Close #3722
 
-* Add check for bool function to `len-as-condition`
-
-* Add `simplifiable-condition` check for extraneous constants in conditionals using and/or.
-
-* Add `condition-evals-to-constant` check for conditionals using and/or that evaluate to a constant.
-
-  Close #3407
-
-* Changed setup.py to work with [distlib](https://pypi.org/project/distlib)
-
-  Close #3555
 
 What's New in Pylint 2.5.4?
 ===========================

--- a/doc/whatsnew/2.6.rst
+++ b/doc/whatsnew/2.6.rst
@@ -5,44 +5,21 @@
 :Release: 2.6
 :Date: 2020-08-20
 
-
 Summary -- Release highlights
 =============================
 
-* Python 3.6+ is now required.
+* `bad-continuation` and `bad-whitespace` have been removed. `black` or another formatter can help you with this better than Pylint
+* Added support for isort 5
 
 New checkers
 ============
-
-* Add support to ``ignored-argument-names`` in DocstringParameterChecker and
-  adds `useless-param-doc` and `useless-type-doc` messages.
-
-* Add `empty-comment` check for empty comments.
 
 * Add `super-with-arguments` check for flagging instances of Python 2 style super calls.
 
 * Add `raise-missing-from` check for exceptions that should have a cause.
 
-* Add `simplifiable-condition` check for extraneous constants in conditionals using and/or.
-
-* Add `condition-evals-to-constant` check for conditionals using and/or that evaluate to a constant.
-
 Other Changes
 =============
-
-* Fix linter multiprocessing pool shutdown which triggered warnings when runned in parallels with other pytest plugins.
-
-* Enums are now required to be named in UPPER_CASE by ``invalid-name``.
-
-* Fix bug that lead to duplicate messages when using ``--jobs 2`` or more.
-
-* Adds option ``check-protected-access-in-special-methods`` in the ClassChecker to activate/deactivate
-  ``protected-access`` message emission for single underscore prefixed attribute in special methods.
-
-* ``inconsistent-return-statements`` message is now emitted if one of ``try/except`` statement
-  is not returning explicitly while the other do.
-
-* Fix false positive message ``useless-super-delegation`` when default keyword argument is a dictionnary.
 
 * `bad-continuation` and `bad-whitespace` have been removed. `black` or another formatter can help you with this better than Pylint
 
@@ -54,10 +31,4 @@ Other Changes
 
 * Add support for both isort 4 and isort 5. If you have pinned isort 4 in your projet requirements, nothing changes. If you use isort 5, though, note that the `known-standard-library` option is not interpreted the same in isort 4 and isort 5 (see `the migration guide in isort documentation`_ for further details). For compatibility's sake for most pylint users, the `known-standard-library` option in pylint now maps to `extra-standard-library` in isort 5. If you really want what `known-standard-library` now means in isort 5, you must disable the `wrong-import-order` check in pylint and run isort manually with a proper isort configuration file.
 
-* Fix vulnerable regular expressions in ``pyreverse``. The ambiguities of vulnerable regular expressions are removed, making the repaired regular expressions safer and faster matching.
-
 .. _the migration guide in isort documentation: https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/#known_standard_library
-
-* `len-as-conditions` is now triggered only for classes that are inheriting directly from list, dict, or set and not implementing the `__bool__` function, or from generators like range or list/dict/set comprehension. This should reduce the false positive for other classes, like pandas's DataFrame or numpy's Array.
-
-* Fixes duplicate code detection for --jobs=2+

--- a/doc/whatsnew/2.7.rst
+++ b/doc/whatsnew/2.7.rst
@@ -1,0 +1,48 @@
+**************************
+ What's New in Pylint 2.7
+**************************
+
+:Release: 2.7
+:Date: 2021-02-XX
+
+Summary -- Release highlights
+=============================
+
+* No more duplicate messages when using multiple jobs.
+* Handling of the new typing provided by mypy 0.8
+* Python 3.6+ is now required.
+
+New checkers
+============
+
+* Add support to ``ignored-argument-names`` in DocstringParameterChecker and
+  adds `useless-param-doc` and `useless-type-doc` messages.
+
+* Add `empty-comment` check for empty comments.
+
+* Add `simplifiable-condition` check for extraneous constants in conditionals using and/or.
+
+* Add `condition-evals-to-constant` check for conditionals using and/or that evaluate to a constant.
+
+Other Changes
+=============
+
+* Fix linter multiprocessing pool shutdown which triggered warnings when runned in parallels with other pytest plugins.
+
+* Enums are now required to be named in UPPER_CASE by ``invalid-name``.
+
+* Fix bug that lead to duplicate messages when using ``--jobs 2`` or more.
+
+* Adds option ``check-protected-access-in-special-methods`` in the ClassChecker to activate/deactivate
+  ``protected-access`` message emission for single underscore prefixed attribute in special methods.
+
+* ``inconsistent-return-statements`` message is now emitted if one of ``try/except`` statement
+  is not returning explicitly while the other do.
+
+* Fix false positive message ``useless-super-delegation`` when default keyword argument is a dictionary.
+
+* Fix vulnerable regular expressions in ``pyreverse``. The ambiguities of vulnerable regular expressions are removed, making the repaired regular expressions safer and faster matching.
+
+* `len-as-conditions` is now triggered only for classes that are inheriting directly from list, dict, or set and not implementing the `__bool__` function, or from generators like range or list/dict/set comprehension. This should reduce the false positive for other classes, like pandas's DataFrame or numpy's Array.
+
+* Fixes duplicate code detection for --jobs=2+

--- a/doc/whatsnew/index.rst
+++ b/doc/whatsnew/index.rst
@@ -9,6 +9,7 @@ High level descriptions of the most important changes between major Pylint versi
 .. toctree::
    :maxdepth: 1
 
+   2.7.rst
    2.6.rst
    2.5.rst
    2.4.rst


### PR DESCRIPTION
## Description

Remove everything that was in 2.6 changelog when it should be in 2.7 following the decision taken in #3831 

This can be checked with
```
git remote add pyorigin git@github.com:PyCQA/pylint.git
git diff pyorigin/2.6 doc/whatsnew/
git diff pyorigin/2.6 ChangeLog
```
The idea is that nothing should be added between 2.6 and now in a 2.6 portion everything done between now and 2.6 should be in 2.7.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |
