### PR TITLE
Fix tox -e pylint and pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,7 @@ repos:
         language: system
         types: [python]
         exclude: tests/functional/|tests/input|tests/extensions/data|tests/regrtest_data/|tests/data/|doc/
+        args: [--load-plugins=pylint.extensions.docparams, pylint.extensions.mccabe]
     -   id: fix-documentation
         name: Fix documentation
         entry: python3 -m script.fix_documentation

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
         language: system
         types: [python]
         exclude: tests/functional/|tests/input|tests/extensions/data|tests/regrtest_data/|tests/data/|doc/
-        args: [--load-plugins=pylint.extensions.docparams, pylint.extensions.mccabe]
+        args: [--load-plugins=pylint.extensions.docparams, pylint.extensions.mccabe, -rn]
     -   id: fix-documentation
         name: Fix documentation
         entry: python3 -m script.fix_documentation

--- a/examples/deprecation_checker.py
+++ b/examples/deprecation_checker.py
@@ -38,7 +38,7 @@ from module mymodule:
     ------------------------------------------------------------------
     Your code has been rated at 2.00/10 (previous run: 2.00/10, +0.00)
 """
-
+from typing import Set, Tuple
 
 from pylint.checkers import BaseChecker, DeprecatedMixin
 from pylint.interfaces import IAstroidChecker
@@ -56,7 +56,7 @@ class DeprecationChecker(DeprecatedMixin, BaseChecker):
     # The name defines a custom section of the config for this checker.
     name = "deprecated"
 
-    def deprecated_methods(self):
+    def deprecated_methods(self) -> Set:
         """Callback method called by DeprecatedMixin for every method/function found in the code.
 
         Returns:
@@ -64,7 +64,7 @@ class DeprecationChecker(DeprecatedMixin, BaseChecker):
         """
         return {"mymodule.deprecated_function", "mymodule.MyClass.deprecated_method"}
 
-    def deprecated_arguments(self, method: str):
+    def deprecated_arguments(self, method: str) -> Tuple:
         """Callback returning the deprecated arguments of method/function.
 
         Returns:

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
 """Checker mixin for deprecated functionality."""
-
+from collections.abc import Iterable
 from itertools import chain
 from typing import Any
 
@@ -39,20 +39,16 @@ class DeprecatedMixin:
         "deprecated-method",
         "deprecated-argument",
     )
-    def visit_call(self, node):
-        """Called when a :class:`.astroid.node_classes.Call` node is visited.
-
-        Args:
-            node (astroid.node_classes.Call): The node to check.
-        """
+    def visit_call(self, node: astroid.node_classes.Call) -> None:
+        """Called when a :class:`.astroid.node_classes.Call` node is visited."""
         try:
             for inferred in node.func.infer():
                 # Calling entry point for deprecation check logic.
                 self.check_deprecated_method(node, inferred)
         except astroid.InferenceError:
-            return
+            pass
 
-    def deprecated_methods(self):
+    def deprecated_methods(self) -> Iterable:
         """Callback returning the deprecated methods/functions.
 
         Returns:
@@ -61,7 +57,7 @@ class DeprecatedMixin:
         # pylint: disable=no-self-use
         return ()
 
-    def deprecated_arguments(self, method: str):
+    def deprecated_arguments(self, method: str) -> Iterable:
         """Callback returning the deprecated arguments of method/function.
 
         Args:

--- a/tox.ini
+++ b/tox.ini
@@ -7,32 +7,9 @@ skip_missing_interpreters = true
 [testenv:pylint]
 deps =
     -r {toxinidir}/requirements_test_min.txt
+    pre-commit==2.10.1
 commands =
-    # This would be greatly simplified by a solution for https://github.com/PyCQA/pylint/issues/352
-    pylint -rn --rcfile={toxinidir}/pylintrc --load-plugins=pylint.extensions.docparams, pylint.extensions.mccabe \
-    {toxinidir}/pylint \
-    {toxinidir}/tests/message/ \
-    {toxinidir}/tests/checkers/ \
-    {toxinidir}/tests/extensions/ \
-    {toxinidir}/tests/utils/ \
-    {toxinidir}/tests/acceptance/ \
-    {toxinidir}/tests/conftest.py \
-    {toxinidir}/tests/test_config.py \
-    {toxinidir}/tests/test_func.py \
-    {toxinidir}/tests/test_functional.py \
-    {toxinidir}/tests/test_import_graph.py \
-    {toxinidir}/tests/test_pragma_parser.py \
-    {toxinidir}/tests/test_pylint_runners.py \
-    {toxinidir}/tests/test_regr.py \
-    {toxinidir}/tests/test_self.py \
-    {toxinidir}/tests/unittest_config.py \
-    {toxinidir}/tests/lint/ \
-    {toxinidir}/tests/unittest_pyreverse_diadefs.py \
-    {toxinidir}/tests/unittest_pyreverse_inspector.py \
-    {toxinidir}/tests/unittest_pyreverse_writer.py \
-    {toxinidir}/tests/unittest_reporters_json.py \
-    {toxinidir}/tests/unittest_reporting.py
-
+    pre-commit run pylint --all-files
 
 [testenv:formatting]
 basepython = python3


### PR DESCRIPTION
## Description

The ``pre-commit run pylint`` command was not exactly the same than ``tox -e pylint``

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #4201 
