### PR TITLE
Extend documentation for issue #4282

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -466,3 +466,5 @@ contributors:
 * Andrew Howe: contributor
 
 * James Sinclair (irgeek): contributor
+
+* Andreas Finkler: contributor

--- a/doc/user_guide/output.rst
+++ b/doc/user_guide/output.rst
@@ -51,6 +51,8 @@ A few other examples:
 
     {path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
 
+The ``--msg-template`` option can only be combined with text-based reporters (``--output-format`` either unspecified or one of: parseable, colorized or msvs).
+If both ``--output-format`` and ``--msg-template`` are specified, the ``--msg-template`` option will take precedence over the default line format defined by the reporter class.
 
 .. _Python new format syntax: https://docs.python.org/2/library/string.html#formatstrings
 

--- a/doc/user_guide/run.rst
+++ b/doc/user_guide/run.rst
@@ -53,6 +53,15 @@ and get its standard output and error:
   from pylint import epylint as lint
   (pylint_stdout, pylint_stderr) = lint.py_run('module_name.py', return_std=True)
 
+It is also possible to include additional Pylint options in the first argument to ``py_run``:
+
+.. sourcecode:: python
+
+  from pylint import epylint as lint
+  (pylint_stdout, pylint_stderr) = lint.py_run('module_name.py --disable C0114', return_std=True)
+
+The options ``--msg-template="{path}:{line}: {category} ({msg_id}, {symbol}, {obj}) {msg}"`` and 
+``--reports=n`` are set implicitly inside the ``epylint`` module.
 
 Command line options
 --------------------

--- a/doc/user_guide/run.rst
+++ b/doc/user_guide/run.rst
@@ -60,7 +60,7 @@ It is also possible to include additional Pylint options in the first argument t
   from pylint import epylint as lint
   (pylint_stdout, pylint_stderr) = lint.py_run('module_name.py --disable C0114', return_std=True)
 
-The options ``--msg-template="{path}:{line}: {category} ({msg_id}, {symbol}, {obj}) {msg}"`` and 
+The options ``--msg-template="{path}:{line}: {category} ({msg_id}, {symbol}, {obj}) {msg}"`` and
 ``--reports=n`` are set implicitly inside the ``epylint`` module.
 
 Command line options


### PR DESCRIPTION
https://github.com/PyCQA/pylint/issues/4282:
Explain connection between ``--output-format`` and ``--msg-template``.
Document which command line options are implicitly set through
``epylint.py_run()``

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

## Related Issue

Closes #4282 
