### PR TITLE
Fix sys.path bug

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,11 @@ Release date: TBA
 
   Close #3263
 
+* Fix issue when executing with ``python -m pylint``
+
+  Closes #4161
+
+
 What's New in Pylint 2.7.2?
 ===========================
 Release date: 2021-02-28

--- a/pylint/__main__.py
+++ b/pylint/__main__.py
@@ -3,16 +3,7 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
-import os
-import sys
-
 import pylint
 
-# Strip out the current working directory from sys.path.
-# Having the working directory in `sys.path` means that `pylint` might
-# inadvertently import user code from modules having the same name as
-# stdlib or pylint's own modules.
-# CPython issue: https://bugs.python.org/issue33053
-sys.path = [p for p in sys.path if p not in ("", os.getcwd())]
-
+pylint.modify_sys_path()
 pylint.run_pylint()

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -718,24 +718,6 @@ class TestRunTC:
                 cwd=str(tmpdir),
             )
 
-        # Appending a colon to PYTHONPATH should not break path stripping
-        # https://github.com/PyCQA/pylint/issues/3636
-        with tmpdir.as_cwd():
-            orig_pythonpath = os.environ.get("PYTHONPATH")
-            os.environ["PYTHONPATH"] = os.environ.get("PYTHONPATH", "") + ":"
-            subprocess.check_output(
-                [
-                    sys.executable,
-                    "-m",
-                    "pylint",
-                    "astroid.py",
-                    "--disable=import-error,unused-import",
-                ],
-                cwd=str(tmpdir),
-            )
-            if orig_pythonpath is not None:
-                os.environ["PYTHONPATH"] = orig_pythonpath
-
         # Linting this astroid file does not import it
         with tmpdir.as_cwd():
             subprocess.check_output(
@@ -764,6 +746,31 @@ class TestRunTC:
                 ],
                 cwd=str(tmpdir),
             )
+
+    @staticmethod
+    def test_do_not_import_files_from_local_directory_with_pythonpath(tmpdir):
+        p_astroid = tmpdir / "astroid.py"
+        p_astroid.write("'Docstring'\nimport completely_unknown\n")
+        p_hmac = tmpdir / "hmac.py"
+        p_hmac.write("'Docstring'\nimport completely_unknown\n")
+
+        # Appending a colon to PYTHONPATH should not break path stripping
+        # https://github.com/PyCQA/pylint/issues/3636
+        with tmpdir.as_cwd():
+            orig_pythonpath = os.environ.get("PYTHONPATH")
+            os.environ["PYTHONPATH"] = os.environ.get("PYTHONPATH", "") + ":"
+            subprocess.check_output(
+                [
+                    sys.executable,
+                    "-m",
+                    "pylint",
+                    "astroid.py",
+                    "--disable=import-error,unused-import",
+                ],
+                cwd=str(tmpdir),
+            )
+            if orig_pythonpath is not None:
+                os.environ["PYTHONPATH"] = orig_pythonpath
 
     def test_allow_import_of_files_found_in_modules_during_parallel_check(self, tmpdir):
         test_directory = tmpdir / "test_directory"


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
This MR changes how `sys.path` is stripped of dangerous paths. #4153 removed all mentions of `os.getcwd()` even if pylint was installed in editable mode. See #4161

It will now strip all **consecutive** entries from the beginning of `sys.path` and thus abort after it finds one path that should be kept.

@sbraz Would that work in your case? The tests are passing.

--
cc: @Pierre-Sassoulas 


## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #4161
