### PR TITLE
Retcon the changelog after 2.7.1 release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,7 +4,19 @@ Pylint's ChangeLog
 
 What's New in Pylint 2.8.0?
 ===========================
+..
+  Put new features here
 
+What's New in Pylint 2.7.2?
+===========================
+..
+  Put bug fixes that will be cherry-picked to latest major version here
+
+
+What's New in Pylint 2.7.1?
+===========================
+
+* Expose `UnittestLinter` in pylint.testutils
 
 * Don't check directories starting with '.' when using register_plugins
 


### PR DESCRIPTION
## Description

Put both 2.7.2 and 2.8.0 in the changelog so cherry-picking is easier (also add the changelog created in 2.7 branch).

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |

| ✓  | :scroll: Docs |
