### PR TITLE
Relax test's dependencies so we're not spammed by dependabot

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,9 +1,9 @@
 -r requirements_test_pre_commit.txt
 -r requirements_test_min.txt
-coveralls==3.0.0
-coverage==5.5
-pre-commit==2.10.1
-pyenchant==3.2.0
-pytest-cov==2.11.1
-pytest-profiling==1.7.0
-pytest-xdist==2.2.1
+coveralls~=3.0
+coverage~=5.5
+pre-commit~=2.10
+pyenchant~=3.2
+pytest-cov~=2.11
+pytest-profiling~=1.7
+pytest-xdist~=2.2

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,3 +1,3 @@
 astroid==2.5.1
-pytest==6.2.2
-pytest-benchmark==3.2.3
+pytest~=6.2
+pytest-benchmark~=3.2


### PR DESCRIPTION

## Description

Github dependabot is opening a PR for every single release of a lib otherwise. And we don't need to fix the test dependencies that accurately.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |
