### PR TITLE
Don't show ``astroid.DuplicateBasesError`` for attribute access

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -57,6 +57,8 @@ Release date: Undefined
 
   Closes #3850
 
+* Don't show ``DuplicateBasesError`` for attribute access
+
 
 What's New in Pylint 2.7.4?
 ===========================

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -985,6 +985,8 @@ accessed. Python regular expressions are accepted.",
                     continue
             except AttributeError:
                 continue
+            except astroid.DuplicateBasesError:
+                continue
             except astroid.NotFoundError:
                 # This can't be moved before the actual .getattr call,
                 # because there can be more values inferred and we are

--- a/tests/functional/d/duplicate_bases.py
+++ b/tests/functional/d/duplicate_bases.py
@@ -2,7 +2,7 @@
 # pylint: disable=missing-docstring,too-few-public-methods,no-init
 
 
-class Duplicates(str, str): # [duplicate-bases]
+class Duplicates(str, str):  # [duplicate-bases]
     pass
 
 
@@ -13,3 +13,6 @@ class Alpha(str):
 class NotDuplicates(Alpha, str):
     """The error should not be emitted for this case, since the
     other same base comes from the ancestors."""
+
+
+print(Duplicates.__mro__)


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Previously an attribute access to a class which has duplicate bases would result in an `astroid.DuplicateBasesError`.
Note: The error for `duplicate-bases` was / is still printed.

**Without MR**
```bash
************* Module functional.d.duplicate_bases
tests/functional/d/duplicate_bases.py:5:0: E0241: Duplicate bases for class 'Duplicates' (duplicate-bases)
Traceback (most recent call last):
  File "/Users/.../pylint/venv-39_link/bin/pylint", line 33, in <module>
    sys.exit(load_entry_point('pylint', 'console_scripts', 'pylint')())
  File "/Users/.../pylint/pylint/__init__.py", line 24, in run_pylint
    PylintRun(sys.argv[1:])
  File "/Users/.../pylint/pylint/lint/run.py", line 358, in __init__
    linter.check(args)
  File "/Users/.../pylint/pylint/lint/pylinter.py", line 877, in check
    self._check_files(
  File "/Users/.../pylint/pylint/lint/pylinter.py", line 911, in _check_files
    self._check_file(get_ast, check_astroid_module, name, filepath, modname)
  File "/Users/.../pylint/pylint/lint/pylinter.py", line 937, in _check_file
    check_astroid_module(ast_node)
  File "/Users/.../pylint/pylint/lint/pylinter.py", line 1071, in check_astroid_module
    retval = self._check_astroid_module(
  File "/Users/.../pylint/pylint/lint/pylinter.py", line 1116, in _check_astroid_module
    walker.walk(ast_node)
  File "/Users/.../pylint/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  File "/Users/.../pylint/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  File "/Users/.../pylint/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  File "/Users/.../pylint/pylint/utils/ast_walker.py", line 72, in walk
    callback(astroid)
  File "/Users/.../pylint/pylint/checkers/typecheck.py", line 981, in visit_attribute
    for n in owner.getattr(node.attrname)
  File "/Users/.../astroid/astroid/scoped_nodes.py", line 2444, in getattr
    result = [self.special_attributes.lookup(name)]
  File "/Users/.../astroid/astroid/interpreter/objectmodel.py", line 124, in lookup
    return getattr(self, IMPL_PREFIX + name)
  File "/Users/.../astroid/astroid/interpreter/objectmodel.py", line 426, in attr___mro__
    mro = self._instance.mro()
  File "/Users/.../astroid/astroid/scoped_nodes.py", line 2937, in mro
    return self._compute_mro(context=context)
  File "/Users/.../astroid/astroid/scoped_nodes.py", line 2926, in _compute_mro
    unmerged_mro = list(clean_duplicates_mro(unmerged_mro, self, context))
  File "/Users/.../astroid/astroid/scoped_nodes.py", line 113, in clean_duplicates_mro
    raise exceptions.DuplicateBasesError(
astroid.exceptions.DuplicateBasesError: Duplicates found in MROs (Duplicates), (str, object), (str, object), (str, str) for <ClassDef.Duplicates l.5 at 0x7fb0c698ffa0>.
```

**With**
```bash
************* Module functional.d.duplicate_bases
tests/functional/d/duplicate_bases.py:5:0: E0241: Duplicate bases for class 'Duplicates' (duplicate-bases)
```

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |