### PR TITLE
fix emacs pylint error when running with tramp

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -470,3 +470,5 @@ contributors:
 * Andreas Finkler: contributor
 
 * Sebastian Müller: contributor
+
+* Ramiro Leal-Cavazos (ramiro050): Fixed bug preventing pylint from working with emacs tramp

--- a/ChangeLog
+++ b/ChangeLog
@@ -83,6 +83,8 @@ Release date: Undefined
 
   Closes #4320
 
+* Fix issue that caused emacs pylint to fail when used with tramp
+
 
 What's New in Pylint 2.7.4?
 ===========================

--- a/elisp/pylint.el
+++ b/elisp/pylint.el
@@ -202,8 +202,9 @@ output buffer, to go to the lines where pylint found matches.
 
   (save-some-buffers (not pylint-ask-about-save) nil)
   (let* ((filename (buffer-file-name))
+         (localname-offset (cl-struct-slot-offset 'tramp-file-name 'localname))
          (filename (or (and (tramp-tramp-file-p filename)
-                         (aref (tramp-dissect-file-name filename) 3))
+                         (elt (tramp-dissect-file-name filename) localname-offset))
                       filename))
          (filename (shell-quote-argument filename))
          (pylint-command (if arg

--- a/elisp/pylint.el
+++ b/elisp/pylint.el
@@ -202,9 +202,9 @@ output buffer, to go to the lines where pylint found matches.
 
   (save-some-buffers (not pylint-ask-about-save) nil)
   (let* ((filename (buffer-file-name))
-         (filename (if (tramp-tramp-file-p filename)
-                       (tramp-file-local-name filename)
-                     filename))
+         (filename (or (and (tramp-tramp-file-p filename)
+                         (aref (tramp-dissect-file-name filename) 3))
+                      filename))
          (filename (shell-quote-argument filename))
          (pylint-command (if arg
                              pylint-alternate-pylint-command

--- a/elisp/pylint.el
+++ b/elisp/pylint.el
@@ -202,9 +202,9 @@ output buffer, to go to the lines where pylint found matches.
 
   (save-some-buffers (not pylint-ask-about-save) nil)
   (let* ((filename (buffer-file-name))
-         (filename (or (and (tramp-tramp-file-p filename)
-                         (aref (tramp-dissect-file-name filename) 3))
-                      filename))
+         (filename (if (tramp-tramp-file-p filename)
+                       (tramp-file-local-name filename)
+                     filename))
          (filename (shell-quote-argument filename))
          (pylint-command (if arg
                              pylint-alternate-pylint-command


### PR DESCRIPTION
## Description

The function `tramp-dissect-file-name` now returns a `tramp-file-name` structure instead of an array. Therefore, the function `aref` can no longer be used to extract the `filename` from a tramp file. This fix correctly extracts the `filename` from the `tramp-file-name` structure by using the emacs built-in function `cl-struct-slot-value`.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |