### PR TITLE
Typing changes + disable unused pylint plugin for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,8 +49,9 @@ repos:
         entry: pylint
         language: system
         types: [python]
+        args: ["-rn", "-sn", "--rcfile=pylintrc", "--load-plugins=pylint.extensions.docparams"]
+        # disabled plugins: pylint.extensions.mccabe
         exclude: tests/functional/|tests/input|tests/extensions/data|tests/regrtest_data/|tests/data/|doc/
-        args: [--load-plugins=pylint.extensions.docparams, pylint.extensions.mccabe, -rn]
     -   id: fix-documentation
         name: Fix documentation
         entry: python3 -m script.fix_documentation

--- a/examples/deprecation_checker.py
+++ b/examples/deprecation_checker.py
@@ -38,7 +38,7 @@ from module mymodule:
     ------------------------------------------------------------------
     Your code has been rated at 2.00/10 (previous run: 2.00/10, +0.00)
 """
-from typing import Set, Tuple
+from typing import Set, Tuple, Union
 
 from pylint.checkers import BaseChecker, DeprecatedMixin
 from pylint.interfaces import IAstroidChecker
@@ -56,7 +56,7 @@ class DeprecationChecker(DeprecatedMixin, BaseChecker):
     # The name defines a custom section of the config for this checker.
     name = "deprecated"
 
-    def deprecated_methods(self) -> Set:
+    def deprecated_methods(self) -> Set[str]:
         """Callback method called by DeprecatedMixin for every method/function found in the code.
 
         Returns:
@@ -64,7 +64,9 @@ class DeprecationChecker(DeprecatedMixin, BaseChecker):
         """
         return {"mymodule.deprecated_function", "mymodule.MyClass.deprecated_method"}
 
-    def deprecated_arguments(self, method: str) -> Tuple:
+    def deprecated_arguments(
+        self, method: str
+    ) -> Tuple[Tuple[Union[int, None], str], ...]:
         """Callback returning the deprecated arguments of method/function.
 
         Returns:

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -2,7 +2,6 @@
 # For details: https://github.com/PyCQA/pylint/blob/master/COPYING
 
 """Checker mixin for deprecated functionality."""
-from collections.abc import Iterable
 from itertools import chain
 from typing import Any, Container, Iterable, Tuple, Union
 

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -4,7 +4,7 @@
 """Checker mixin for deprecated functionality."""
 from collections.abc import Iterable
 from itertools import chain
-from typing import Any
+from typing import Any, Container, Iterable, Tuple, Union
 
 import astroid
 
@@ -39,7 +39,7 @@ class DeprecatedMixin:
         "deprecated-method",
         "deprecated-argument",
     )
-    def visit_call(self, node: astroid.node_classes.Call) -> None:
+    def visit_call(self, node: astroid.Call) -> None:
         """Called when a :class:`.astroid.node_classes.Call` node is visited."""
         try:
             for inferred in node.func.infer():
@@ -48,7 +48,7 @@ class DeprecatedMixin:
         except astroid.InferenceError:
             pass
 
-    def deprecated_methods(self) -> Iterable:
+    def deprecated_methods(self) -> Container[str]:
         """Callback returning the deprecated methods/functions.
 
         Returns:
@@ -57,7 +57,9 @@ class DeprecatedMixin:
         # pylint: disable=no-self-use
         return ()
 
-    def deprecated_arguments(self, method: str) -> Iterable:
+    def deprecated_arguments(
+        self, method: str
+    ) -> Iterable[Tuple[Union[int, None], str]]:
         """Callback returning the deprecated arguments of method/function.
 
         Args:

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
 commands =
     pre-commit run pylint --all-files
 
+
 [testenv:formatting]
 basepython = python3
 deps =


### PR DESCRIPTION
## Description
Followup to #4202. I noticed that the `pylint.extensions.mccabe` extension isn't loaded during the `pre-commit` check. There shouldn't be space between the extensions in the list. This was also an issue with the `tox` command. Enabling the extension results in multiple style warnings which is why I chose to disable it for now.

Furthermore, I added the `-sn` argument to hide the score during the pre-commit run and did some small typing changes.

cc: @Pierre-Sassoulas 

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
#4201