### PR TITLE
Improve handling of assignment expressions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -71,6 +71,10 @@ Release date: TBA
 
   Closes #4218
 
+* Improve handling of assignment expressions, better edge case handling
+
+  Closes #3763, #4238
+
 
 What's New in Pylint 2.7.2?
 ===========================

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -8,6 +8,7 @@ from astroid.__pkginfo__ import version as astroid_version
 from pylint.__pkginfo__ import version as pylint_version
 
 PY38_PLUS = sys.version_info[:2] >= (3, 8)
+PY39_PLUS = sys.version_info[:2] >= (3, 9)
 PY310_PLUS = sys.version_info[:2] >= (3, 10)
 
 

--- a/tests/functional/a/assignment_expression.py
+++ b/tests/functional/a/assignment_expression.py
@@ -8,6 +8,9 @@ else:
     x = False
 
 x = b if (b := True) else False
+x2: bool = b2 if (b2 := True) else False
+x3 = 0
+x3 += b3 if (b3 := 4) else 6
 
 a = ["a   ", "b   ", "c   "]
 c = [text for el in a if (text := el.strip()) == "b"]
@@ -47,6 +50,24 @@ function = lambda: (
     i := h,
 )
 print(function())
+
+
+# https://github.com/PyCQA/pylint/issues/3763
+foo if (foo := 3 - 2) > 0 else 0  # [pointless-statement]
+
+
+# https://github.com/PyCQA/pylint/issues/4238
+l1 = f'The number {(count1 := 4)} ' \
+     f'is equal to {count1}'
+l2: str = (
+    f'The number {(count2 := 4)} '
+    f'is equal to {count2}'
+)
+l3 = "Hello "
+l3 += (
+    f'The number {(count3 := 4)} '
+    f'is equal to {count3}'
+)
 
 
 # check wrong usage

--- a/tests/functional/a/assignment_expression.txt
+++ b/tests/functional/a/assignment_expression.txt
@@ -1,3 +1,4 @@
-used-before-assignment:53:7::Using variable 'err_a' before assignment
-used-before-assignment:54:6::Using variable 'err_b' before assignment
-used-before-assignment:56:13::Using variable 'err_d' before assignment
+pointless-statement:56:0::Statement seems to have no effect
+used-before-assignment:74:7::Using variable 'err_a' before assignment
+used-before-assignment:75:6::Using variable 'err_b' before assignment
+used-before-assignment:77:13::Using variable 'err_d' before assignment


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Fixed some small issues with assignment expressions.

**Multiline strings**
```py
l1 = f'The number {(count1 := 4)} ' \
     f'is equal to {count1}'
```
This caused a `used-before-assignment` error in Python **3.8**. The root cause is in the builtin `ast` module. Until **3.9**, all nodes where parsed as being on the same line. I added some special case handling for it.
**However this might cause some errors to remain unnoticed!**

**Assignment expression with `Expr`**
```py
foo if (foo := 3 - 2) > 0 else 0
```

**Assignment expression with `AnnAssign` and `AugAssign`**
```py
x2: bool = b2 if (b2 := True) else False
x3 = 0
x3 += b3 if (b3 := 4) else 6
```

--

I believe this could be included with `2.7.3`



## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #3763
Closes #4238