### PR TITLE
Apply const-naming-style to module const annotated with Final

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,9 @@ Release date: Undefined
 ..
   Put new features here and also in 'doc/whatsnew/2.8.rst'
 
+* Apply ``const-naming-style`` to module constants annotated with
+  ``typing.Final``
+
 
 What's New in Pylint 2.7.5?
 ===========================

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1983,6 +1983,10 @@ class NameChecker(_BasicChecker):
                     self._check_name("const", node.name, node)
             elif isinstance(assign_type, astroid.ExceptHandler):
                 self._check_name("variable", node.name, node)
+            elif isinstance(
+                assign_type, astroid.AnnAssign
+            ) and utils.is_assign_name_annotated_with(node, "Final"):
+                self._check_name("const", node.name, node)
         elif isinstance(frame, astroid.FunctionDef):
             # global introduced variable aren't in the function locals
             if node.name in frame and node.name not in frame.argnames():

--- a/tests/functional/n/name/name_final.py
+++ b/tests/functional/n/name/name_final.py
@@ -11,3 +11,6 @@ class Foo:
     CLASS_CONST3: typing.Final
     variable2: typing.Final[int]  # [invalid-name]
     CLASS_CONST4: Final[typing.ClassVar[str]] = "valid"
+
+MODULE_CONST: Final = 1
+module_var: typing.Final[str] = "const"  # [invalid-name]

--- a/tests/functional/n/name/name_final.txt
+++ b/tests/functional/n/name/name_final.txt
@@ -1,2 +1,3 @@
 invalid-name:10:4:Foo:"Class constant name ""variable"" doesn't conform to UPPER_CASE naming style"
 invalid-name:12:4:Foo:"Class constant name ""variable2"" doesn't conform to UPPER_CASE naming style"
+invalid-name:16:0::"Constant name ""module_var"" doesn't conform to UPPER_CASE naming style"

--- a/tests/functional/n/name/name_final_snake_case.py
+++ b/tests/functional/n/name/name_final_snake_case.py
@@ -11,3 +11,6 @@ class Foo:
     CLASS_CONST3: typing.Final  # [invalid-name]
     variable2: typing.Final[int]
     CLASS_CONST4: Final[typing.ClassVar[str]] = "invalid name"  # [invalid-name]
+
+MODULE_CONST: Final = 1  # [invalid-name]
+module_var: typing.Final[str] = "const"

--- a/tests/functional/n/name/name_final_snake_case.rc
+++ b/tests/functional/n/name/name_final_snake_case.rc
@@ -3,3 +3,4 @@ min_pyver=3.8
 
 [BASIC]
 class-const-naming-style=snake_case
+const-naming-style=snake_case

--- a/tests/functional/n/name/name_final_snake_case.txt
+++ b/tests/functional/n/name/name_final_snake_case.txt
@@ -2,3 +2,4 @@ invalid-name:8:4:Foo:"Class constant name ""CLASS_CONST"" doesn't conform to sna
 invalid-name:9:4:Foo:"Class constant name ""CLASS_CONST2"" doesn't conform to snake_case naming style"
 invalid-name:11:4:Foo:"Class constant name ""CLASS_CONST3"" doesn't conform to snake_case naming style"
 invalid-name:13:4:Foo:"Class constant name ""CLASS_CONST4"" doesn't conform to snake_case naming style"
+invalid-name:15:0::"Constant name ""MODULE_CONST"" doesn't conform to snake_case naming style"


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
This depends on #4279 and should be rebased once it's merged.

Apply the `const-naming-style` to module constants if they are annotated with with `typing.Final`.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |