### PR TITLE
tox: run formatting by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4
-envlist = py36, py37, py38, py39, pypy, pylint, benchmark
+envlist = formatting, py36, py37, py38, py39, pypy, benchmark
 skip_missing_interpreters = true
 
 


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor. (n/a)
- [x] Add a ChangeLog entry describing what your PR does. (n/a?)
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`. (n/a)
- [x] Write a good description on what the PR does.

## Description

Change tox to run formatting instead of pylint by default, to get
flake8, mypy, and other checks. Formatting runs first because some of
the pre-commit hooks may modify files.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Related Issue

Followup to https://github.com/PyCQA/pylint/issues/4201#issuecomment-792338107