### PR TITLE
Fix false positive when map() receives iterable

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -445,3 +445,5 @@ contributors:
 * Marc Mueller (cdce8p): contributor
 
 * David Gilman: contributor
+
+* Tiago Honorato: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,10 @@ Pylint's ChangeLog
 What's New in Pylint 2.7.0?
 ===========================
 
+* Fix false positive for ``builtin-not-iterating`` when ``map`` receives iterable
+
+  Closes #4078
+
 * Python 3.6+ is now required.
 
 * Fix false positive for ``builtin-not-iterating`` when ``zip`` receives iterable

--- a/doc/whatsnew/2.7.rst
+++ b/doc/whatsnew/2.7.rst
@@ -29,7 +29,7 @@ New checkers
 Other Changes
 =============
 
-* Fix false positive for ``builtin-not-iterating`` when ``zip`` receives iterable
+* Fix false positive for ``builtin-not-iterating`` when ``zip`` or ``map`` receives iterable
 
 * Fix linter multiprocessing pool shutdown which triggered warnings when runned in parallels with other pytest plugins.
 

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -97,6 +97,7 @@ _ACCEPTS_ITERATOR = {
     "frozenset",
     "OrderedDict",
     "zip",
+    "map",
 }
 ATTRIBUTES_ACCEPTS_ITERATOR = {"join", "from_iterable"}
 _BUILTIN_METHOD_ACCEPTS_ITERATOR = {

--- a/tests/checkers/unittest_python3.py
+++ b/tests/checkers/unittest_python3.py
@@ -187,6 +187,11 @@ class TestPython3Checker(testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.walk(module)
 
+    def as_argument_to_map_test(self, fxn):
+        module = astroid.parse(f"list(map(__, {fxn}()))")
+        with self.assertNoMessages():
+            self.walk(module)
+
     def as_iterable_in_unpacking(self, fxn):
         node = astroid.extract_node(
             f"""
@@ -224,7 +229,7 @@ class TestPython3Checker(testutils.CheckerTestCase):
         self.as_iterable_in_starred_context(fxn)
         self.as_argument_to_itertools_functions(fxn)
         self.as_argument_to_zip_test(fxn)
-
+        self.as_argument_to_map_test(fxn)
         for func in (
             "iter",
             "list",


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Since ``map()`` supports iterables, it should not issue ``builtin-not-iterating`` for iterable arguments.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Closes #4078
