### PR TITLE
Expose UnittestLinter in testutils after 2.7

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -450,3 +450,5 @@ contributors:
     - Added new checks 'consider-using-generator' and 'use-a-generator'.
 
 * Tiago Honorato: contributor
+
+* Lefteris Karapetsas: contributor

--- a/pylint/testutils/__init__.py
+++ b/pylint/testutils/__init__.py
@@ -40,6 +40,7 @@ __all__ = [
     "GenericTestReporter",
     "UPDATE_FILE",
     "UPDATE_OPTION",
+    "UnittestLinter",
 ]
 
 from pylint.testutils.checker_test_case import CheckerTestCase
@@ -52,3 +53,4 @@ from pylint.testutils.lint_module_test import LintModuleTest
 from pylint.testutils.output_line import Message
 from pylint.testutils.reporter_for_tests import GenericTestReporter, MinimalTestReporter
 from pylint.testutils.tokenize_str import _tokenize_str
+from pylint.testutils.unittest_linter import UnittestLinter


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

 - [X] Add yourself to CONTRIBUTORS if you are a new contributor.
 - [ ] Add a ChangeLog entry describing what your PR does.  -> It's just a refactor. Should I?
 - [X] Write a good description on what the PR does.

## Description

In the project I am working on we just upgraded to 2.7 and got hit by a [missing import](https://github.com/rotki/rotki/pull/2417/checks?check_run_id=1946892832) for `UnitTestLinter`. We have some custom pylint plugins. I see that there was a refactor in testutils for 2.7 and I assume exposing this class from __init__.py was missed. So I am going ahead and adding it with this PR. Hope it's fine.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

