### PR TITLE
Don't auto-enable postponed evaluation of type annotations with PY310

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -43,6 +43,8 @@ Release date: Undefined
 
   Closes #3406
 
+* Don't auto-enable postponed evaluation of type annotations with Python 3.10
+
 
 What's New in Pylint 2.7.5?
 ===========================

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -70,8 +70,6 @@ from typing import (
 import _string
 import astroid
 
-from pylint.constants import PY310_PLUS
-
 BUILTINS_NAME = builtins.__name__
 COMP_NODE_TYPES = (
     astroid.ListComp,
@@ -1328,9 +1326,6 @@ def get_node_last_lineno(node: astroid.node_classes.NodeNG) -> int:
 
 def is_postponed_evaluation_enabled(node: astroid.node_classes.NodeNG) -> bool:
     """Check if the postponed evaluation of annotations is enabled"""
-    if PY310_PLUS:
-        return True
-
     module = node.root()
     return "annotations" in module.future_imports
 


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
PEP 563, postponed evaluation of type annotations, will be delayed, at least until Python 3.11
Since it's not yet clear when exactly it will become the default, I propose to remove the check for now and add it back once we know more.
https://mail.python.org/archives/list/python-dev@python.org/thread/CLVXXPQ2T2LQ5MP2Y53VVQFCXYWQJHKZ/


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue
--