### PR TITLE
Fix changelog: print removal need to be in '2.7.3'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,8 +15,6 @@ Release date: TBA
   alternative to ``extension-pkg-whitelist`` and the message ``blacklisted-name`` is now emitted as
   ``disallowed-name``. The previous names are accepted to maintain backward compatibility.
 
-* Remove unwanted print to stdout from ``_emit_no_member``
-
 
 What's New in Pylint 2.7.3?
 ===========================
@@ -24,6 +22,8 @@ Release date: TBA
 
 ..
   Put bug fixes that will be cherry-picked to latest major version here
+
+* Remove unwanted print to stdout from ``_emit_no_member``
 
 * Introduce a command-line option to specify pyreverse output directory
 


### PR DESCRIPTION
## Description

Fixing the changelog following a mistake while reviewing #4230 

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

## Related Issue

#4230 
