### PR TITLE
Run CI checks on every release branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 2.*
   pull_request: ~
 
 env:


### PR DESCRIPTION
## Description
I noticed that the CI checks where not run after a commit to a release branch (`2.7`). This small MR adds that.

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |