### PR TITLE
Update astroid dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,7 @@ jobs:
       - name: Fetch astroid commit hash
         id: fetch-astroid-hash
         run: >-
-          echo "::set-output name=hash::"$(
-            curl -s https://api.github.com/repos/PyCQA/astroid/branches/master |
-            grep -E '^    "sha": "(\S*)' | awk '{print substr($0, 13, 40)}')
+          echo "::set-output name=hash::"$(python script/fetch_astroid_hash.py)
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-
@@ -205,9 +203,7 @@ jobs:
       - name: Fetch astroid commit hash
         id: fetch-astroid-hash
         run: >-
-          echo "::set-output name=hash::"$(
-            curl -s https://api.github.com/repos/PyCQA/astroid/branches/master |
-            grep -E '^    "sha": "(\S*)' | awk '{print substr($0, 13, 40)}')
+          echo "::set-output name=hash::"$(python script/fetch_astroid_hash.py)
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-
@@ -379,9 +375,7 @@ jobs:
       - name: Fetch astroid commit hash
         id: fetch-astroid-hash
         run: >-
-          echo "::set-output name=hash::"$(
-            curl -s https://api.github.com/repos/PyCQA/astroid/branches/master |
-            grep -E '^    "sha": "(\S*)' | awk '{print substr($0, 13, 40)}')
+          echo "::set-output name=hash::"$(python script/fetch_astroid_hash.py)
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
   pull_request: ~
 
 env:
-  CACHE_VERSION: 0
+  CACHE_VERSION: 1
   DEFAULT_PYTHON: 3.6
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
 
@@ -32,6 +32,11 @@ jobs:
         id: fetch-astroid-hash
         run: >-
           echo "::set-output name=hash::"$(python script/fetch_astroid_hash.py)
+      - name: Check astroid commit hash
+        if: steps.fetch-astroid-hash.outputs.hash == ''
+        run: |
+          echo "Error with astroid hash generation, check logs!"
+          exit 1
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-
@@ -204,6 +209,11 @@ jobs:
         id: fetch-astroid-hash
         run: >-
           echo "::set-output name=hash::"$(python script/fetch_astroid_hash.py)
+      - name: Check astroid commit hash
+        if: steps.fetch-astroid-hash.outputs.hash == ''
+        run: |
+          echo "Error with astroid hash generation, check logs!"
+          exit 1
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-
@@ -376,6 +386,11 @@ jobs:
         id: fetch-astroid-hash
         run: >-
           echo "::set-output name=hash::"$(python script/fetch_astroid_hash.py)
+      - name: Check astroid commit hash
+        if: steps.fetch-astroid-hash.outputs.hash == ''
+        run: |
+          echo "Error with astroid hash generation, check logs!"
+          exit 1
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-

--- a/ChangeLog
+++ b/ChangeLog
@@ -182,6 +182,8 @@ What's New in Pylint 2.7.0?
 
 * Add Github Actions to replace Travis and AppVeyor in the future
 
+* Update Astroid version to `2.5`
+
 
 What's New in Pylint 2.6.1?
 ===========================

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -40,7 +40,7 @@ if dev_version is not None:
     version += "-dev" + str(dev_version)
 
 install_requires = [
-    "astroid>=2.4.0,<=2.6",
+    "astroid==2.5",
     "isort>=4.2.5,<6",
     "mccabe>=0.6,<0.7",
     "toml>=0.7.1",

--- a/requirements_test_pypy.txt
+++ b/requirements_test_pypy.txt
@@ -1,4 +1,4 @@
-astroid @ git+git://github.com/PyCQA/astroid.git@master
+astroid @ git+git://github.com/PyCQA/astroid.git@2.5
 coveralls
 coverage<5.0
 pytest

--- a/script/fetch_astroid_hash.py
+++ b/script/fetch_astroid_hash.py
@@ -1,0 +1,47 @@
+#!/bin/python
+"""Small script to fetch last commit hash for tracked astroid branch."""
+import json
+import subprocess
+import sys
+from typing import List
+
+REQUIREMENTS_FILE = "requirements_test_pypy.txt"
+GITHUB_API_URI = "https://api.github.com/repos/PyCQA/astroid/branches/"
+
+
+class ScriptError(Exception):
+    pass
+
+
+def read_branch_from_file(file: str) -> str:
+    with open(file) as fp:
+        data: List[str] = fp.read().split("\n")
+    astroid = [line.strip() for line in data if line.strip().startswith("astroid")]
+    if len(astroid) == 0:
+        raise ScriptError(f"No astroid dependency found in: {file}")
+    if len(astroid) > 1:
+        raise ScriptError(f"Multiple astroid dependencies found in: {file}")
+
+    return astroid[0].split("@")[2]
+
+
+def fetch_hash(branch: str) -> str:
+    uri = f"{GITHUB_API_URI}{branch}"
+    p = subprocess.run(["curl", "-s", uri], stdout=subprocess.PIPE, check=True)
+    if p.stdout is False:
+        raise ScriptError(f"Could not fetch API result from: {uri}")
+    json_dict = json.loads(p.stdout.decode("utf-8"))
+    try:
+        return json_dict["commit"]["sha"]
+    except KeyError as ex:
+        raise ScriptError("Could not read hash") from ex
+
+
+def main():
+    branch = read_branch_from_file(REQUIREMENTS_FILE)
+    commit_hash = fetch_hash(branch)
+    sys.stdout.write(commit_hash)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Update required astroid dependency to `astroid==2.5` for the next pylint release.
I've also added a short script to fetch the correct astroid hash during CI runs.

**Why `==2.5` and not `~=2.5`?**
This is something I would like to discuss here further.
I believe that it might be beneficial to lock it to `2.5` instead of only requiring the minor version to match. Most users probably only define a `pylint` version in their test requirements. So when `astroid` pushes a new bugfix release, it won't be installed since the requirement is already satisfied. The solution would be to also release a small pylint update the updates the astroid dependency.

The only drawback I can think of is, that it might lead to conflicts if another project is also using `astroid` as a dependency but with a different version. Don't know how common that would be. I would imagine most use only `pylint`.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

https://github.com/PyCQA/pylint/issues/4055#issuecomment-782837754
