### PR TITLE
Add --fail-on option (#4227)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -478,3 +478,5 @@ contributors:
 * manderj: contributor
 
 * qwiddle: contributor
+
+* das-intensity: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,8 @@ Release date: TBA
 ..
   Put new features and bugfixes here and also in 'doc/whatsnew/2.9.rst'
 
+* Added ``--fail-on`` option to return non-zero exit codes regardless of ``--fail-under`` value.
+
 
 What's New in Pylint 2.8.0?
 ===========================

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -14,3 +14,5 @@ New checkers
 
 Other Changes
 =============
+
+* New option ``--fail-on=<msg ids>`` to return non-zero exit codes regardless of ``fail-under`` value.

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -625,13 +625,12 @@ class PyLinter(
         fail_on_msgs = self.config.fail_on
         if not vals:
             return
-        all_cats = ["C", "R", "W", "E"]
 
         fail_on_cats = set()
         fail_on_msgs = set()
         for fail_on_msg in fail_on_msgs:
             # If value is a cateogry, add category, else add message
-            if val in all_cats:
+            if val in MSG_TYPES:
                 fail_on_cats.add(val)
             else:
                 fail_on_msgs.add(val)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -622,7 +622,7 @@ class PyLinter(
             self.disable(checker.name)
 
     def enable_fail_on_messages(self):
-        fail_on_msgs= self.config.fail_on
+        fail_on_msgs = self.config.fail_on
         if not vals:
             return
         all_cats = ["C", "R", "W", "E"]

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -622,14 +622,14 @@ class PyLinter(
             self.disable(checker.name)
 
     def enable_fail_on_messages(self):
-        vals = self.config.fail_on
+        fail_on_msgs= self.config.fail_on
         if not vals:
             return
         all_cats = ["C", "R", "W", "E"]
 
         fail_on_cats = set()
         fail_on_msgs = set()
-        for val in vals:
+        for fail_on_msg in fail_on_msgs:
             # If value is a cateogry, add category, else add message
             if val in all_cats:
                 fail_on_cats.add(val)
@@ -639,8 +639,7 @@ class PyLinter(
         # For every message in every checker, if cat or msg flagged, enable check
         for all_checkers in self._checkers.values():
             for checker in all_checkers:
-                msgs = checker.messages
-                for msg in msgs:
+                for msg in checker.messages:
                     if msg.msgid in fail_on_msgs or msg.symbol in fail_on_msgs:
                         # message id/symbol matched, enable and flag it
                         self.enable(msg.msgid)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -649,8 +649,7 @@ class PyLinter(
                         self.fail_on_symbols.append(msg.symbol)
 
     def any_fail_on_issues(self):
-        issue_symbols = list(self.stats["by_msg"])
-        return any(x in self.fail_on_symbols for x in issue_symbols)
+        return any(x in self.fail_on_symbols for x in self.stats["by_msg"])
 
     def disable_noerror_messages(self):
         for msgcat, msgids in self.msgs_store._msgs_by_category.items():

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -622,13 +622,18 @@ class PyLinter(
             self.disable(checker.name)
 
     def enable_fail_on_messages(self):
-        fail_on_msgs = self.config.fail_on
-        if not vals:
+        """enable 'fail on' msgs
+
+        Convert values in config.fail_on (which might be msg category, msg id,
+        or symbol) to specific msgs, then enable and flag them for later.
+        """
+        fail_on_vals = self.config.fail_on
+        if not fail_on_vals:
             return
 
         fail_on_cats = set()
         fail_on_msgs = set()
-        for fail_on_msg in fail_on_msgs:
+        for val in fail_on_vals:
             # If value is a cateogry, add category, else add message
             if val in MSG_TYPES:
                 fail_on_cats.add(val)

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -368,6 +368,9 @@ group are mutually exclusive.",
         # load plugin specific configuration.
         linter.load_plugin_configuration()
 
+        # Now that plugins are loaded, get list of all fail_on messages, and enable them
+        linter.enable_fail_on_messages()
+
         if self._output:
             try:
                 with open(self._output, "w") as output:
@@ -392,7 +395,12 @@ group are mutually exclusive.",
             if linter.config.exit_zero:
                 sys.exit(0)
             else:
-                if score_value and score_value >= linter.config.fail_under:
+                if (
+                    score_value
+                    and score_value >= linter.config.fail_under
+                    # detected messages flagged by --fail-on prevent non-zero exit code
+                    and not linter.any_fail_on_issues()
+                ):
                     sys.exit(0)
                 sys.exit(self.linter.msg_status)
 

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -742,7 +742,7 @@ class TestRunTC:
         )
 
     def test_fail_on(self):
-        """ Run same test cases as --fail-under, but run with/without a detected issue code """
+        """Run same test cases as --fail-under, but run with/without a detected issue code"""
         test_cases = [
             # missing-function-docstring (C0116) is issue in both files
             # --fail-under should be irrelevant as missing-function-docstring is hit


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

The current `--fail-under` option actually is more of a "do not fail over", whereby if the score is higher, the return code is zero, regardless of any types of errors.

This means that you cannot e.g. fail on
- score less than 7.0 OR
- any error-category messages

which for obvious reasons really restricts the utility of `--fail-under`.

The new `--fail-on` specifies messages/categories to enable that, if detected, will not return non-zero error code, regardless of what `--fail-under` is set to. For example to catch the above case, we can do:
```
$ pylint --fail-under=7.0 --fail-on=E myfile.py
```

If a category is specified, it will use already-enabled checks only (it will not enable every message/check in that category).

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue

Closes #4227
