### PR TITLE
Small refactor before adding ``unknown-message-in-pylintrc`` warning

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 ignore =
     E203, W503, # Incompatible with black see https://github.com/ambv/black/issues/315
-    E501, # Lot of offending line right now
+    E501, # Lot of lines too long right now
 
 max-line-length=88
 max-complexity=39

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -237,7 +237,8 @@ class OptionsManagerMixIn:
 
     def read_config_file(self, config_file=None, verbose=None):
         """Read the configuration file but do not load it (i.e. dispatching
-        values to each options provider)"""
+        values to each options provider)
+        """
         help_level = 1
         while help_level <= self._maxlevel:
             opt = "-".join(["long"] * help_level) + "-help"

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -236,22 +236,24 @@ class OptionsManagerMixIn:
             provider.load_defaults()
 
     def read_config_file(self, config_file=None, verbose=None):
-        """read the configuration file but do not load it (i.e. dispatching
-        values to each options provider)
-        """
-        helplevel = 1
-        while helplevel <= self._maxlevel:
-            opt = "-".join(["long"] * helplevel) + "-help"
+        """Read the configuration file but do not load it (i.e. dispatching
+        values to each options provider)"""
+        help_level = 1
+        while help_level <= self._maxlevel:
+            opt = "-".join(["long"] * help_level) + "-help"
             if opt in self._all_options:
                 break  # already processed
-
-            helpfunc = functools.partial(self.helpfunc, level=helplevel)
-            helpmsg = "%s verbose help." % " ".join(["more"] * helplevel)
-            optdict = {"action": "callback", "callback": helpfunc, "help": helpmsg}
+            help_function = functools.partial(self.helpfunc, level=help_level)
+            help_msg = "%s verbose help." % " ".join(["more"] * help_level)
+            optdict = {
+                "action": "callback",
+                "callback": help_function,
+                "help": help_msg,
+            }
             provider = self.options_providers[0]
             self.add_optik_option(provider, self.cmdline_parser, opt, optdict)
             provider.options += ((opt, optdict),)
-            helplevel += 1
+            help_level += 1
         if config_file is None:
             config_file = self.config_file
         if config_file is not None:
@@ -303,9 +305,8 @@ class OptionsManagerMixIn:
         print(msg, file=sys.stderr)
 
     def load_config_file(self):
-        """dispatch values previously read from a configuration file to each
-        options provider)
-        """
+        """Dispatch values previously read from a configuration file to each
+        options provider)"""
         parser = self.cfgfile_parser
         for section in parser.sections():
             for option, value in parser.items(section):

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -457,8 +457,8 @@ class PyLinter(
         self.option_groups = option_groups + PyLinter.option_groups
         self._options_methods = {"enable": self.enable, "disable": self.disable}
         self._bw_options_methods = {
-            "disable-msg": self.disable,
-            "enable-msg": self.enable,
+            "disable-msg": self._options_methods["disable"],
+            "enable-msg": self._options_methods["enable"],
         }
         MessagesHandlerMixIn.__init__(self)
         reporters.ReportsHandlerMixIn.__init__(self)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -436,9 +436,8 @@ class PyLinter(
     )
 
     def __init__(self, options=(), reporter=None, option_groups=(), pylintrc=None):
-        # some stuff has to be done before ancestors initialization...
-        #
-        # messages store / checkers / reporter / astroid manager
+        """Some stuff has to be done before ancestors initialization...
+        messages store / checkers / reporter / astroid manager"""
         self.msgs_store = MessageDefinitionStore()
         self.reporter = None
         self._reporter_name = None
@@ -690,13 +689,11 @@ class PyLinter(
         print("")
 
     # block level option handling #############################################
-    #
     # see func_block_disable_msg.py test case for expected behaviour
 
     def process_tokens(self, tokens):
-        """process tokens from the current module to search for module/block
-        level options
-        """
+        """Process tokens from the current module to search for module/block level
+        options."""
         control_pragmas = {"disable", "enable"}
         prev_line = None
         saw_newline = True
@@ -715,7 +712,6 @@ class PyLinter(
             match = OPTION_PO.search(content)
             if match is None:
                 continue
-
             try:
                 for pragma_repr in parse_pragma(match.group(2)):
                     if pragma_repr.action in ("disable-all", "skip-file"):
@@ -826,7 +822,7 @@ class PyLinter(
 
         :param str modname: The name of the module to be checked.
         :param str path: The full path to the source code of the module.
-        :param bool is_argument: Whetter the file is an argument to pylint or not.
+        :param bool is_argument: Whether the file is an argument to pylint or not.
                                  Files which respect this property are always
                                  checked, since the user requested it explicitly.
         :returns: True if the module should be checked.

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -45,14 +45,13 @@ class MessagesHandlerMixIn:
     def _register_by_id_managed_msg(self, msgid_or_symbol: str, line, is_disabled=True):
         """If the msgid is a numeric one, then register it to inform the user
         it could furnish instead a symbolic msgid."""
-        try:
-            if msgid_or_symbol[1:].isdigit():
+        if msgid_or_symbol[1:].isdigit():
+            try:
                 symbol = self.msgs_store.message_id_store.get_symbol(msgid=msgid_or_symbol)  # type: ignore
-                msgid = msgid_or_symbol
-                managed = (self.current_name, msgid, symbol, line, is_disabled)  # type: ignore
-                MessagesHandlerMixIn.__by_id_managed_msgs.append(managed)
-        except KeyError:
-            pass
+            except UnknownMessageError:
+                return
+            managed = (self.current_name, msgid_or_symbol, symbol, line, is_disabled)  # type: ignore
+            MessagesHandlerMixIn.__by_id_managed_msgs.append(managed)
 
     def disable(self, msgid, scope="package", line=None, ignore_unknown=False):
         self._set_msg_status(

--- a/pylint/message/message_id_store.py
+++ b/pylint/message/message_id_store.py
@@ -26,10 +26,18 @@ class MessageIdStore:
         return result
 
     def get_symbol(self, msgid: str) -> str:
-        return self.__msgid_to_symbol[msgid]
+        try:
+            return self.__msgid_to_symbol[msgid]
+        except KeyError as e:
+            msg = f"'{msgid}' is not stored in the message store."
+            raise UnknownMessageError(msg) from e
 
     def get_msgid(self, symbol: str) -> str:
-        return self.__symbol_to_msgid[symbol]
+        try:
+            return self.__symbol_to_msgid[symbol]
+        except KeyError as e:
+            msg = f"'{symbol}' is not stored in the message store."
+            raise UnknownMessageError(msg) from e
 
     def register_message_definition(self, message_definition):
         self.check_msgid_and_symbol(message_definition.msgid, message_definition.symbol)

--- a/tests/message/unittest_message_id_store.py
+++ b/tests/message/unittest_message_id_store.py
@@ -55,9 +55,9 @@ def test_add_msgid_and_symbol(empty_msgid_store):
     assert empty_msgid_store.get_symbol("E1235") == "new-sckiil"
     assert empty_msgid_store.get_msgid("old-sckiil") == "C1235"
     assert empty_msgid_store.get_msgid("new-sckiil") == "E1235"
-    with pytest.raises(KeyError):
+    with pytest.raises(UnknownMessageError):
         empty_msgid_store.get_symbol("C1234")
-    with pytest.raises(KeyError):
+    with pytest.raises(UnknownMessageError):
         empty_msgid_store.get_msgid("not-exist")
 
 


### PR DESCRIPTION
Before working on the unknown message in pylintrc disable/enable, some fix came to mind.

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Related Issue

Inspired by #4265 
