### PR TITLE
Fix PEP 585 - collections.abc.Set

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,8 @@ Release date: Undefined
 ..
   Put bug fixes that will be cherry-picked to latest major version here
 
+* Fix issue with PEP 585 syntax and the use of ``collections.abc.Set``
+
 
 What's New in Pylint 2.7.4?
 ===========================

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -251,7 +251,7 @@ SUBSCRIPTABLE_CLASSES_PEP585 = frozenset(
         "_collections_abc.Container",
         "_collections_abc.Collection",
         "_collections_abc.Callable",
-        "_collections_abc.Set # typing.AbstractSet",
+        "_collections_abc.Set",
         "_collections_abc.MutableSet",
         "_collections_abc.Mapping",
         "_collections_abc.MutableMapping",


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Fix an issue introduced with the last refactoring of the PEP 585 syntax. `collections.abc.Set` wouldn't be identified correctly, since the `qname()` string contained a comment that should have been deleted.

/CC: @Pierre-Sassoulas, @hippo91 


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
--
