### PR TITLE
Fix class-const naming style

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,12 @@ Release date: Undefined
 
 * Fix issue with PEP 585 syntax and the use of ``collections.abc.Set``
 
+* Fix issue that caused class variables annotated with ``typing.ClassVar`` to be
+  identified as class constants. Now, class variables annotated with
+  ``typing.Final`` are identified as such.
+
+  Closes #4277
+
 
 What's New in Pylint 2.7.4?
 ===========================
@@ -31,7 +37,7 @@ Release date: 2021-03-30
 
 * Fix issue with annotated class constants
 
-  * Closes #4264
+  Closes #4264
 
 
 What's New in Pylint 2.7.3?

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1994,7 +1994,7 @@ class NameChecker(_BasicChecker):
                     if (
                         ancestor.name == "Enum"
                         and ancestor.root().name == "enum"
-                        or utils.is_class_var(node)
+                        or utils.is_assign_name_annotated_with(node, "Final")
                     ):
                         self._check_name("class_const", node.name, node)
                         break

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1459,8 +1459,12 @@ def is_attribute_typed_annotation(
     return False
 
 
-def is_class_var(node: astroid.AssignName) -> bool:
-    """Test if node has `ClassVar` annotation."""
+def is_assign_name_annotated_with(node: astroid.AssignName, typing_name: str) -> bool:
+    """Test if AssignName node has `typing_name` annotation.
+
+    Especially useful to check for `typing._SpecialForm` instances
+    like: `Union`, `Optional`, `Literal`, `ClassVar`, `Final`.
+    """
     if not isinstance(node.parent, astroid.AnnAssign):
         return False
     annotation = node.parent.annotation
@@ -1468,9 +1472,9 @@ def is_class_var(node: astroid.AssignName) -> bool:
         annotation = annotation.value
     if (
         isinstance(annotation, astroid.Name)
-        and annotation.name == "ClassVar"
+        and annotation.name == typing_name
         or isinstance(annotation, astroid.Attribute)
-        and annotation.attrname == "ClassVar"
+        and annotation.attrname == typing_name
     ):
         return True
     return False

--- a/tests/functional/n/name/name_final.py
+++ b/tests/functional/n/name/name_final.py
@@ -1,0 +1,13 @@
+# pylint: disable=missing-docstring,too-few-public-methods
+"""Test typing.Final"""
+import typing
+from typing import Final
+
+class Foo:
+    """Class with class constants annotated with Final."""
+    CLASS_CONST: Final[int] = 42
+    CLASS_CONST2: Final = "const"
+    variable: Final[str] = "invalid name"  # [invalid-name]
+    CLASS_CONST3: typing.Final
+    variable2: typing.Final[int]  # [invalid-name]
+    CLASS_CONST4: Final[typing.ClassVar[str]] = "valid"

--- a/tests/functional/n/name/name_final.rc
+++ b/tests/functional/n/name/name_final.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.8

--- a/tests/functional/n/name/name_final.txt
+++ b/tests/functional/n/name/name_final.txt
@@ -1,0 +1,2 @@
+invalid-name:10:4:Foo:"Class constant name ""variable"" doesn't conform to UPPER_CASE naming style"
+invalid-name:12:4:Foo:"Class constant name ""variable2"" doesn't conform to UPPER_CASE naming style"

--- a/tests/functional/n/name/name_final_snake_case.py
+++ b/tests/functional/n/name/name_final_snake_case.py
@@ -1,0 +1,13 @@
+# pylint: disable=missing-docstring,too-few-public-methods
+"""Test typing.Final with name style snake_case."""
+import typing
+from typing import Final
+
+class Foo:
+    """Class with class constants annotated with Final."""
+    CLASS_CONST: Final[int] = 42  # [invalid-name]
+    CLASS_CONST2: Final = "const"  # [invalid-name]
+    variable: Final[str] = "invalid name"
+    CLASS_CONST3: typing.Final  # [invalid-name]
+    variable2: typing.Final[int]
+    CLASS_CONST4: Final[typing.ClassVar[str]] = "invalid name"  # [invalid-name]

--- a/tests/functional/n/name/name_final_snake_case.rc
+++ b/tests/functional/n/name/name_final_snake_case.rc
@@ -1,0 +1,5 @@
+[testoptions]
+min_pyver=3.8
+
+[BASIC]
+class-const-naming-style=snake_case

--- a/tests/functional/n/name/name_final_snake_case.txt
+++ b/tests/functional/n/name/name_final_snake_case.txt
@@ -1,0 +1,4 @@
+invalid-name:8:4:Foo:"Class constant name ""CLASS_CONST"" doesn't conform to snake_case naming style"
+invalid-name:9:4:Foo:"Class constant name ""CLASS_CONST2"" doesn't conform to snake_case naming style"
+invalid-name:11:4:Foo:"Class constant name ""CLASS_CONST3"" doesn't conform to snake_case naming style"
+invalid-name:13:4:Foo:"Class constant name ""CLASS_CONST4"" doesn't conform to snake_case naming style"

--- a/tests/functional/n/name/name_styles.py
+++ b/tests/functional/n/name/name_styles.py
@@ -154,6 +154,6 @@ class Bar:
     """Class with class constants annotated with ClassVar."""
     CLASS_CONST: ClassVar[int] = 42
     CLASS_CONST2: ClassVar = "const"
-    variable: ClassVar[str] = "invalid name"  # [invalid-name]
+    variable: ClassVar[str] = "invalid name"
     CLASS_CONST3: typing.ClassVar
-    variable2: typing.ClassVar[int]  # [invalid-name]
+    variable2: typing.ClassVar[int]

--- a/tests/functional/n/name/name_styles.txt
+++ b/tests/functional/n/name/name_styles.txt
@@ -15,5 +15,3 @@ invalid-name:110:4:FooClass.PROPERTY_NAME:"Attribute name ""PROPERTY_NAME"" does
 invalid-name:115:4:FooClass.ABSTRACT_PROPERTY_NAME:"Attribute name ""ABSTRACT_PROPERTY_NAME"" doesn't conform to snake_case naming style":INFERENCE
 invalid-name:120:4:FooClass.PROPERTY_NAME_SETTER:"Attribute name ""PROPERTY_NAME_SETTER"" doesn't conform to snake_case naming style":INFERENCE
 invalid-name:151:4:FooEnum:"Class constant name ""bad_enum_name"" doesn't conform to UPPER_CASE naming style"
-invalid-name:157:4:Bar:"Class constant name ""variable"" doesn't conform to UPPER_CASE naming style"
-invalid-name:159:4:Bar:"Class constant name ""variable2"" doesn't conform to UPPER_CASE naming style"


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
`typing.ClassVar` should not be identified as a class constant for the naming style `class-const`. Instead `typing.Final` should be.

This should probably be included in `2.7.5`

--
`typing.Final` could probably be used to identify module constants as well, but that should be another MR.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #4277
