### PR TITLE
Fix false-positive no-member for typed annotations without default value

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,10 @@ Release date: TBA
 
   Closes #4180
 
+* Fix false-positive ``no-member`` for typed annotations without default value.
+
+  Closes #3167
+
 
 What's New in Pylint 2.7.2?
 ===========================

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -474,12 +474,7 @@ def _emit_no_member(node, owner, owner_name, ignored_mixins=True, ignored_none=T
 
         # Exclude typed annotations, since these might actually exist
         # at some point during the runtime of the program.
-        attribute = owner.locals.get(node.attrname, [None])[0]
-        if (
-            attribute
-            and isinstance(attribute, astroid.AssignName)
-            and isinstance(attribute.parent, astroid.AnnAssign)
-        ):
+        if utils.is_attribute_typed_annotation(owner, node.attrname):
             return False
     if isinstance(owner, objects.Super):
         # Verify if we are dealing with an invalid Super object.

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1435,3 +1435,27 @@ def is_classdef_type(node: astroid.ClassDef) -> bool:
         if isinstance(base, astroid.Name) and base.name == "type":
             return True
     return False
+
+
+def is_attribute_typed_annotation(
+    node: Union[astroid.ClassDef, astroid.Instance], attr_name: str
+) -> bool:
+    """Test if attribute is typed annotation in current node
+    or any base nodes.
+    """
+    attribute = node.locals.get(attr_name, [None])[0]
+    if (
+        attribute
+        and isinstance(attribute, astroid.AssignName)
+        and isinstance(attribute.parent, astroid.AnnAssign)
+    ):
+        return True
+    for base in node.bases:
+        inferred = safe_infer(base)
+        if (
+            inferred
+            and isinstance(inferred, astroid.ClassDef)
+            and is_attribute_typed_annotation(inferred, attr_name)
+        ):
+            return True
+    return False

--- a/tests/functional/m/member_checks_typed_annotations.py
+++ b/tests/functional/m/member_checks_typed_annotations.py
@@ -1,0 +1,25 @@
+# pylint: disable=missing-docstring,invalid-name,too-few-public-methods
+class A:
+    myfield: int
+
+class B(A):
+    pass
+
+class C:
+    pass
+
+class D(C, B):
+    pass
+
+
+a = A()
+print(a.myfield)
+
+b = B()
+print(b.myfield)
+
+d = D()
+print(d.myfield)
+
+c = C()
+print(c.myfield)  # [no-member]

--- a/tests/functional/m/member_checks_typed_annotations.txt
+++ b/tests/functional/m/member_checks_typed_annotations.txt
@@ -1,0 +1,1 @@
+no-member:25:6::Instance of 'C' has no 'myfield' member:INFERENCE


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Fix false-positive `no-member` for typed annotations without default value.

```py
class A:
    myfield: int

class B(A):
    pass

a = A()
print(a.myfield)

b = B()
print(b.myfield)  # No longer emits `no-member` warning 
```

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #3167 