### PR TITLE
Partially revert astroid install requirement

### DIFF
--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -40,7 +40,7 @@ if dev_version is not None:
     version += "-dev" + str(dev_version)
 
 install_requires = [
-    "astroid==2.5.0",
+    "astroid>=2.5.0,<2.7",
     "isort>=4.2.5,<6",
     "mccabe>=0.6,<0.7",
     "toml>=0.7.1",


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Partially revert the `install_requires` version for astroid. It seems to cause too many issues for users and developers if it's pinned to a specific version.

A better solution might be to update the min dependency every so often after a new release turned out to be stable. For this MR I updated it from `>=2.4.0` to `>=2.4.2` for example.

--

I didn't update the `requirements` files, since it still might be best to run the CI checks against the latest released version. If that would be of interest, I could add another CI workflow for it. Test different astroid versions maybe once per day.?


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue
https://github.com/PyCQA/pylint/pull/4116#issuecomment-782978451
https://github.com/PyCQA/pylint/issues/4119#issuecomment-783646510