### PR TITLE
Improve exception debugging

### DIFF
--- a/pylint/utils/ast_walker.py
+++ b/pylint/utils/ast_walker.py
@@ -13,6 +13,7 @@ class ASTWalker:
         self.visit_events = collections.defaultdict(list)
         self.leave_events = collections.defaultdict(list)
         self.linter = linter
+        self.exception_msg = False
 
     def _is_method_enabled(self, method):
         if not hasattr(method, "checks_msgs"):
@@ -65,13 +66,20 @@ class ASTWalker:
         visit_events = self.visit_events.get(cid, ())
         leave_events = self.leave_events.get(cid, ())
 
-        if astroid.is_statement:
-            self.nbstatements += 1
-        # generate events for this node on each checker
-        for callback in visit_events or ():
-            callback(astroid)
-        # recurse on children
-        for child in astroid.get_children():
-            self.walk(child)
-        for callback in leave_events or ():
-            callback(astroid)
+        try:
+            if astroid.is_statement:
+                self.nbstatements += 1
+            # generate events for this node on each checker
+            for callback in visit_events or ():
+                callback(astroid)
+            # recurse on children
+            for child in astroid.get_children():
+                self.walk(child)
+            for callback in leave_events or ():
+                callback(astroid)
+        except Exception:
+            if self.exception_msg is False:
+                file = getattr(astroid.root(), "file", None)
+                print(f"Exception on node {repr(astroid)} in file '{file}'")
+                self.exception_msg = True
+            raise


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Improve exception / crash debugging by printing the node and file on which the exception occurred.
Example  output:
```
Exception on node <If l.19 at 0x7f81f0290430> in file '/../pylint/test2.py'
Traceback (most recent call last):
  File "/../pylint/venv-39_link/bin/pylint", line 33, in <module>
    sys.exit(load_entry_point('pylint', 'console_scripts', 'pylint')())
  File "/../pylint/pylint/__init__.py", line 24, in run_pylint
    PylintRun(sys.argv[1:])
  File "/../pylint/pylint/lint/run.py", line 358, in __init__
    linter.check(args)
  File "/../pylint/pylint/lint/pylinter.py", line 873, in check
    self._check_files(
  File "/../pylint/pylint/lint/pylinter.py", line 907, in _check_files
    self._check_file(get_ast, check_astroid_module, name, filepath, modname)
  File "/../pylint/pylint/lint/pylinter.py", line 933, in _check_file
    check_astroid_module(ast_node)
  File "/../pylint/pylint/lint/pylinter.py", line 1067, in check_astroid_module
    retval = self._check_astroid_module(
  File "/../pylint/pylint/lint/pylinter.py", line 1112, in _check_astroid_module
    walker.walk(ast_node)
  File "/../pylint/pylint/utils/ast_walker.py", line 77, in walk
    self.walk(child)
  File "/../pylint/pylint/utils/ast_walker.py", line 74, in walk
    callback(astroid)
  File "/../pylint/pylint/checkers/refactoring/refactoring_checker.py", line 622, in visit_if
    self._check_consider_using_min_max_builtin(node)
  File "/../pylint/pylint/checkers/refactoring/refactoring_checker.py", line 680, in _check_consider_using_min_max_builtin
    right_statement_value = right_statement.value
AttributeError: 'UnaryOp' object has no attribute 'value'
```

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |