### PR TITLE
Fix issue with annotated class constants

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,9 @@ Release date: Undefined
 ..
   Put bug fixes that will be cherry-picked to latest major version here
 
+* Fix issue with annotated class constants
+
+  * Closes #4264
 
 
 What's New in Pylint 2.7.3?

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1461,9 +1461,16 @@ def is_attribute_typed_annotation(
 
 def is_class_var(node: astroid.AssignName) -> bool:
     """Test if node has `ClassVar` annotation."""
-    return isinstance(node.parent, astroid.AnnAssign) and (
-        isinstance(node.parent.annotation, astroid.Subscript)
-        and node.parent.annotation.value.name == "ClassVar"
-        or isinstance(node.parent.annotation, astroid.Name)
-        and node.parent.annotation.name == "ClassVar"
-    )
+    if not isinstance(node.parent, astroid.AnnAssign):
+        return False
+    annotation = node.parent.annotation
+    if isinstance(annotation, astroid.Subscript):
+        annotation = annotation.value
+    if (
+        isinstance(annotation, astroid.Name)
+        and annotation.name == "ClassVar"
+        or isinstance(annotation, astroid.Attribute)
+        and annotation.attrname == "ClassVar"
+    ):
+        return True
+    return False

--- a/tests/functional/n/name/name_styles.py
+++ b/tests/functional/n/name/name_styles.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 import abc
 import collections
+import typing
 from enum import Enum
 from typing import ClassVar
 
@@ -154,3 +155,5 @@ class Bar:
     CLASS_CONST: ClassVar[int] = 42
     CLASS_CONST2: ClassVar = "const"
     variable: ClassVar[str] = "invalid name"  # [invalid-name]
+    CLASS_CONST3: typing.ClassVar
+    variable2: typing.ClassVar[int]  # [invalid-name]

--- a/tests/functional/n/name/name_styles.txt
+++ b/tests/functional/n/name/name_styles.txt
@@ -1,18 +1,19 @@
-invalid-name:10:0::"Constant name ""bad_const_name"" doesn't conform to UPPER_CASE naming style"
-invalid-name:13:0:BADFUNCTION_name:"Function name ""BADFUNCTION_name"" doesn't conform to snake_case naming style"
-invalid-name:15:4:BADFUNCTION_name:"Variable name ""BAD_LOCAL_VAR"" doesn't conform to snake_case naming style"
-invalid-name:19:0:func_bad_argname:"Argument name ""NOT_GOOD"" doesn't conform to snake_case naming style"
-invalid-name:29:0:bad_class_name:"Class name ""bad_class_name"" doesn't conform to PascalCase naming style"
-invalid-name:40:8:CorrectClassName.__init__:"Attribute name ""_Bad_AtTR_name"" doesn't conform to snake_case naming style"
-invalid-name:41:8:CorrectClassName.__init__:"Attribute name ""Bad_PUBLIC_name"" doesn't conform to snake_case naming style"
-invalid-name:46:4:CorrectClassName.BadMethodName:"Method name ""BadMethodName"" doesn't conform to snake_case naming style":INFERENCE
-invalid-name:52:4:CorrectClassName.__DunDER_IS_not_free_for_all__:"Method name ""__DunDER_IS_not_free_for_all__"" doesn't conform to snake_case naming style":INFERENCE
-invalid-name:82:0::"Class name ""BAD_NAME_FOR_CLASS"" doesn't conform to PascalCase naming style"
-invalid-name:83:0::"Class name ""NEXT_BAD_NAME_FOR_CLASS"" doesn't conform to PascalCase naming style"
-invalid-name:90:0::"Class name ""NOT_CORRECT"" doesn't conform to PascalCase naming style"
-invalid-name:96:4:test_globals:"Constant name ""AlsoCorrect"" doesn't conform to UPPER_CASE naming style"
-invalid-name:109:4:FooClass.PROPERTY_NAME:"Attribute name ""PROPERTY_NAME"" doesn't conform to snake_case naming style":INFERENCE
-invalid-name:114:4:FooClass.ABSTRACT_PROPERTY_NAME:"Attribute name ""ABSTRACT_PROPERTY_NAME"" doesn't conform to snake_case naming style":INFERENCE
-invalid-name:119:4:FooClass.PROPERTY_NAME_SETTER:"Attribute name ""PROPERTY_NAME_SETTER"" doesn't conform to snake_case naming style":INFERENCE
-invalid-name:150:4:FooEnum:"Class constant name ""bad_enum_name"" doesn't conform to UPPER_CASE naming style"
-invalid-name:156:4:Bar:"Class constant name ""variable"" doesn't conform to UPPER_CASE naming style"
+invalid-name:11:0::"Constant name ""bad_const_name"" doesn't conform to UPPER_CASE naming style"
+invalid-name:14:0:BADFUNCTION_name:"Function name ""BADFUNCTION_name"" doesn't conform to snake_case naming style"
+invalid-name:16:4:BADFUNCTION_name:"Variable name ""BAD_LOCAL_VAR"" doesn't conform to snake_case naming style"
+invalid-name:20:0:func_bad_argname:"Argument name ""NOT_GOOD"" doesn't conform to snake_case naming style"
+invalid-name:30:0:bad_class_name:"Class name ""bad_class_name"" doesn't conform to PascalCase naming style"
+invalid-name:41:8:CorrectClassName.__init__:"Attribute name ""_Bad_AtTR_name"" doesn't conform to snake_case naming style"
+invalid-name:42:8:CorrectClassName.__init__:"Attribute name ""Bad_PUBLIC_name"" doesn't conform to snake_case naming style"
+invalid-name:47:4:CorrectClassName.BadMethodName:"Method name ""BadMethodName"" doesn't conform to snake_case naming style":INFERENCE
+invalid-name:53:4:CorrectClassName.__DunDER_IS_not_free_for_all__:"Method name ""__DunDER_IS_not_free_for_all__"" doesn't conform to snake_case naming style":INFERENCE
+invalid-name:83:0::"Class name ""BAD_NAME_FOR_CLASS"" doesn't conform to PascalCase naming style"
+invalid-name:84:0::"Class name ""NEXT_BAD_NAME_FOR_CLASS"" doesn't conform to PascalCase naming style"
+invalid-name:91:0::"Class name ""NOT_CORRECT"" doesn't conform to PascalCase naming style"
+invalid-name:97:4:test_globals:"Constant name ""AlsoCorrect"" doesn't conform to UPPER_CASE naming style"
+invalid-name:110:4:FooClass.PROPERTY_NAME:"Attribute name ""PROPERTY_NAME"" doesn't conform to snake_case naming style":INFERENCE
+invalid-name:115:4:FooClass.ABSTRACT_PROPERTY_NAME:"Attribute name ""ABSTRACT_PROPERTY_NAME"" doesn't conform to snake_case naming style":INFERENCE
+invalid-name:120:4:FooClass.PROPERTY_NAME_SETTER:"Attribute name ""PROPERTY_NAME_SETTER"" doesn't conform to snake_case naming style":INFERENCE
+invalid-name:151:4:FooEnum:"Class constant name ""bad_enum_name"" doesn't conform to UPPER_CASE naming style"
+invalid-name:157:4:Bar:"Class constant name ""variable"" doesn't conform to UPPER_CASE naming style"
+invalid-name:159:4:Bar:"Class constant name ""variable2"" doesn't conform to UPPER_CASE naming style"


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
This MR fixes an issue introduced with #4185. The error occurs if a class var with an annotation subscript, that is an attribute, is parsed. See example below
```py
import typing
from typing import List

import custom_path


class Custom:
    var: List[int]
    var2: typing.List[int]  # error

    var3: custom_path.MyOtherClass  # works
```

A workaround, until a new version is released, would be to not use attribute access for class variable annotations with subscript. Instead import the name directly, eg. `from typing import List`.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #4264
