### PR TITLE
Fix astroid.Inference error for undefined-variables with len()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -48,6 +48,10 @@ Release date: TBA
 
   Closes #4181
 
+* Fix astroid.Inference error for undefined-variables with ``len()```
+
+  Closes #4215
+
 
 What's New in Pylint 2.7.2?
 ===========================

--- a/pylint/checkers/refactoring/len_checker.py
+++ b/pylint/checkers/refactoring/len_checker.py
@@ -73,7 +73,11 @@ class LenChecker(checkers.BaseChecker):
             # The node is a generator or comprehension as in len([x for x in ...])
             self.add_message("len-as-condition", node=node)
             return
-        instance = next(len_arg.infer())
+        try:
+            instance = next(len_arg.infer())
+        except astroid.InferenceError:
+            # Probably undefined-varible, abort check
+            return
         mother_classes = self.base_classes_of_node(instance)
         affected_by_pep8 = any(
             t in mother_classes for t in ["str", "tuple", "list", "set"]

--- a/tests/functional/l/len_checks.py
+++ b/tests/functional/l/len_checks.py
@@ -175,3 +175,12 @@ def github_issue_1879():
     # assert len(function_returning_generator(z))
     # assert len(function_returning_comprehension(z))
     # assert len(function_returning_function(z))
+
+
+def github_issue_4215():
+    # Test undefined variables
+    # https://github.com/PyCQA/pylint/issues/4215
+    if len(undefined_var):  # [undefined-variable]
+        pass
+    if len(undefined_var2[0]):  # [undefined-variable]
+        pass

--- a/tests/functional/l/len_checks.txt
+++ b/tests/functional/l/len_checks.txt
@@ -21,3 +21,5 @@ len-as-condition:128:11:github_issue_1879:Do not use `len(SEQUENCE)` without com
 len-as-condition:129:11:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:130:11:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
 len-as-condition:171:11:github_issue_1879:Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty
+undefined-variable:183:11:github_issue_4215:Undefined variable 'undefined_var'
+undefined-variable:185:11:github_issue_4215:Undefined variable 'undefined_var2'


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Wrap `node.infer()` in `try ... except` to catch `astroid.InferenceError` if variable is undefined.
The error seems to be a result of https://github.com/PyCQA/pylint/commit/e50d7331e85a45cab09180cd4321bc91f3bde562

--

This could be included in `2.7.3`


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #4215 
