### PR TITLE
Wip - Puts issue #4118 under test - test min similarities

### DIFF
--- a/tests/checkers/unittest_similar.py
+++ b/tests/checkers/unittest_similar.py
@@ -447,6 +447,7 @@ min-similarity-lines={min_similarity_lines}
     return exit_code, stdout
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("min_similarity_lines", [0, 1, 4, 1000])
 def test_configuration_is_passed_to_workers(tmp_path, min_similarity_lines):
     """Tests check_parallel passes the configuration to sub-workers
@@ -506,6 +507,7 @@ persistent=no
     return exit_code, stdout
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("min_similarity_lines", [0, 1, 4, 1000])
 def test_configuration_is_passed_to_workers_cli(tmp_path, min_similarity_lines):
     exit_no_job, stdout_no_job = _simcheck_with_cli(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ from test_self import _patch_streams
 import pylint.lint
 
 
-def run_with_config_file(config_file, args):
+def run_with_config_file(config_file;Union[Path, str], args: List[str]) -> Tuple[runner?, int, str]:
     """Initialize and runs pylint with the given configuration filei and args.
 
     Returns tuple of (runner, exit_code)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description

Puts issue #4118 under test …
1b477cd
Taken in isolation, this commit may appear heavy-weight. The intent here
is to have a linter run and retain all state information about that run
so we can inspect what happened.

What this commit shows is that the checkers the linter knows about have
the right config, but still multi-job [MJ] runs are incorrect.
    see: assert checker.config.min_similarity_lines == min_similarity_lines

I think the MJ failiures are because SimilarChecker.reduce_map_data()
constructs a new SimilarChecker and then the linter doesn't call
set_option().

The process by which the set_option() calls are made in the normal run
is opaque to me, but perhaps someone else has a better idea(?).

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
