### PR TITLE
Fix false-positive for unused-import on class keyword arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -27,9 +27,12 @@ Release date: TBA
 ..
   Put bug fixes that will be cherry-picked to latest major version here
 
+* Bump ``astroid`` version to ``2.5.2``
+
 * Fix false positive for ``method-hidden`` when using private attribute and method
 
   Closes #3936
+
 * ``use-symbolic-message-instead`` now also works on legacy messages like ``C0111`` (``missing-docstring``).
 
 * Remove unwanted print to stdout from ``_emit_no_member``

--- a/ChangeLog
+++ b/ChangeLog
@@ -77,6 +77,10 @@ Release date: TBA
 
 * Improve check if class is subscriptable PEP585
 
+* Fix false-positive for ``unused-import`` on class keyword arguments
+
+  Closes #3202
+
 
 What's New in Pylint 2.7.2?
 ===========================

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -39,7 +39,7 @@ if dev_version is not None:
     version += "-dev" + str(dev_version)
 
 install_requires = [
-    "astroid>=2.5.1,<2.7",
+    "astroid>=2.5.2,<2.7",
     "isort>=4.2.5,<6",
     "mccabe>=0.6,<0.7",
     "toml>=0.7.1",

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -976,6 +976,14 @@ class VariablesChecker(BaseChecker):
             ):
                 continue
 
+            # Ignore inner class scope for keywords in class definition
+            if (
+                current_consumer.scope_type == "class"
+                and isinstance(node.parent, astroid.Keyword)
+                and isinstance(node.parent.parent, astroid.ClassDef)
+            ):
+                continue
+
             # if the name node is used as a function default argument's value or as
             # a decorator, then start from the parent frame of the function instead
             # of the function frame - and thus open an inner class scope

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,3 +1,3 @@
-astroid==2.5.1
+astroid==2.5.2
 pytest~=6.2
 pytest-benchmark~=3.2

--- a/tests/functional/u/unused/unused_import_class_def_keyword.py
+++ b/tests/functional/u/unused/unused_import_class_def_keyword.py
@@ -1,0 +1,38 @@
+"""
+Test false-positive for unused-import on class keyword arguments
+
+    https://github.com/PyCQA/pylint/issues/3202
+"""
+# pylint: disable=missing-docstring,too-few-public-methods,invalid-name,import-error
+
+# Imports don't exist! Only check `unused-import`
+from const import DOMAIN
+from const import DOMAIN_2
+from const import DOMAIN_3
+
+
+class Child:
+    def __init_subclass__(cls, **kwargs):
+        pass
+
+class Parent(Child, domain=DOMAIN):
+    pass
+
+
+# Alternative 1
+class Parent_2(Child, domain=DOMAIN_2):
+    DOMAIN_2 = DOMAIN_2
+
+
+# Alternative 2
+class A:
+    def __init__(self, arg):
+        pass
+
+class B:
+    CONF = "Hello World"
+    SCHEMA = A(arg=CONF)
+
+
+# Test normal instantiation
+A(arg=DOMAIN_3)


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Fix a false-positive the occurs after https://github.com/PyCQA/astroid/pull/919 is merged.

```py
from const import DOMAIN_2  # would be (falsely) flagged as unused-import

class Child:
    def __init_subclass__(cls, **kwargs):
        pass
class Parent_2(Child, domain=DOMAIN_2):
    DOMAIN_2 = DOMAIN_2
```
Furthermore, I added some test cases for #3202.

This MR depends on https://github.com/PyCQA/astroid/pull/919

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #3202
