### PR TITLE
Improve flexibility for property decorated methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,10 @@ What's New in Pylint 2.7.2?
 What's New in Pylint 2.7.1?
 ===========================
 
+*Add more flexibility when checking whether method is decorated with property
+
+ Closes #4023
+
 * Expose `UnittestLinter` in pylint.testutils
 
 * Don't check directories starting with '.' when using register_plugins

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -778,15 +778,7 @@ def error_of_type(handler: astroid.ExceptHandler, error_type) -> bool:
 
 def decorated_with_property(node: astroid.FunctionDef) -> bool:
     """Detect if the given function node is decorated with a property. """
-    if not node.decorators:
-        return False
-    for decorator in node.decorators.nodes:
-        try:
-            if _is_property_decorator(decorator):
-                return True
-        except astroid.InferenceError:
-            pass
-    return False
+    return _bases._is_property(node)
 
 
 def _is_property_kind(node, *kinds):
@@ -812,20 +804,6 @@ def is_property_deleter(node: astroid.FunctionDef) -> bool:
 def is_property_setter_or_deleter(node: astroid.FunctionDef) -> bool:
     """Check if the given node is either a property setter or a deleter"""
     return _is_property_kind(node, "setter", "deleter")
-
-
-def _is_property_decorator(decorator: astroid.Name) -> bool:
-    for inferred in decorator.infer():
-        if isinstance(inferred, astroid.ClassDef):
-            if inferred.root().name == BUILTINS_NAME and inferred.name == "property":
-                return True
-            for ancestor in inferred.ancestors():
-                if (
-                    ancestor.name == "property"
-                    and ancestor.root().name == BUILTINS_NAME
-                ):
-                    return True
-    return False
 
 
 def decorated_with(

--- a/tests/checkers/unittest_classes.py
+++ b/tests/checkers/unittest_classes.py
@@ -97,6 +97,24 @@ class TestVariablesChecker(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
+    def test_property_decorated_method(self):
+        node = astroid.parse(
+            """
+        import functools
+        class Test():
+            @property
+            def test_property(self):
+                return 5
+
+        class Child(Test):
+            @functools.cached_property
+            def test_property(self):
+                return super().test_property + 5
+        """
+        )
+        with self.assertNoMessages():
+            self.walk(node)
+
     def test_uninferable_attribute(self):
         """Make sure protect-access doesn't raise an exception Uninferable attributes"""
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
When checking whether a method is decorated with property, only ``@property`` would be recognized as a possible property.

Signed-off-by: Tiago Honorato <tiagohonorato1@gmail.com>

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|  | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->

Closes #4023
