### PR TITLE
Fix false-positive ``used-before-assignment`` in function returns

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,10 @@ Release date: Undefined
   only contain ``__version__`` (also accessible with ``pylint.__version__``), other meta-information are still
   accessible with ``import importlib;metadata.metadata('pylint')``.
 
+* Fix false-positive ``used-before-assignment`` in function returns.
+
+  Closes #4301
+
 
 What's New in Pylint 2.7.5?
 ===========================

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1457,7 +1457,12 @@ class VariablesChecker(BaseChecker):
                             and defnode.lineno == node.lineno
                             and isinstance(
                                 defstmt,
-                                (astroid.Assign, astroid.AnnAssign, astroid.AugAssign),
+                                (
+                                    astroid.Assign,
+                                    astroid.AnnAssign,
+                                    astroid.AugAssign,
+                                    astroid.Return,
+                                ),
                             )
                             and isinstance(defstmt.value, astroid.JoinedStr)
                         )

--- a/tests/functional/a/assignment_expression.py
+++ b/tests/functional/a/assignment_expression.py
@@ -1,5 +1,6 @@
 """Test assignment expressions"""
-# pylint: disable=missing-docstring,unused-argument,unused-import,invalid-name,blacklisted-name,unused-variable
+# pylint: disable=missing-docstring,unused-argument,unused-import,invalid-name
+# pylint: disable=blacklisted-name,unused-variable,pointless-statement
 import re
 
 if (a := True):
@@ -14,6 +15,15 @@ x3 += b3 if (b3 := 4) else 6
 
 a = ["a   ", "b   ", "c   "]
 c = [text for el in a if (text := el.strip()) == "b"]
+
+
+# check wrong usage
+assert err_a, (err_a := 2)  # [used-before-assignment]
+print(err_b and (err_b := 2))  # [used-before-assignment]
+values = (
+    err_c := err_d,  # [used-before-assignment]
+    err_d := 2,
+)
 
 
 # https://github.com/PyCQA/pylint/issues/3347
@@ -53,7 +63,7 @@ print(function())
 
 
 # https://github.com/PyCQA/pylint/issues/3763
-foo if (foo := 3 - 2) > 0 else 0  # [pointless-statement]
+foo if (foo := 3 - 2) > 0 else 0
 
 
 # https://github.com/PyCQA/pylint/issues/4238
@@ -70,10 +80,7 @@ l3 += (
 )
 
 
-# check wrong usage
-assert err_a, (err_a := 2)  # [used-before-assignment]
-print(err_b and (err_b := 2))  # [used-before-assignment]
-values = (
-    err_c := err_d,  # [used-before-assignment]
-    err_d := 2,
-)
+# https://github.com/PyCQA/pylint/issues/4301
+def func2():
+    return f'The number {(count := 4)} ' \
+           f'is equal to {count}'

--- a/tests/functional/a/assignment_expression.txt
+++ b/tests/functional/a/assignment_expression.txt
@@ -1,4 +1,3 @@
-pointless-statement:56:0::Statement seems to have no effect
-used-before-assignment:74:7::Using variable 'err_a' before assignment
-used-before-assignment:75:6::Using variable 'err_b' before assignment
-used-before-assignment:77:13::Using variable 'err_d' before assignment
+used-before-assignment:21:7::Using variable 'err_a' before assignment
+used-before-assignment:22:6::Using variable 'err_b' before assignment
+used-before-assignment:24:13::Using variable 'err_d' before assignment


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
This MR addresses a false-positive that occurred for assignment expressions in function returns.
The following is valid and should not raise an `used-before-assignment` error.
```py
def func():
    return f'The number {(count := 4)} ' \
           f'is equal to {count}'
```

This is a followup to #4253

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #4301