### PR TITLE
remove print call from _emit_no_member method

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,8 @@ Release date: TBA
   alternative to ``extension-pkg-whitelist`` and the message ``blacklisted-name`` is now emitted as
   ``disallowed-name``. The previous names are accepted to maintain backward compatibility.
 
+* Remove unwanted print to stdout from ``_emit_no_member``
+
 
 What's New in Pylint 2.7.3?
 ===========================

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -508,7 +508,6 @@ def _emit_no_member(node, owner, owner_name, ignored_mixins=True, ignored_none=T
         and owner_name == "__members__"
         and node.attrname in ["items", "values", "keys"]
     ):
-        print(node.attrname)
         # Avoid false positive on Enum.__members__.{items(), values, keys}
         # See https://github.com/PyCQA/pylint/issues/4123
         return False


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description

Pylint 2.7.2 has a left over print call in `_emit_no_member` this breaks the expected output using formats such as Junit from junit_pylint etc. It would be really nice if this fix was cherry-picked into pylint 2.7.3 as the output generated by 2.7.2 is currently invalid. 

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
