### PR TITLE
Only print verbose logs if pytest -v

### DIFF
--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -94,11 +94,11 @@ TEST_WITH_EXPECTED_DEPRECATION = [
 
 
 @pytest.mark.parametrize("test_file", TESTS, ids=TESTS_NAMES)
-def test_functional(test_file, recwarn):
+def test_functional(test_file, recwarn, pytestconfig):
     if UPDATE_FILE.exists():
-        lint_test = LintModuleOutputUpdate(test_file)
+        lint_test = LintModuleOutputUpdate(test_file, pytestconfig)
     else:
-        lint_test = testutils.LintModuleTest(test_file)
+        lint_test = testutils.LintModuleTest(test_file, pytestconfig)
     lint_test.setUp()
     lint_test._runTest()
     warning = None


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Only print the verbose error log with the actual output if pytest is executed with `-v`.

--
CC: @Pierre-Sassoulas 

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Related Issue
https://github.com/PyCQA/pylint/pull/4240#issuecomment-808474047
