### PR TITLE
Ejf/improved spellcheck 4319 4320

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -63,6 +63,14 @@ Release date: Undefined
 
 * Don't show ``DuplicateBasesError`` for attribute access
 
+* Allow code flanked in backticks to be skipped by spellchecker
+
+  Closes #4319
+
+* Allow Python tool directives (for black, flake8, zimports, isort, mypy, bandit, pycharm) at beginning of comments to be skipped by spellchecker
+
+  Closes #4320
+
 
 What's New in Pylint 2.7.4?
 ===========================
@@ -298,7 +306,7 @@ Release date: 2021-02-21
 
   Close #2738
 
-* Fix ``duplicate-code`` false positive when lines only contain whitespace and non-alphanumeric characters (e.g. parentheses, bracket, comman, etc.)
+* Fix ``duplicate-code`` false positive when lines only contain whitespace and non-alphanumeric characters (e.g. parentheses, bracket, comma, etc.)
 
 * Improve lint message for ``singleton-comparison`` with bools
 

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -182,9 +182,8 @@ CODE_FLANKED_IN_BACKTICK_REGEX = re.compile(r"(\s|^)(`{1,2})([^`]+)(\2)([^`]|$)"
 def _strip_code_flanked_in_backticks(line: str) -> str:
     """Alter line so code flanked in backticks is ignored.
 
-    Pyenchant automatically strips backticks when parsing tokens, so this cannot be done at the individual filter level.
-
-    """
+    Pyenchant automatically strips backticks when parsing tokens,
+    so this cannot be done at the individual filter level."""
 
     def replace_code_but_leave_surrounding_characters(match_obj) -> str:
         return match_obj.group(1) + match_obj.group(5)

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -317,7 +317,6 @@ class SpellingChecker(BaseTokenChecker):
                 WordsWithUnderscores,
                 CamelCasedWord,
                 SphinxDirectives,
-                # BlackDirectives
             ],
         )
         self.initialized = True
@@ -334,6 +333,7 @@ class SpellingChecker(BaseTokenChecker):
             initial_space = 0
         if line.strip().startswith("#") and "docstring" not in msgid:
             line = line.strip()[1:]
+            # A ``Filter`` cannot determine if the directive is at the beginning of a line, nor determine if a colon is present or not (``pyenchant`` strips trailing colons). So implementing this here.
             for iter_directive in (
                 "fmt: on",
                 "fmt: off",

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -278,7 +278,7 @@ class SpellingChecker(BaseTokenChecker):
                 "default": "fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:",
                 "type": "string",
                 "metavar": "<comma separated words>",
-                "help": "List of comma separated words that should not be considered directives if they appear and the beginning of a comment and should not be checked.",
+                "help": "List of comma separated words that should be considered directives if they appear and the beginning of a comment and should not be checked.",
             },
         ),
     )

--- a/pylint/testutils/decorator.py
+++ b/pylint/testutils/decorator.py
@@ -11,13 +11,15 @@ def set_config(**kwargs):
 
     def _wrapper(fun):
         @functools.wraps(fun)
-        def _forward(self):
+        def _forward(self, *args, **test_function_kwargs):
             for key, value in kwargs.items():
                 setattr(self.checker.config, key, value)
             if isinstance(self, CheckerTestCase):
                 # reopen checker in case, it may be interested in configuration change
                 self.checker.open()
-            fun(self)
+            fun(
+                self, *args, **test_function_kwargs
+            )  # Passing the args and kwargs back to the test function itself allows this decorator to be used on parametrized test cases
 
         return _forward
 

--- a/pylint/testutils/decorator.py
+++ b/pylint/testutils/decorator.py
@@ -7,7 +7,11 @@ from pylint.testutils.checker_test_case import CheckerTestCase
 
 
 def set_config(**kwargs):
-    """Decorator for setting config values on a checker."""
+    """Decorator for setting config values on a checker.
+
+    Passing the args and kwargs back to the test function itself
+    allows this decorator to be used on parametrized test cases.
+    """
 
     def _wrapper(fun):
         @functools.wraps(fun)
@@ -17,9 +21,7 @@ def set_config(**kwargs):
             if isinstance(self, CheckerTestCase):
                 # reopen checker in case, it may be interested in configuration change
                 self.checker.open()
-            fun(
-                self, *args, **test_function_kwargs
-            )  # Passing the args and kwargs back to the test function itself allows this decorator to be used on parametrized test cases
+            fun(self, *args, **test_function_kwargs)
 
         return _forward
 

--- a/tests/checkers/unittest_spelling.py
+++ b/tests/checkers/unittest_spelling.py
@@ -37,7 +37,9 @@ if enchant is not None:
         pass
 
 
-class TestSpellingChecker(CheckerTestCase):
+class TestSpellingChecker(
+    CheckerTestCase
+):  # pylint:disable=too-many-public-methods # This is a test case class, not sure why it would be relevant to have this pylint rule enforced for test case classes
     CHECKER_CLASS = spelling.SpellingChecker
 
     skip_on_missing_package_or_dict = pytest.mark.skipif(
@@ -303,37 +305,6 @@ class TestSpellingChecker(CheckerTestCase):
         ):
             self.checker.visit_classdef(stmt)
 
-    # @skip_on_missing_package_or_dict
-    # # @set_config(spelling_dict=spell_dict)
-    # @pytest.mark.parametrize(
-    #     "num_files,num_jobs,num_checkers",
-    #     [
-    #         (1, 2, 1),
-    #         (1, 2, 2),
-    #         (1, 2, 3),
-    #         (2, 2, 1),
-    #         (2, 2, 2),
-    #         (2, 2, 3),
-    #         (3, 2, 1),
-    #         (3, 2, 2),
-    #         (3, 2, 3),
-    #         (3, 1, 1),
-    #         (3, 1, 2),
-    #         (3, 1, 3),
-    #         (3, 5, 1),
-    #         (3, 5, 2),
-    #         (3, 5, 3),
-    #         (10, 2, 1),
-    #         (10, 2, 2),
-    #         (10, 2, 3),
-    #         (2, 10, 1),
-    #         (2, 10, 2),
-    #         (2, 10, 3),
-    #     ],
-    # )
-    # def test_compare_workers_to_single_proc(self, num_files, num_jobs, num_checkers):
-    #     assert True
-
     @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     @pytest.mark.parametrize(
@@ -351,6 +322,7 @@ class TestSpellingChecker(CheckerTestCase):
             ("noqa", ":", "flake8 / zimports directive"),
             ("nosec", "", "bandit directive"),
             ("isort", ":skip", "isort directive"),
+            ("mypy", ":", "mypy directive"),
         ),
     )
     def test_skip_tool_directives_at_beginning_of_comments_but_still_raise_error_if_directive_appears_later_in_comment(  # pylint:disable=unused-argument # Having the extra description parameter allows the description to show up in the pytest output as part of the test name when running parametrized tests
@@ -366,6 +338,42 @@ class TestSpellingChecker(CheckerTestCase):
                     full_comment,
                     f"  {'^'*len(misspelled_portion_of_directive)}",
                     self._get_msg_suggestions(misspelled_portion_of_directive),
+                ),
+            )
+        ):
+            self.checker.process_tokens(_tokenize_str(full_comment))
+
+    @skip_on_missing_package_or_dict
+    @set_config(spelling_dict=spell_dict)
+    def test_skip_code_flanked_in_double_backticks(self):
+        full_comment = "# The function ``.qsize()`` .qsize()"
+        with self.assertAddsMessages(
+            Message(
+                "wrong-spelling-in-comment",
+                line=1,
+                args=(
+                    "qsize",
+                    full_comment,
+                    "                 ^^^^^",
+                    self._get_msg_suggestions("qsize"),
+                ),
+            )
+        ):
+            self.checker.process_tokens(_tokenize_str(full_comment))
+
+    @skip_on_missing_package_or_dict
+    @set_config(spelling_dict=spell_dict)
+    def test_skip_code_flanked_in_single_backticks(self):
+        full_comment = "# The function `.qsize()` .qsize()"
+        with self.assertAddsMessages(
+            Message(
+                "wrong-spelling-in-comment",
+                line=1,
+                args=(
+                    "qsize",
+                    full_comment,
+                    "                 ^^^^^",
+                    self._get_msg_suggestions("qsize"),
                 ),
             )
         ):

--- a/tests/checkers/unittest_spelling.py
+++ b/tests/checkers/unittest_spelling.py
@@ -303,6 +303,74 @@ class TestSpellingChecker(CheckerTestCase):
         ):
             self.checker.visit_classdef(stmt)
 
+    # @skip_on_missing_package_or_dict
+    # # @set_config(spelling_dict=spell_dict)
+    # @pytest.mark.parametrize(
+    #     "num_files,num_jobs,num_checkers",
+    #     [
+    #         (1, 2, 1),
+    #         (1, 2, 2),
+    #         (1, 2, 3),
+    #         (2, 2, 1),
+    #         (2, 2, 2),
+    #         (2, 2, 3),
+    #         (3, 2, 1),
+    #         (3, 2, 2),
+    #         (3, 2, 3),
+    #         (3, 1, 1),
+    #         (3, 1, 2),
+    #         (3, 1, 3),
+    #         (3, 5, 1),
+    #         (3, 5, 2),
+    #         (3, 5, 3),
+    #         (10, 2, 1),
+    #         (10, 2, 2),
+    #         (10, 2, 3),
+    #         (2, 10, 1),
+    #         (2, 10, 2),
+    #         (2, 10, 3),
+    #     ],
+    # )
+    # def test_compare_workers_to_single_proc(self, num_files, num_jobs, num_checkers):
+    #     assert True
+
+    @skip_on_missing_package_or_dict
+    @set_config(spelling_dict=spell_dict)
+    @pytest.mark.parametrize(
+        ",".join(
+            (
+                "misspelled_portion_of_directive",
+                "second_portion_of_directive",
+                "description",
+            )
+        ),
+        (
+            ("fmt", ": on", "black directive to turn on formatting"),
+            ("fmt", ": off", "black directive to turn off formatting"),
+            ("noqa", "", "pycharm directive"),
+            ("noqa", ":", "flake8 / zimports directive"),
+            ("nosec", "", "bandit directive"),
+            ("isort", ":skip", "isort directive"),
+        ),
+    )
+    def test_skip_tool_directives_at_beginning_of_comments_but_still_raise_error_if_directive_appears_later_in_comment(  # pylint:disable=unused-argument # Having the extra description parameter allows the description to show up in the pytest output as part of the test name when running parametrized tests
+        self, misspelled_portion_of_directive, second_portion_of_directive, description
+    ):
+        full_comment = f"# {misspelled_portion_of_directive}{second_portion_of_directive} {misspelled_portion_of_directive}"
+        with self.assertAddsMessages(
+            Message(
+                "wrong-spelling-in-comment",
+                line=1,
+                args=(
+                    misspelled_portion_of_directive,
+                    full_comment,
+                    f"  {'^'*len(misspelled_portion_of_directive)}",
+                    self._get_msg_suggestions(misspelled_portion_of_directive),
+                ),
+            )
+        ):
+            self.checker.process_tokens(_tokenize_str(full_comment))
+
     @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_handle_words_joined_by_forward_slash(self):

--- a/tests/checkers/unittest_spelling.py
+++ b/tests/checkers/unittest_spelling.py
@@ -380,6 +380,27 @@ class TestSpellingChecker(
             self.checker.process_tokens(_tokenize_str(full_comment))
 
     @skip_on_missing_package_or_dict
+    @set_config(
+        spelling_dict=spell_dict,
+        spelling_ignore_comment_directives="newdirective:,noqa",
+    )
+    def test_skip_directives_specified_in_pylintrc(self):
+        full_comment = "# newdirective: do this newdirective"
+        with self.assertAddsMessages(
+            Message(
+                "wrong-spelling-in-comment",
+                line=1,
+                args=(
+                    "newdirective",
+                    full_comment,
+                    "          ^^^^^^^^^^^^",
+                    self._get_msg_suggestions("newdirective"),
+                ),
+            )
+        ):
+            self.checker.process_tokens(_tokenize_str(full_comment))
+
+    @skip_on_missing_package_or_dict
     @set_config(spelling_dict=spell_dict)
     def test_handle_words_joined_by_forward_slash(self):
         stmt = astroid.extract_node(

--- a/tests/checkers/unittest_spelling.py
+++ b/tests/checkers/unittest_spelling.py
@@ -37,9 +37,9 @@ if enchant is not None:
         pass
 
 
-class TestSpellingChecker(
-    CheckerTestCase
-):  # pylint:disable=too-many-public-methods # This is a test case class, not sure why it would be relevant to have this pylint rule enforced for test case classes
+class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-methods
+    # This is a test case class, not sure why it would be relevant to have
+    #   this pylint rule enforced for test case classes.
     CHECKER_CLASS = spelling.SpellingChecker
 
     skip_on_missing_package_or_dict = pytest.mark.skipif(
@@ -325,8 +325,14 @@ class TestSpellingChecker(
             ("mypy", ":", "mypy directive"),
         ),
     )
-    def test_skip_tool_directives_at_beginning_of_comments_but_still_raise_error_if_directive_appears_later_in_comment(  # pylint:disable=unused-argument # Having the extra description parameter allows the description to show up in the pytest output as part of the test name when running parametrized tests
-        self, misspelled_portion_of_directive, second_portion_of_directive, description
+    def test_skip_tool_directives_at_beginning_of_comments_but_still_raise_error_if_directive_appears_later_in_comment(  # pylint:disable=unused-argument
+        # Having the extra description parameter allows the description
+        #   to show up in the pytest output as part of the test name
+        #   when running parametrized tests.
+        self,
+        misspelled_portion_of_directive,
+        second_portion_of_directive,
+        description,
     ):
         full_comment = f"# {misspelled_portion_of_directive}{second_portion_of_directive} {misspelled_portion_of_directive}"
         with self.assertAddsMessages(


### PR DESCRIPTION
## Description

Skips spellchecking on code flanked in single or double backticks in comments/docstrings.  Skips spellchecking on Python directives if and only if they are directly at the beginning of a comment (for tools such as black, flake8, zimports, isort, mypy, bandit, pycharm)

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Spellchecker was overzealous about python code and tool directives in comments          |

Also some minor correcting to spelling errors in the code of spelling.py itself and minor refactor to remove some duplicate code (added the `RegExFilter` parent class).

Also, corrected a typo in the Changlog for 2.7.0 in an entry I submitted.

## Related Issue

Closes #4319, #4320 
