### PR TITLE
Use Python official doc's terminology

### DIFF
--- a/doc/user_guide/run.rst
+++ b/doc/user_guide/run.rst
@@ -102,10 +102,10 @@ configuration file in the following order and uses the first one it finds:
    providing it has at least one ``tool.pylint.`` section.
 #. ``setup.cfg`` in the current working directory,
    providing it has at least one ``pylint.`` section
-#. If the current working directory is in a Python module, Pylint searches \
-   up the hierarchy of Python modules until it finds a ``pylintrc`` file. \
+#. If the current working directory is in a Python package, Pylint searches \
+   up the hierarchy of Python packages until it finds a ``pylintrc`` file. \
    This allows you to specify coding standards on a module-by-module \
-   basis.  Of course, a directory is judged to be a Python module if it \
+   basis.  Of course, a directory is judged to be a Python package if it \
    contains an ``__init__.py`` file.
 #. The file named by environment variable ``PYLINTRC``
 #. if you have a home directory which isn't ``/root``:


### PR DESCRIPTION
A directory containing a __init__.py file is called a package, as per https://docs.python.org/3/tutorial/modules.html#packages

## Description
Use Python official terminology to not confuse people

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

