### PR TITLE
Select last inferred value for usage

### DIFF
--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1227,15 +1227,6 @@ def safe_infer(
                 and len(inferred.args.args) != len(value.args.args)
             ):
                 return None  # Different number of arguments indicates ambiguity
-            if isinstance(inferred, astroid.objects.PartialFunction):
-                # Before https://github.com/PyCQA/astroid/pull/1097,
-                # partials got placed into the same scope as parents
-                # even though they usually have different names and may be
-                # defined elsewhere.
-                # We do not select the later value in this case.
-                # This condition can be removed if astroid#1097 is
-                # guaranteed to be present.
-                continue
             # For multiple inferences of the same type, select the last one
             value = inferred
     except astroid.InferenceError:

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1219,14 +1219,8 @@ def safe_infer(
             inferred_type = _get_python_type_of_node(inferred)
             if inferred_type not in inferred_types:
                 return None  # If there is ambiguity on the inferred node.
-            if (
-                isinstance(inferred, nodes.FunctionDef)
-                and inferred.args.args is not None
-                and isinstance(value, nodes.FunctionDef)
-                and value.args.args is not None
-                and len(inferred.args.args) != len(value.args.args)
-            ):
-                return None  # Different number of arguments indicates ambiguity
+            # For multiple inferences of the same type, select the last one
+            value = inferred
     except astroid.InferenceError:
         return None  # There is some kind of ambiguity
     except StopIteration:

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1219,6 +1219,14 @@ def safe_infer(
             inferred_type = _get_python_type_of_node(inferred)
             if inferred_type not in inferred_types:
                 return None  # If there is ambiguity on the inferred node.
+            if (
+                isinstance(inferred, nodes.FunctionDef)
+                and inferred.args.args is not None
+                and isinstance(value, nodes.FunctionDef)
+                and value.args.args is not None
+                and len(inferred.args.args) != len(value.args.args)
+            ):
+                return None  # Different number of arguments indicates ambiguity
             if isinstance(inferred, astroid.objects.PartialFunction):
                 # Before https://github.com/PyCQA/astroid/pull/1097,
                 # partials got placed into the same scope as parents

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1219,6 +1219,15 @@ def safe_infer(
             inferred_type = _get_python_type_of_node(inferred)
             if inferred_type not in inferred_types:
                 return None  # If there is ambiguity on the inferred node.
+            if isinstance(inferred, astroid.objects.PartialFunction):
+                # Before https://github.com/PyCQA/astroid/pull/1097,
+                # partials got placed into the same scope as parents
+                # even though they usually have different names and may be
+                # defined elsewhere.
+                # We do not select the later value in this case.
+                # This condition can be removed if astroid#1097 is
+                # guaranteed to be present.
+                continue
             # For multiple inferences of the same type, select the last one
             value = inferred
     except astroid.InferenceError:


### PR DESCRIPTION
Fixes the underlying issue associated with https://github.com/PyCQA/pylint/issues/3825, where a module with two function definitions in a third party should have the last definition selected instead of the first.

In the numpy.lib case, there are two functions with the same name in the same scope. The first is selected resulting in bad signatures:
```
# from .function_base import *
def unique(x):

# from .arraysetops import *
def unique(ar, return_index=False, return_inverse=False,
           return_counts=False, axis=None):
```

This was fixed upstream by numpy by removing the first definition, but this was definitely something bothering me because the behavior did not match python behavior properly. I hope it fixes other folks' issues as well.

At the same time, safe_infer is a heavily used function in the pylint codebase and should be subject to additional scrutiny.

Most inference cases are expected to have a single inferred result, so they wouldn't be affected by this.
For inference cases where two different types are seen, we return None. This is the same behavior.

In the case of multiple inference results of the same pytype, this behavior changes:
FunctionDef: later function definition is chosen (seems like fixed behavior)
Import by name: last import with same name wins (seems like fixed behavior)
Assign: last value inferred (seems like fixed behavior)
Sequence: last item inferred instead of first (different behavior, still one-of-many).
Returns: last return value used (different behavior than before, but still using one-of-many).

## Steps

Todo after acknowledgement

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #3825
