### PR TITLE
Add python 3.10 dev in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
@@ -189,7 +189,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v2.3.4
@@ -321,7 +321,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
@@ -363,7 +363,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
     steps:
       - name: Set temp directory
         run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -469,7 +469,8 @@ def _emit_no_member(node, owner, owner_name, ignored_mixins=True, ignored_none=T
             except astroid.MroError:
                 return False
             if metaclass:
-                return metaclass.qname() == "enum.EnumMeta"
+                # Renamed in Python 3.10 to `EnumType`
+                return metaclass.qname() in ("enum.EnumMeta", "enum.EnumType")
             return False
         if not has_known_bases(owner):
             return False

--- a/pylint/testutils/get_test_info.py
+++ b/pylint/testutils/get_test_info.py
@@ -25,18 +25,18 @@ def _get_tests_info(input_dir, msg_dir, prefix, suffix):
         # filter input files :
         pyrestr = fbase.rsplit("_py", 1)[-1]  # like _26 or 26
         if pyrestr.isdigit():  # '24', '25'...
-            if SYS_VERS_STR < pyrestr:
+            if pyrestr.isdigit() and int(SYS_VERS_STR) < int(pyrestr):
                 continue
         if pyrestr.startswith("_") and pyrestr[1:].isdigit():
             # skip test for higher python versions
-            if SYS_VERS_STR >= pyrestr[1:]:
+            if pyrestr[1:].isdigit() and int(SYS_VERS_STR) >= int(pyrestr[1:]):
                 continue
         messages = glob(join(msg_dir, fbase + "*.txt"))
         # the last one will be without ext, i.e. for all or upper versions:
         if messages:
             for outfile in sorted(messages, reverse=True):
                 py_rest = outfile.rsplit("_py", 1)[-1][:-4]
-                if py_rest.isdigit() and SYS_VERS_STR >= py_rest:
+                if py_rest.isdigit() and int(SYS_VERS_STR) >= int(py_rest):
                     break
         else:
             # This will provide an error message indicating the missing filename.

--- a/tests/functional/m/member/member_checks_py37.py
+++ b/tests/functional/m/member/member_checks_py37.py
@@ -1,8 +1,8 @@
 # pylint: disable=missing-docstring
-import collections
+import collections.abc
 import asyncio
 
-isinstance([], collections.Iterable)
+isinstance([], collections.abc.Iterable)
 
 
 async def gen():

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -120,7 +120,7 @@ def gen_tests(filter_rgx):
         tests.append((module_file, messages_file, dependencies))
     if UPDATE_FILE.exists():
         return tests
-    assert len(tests) < 12, "Please do not add new test cases here." + "\n".join(
+    assert len(tests) < 13, "Please do not add new test cases here." + "\n".join(
         str(k) for k in tests if not k[2]
     )
     return tests

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -120,7 +120,7 @@ def gen_tests(filter_rgx):
         tests.append((module_file, messages_file, dependencies))
     if UPDATE_FILE.exists():
         return tests
-    assert len(tests) < 13, "Please do not add new test cases here." + "\n".join(
+    assert len(tests) < 12, "Please do not add new test cases here." + "\n".join(
         str(k) for k in tests if not k[2]
     )
     return tests

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -399,8 +399,10 @@ class TestRunTC:
         for key, value in expected.items():
             assert key in message
             assert message[key] == value
-        assert "invalid syntax" in message["message"].lower()
-        assert "<unknown>" in message["message"].lower()
+        msg = message["message"].lower()
+        assert any(x in msg for x in ["expected ':'", "invalid syntax"])
+        assert "<unknown>" in msg
+        assert "line 1" in msg
 
     def test_json_report_when_file_is_missing(self):
         out = StringIO()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4
-envlist = formatting, py36, py37, py38, py39, pypy, benchmark
+envlist = formatting, py36, py37, py38, py39, py310, pypy, benchmark
 skip_missing_interpreters = true
 
 [testenv:pylint]


### PR DESCRIPTION
## Description

In order to be ready when python 3.10 goes out. For python 3.9 we were a little late and we had to do everything almost at the time when it became the default python in the new debian. See #3959 

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |

