### PR TITLE
Allow protected-access in class methods

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -464,3 +464,5 @@ contributors:
 * Konstantina Saketou: contributor
 
 * Andrew Howe: contributor
+
+* James Sinclair (irgeek): contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,11 @@ Release date: Undefined
 ..
   Put bug fixes that will be cherry-picked to latest major version here
 
+* Improved protected access checks to allow access inside class methods
+
+  Closes #1159
+
+
 
 
 What's New in Pylint 2.7.3?

--- a/doc/whatsnew/2.7.rst
+++ b/doc/whatsnew/2.7.rst
@@ -56,3 +56,5 @@ Other Changes
 * Fixes duplicate code detection for --jobs=2+
 
 * New option ``allowed-redefined-builtins`` defines variable names allowed to shadow builtins.
+
+* Improved protected access checks to allow access inside class methods

--- a/tests/functional/a/access/access_to_protected_members.py
+++ b/tests/functional/a/access/access_to_protected_members.py
@@ -99,3 +99,115 @@ class Issue1802(object):
         if isinstance(other, self.__class__):
             return self._foo == other._foo  # [protected-access]
         return False
+
+
+class Issue1159OtherClass(object):
+    """Test for GitHub issue 1159"""
+
+    _foo = 0
+
+    def __init__(self):
+        self._bar = 0
+
+
+class Issue1159(object):
+    """Test for GitHub issue 1159"""
+
+    _foo = 0
+
+    def __init__(self):
+        self._bar = 0
+
+    @classmethod
+    def access_cls_attr(cls):
+        """
+        Access to protected class members inside class methods is OK.
+        """
+
+        _ = cls._foo
+
+    @classmethod
+    def assign_cls_attr(cls):
+        """
+        Assignment to protected class members inside class methods is OK.
+        """
+
+        cls._foo = 1
+
+    @classmethod
+    def access_inst_attr(cls):
+        """
+        Access to protected instance members inside class methods is OK.
+        """
+
+        instance = cls()
+        _ = instance._bar
+
+    @classmethod
+    def assign_inst_attr(cls):
+        """
+        Assignment to protected members inside class methods is OK.
+        """
+
+        instance = cls()
+        instance._bar = 1
+
+    @classmethod
+    def access_other_attr(cls):
+        """
+        Access to protected instance members of other classes is not OK.
+        """
+
+        instance = Issue1159OtherClass()
+        instance._bar = 3  # [protected-access]
+        _ = instance._foo  # [protected-access]
+
+
+class Issue1159Subclass(Issue1159):
+    """Test for GitHub issue 1159"""
+
+    @classmethod
+    def access_inst_attr(cls):
+        """
+        Access to protected instance members inside class methods is OK.
+        """
+
+        instance = cls()
+        _ = instance._bar
+
+    @classmethod
+    def assign_inst_attr(cls):
+        """
+        Assignment to protected instance members inside class methods is OK.
+        """
+
+        instance = cls()
+        instance._bar = 1
+
+    @classmethod
+    def access_missing_member(cls):
+        """
+        Access to unassigned members inside class methods is not OK.
+        """
+
+        instance = cls()
+        _ = instance._baz  # [no-member,protected-access]
+
+    @classmethod
+    def assign_missing_member(cls):
+        """
+        Defining attributes outside init is still not OK.
+        """
+
+        instance = cls()
+        instance._qux = 1  # [attribute-defined-outside-init]
+
+    @classmethod
+    def access_other_attr(cls):
+        """
+        Access to protected instance members of other classes is not OK.
+        """
+
+        instance = Issue1159OtherClass()
+        instance._bar = 3  # [protected-access]
+        _ = instance._foo  # [protected-access]

--- a/tests/functional/a/access/access_to_protected_members.txt
+++ b/tests/functional/a/access/access_to_protected_members.txt
@@ -7,3 +7,10 @@ protected-access:58:19:Issue1031.incorrect_access:Access to a protected member _
 protected-access:72:48:Issue1802.__eq__:Access to a protected member __private of a client class
 protected-access:80:32:Issue1802.not_in_special:Access to a protected member _foo of a client class
 protected-access:100:32:Issue1802.__fake_special__:Access to a protected member _foo of a client class
+protected-access:162:8:Issue1159.access_other_attr:Access to a protected member _bar of a client class
+protected-access:163:12:Issue1159.access_other_attr:Access to a protected member _foo of a client class
+no-member:194:12:Issue1159Subclass.access_missing_member:Instance of 'Issue1159Subclass' has no '_baz' member; maybe '_bar'?:INFERENCE
+protected-access:194:12:Issue1159Subclass.access_missing_member:Access to a protected member _baz of a client class
+attribute-defined-outside-init:203:8:Issue1159Subclass.assign_missing_member:Attribute '_qux' defined outside __init__
+protected-access:212:8:Issue1159Subclass.access_other_attr:Access to a protected member _bar of a client class
+protected-access:213:12:Issue1159Subclass.access_other_attr:Access to a protected member _foo of a client class


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

This is a pretty basic change to allow accessing protected member inside class methods. It performs three checks:

1. Are we in a class method
2. Is the inferred value of the access expression an instance of the class
3. Is the attribute name being accessed an instance or class member of the class

If all three check out, then we allow access to protected members.

I've added tests for the new behaviour, as well as some (potentially redundant) tests to make sure I wasn't picking up attributes of other classes.

I wasn't 100% sure about how to structure the change log entries, but I've added what I thought was correct. If they need to be amended I can certainly do that.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Related Issue

Closes #1159