### PR TITLE
Fix Enum invalid name with snake_case preset

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,6 @@ Release date: TBA
 ..
   Put new features here
 
-* Workflow and packaging improvements
 
 What's New in Pylint 2.7.3?
 ===========================
@@ -17,6 +16,10 @@ Release date: TBA
 
 ..
   Put bug fixes that will be cherry-picked to latest major version here
+
+* Fix issue with Enums and `class-attribute-naming-style=snake_case`
+
+  Closes #4149
 
 
 What's New in Pylint 2.7.2?
@@ -29,6 +32,9 @@ Release date: 2021-02-28
 * Properly strip dangerous sys.path entries (not just the first one)
 
   Closes #3636
+
+* Workflow and packaging improvements
+
 
 What's New in Pylint 2.7.1?
 ===========================

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1986,7 +1986,8 @@ class NameChecker(_BasicChecker):
                     if ancestor.name == "Enum" and ancestor.root().name == "enum":
                         self._check_name("const", node.name, node)
                         break
-                self._check_name("class_attribute", node.name, node)
+                else:
+                    self._check_name("class_attribute", node.name, node)
 
     def _recursive_check_names(self, args, node):
         """check names in a possibly recursive list <arg>"""

--- a/tests/functional/n/name_preset_snake_case.py
+++ b/tests/functional/n/name_preset_snake_case.py
@@ -1,4 +1,6 @@
 # pylint: disable=missing-docstring,too-few-public-methods
+from enum import Enum
+
 __version__ = "1.0"
 SOME_CONSTANT = 42  # [invalid-name]
 
@@ -21,3 +23,8 @@ class MyClass:  # [invalid-name]
 
 def sayHello():  # [invalid-name]
     pass
+
+
+class FooEnum(Enum):  # [invalid-name]
+    const_with_snake_case = 42
+    another_const = 43

--- a/tests/functional/n/name_preset_snake_case.txt
+++ b/tests/functional/n/name_preset_snake_case.txt
@@ -1,3 +1,4 @@
-invalid-name:3:0::"Constant name ""SOME_CONSTANT"" doesn't conform to snake_case naming style ('([^\\W\\dA-Z][^\\WA-Z]*|__.*__)$' pattern)"
-invalid-name:10:0:MyClass:"Class name ""MyClass"" doesn't conform to snake_case naming style ('[^\\W\\dA-Z][^\\WA-Z]+$' pattern)"
-invalid-name:22:0:sayHello:"Function name ""sayHello"" doesn't conform to snake_case naming style ('([^\\W\\dA-Z][^\\WA-Z]{2,}|_[^\\WA-Z]*|__[^\\WA-Z\\d_][^\\WA-Z]+__)$' pattern)"
+invalid-name:5:0::"Constant name ""SOME_CONSTANT"" doesn't conform to snake_case naming style ('([^\\W\\dA-Z][^\\WA-Z]*|__.*__)$' pattern)"
+invalid-name:12:0:MyClass:"Class name ""MyClass"" doesn't conform to snake_case naming style ('[^\\W\\dA-Z][^\\WA-Z]+$' pattern)"
+invalid-name:24:0:sayHello:"Function name ""sayHello"" doesn't conform to snake_case naming style ('([^\\W\\dA-Z][^\\WA-Z]{2,}|_[^\\WA-Z]*|__[^\\WA-Z\\d_][^\\WA-Z]+__)$' pattern)"
+invalid-name:28:0:FooEnum:"Class name ""FooEnum"" doesn't conform to snake_case naming style ('[^\\W\\dA-Z][^\\WA-Z]+$' pattern)"


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description
Fixes an issue where Enum constants would be name checked as `class_attributes` and thus the name preset didn't apply correctly. The Enum check was introduced with #3896

This could be included in a `2.7.3` release if that is planned.

cc: @iFreilicht


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

Closes: #4149