### PR TITLE
Properly strip dangerous sys.path entries (not just the first one)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -452,3 +452,5 @@ contributors:
 * Tiago Honorato: contributor
 
 * Lefteris Karapetsas: contributor
+
+* Louis Sautier: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,9 @@ What's New in Pylint 2.7.2?
 * Fix False Positive on `Enum.__members__.items()`, `Enum.__members__.values`, and `Enum.__members__.keys`
   Closes #4123
 
+* Properly strip dangerous sys.path entries (not just the first one)
+
+  Closes #3636
 
 What's New in Pylint 2.7.1?
 ===========================

--- a/pylint/__main__.py
+++ b/pylint/__main__.py
@@ -13,7 +13,6 @@ import pylint
 # inadvertently import user code from modules having the same name as
 # stdlib or pylint's own modules.
 # CPython issue: https://bugs.python.org/issue33053
-if sys.path[0] == "" or sys.path[0] == os.getcwd():
-    sys.path.pop(0)
+sys.path = [p for p in sys.path if p not in ("", os.getcwd())]
 
 pylint.run_pylint()

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -716,6 +716,24 @@ class TestRunTC:
                 cwd=str(tmpdir),
             )
 
+        # Appending a colon to PYTHONPATH should not break path stripping
+        # https://github.com/PyCQA/pylint/issues/3636
+        with tmpdir.as_cwd():
+            orig_pythonpath = os.environ.get("PYTHONPATH")
+            os.environ["PYTHONPATH"] = os.environ.get("PYTHONPATH", "") + ":"
+            subprocess.check_output(
+                [
+                    sys.executable,
+                    "-m",
+                    "pylint",
+                    "astroid.py",
+                    "--disable=import-error,unused-import",
+                ],
+                cwd=str(tmpdir),
+            )
+            if orig_pythonpath is not None:
+                os.environ["PYTHONPATH"] = orig_pythonpath
+
         # Linting this astroid file does not import it
         with tmpdir.as_cwd():
             subprocess.check_output(


### PR DESCRIPTION
Hello @PCManticore, can you please review this since you wrote the initial implementation of the `sys.path` fix?
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>` → **I don't think it is necessary, let me know if I am wrong**.
- [x] Write a good description on what the PR does.

## Description
 51c646bf70a6e0a86492bfd2ddd1885671d64d67 only stripped the first dangerous `sys.path` entry, causing problems when `PYTHONPATH` starts or ends with a colon.

This commit ensures all bad entries are removed. I consider this harmless but I might be wrong, please let me know if I am missing something.

I have added a new block to `test_do_not_import_files_from_local_directory` in order to make sure that pylint does not fail when `PYTHONPATH` ends with a colon. This test would always fail without the change to `pylint/__main__.py `


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #3636
-->
