### PR TITLE
Fix regression with sys.path filter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -84,6 +84,10 @@ Release date: TBA
 
   Closes #3202
 
+* Fix regression with plugins on PYTHONPATH if latter is cwd
+
+  Closes #4252
+
 
 What's New in Pylint 2.7.2?
 ===========================

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -731,12 +731,16 @@ class TestRunTC:
             original_pythonpath = os.environ.get("PYTHONPATH")
             if new_pythonpath:
                 os.environ["PYTHONPATH"] = new_pythonpath
+            elif new_pythonpath is None and original_pythonpath is not None:
+                # If new_pythonpath is None, make sure to delete PYTHONPATH if present
+                del os.environ["PYTHONPATH"]
             try:
                 yield
             finally:
                 if original_pythonpath:
                     os.environ["PYTHONPATH"] = original_pythonpath
-                elif new_pythonpath:
+                elif new_pythonpath is not None:
+                    # Only delete PYTHONPATH if new_pythonpath wasn't None
                     del os.environ["PYTHONPATH"]
 
         with test_sys_path(), patch("os.getcwd") as mock_getcwd:
@@ -904,7 +908,7 @@ class TestRunTC:
         # https://github.com/PyCQA/pylint/issues/3636
         with tmpdir.as_cwd():
             orig_pythonpath = os.environ.get("PYTHONPATH")
-            os.environ["PYTHONPATH"] = os.environ.get("PYTHONPATH", "") + ":"
+            os.environ["PYTHONPATH"] = f"{(orig_pythonpath or '').strip(':')}:"
             subprocess.check_output(
                 [
                     sys.executable,


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
This MR fixes the regression with `sys.path` filter by checking `PYTHONPATH` **before** removing any additional entries.
This should fix the new issue (#4252) without undoing the previous one.

This should ideally be included in `2.7.3`

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #4252

Followup to
#4153
#4164

--
CC: @sbraz, @Pierre-Sassoulas