### PR TITLE
Fix various problems with --import-graph filename parsing

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -462,3 +462,5 @@ contributors:
 * Mark Byrne: contributor
 
 * Konstantina Saketou: contributor
+
+* Andrew Howe: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -77,6 +77,8 @@ Release date: TBA
 
 * Improve check if class is subscriptable PEP585
 
+* Fix documentation and filename handling of --import-graph
+
 
 What's New in Pylint 2.7.2?
 ===========================

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -177,7 +177,7 @@ def _repr_tree_defs(data, indent_str=None):
 def _dependencies_graph(filename, dep_info):
     """write dependencies as a dot (graphviz) file"""
     done = {}
-    printer = DotBackend(filename[:-4], rankdir="LR")
+    printer = DotBackend(os.path.splitext(os.path.basename(filename))[0], rankdir="LR")
     printer.emit('URL="." node[shape="box"]')
     for modname, dependencies in sorted(dep_info.items()):
         done[modname] = 1
@@ -189,15 +189,15 @@ def _dependencies_graph(filename, dep_info):
     for depmodname, dependencies in sorted(dep_info.items()):
         for modname in dependencies:
             printer.emit_edge(modname, depmodname)
-    printer.generate(filename)
+    return printer.generate(filename)
 
 
 def _make_graph(filename, dep_info, sect, gtype):
     """generate a dependencies graph and add some information about it in the
     report's section
     """
-    _dependencies_graph(filename, dep_info)
-    sect.append(Paragraph(f"{gtype}imports graph has been written to {filename}"))
+    outputfile = _dependencies_graph(filename, dep_info)
+    sect.append(Paragraph(f"{gtype}imports graph has been written to {outputfile}"))
 
 
 # the import checker itself ###################################################
@@ -334,9 +334,9 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             {
                 "default": "",
                 "type": "string",
-                "metavar": "<file.dot>",
-                "help": "Create a graph of every (i.e. internal and"
-                " external) dependencies in the given file"
+                "metavar": "<file.gv>",
+                "help": "Output a graph (.gv or any supported image format) of"
+                " all (i.e. internal and external) dependencies to the given file"
                 " (report RP0402 must not be disabled).",
             },
         ),
@@ -345,9 +345,10 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             {
                 "default": "",
                 "type": "string",
-                "metavar": "<file.dot>",
-                "help": "Create a graph of external dependencies in the"
-                " given file (report RP0402 must not be disabled).",
+                "metavar": "<file.gv>",
+                "help": "Output a graph (.gv or any supported image format)"
+                " of external dependencies to the given file"
+                " (report RP0402 must not be disabled).",
             },
         ),
         (
@@ -355,9 +356,10 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             {
                 "default": "",
                 "type": "string",
-                "metavar": "<file.dot>",
-                "help": "Create a graph of internal dependencies in the"
-                " given file (report RP0402 must not be disabled).",
+                "metavar": "<file.gv>",
+                "help": "Output a graph (.gv or any supported image format)"
+                " of internal dependencies to the given file"
+                " (report RP0402 must not be disabled).",
             },
         ),
         (

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -44,6 +44,7 @@ import copy
 import os
 import sys
 from distutils import sysconfig
+from typing import Dict, List
 
 import astroid
 from astroid import modutils
@@ -58,7 +59,7 @@ from pylint.checkers.utils import (
 from pylint.exceptions import EmptyReportError
 from pylint.graph import DotBackend, get_cycles
 from pylint.interfaces import IAstroidChecker
-from pylint.reporters.ureports.nodes import Paragraph, VerbatimText
+from pylint.reporters.ureports.nodes import Paragraph, VerbatimText, VNode
 from pylint.utils import IsortDriver, get_global_option
 
 
@@ -174,7 +175,7 @@ def _repr_tree_defs(data, indent_str=None):
     return "\n".join(lines)
 
 
-def _dependencies_graph(filename, dep_info):
+def _dependencies_graph(filename: str, dep_info: Dict[str, List[str]]) -> str:
     """write dependencies as a dot (graphviz) file"""
     done = {}
     printer = DotBackend(os.path.splitext(os.path.basename(filename))[0], rankdir="LR")
@@ -192,7 +193,7 @@ def _dependencies_graph(filename, dep_info):
     return printer.generate(filename)
 
 
-def _make_graph(filename, dep_info, sect, gtype):
+def _make_graph(filename: str, dep_info: Dict[str, List[str]], sect: VNode, gtype: str):
     """generate a dependencies graph and add some information about it in the
     report's section
     """

--- a/pylint/graph.py
+++ b/pylint/graph.py
@@ -18,6 +18,7 @@
 """
 import codecs
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -28,7 +29,7 @@ def target_info_from_filename(filename):
     """Transforms /some/path/foo.png into ('/some/path', 'foo.png', 'png')."""
     basename = osp.basename(filename)
     storedir = osp.dirname(osp.abspath(filename))
-    target = filename.split(".")[-1]
+    target = osp.splitext(filename)[-1][1:]
     return storedir, basename, target
 
 
@@ -84,25 +85,36 @@ class DotBackend:
 
         :rtype: str
         :return: a path to the generated file
+        :raises RuntimeError: if the executable for rendering was not found
         """
+        graphvis_extensions = ("dot", "gv")
         name = self.graphname
         if outputfile is not None:
             _, _, target = target_info_from_filename(outputfile)
-            if target != "dot":
-                pdot, dot_sourcepath = tempfile.mkstemp(".dot", name)
+            if not target:
+                target = "png"
+                outputfile = outputfile + "." + target
+            if target not in graphvis_extensions:
+                pdot, dot_sourcepath = tempfile.mkstemp(".gv", name)
                 os.close(pdot)
             else:
                 dot_sourcepath = outputfile
         else:
             target = "png"
-            pdot, dot_sourcepath = tempfile.mkstemp(".dot", name)
+            pdot, dot_sourcepath = tempfile.mkstemp(".gv", name)
             ppng, outputfile = tempfile.mkstemp(".png", name)
             os.close(pdot)
             os.close(ppng)
         pdot = codecs.open(dot_sourcepath, "w", encoding="utf8")
         pdot.write(self.source)
         pdot.close()
-        if target != "dot":
+        if target not in graphvis_extensions:
+            if shutil.which(self.renderer) is None:
+                raise RuntimeError(
+                    f"Cannot generate `{outputfile}` because '{self.renderer}' "
+                    "executable not found. Install Graphvis, or specify a `.gv` "
+                    "outputfile to produce the DOT source code."
+                )
             use_shell = sys.platform == "win32"
             if mapfile:
                 subprocess.call(

--- a/pylint/graph.py
+++ b/pylint/graph.py
@@ -77,7 +77,7 @@ class DotBackend:
 
     source = property(get_source)
 
-    def generate(self, outputfile=None, mapfile=None):
+    def generate(self, outputfile: str = None, mapfile: str = None) -> str:
         """Generates a graph file.
 
         :param str outputfile: filename and path [defaults to graphname.png]
@@ -87,32 +87,32 @@ class DotBackend:
         :return: a path to the generated file
         :raises RuntimeError: if the executable for rendering was not found
         """
-        graphvis_extensions = ("dot", "gv")
+        graphviz_extensions = ("dot", "gv")
         name = self.graphname
-        if outputfile is not None:
-            _, _, target = target_info_from_filename(outputfile)
-            if not target:
-                target = "png"
-                outputfile = outputfile + "." + target
-            if target not in graphvis_extensions:
-                pdot, dot_sourcepath = tempfile.mkstemp(".gv", name)
-                os.close(pdot)
-            else:
-                dot_sourcepath = outputfile
-        else:
+        if outputfile is None:
             target = "png"
             pdot, dot_sourcepath = tempfile.mkstemp(".gv", name)
             ppng, outputfile = tempfile.mkstemp(".png", name)
             os.close(pdot)
             os.close(ppng)
-        pdot = codecs.open(dot_sourcepath, "w", encoding="utf8")
-        pdot.write(self.source)
-        pdot.close()
-        if target not in graphvis_extensions:
+        else:
+            _, _, target = target_info_from_filename(outputfile)
+            if not target:
+                target = "png"
+                outputfile = outputfile + "." + target
+            if target not in graphviz_extensions:
+                pdot, dot_sourcepath = tempfile.mkstemp(".gv", name)
+                os.close(pdot)
+            else:
+                dot_sourcepath = outputfile
+        pdot = codecs.open(dot_sourcepath, "w", encoding="utf8")  # type: ignore
+        pdot.write(self.source)  # type: ignore
+        pdot.close()  # type: ignore
+        if target not in graphviz_extensions:
             if shutil.which(self.renderer) is None:
                 raise RuntimeError(
                     f"Cannot generate `{outputfile}` because '{self.renderer}' "
-                    "executable not found. Install Graphvis, or specify a `.gv` "
+                    "executable not found. Install graphviz, or specify a `.gv` "
                     "outputfile to produce the DOT source code."
                 )
             use_shell = sys.platform == "win32"

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -63,8 +63,8 @@ URL="." node[shape="box"]
 
 
 @pytest.mark.parametrize("filename", ["graph.png", "graph"])
-def test_missing_graphvis(filename):
-    """Raises if graphvis is not installed, and defaults to png if no extension given"""
+def test_missing_graphviz(filename):
+    """Raises if graphviz is not installed, and defaults to png if no extension given"""
     with pytest.raises(RuntimeError, match=r"Cannot generate `graph\.png`.*"):
         imports._dependencies_graph(filename, {"a": ["b", "c"], "b": ["c"]})
 

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -26,8 +26,8 @@ from pylint.lint import PyLinter
 
 
 @pytest.fixture
-def dest():
-    dest = "dependencies_graph.dot"
+def dest(request):
+    dest = request.param
     yield dest
     try:
         os.remove(dest)
@@ -36,13 +36,18 @@ def dest():
         pass
 
 
+POSSIBLE_DOT_FILENAMES = ["foo.dot", "foo.gv", "tests/regrtest_data/foo.dot"]
+
+
+@pytest.mark.parametrize("dest", POSSIBLE_DOT_FILENAMES, indirect=True)
 def test_dependencies_graph(dest):
+    """DOC files are correctly generated, and the graphname is the basename"""
     imports._dependencies_graph(dest, {"labas": ["hoho", "yep"], "hoho": ["yep"]})
     with open(dest) as stream:
         assert (
             stream.read().strip()
             == """
-digraph "dependencies_graph" {
+digraph "foo" {
 rankdir=LR
 charset="utf-8"
 URL="." node[shape="box"]
@@ -55,6 +60,13 @@ URL="." node[shape="box"]
 }
 """.strip()
         )
+
+
+@pytest.mark.parametrize("filename", ["graph.png", "graph"])
+def test_missing_graphvis(filename):
+    """Raises if graphvis is not installed, and defaults to png if no extension given"""
+    with pytest.raises(RuntimeError, match=r"Cannot generate `graph\.png`.*"):
+        imports._dependencies_graph(filename, {"a": ["b", "c"], "b": ["c"]})
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description
The pre-existing code looks extremely dodgy, but I've tried to avoid making any backwards-incompatible changes while fixing some problems that made it very difficult to work out how to use this option.

Changes:
 - Raise error if graphvis is not installed (instead of mistakenly reporting success)
 - Fix tempfile creation bug when outputfile includes directories
 - Fix bug when using file extension that isn't 3 characters long
 - Fix confusing help text
 - Rename deprecated .dot extension to .gv
 - Default to .png if no extension is specified

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
