### PR TITLE
Don't reset similarities config to defaults in parallel mode

### DIFF
--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -427,7 +427,10 @@ class SimilarChecker(BaseChecker, Similar, MapReduceMixin):
         """Reduces and recombines data into a format that we can report on
 
         The partner function of get_map_data()"""
-        recombined = SimilarChecker(linter)
+        try:
+            recombined = linter._checkers["similarities"][0]
+        except:
+            recombined = SimilarChecker(linter)
         recombined.open()
         Similar.combine_mapreduce_data(recombined, linesets_collection=data)
         recombined.close()


### PR DESCRIPTION
When parallel mode is used (`--jobs 0`, `--jobs 2`, ...), the `similarities` checker seems to ignore the `min-similarity-lines` config values provided by the user. Instead it seems to use the builtin default value of 4. In "serial mode" (i.e. not specifying `--jobs`), this is not an issue.

The `reduce_map_data` method is a class method, so a new instance of the similarity checker is created. I narrowed down the issue to the fact that this instance is not configured. I'm not sure if this is the right way to fix this, but using the originally configured instance of this checker, instead of creating a new one, works.

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
