### PR TITLE
Bug pylint 4019

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,10 @@ Release date: Undefined
 ..
   Put bug fixes that will be cherry-picked to latest major version here
 
+* During detection of ``inconsistent-return-statements`` consider that ``assert False`` is a return node.
+
+  Closes #4019
+
 * Functions that never returns may declare ``NoReturn`` as type hints, so that
   ``inconsistent-return-statements`` is not emitted.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -37,7 +37,7 @@ Release date: Undefined
 * During detection of ``inconsistent-return-statements`` consider that ``assert False`` is a return node.
 
   Closes #4019
-  
+
 * Run will not fail if score exactly equals ``config.fail_under`.
 
 * Functions that never returns may declare ``NoReturn`` as type hints, so that

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1386,7 +1386,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             and isinstance(node.test, astroid.Const)
             and not node.test.value
         ):
-            #  consider assert False as a return node
+            # consider assert False as a return node
             return True
         # recurses on the children of the node
         return any(self._is_node_return_ended(_child) for _child in node.get_children())

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1381,6 +1381,13 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             return any(
                 self._is_node_return_ended(_child) for _child in all_but_handler
             ) and all(self._is_node_return_ended(_child) for _child in handlers)
+        if (
+            isinstance(node, astroid.Assert)
+            and isinstance(node.test, astroid.Const)
+            and not node.test.value
+        ):
+            #  consider assert False as a return node
+            return True
         # recurses on the children of the node
         return any(self._is_node_return_ended(_child) for _child in node.get_children())
 

--- a/tests/functional/i/inconsistent/inconsistent_returns.py
+++ b/tests/functional/i/inconsistent/inconsistent_returns.py
@@ -387,3 +387,21 @@ def bug_pylint_4122_bis(s):
         return n
     except ValueError:
         parser_error_name('parser error')
+
+
+def bug_pylint_4019(x):
+    """
+    assert False is equivalent to a return
+    """
+    if x == 1:
+        return 42
+    assert False
+
+
+def bug_pylint_4019_wrong(x):  # [inconsistent-return-statements]
+    """
+    assert True is not equivalent to a return
+    """
+    if x == 1:
+        return 42
+    assert True

--- a/tests/functional/i/inconsistent/inconsistent_returns.py
+++ b/tests/functional/i/inconsistent/inconsistent_returns.py
@@ -389,6 +389,7 @@ def bug_pylint_4122_bis(s):
         parser_error_name('parser error')
 
 
+# https://github.com/PyCQA/pylint/issues/4019
 def bug_pylint_4019(x):
     """
     assert False is equivalent to a return

--- a/tests/functional/i/inconsistent/inconsistent_returns.txt
+++ b/tests/functional/i/inconsistent/inconsistent_returns.txt
@@ -15,3 +15,4 @@ inconsistent-return-statements:267:0:bug_3468:Either all return statements in a 
 inconsistent-return-statements:277:0:bug_3468_variant:Either all return statements in a function should return an expression, or none of them should.
 inconsistent-return-statements:322:0:bug_pylint_3873_1:Either all return statements in a function should return an expression, or none of them should.
 inconsistent-return-statements:366:0:bug_pylint_4122_wrong:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:401:0:bug_pylint_4019_wrong:Either all return statements in a function should return an expression, or none of them should.

--- a/tests/functional/i/inconsistent/inconsistent_returns.txt
+++ b/tests/functional/i/inconsistent/inconsistent_returns.txt
@@ -15,4 +15,4 @@ inconsistent-return-statements:267:0:bug_3468:Either all return statements in a 
 inconsistent-return-statements:277:0:bug_3468_variant:Either all return statements in a function should return an expression, or none of them should.
 inconsistent-return-statements:322:0:bug_pylint_3873_1:Either all return statements in a function should return an expression, or none of them should.
 inconsistent-return-statements:366:0:bug_pylint_4122_wrong:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:401:0:bug_pylint_4019_wrong:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:402:0:bug_pylint_4019_wrong:Either all return statements in a function should return an expression, or none of them should.


### PR DESCRIPTION
## Steps

- [x] Add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
During detection of `inconsistent-return-statements`, consider that an `assert False` statement is equivalent to a return node.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #4019

