### PR TITLE
Exempt TypedDict from too-few-public-methods check

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,10 @@ Release date: TBA
 
   Closes #4161
 
+* Exempt ``typing.TypedDict`` from ``too-few-public-methods`` check.
+
+  Closes #4180
+
 
 What's New in Pylint 2.7.2?
 ===========================

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -95,16 +95,17 @@ SPECIAL_OBJ = re.compile("^_{2}[a-z]+_{2}$")
 DATACLASSES_DECORATORS = frozenset({"dataclass", "attrs"})
 DATACLASS_IMPORT = "dataclasses"
 TYPING_NAMEDTUPLE = "typing.NamedTuple"
+TYPING_TYPEDDICT = "typing.TypedDict"
 
 
 def _is_exempt_from_public_methods(node: astroid.ClassDef) -> bool:
     """Check if a class is exempt from too-few-public-methods"""
 
-    # If it's a typing.Namedtuple or an Enum
+    # If it's a typing.Namedtuple, typing.TypedDict or an Enum
     for ancestor in node.ancestors():
         if ancestor.name == "Enum" and ancestor.root().name == "enum":
             return True
-        if ancestor.qname() == TYPING_NAMEDTUPLE:
+        if ancestor.qname() in (TYPING_NAMEDTUPLE, TYPING_TYPEDDICT):
             return True
 
     # Or if it's a dataclass

--- a/tests/functional/t/typedDict.py
+++ b/tests/functional/t/typedDict.py
@@ -1,5 +1,5 @@
 """Test typing.TypedDict"""
-# pylint: disable=invalid-name,missing-class-docstring,too-few-public-methods
+# pylint: disable=invalid-name,missing-class-docstring
 import typing
 from typing import TypedDict
 


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Don't check `too-few-public-methods` for `typing.TypedDict`.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #4180