### PR TITLE
Small performance improvement (PEP 585 check)

### DIFF
--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1341,7 +1341,10 @@ def is_class_subscriptable_pep585_with_postponed_evaluation_enabled(
     """Check if class is subscriptable with PEP 585 and
     postponed evaluation enabled.
     """
-    if not is_postponed_evaluation_enabled(node):
+    if (
+        not is_postponed_evaluation_enabled(node)
+        or value.qname() not in SUBSCRIPTABLE_CLASSES_PEP585
+    ):
         return False
 
     parent_node = node.parent
@@ -1354,9 +1357,7 @@ def is_class_subscriptable_pep585_with_postponed_evaluation_enabled(
         parent_node = parent_node.parent
         if isinstance(parent_node, astroid.Module):
             return False
-    if value.qname() in SUBSCRIPTABLE_CLASSES_PEP585:
-        return True
-    return False
+    return True
 
 
 def is_subclass_of(child: astroid.ClassDef, parent: astroid.ClassDef) -> bool:


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Small performance improvement for PEP 585 check.
Fail early if `value.qname() not in SUBSCRIPTABLE_CLASSES_PEP585` and only then check for parent in while loop.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue
--