### PR TITLE
Enhancement 1070 file output

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,7 +12,7 @@ Release date: Undefined
 * Add new extension ``ConfusingConsecutiveElifChecker``. This optional checker emits a refactoring message (R5601 ``confusing-consecutive-elif``)
   if if/elif statements with different indentation levels follow directly one after the other.
 
-* New option ``--output-file=<file>`` to output result to a file rather than printing to stdout.
+* New option ``--output=<file>`` to output result to a file rather than printing to stdout.
 
   Closes #1070
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ Release date: Undefined
 * Add new extension ``ConfusingConsecutiveElifChecker``. This optional checker emits a refactoring message (R5601 ``confusing-consecutive-elif``)
   if if/elif statements with different indentation levels follow directly one after the other.
 
+* New option ``--output-file=<file>`` to output result to a file rather than printing to stdout.
+
+  Closes #1070
+
 * Use a prescriptive message for ``unidiomatic-typecheck``
 
   Closes #3891
@@ -51,7 +55,7 @@ Release date: Undefined
 
   Closes #4019
 
-* Run will not fail if score exactly equals ``config.fail_under`.
+* Run will not fail if score exactly equals ``config.fail_under``.
 
 * Functions that never returns may declare ``NoReturn`` as type hints, so that
   ``inconsistent-return-statements`` is not emitted.

--- a/doc/user_guide/run.rst
+++ b/doc/user_guide/run.rst
@@ -180,4 +180,6 @@ exit code  meaning                    stderr stream message
                                       - "<return of linter.help()>"
                                       - "Jobs number <#> should be greater \
                                         than 0"
+                                      - "<IOError message when trying to open \
+                                        output file>"
 =========  =========================  ==========================================

--- a/doc/whatsnew/2.8.rst
+++ b/doc/whatsnew/2.8.rst
@@ -20,6 +20,10 @@ New checkers
 Other Changes
 =============
 
+* New option ``--output-file=<file>`` to output result to a file rather than printing to stdout.
+
+  Closes #1070
+
 * Reduce usage of blacklist/whitelist terminology. Notably, ``extension-pkg-allow-list`` is an
   alternative to ``extension-pkg-whitelist`` and the message ``blacklisted-name`` is now emitted as
   ``disallowed-name``. The previous names are accepted to maintain backward compatibility.

--- a/doc/whatsnew/2.8.rst
+++ b/doc/whatsnew/2.8.rst
@@ -20,7 +20,7 @@ New checkers
 Other Changes
 =============
 
-* New option ``--output-file=<file>`` to output result to a file rather than printing to stdout.
+* New option ``--output=<file>`` to output result to a file rather than printing to stdout.
 
   Closes #1070
 

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -79,6 +79,7 @@ group are mutually exclusive.",
         do_exit=UNUSED_PARAM_SENTINEL,
     ):  # pylint: disable=redefined-builtin
         self._rcfile = None
+        self._output_file = None
         self._version_asked = False
         self._plugins = []
         self.verbose = None
@@ -92,6 +93,7 @@ group are mutually exclusive.",
                     "rcfile": (self.cb_set_rcfile, True),
                     "load-plugins": (self.cb_add_plugins, True),
                     "verbose": (self.cb_verbose_mode, False),
+                    "output-file": (self.cb_set_output_file, True),
                 },
             )
         except ArgumentPreprocessingError as ex:
@@ -109,6 +111,17 @@ group are mutually exclusive.",
                         "type": "string",
                         "metavar": "<file>",
                         "help": "Specify a configuration file to load.",
+                    },
+                ),
+                (
+                    "output-file",
+                    {
+                        "action": "callback",
+                        "callback": Run._return_one,
+                        "group": "Commands",
+                        "type": "string",
+                        "metavar": "<file>",
+                        "help": "Specify an output file.",
                     },
                 ),
                 (
@@ -355,8 +368,18 @@ group are mutually exclusive.",
         # load plugin specific configuration.
         linter.load_plugin_configuration()
 
-        linter.check(args)
-        score_value = linter.generate_reports()
+        if self._output_file:
+            try:
+                with open(self._output_file, "w") as output:
+                    linter.reporter.set_output(output)
+                    linter.check(args)
+                    score_value = linter.generate_reports()
+            except IOError as ex:
+                print(ex, file=sys.stderr)
+                sys.exit(32)
+        else:
+            linter.check(args)
+            score_value = linter.generate_reports()
 
         if do_exit is not UNUSED_PARAM_SENTINEL:
             warnings.warn(
@@ -380,6 +403,10 @@ group are mutually exclusive.",
     def cb_set_rcfile(self, name, value):
         """callback for option preprocessing (i.e. before option parsing)"""
         self._rcfile = value
+
+    def cb_set_output_file(self, name, value):
+        """callback for option preprocessing (i.e. before option parsing)"""
+        self._output_file = value
 
     def cb_add_plugins(self, name, value):
         """callback for option preprocessing (i.e. before option parsing)"""

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -79,7 +79,7 @@ group are mutually exclusive.",
         do_exit=UNUSED_PARAM_SENTINEL,
     ):  # pylint: disable=redefined-builtin
         self._rcfile = None
-        self._output_file = None
+        self._output = None
         self._version_asked = False
         self._plugins = []
         self.verbose = None
@@ -93,7 +93,7 @@ group are mutually exclusive.",
                     "rcfile": (self.cb_set_rcfile, True),
                     "load-plugins": (self.cb_add_plugins, True),
                     "verbose": (self.cb_verbose_mode, False),
-                    "output-file": (self.cb_set_output_file, True),
+                    "output": (self.cb_set_output, True),
                 },
             )
         except ArgumentPreprocessingError as ex:
@@ -114,7 +114,7 @@ group are mutually exclusive.",
                     },
                 ),
                 (
-                    "output-file",
+                    "output",
                     {
                         "action": "callback",
                         "callback": Run._return_one,
@@ -368,9 +368,9 @@ group are mutually exclusive.",
         # load plugin specific configuration.
         linter.load_plugin_configuration()
 
-        if self._output_file:
+        if self._output:
             try:
-                with open(self._output_file, "w") as output:
+                with open(self._output, "w") as output:
                     linter.reporter.set_output(output)
                     linter.check(args)
                     score_value = linter.generate_reports()
@@ -404,9 +404,9 @@ group are mutually exclusive.",
         """callback for option preprocessing (i.e. before option parsing)"""
         self._rcfile = value
 
-    def cb_set_output_file(self, name, value):
+    def cb_set_output(self, name, value):
         """callback for option preprocessing (i.e. before option parsing)"""
-        self._output_file = value
+        self._output = value
 
     def cb_add_plugins(self, name, value):
         """callback for option preprocessing (i.e. before option parsing)"""

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -374,7 +374,7 @@ group are mutually exclusive.",
                     linter.reporter.set_output(output)
                     linter.check(args)
                     score_value = linter.generate_reports()
-            except IOError as ex:
+            except OSError as ex:
                 print(ex, file=sys.stderr)
                 sys.exit(32)
         else:

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -45,6 +45,7 @@ import warnings
 from copy import copy
 from io import StringIO
 from os.path import abspath, dirname, join
+from pathlib import Path
 from typing import Generator, Optional
 from unittest import mock
 from unittest.mock import patch
@@ -161,6 +162,21 @@ class TestRunTC:
         actual_output = self._clean_paths(out.getvalue())
         expected_output = self._clean_paths(expected_output)
         assert expected_output.strip() in actual_output.strip()
+
+    def _test_output_file(self, args, filename, expected_output):
+        """
+        Run Pylint with the ``output-file`` option set (must be included in
+        the ``args`` passed to this method!) and check the file content afterwards.
+        """
+        out = StringIO()
+        self._run_pylint(args, out=out)
+        cmdline_output = out.getvalue()
+        file_output = self._clean_paths(Path(filename).read_text(encoding="utf-8"))
+        expected_output = self._clean_paths(expected_output)
+        assert (
+            cmdline_output == ""
+        ), "Unexpected output to stdout/stderr while output-file option was set"
+        assert expected_output.strip() in file_output.strip()
 
     def test_pkginfo(self):
         """Make pylint check itself."""
@@ -1031,3 +1047,82 @@ class TestRunTC:
             HERE, "regrtest_data", "regression_missing_init_3564", "subdirectory/"
         )
         self._test_output([path, "-j2"], expected_output="No such file or directory")
+
+    def test_output_file_valid_path(self, tmpdir):
+        path = join(HERE, "regrtest_data", "unused_variable.py")
+        output_file = tmpdir / "output.txt"
+        expected = "Your code has been rated at 7.50/10"
+        self._test_output_file(
+            [path, f"--output-file={output_file}"],
+            output_file,
+            expected_output=expected,
+        )
+
+    def test_output_file_invalid_path_exits_with_code_32(self):
+        path = join(HERE, "regrtest_data", "unused_variable.py")
+        output_file = "thisdirectorydoesnotexit/output.txt"
+        self._runtest([path, f"--output-file={output_file}"], code=32)
+
+    @pytest.mark.parametrize(
+        "output_format, expected_output",
+        [
+            (
+                "text",
+                "tests/regrtest_data/unused_variable.py:4:4: W0612: Unused variable 'variable' (unused-variable)",
+            ),
+            (
+                "parseable",
+                "tests/regrtest_data/unused_variable.py:4: [W0612(unused-variable), test] Unused variable 'variable'",
+            ),
+            (
+                "msvs",
+                "tests/regrtest_data/unused_variable.py(4): [W0612(unused-variable)test] Unused variable 'variable'",
+            ),
+            (
+                "colorized",
+                "tests/regrtest_data/unused_variable.py:4:4: W0612: [35mUnused variable 'variable'[0m ([35munused-variable[0m)",
+            ),
+            ("json", '"message": "Unused variable \'variable\'",'),
+        ],
+    )
+    def test_output_file_can_be_combined_with_output_format_option(
+        self, tmpdir, output_format, expected_output
+    ):
+        path = join(HERE, "regrtest_data", "unused_variable.py")
+        output_file = tmpdir / "output.txt"
+        self._test_output_file(
+            [path, f"--output-file={output_file}", f"--output-format={output_format}"],
+            output_file,
+            expected_output,
+        )
+
+    def test_output_file_can_be_combined_with_custom_reporter(self, tmpdir):
+        path = join(HERE, "regrtest_data", "unused_variable.py")
+        output_file = tmpdir / "output.txt"
+        # It does not really have to be a truly custom reporter.
+        # It is only important that it is being passed explicitly to ``Run``.
+        myreporter = TextReporter()
+        self._run_pylint(
+            [path, f"--output-file={output_file}"],
+            out=sys.stdout,
+            reporter=myreporter,
+        )
+        assert output_file.exists()
+
+    def test_output_file_specified_in_rcfile(self, tmpdir):
+        output_file = tmpdir / "output.txt"
+        rcfile = tmpdir / "pylintrc"
+        rcfile_contents = textwrap.dedent(
+            f"""
+        [MASTER]
+        output-file={output_file}
+        """
+        )
+        rcfile.write_text(rcfile_contents, encoding="utf-8")
+        path = join(HERE, "regrtest_data", "unused_variable.py")
+        expected = "Your code has been rated at 7.50/10"
+        self._test_output_file(
+            [path, f"--output-file={output_file}", f"--rcfile={rcfile}"],
+            output_file,
+            expected_output=expected,
+        )

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -165,7 +165,7 @@ class TestRunTC:
 
     def _test_output_file(self, args, filename, expected_output):
         """
-        Run Pylint with the ``output-file`` option set (must be included in
+        Run Pylint with the ``output`` option set (must be included in
         the ``args`` passed to this method!) and check the file content afterwards.
         """
         out = StringIO()
@@ -175,7 +175,7 @@ class TestRunTC:
         expected_output = self._clean_paths(expected_output)
         assert (
             cmdline_output == ""
-        ), "Unexpected output to stdout/stderr while output-file option was set"
+        ), "Unexpected output to stdout/stderr while output option was set"
         assert expected_output.strip() in file_output.strip()
 
     def test_pkginfo(self):
@@ -1053,7 +1053,7 @@ class TestRunTC:
         output_file = tmpdir / "output.txt"
         expected = "Your code has been rated at 7.50/10"
         self._test_output_file(
-            [path, f"--output-file={output_file}"],
+            [path, f"--output={output_file}"],
             output_file,
             expected_output=expected,
         )
@@ -1061,7 +1061,7 @@ class TestRunTC:
     def test_output_file_invalid_path_exits_with_code_32(self):
         path = join(HERE, "regrtest_data", "unused_variable.py")
         output_file = "thisdirectorydoesnotexit/output.txt"
-        self._runtest([path, f"--output-file={output_file}"], code=32)
+        self._runtest([path, f"--output={output_file}"], code=32)
 
     @pytest.mark.parametrize(
         "output_format, expected_output",
@@ -1091,7 +1091,7 @@ class TestRunTC:
         path = join(HERE, "regrtest_data", "unused_variable.py")
         output_file = tmpdir / "output.txt"
         self._test_output_file(
-            [path, f"--output-file={output_file}", f"--output-format={output_format}"],
+            [path, f"--output={output_file}", f"--output-format={output_format}"],
             output_file,
             expected_output,
         )
@@ -1103,7 +1103,7 @@ class TestRunTC:
         # It is only important that it is being passed explicitly to ``Run``.
         myreporter = TextReporter()
         self._run_pylint(
-            [path, f"--output-file={output_file}"],
+            [path, f"--output={output_file}"],
             out=sys.stdout,
             reporter=myreporter,
         )
@@ -1115,14 +1115,14 @@ class TestRunTC:
         rcfile_contents = textwrap.dedent(
             f"""
         [MASTER]
-        output-file={output_file}
+        output={output_file}
         """
         )
         rcfile.write_text(rcfile_contents, encoding="utf-8")
         path = join(HERE, "regrtest_data", "unused_variable.py")
         expected = "Your code has been rated at 7.50/10"
         self._test_output_file(
-            [path, f"--output-file={output_file}", f"--rcfile={rcfile}"],
+            [path, f"--output={output_file}", f"--rcfile={rcfile}"],
             output_file,
             expected_output=expected,
         )


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
This PR is a proposal for closing #1070.
It adds a new option ``--output-file`` which can be optionally specified.
If set, all messages and reports will be saved to the specified file instead of being printed to stdout.
It can be combined with all of the existing reporters/output formats.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue

Closes #1070 
