### PR TITLE
Fix False positive on Enum.__members__.items()

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -10,19 +10,54 @@ about: Report a bug in pylint
   Before you submit this, make sure that the issue doesn't already exist
   or if it is not closed.
 
-  Is your issue fixed on the preview release?: pip install pylint astroid --pre -U
-
+  Is your issue fixed on the preview release?:
+    pip install pylint astroid --pre -U
 -->
 
 ### Steps to reproduce
-1.
-2.
-3.
+
+<!--
+Given a file `a.py`:
+```python
+# (Disable message unrelated to the bug)
+# pylint: disable=missing-docstring,...
+
+```
+
+Given multiple files:
+```
+__init__.py
+a.py
+module\
+    __init__.py
+    b.py
+    c.py
+```
+-->
 
 ### Current behavior
+<!--
+Result of `pylint a.py`:
+```
 
+```
+-->
 
 ### Expected behavior
 
 
 ### pylint --version output
+
+Result of `pylint --version` output:
+```
+
+```
+
+<!--
+Additional dependencies:
+```
+pandas==0.23.2
+marshmallow==3.10.0
+...
+```
+-->

--- a/.github/ISSUE_TEMPLATE/2_Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_Feature_request.md
@@ -17,6 +17,5 @@ A clear and concise description of what the problem is.
 ### Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-
 ### Additional context
 Add any other context about the feature request here.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -319,6 +319,55 @@ jobs:
           . venv/bin/activate
           coveralls --rcfile=${{ env.COVERAGERC_FILE }} --service=github
 
+  benchmark-linux:
+    name: Run benchmark tests Python ${{ matrix.python-version }} (Linux)
+    runs-on: ubuntu-latest
+    needs: prepare-tests-linux
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8, 3.9]
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.3.4
+      - name: Set up Python ${{ matrix.python-version }}
+        id: python
+        uses: actions/setup-python@v2.2.1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Restore Python virtual environment
+        id: cache-venv
+        uses: actions/cache@v2.1.4
+        with:
+          path: venv
+          key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            needs.prepare-tests-linux.outputs.python-key }}
+      - name: Fail job if Python cache restore failed
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore Python venv from cache"
+          exit 1
+      - name: Run pytest
+        run: |
+          . venv/bin/activate
+          pip install pygal
+          pip install -e .
+          pytest --exitfirst \
+            --benchmark-only \
+            --benchmark-autosave \
+            --benchmark-save-data \
+            --benchmark-group-by="group"
+      - name: Create partial artifact name suffix
+        id: artifact-name-suffix
+        run: >-
+          echo "::set-output name=datetime::"$(date "+%Y%m%d_%H%M")
+      - name: Upload benchmark artifact
+        uses: actions/upload-artifact@v2.2.2
+        with:
+          name: benchmark-${{ runner.os }}-${{ matrix.python-version }}_${{
+            steps.artifact-name-suffix.outputs.datetime }}
+          path: .benchmarks/
+
 
   pytest-windows:
     name: Run tests Python ${{ matrix.python-version }} (Windows)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 2.*
   pull_request: ~
 
 env:

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ What's New in Pylint 2.7.2?
 ..
   Put bug fixes that will be cherry-picked to latest major version here
 
+* Fix False Positive on `Enum.__members__.items()`, `Enum.__members__.values`, and `Enum.__members__.keys`
+  
+  Closes #4123
+
 
 What's New in Pylint 2.7.1?
 ===========================

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,7 +13,6 @@ What's New in Pylint 2.7.2?
   Put bug fixes that will be cherry-picked to latest major version here
 
 * Fix False Positive on `Enum.__members__.items()`, `Enum.__members__.values`, and `Enum.__members__.keys`
-  
   Closes #4123
 
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ What's New in Pylint 2.8.0?
 ===========================
 
 
+* Don't check directories starting with '.' when using register_plugins
+
+  Closes #4119
+
 
 What's New in Pylint 2.7.0?
 ===========================

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,7 +4,19 @@ Pylint's ChangeLog
 
 What's New in Pylint 2.8.0?
 ===========================
+..
+  Put new features here
 
+What's New in Pylint 2.7.2?
+===========================
+..
+  Put bug fixes that will be cherry-picked to latest major version here
+
+
+What's New in Pylint 2.7.1?
+===========================
+
+* Expose `UnittestLinter` in pylint.testutils
 
 * Don't check directories starting with '.' when using register_plugins
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -510,9 +510,10 @@ def _emit_no_member(node, owner, owner_name, ignored_mixins=True, ignored_none=T
         and isinstance(owner.parent, astroid.ClassDef)
         and owner.parent.name == "EnumMeta"
         and owner_name == "__members__"
-        and node.attrname == "items"
+        and node.attrname in ["items", "values", "keys"]
     ):
-        # Avoid false positive on Enum.__members__.items()
+        print(node.attrname)
+        # Avoid false positive on Enum.__members__.{items(), values, keys}
         # See https://github.com/PyCQA/pylint/issues/4123
         return False
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -505,6 +505,17 @@ def _emit_no_member(node, owner, owner_name, ignored_mixins=True, ignored_none=T
                 return False
         except astroid.NotFoundError:
             return True
+    if (
+        owner.parent
+        and isinstance(owner.parent, astroid.ClassDef)
+        and owner.parent.name == "EnumMeta"
+        and owner_name == "__members__"
+        and node.attrname == "items"
+    ):
+        # Avoid false positive on Enum.__members__.items()
+        # See https://github.com/PyCQA/pylint/issues/4123
+        return False
+
     return True
 
 

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -248,7 +248,11 @@ def register_plugins(linter, directory):
         if (
             extension in PY_EXTS
             and base != "__init__"
-            or (not extension and os.path.isdir(os.path.join(directory, base)))
+            or (
+                not extension
+                and os.path.isdir(os.path.join(directory, base))
+                and not filename.startswith(".")
+            )
         ):
             try:
                 module = modutils.load_module_from_file(

--- a/tests/functional/m/member_checks.py
+++ b/tests/functional/m/member_checks.py
@@ -217,3 +217,13 @@ class SomeClassUsingSlice:
         else:
             self.attribute = []
             self.attribute.append(1)
+
+from enum import Enum
+class Animal(Enum):
+    ANT = 1
+    BEE = 2
+    CAT = 3
+    DOG = 4
+# To test false positive no-member on Enum.__members__.items()
+for itm in Animal.__members__.items():
+    print(itm)

--- a/tests/functional/m/member_checks.py
+++ b/tests/functional/m/member_checks.py
@@ -227,3 +227,7 @@ class Animal(Enum):
 # To test false positive no-member on Enum.__members__.items()
 for itm in Animal.__members__.items():
     print(itm)
+for keyy in Animal.__members__.keys:
+    print(keyy)
+for vall in Animal.__members__.values:
+    print(vall)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Fix #4123 issue about "False positive on `Enum.__members__.items()`". I add a conditional at `_emit_no_member` function in typecheck.py.

I am curious if there are any other cases similar to this one.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue
Closes #4123
