### PR TITLE
Fix benchmark test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -319,6 +319,55 @@ jobs:
           . venv/bin/activate
           coveralls --rcfile=${{ env.COVERAGERC_FILE }} --service=github
 
+  benchmark-linux:
+    name: Run benchmark tests Python ${{ matrix.python-version }} (Linux)
+    runs-on: ubuntu-latest
+    needs: prepare-tests-linux
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8, 3.9]
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.3.4
+      - name: Set up Python ${{ matrix.python-version }}
+        id: python
+        uses: actions/setup-python@v2.2.1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Restore Python virtual environment
+        id: cache-venv
+        uses: actions/cache@v2.1.4
+        with:
+          path: venv
+          key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            needs.prepare-tests-linux.outputs.python-key }}
+      - name: Fail job if Python cache restore failed
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore Python venv from cache"
+          exit 1
+      - name: Run pytest
+        run: |
+          . venv/bin/activate
+          pip install pygal
+          pip install -e .
+          pytest --exitfirst \
+            --benchmark-only \
+            --benchmark-autosave \
+            --benchmark-save-data \
+            --benchmark-group-by="group"
+      - name: Create partial artifact name suffix
+        id: artifact-name-suffix
+        run: >-
+          echo "::set-output name=datetime::"$(date "+%Y%m%d_%H%M")
+      - name: Upload benchmark artifact
+        uses: actions/upload-artifact@v2.2.2
+        with:
+          name: benchmark-${{ runner.os }}-${{ matrix.python-version }}_${{
+            steps.artifact-name-suffix.outputs.datetime }}
+          path: .benchmarks/
+
 
   pytest-windows:
     name: Run tests Python ${{ matrix.python-version }} (Windows)

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ What's New in Pylint 2.8.0?
 ===========================
 
 
+* Don't check directories starting with '.' when using register_plugins
+
+  Closes #4119
+
 
 What's New in Pylint 2.7.0?
 ===========================

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -248,7 +248,11 @@ def register_plugins(linter, directory):
         if (
             extension in PY_EXTS
             and base != "__init__"
-            or (not extension and os.path.isdir(os.path.join(directory, base)))
+            or (
+                not extension
+                and os.path.isdir(os.path.join(directory, base))
+                and not filename.startswith(".")
+            )
         ):
             try:
                 module = modutils.load_module_from_file(


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
This MR fixes the currently broken benchmark test and adds a CI job to run the benchmark every time.

The fix doesn't require any changes in astroid. The `register_plugins` didn't filter `.`-foldernames (eg. `.github`) and thus `modutils.load_module_from_file` was called. Astroid uses `importlib.import_module` which interprets the `.` as a relative import. I believe it's highly unlikely that some project would define their plugins in a hidden directory which is why I added a simply filter for it.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

Closes #4119

--

cc: @Pierre-Sassoulas, @hippo91 