### PR TITLE
Remove 2.8.0 breaking changes in ``__pkginfo__``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,11 @@ Release date: TBA
 ..
   Put new features and bugfixes here and also in 'doc/whatsnew/2.9.rst'
 
+* Add numversion back (temporarily) in ``__pkginfo__`` because it broke Pylama and revert the unnecessary
+  ``pylint.version`` breaking change.
+
+  Closes #4399
+
 
 What's New in Pylint 2.8.0?
 ===========================
@@ -46,7 +51,7 @@ Release date: 2021-04-24
 * The 'doc' extra-require has been removed.
 
 * ``__pkginfo__`` now only contain ``__version__`` (also accessible with ``pylint.__version__``), other meta-information are still
-  accessible with ``import importlib;metadata.metadata('pylint')``.
+  accessible with ``from importlib import metadata;metadata.metadata('pylint')``.
 
 * COPYING has been renamed to LICENSE for standardization.
 

--- a/doc/whatsnew/2.8.rst
+++ b/doc/whatsnew/2.8.rst
@@ -8,6 +8,17 @@
 Summary -- Release highlights
 =============================
 
+Breaking changes
+================
+
+* The 'doc' extra-require has been removed. `__pkginfo__`` does not contain the package metadata anymore
+  (except ``numversion``, until 3.0). Meta-information are accessible with
+
+```python
+from importlib import metadata
+metadata.metadata('pylint')
+```
+Prefer that to an import from ``__pkginfo__``.
 
 New checkers
 ============
@@ -42,9 +53,6 @@ Other Changes
 
 * The packaging is now done via setuptools exclusively. ``doc``, ``tests``, ``man``, ``elisp`` and ``Changelog`` are
   not packaged anymore - reducing the size of the package by 75%.
-
-* The 'doc' extra-require has been removed. ``pylint.version`` is now ``pylint.__version__`` and ``__pkginfo__`` does
-  not contain the package metadata anymore.
 
 * Updated ``astroid`` to 2.5.4
 

--- a/pylint/__init__.py
+++ b/pylint/__init__.py
@@ -74,4 +74,5 @@ def modify_sys_path() -> None:
         sys.path.pop(1)
 
 
-__all__ = ["__version__"]
+version = __version__
+__all__ = ["__version__", "version"]

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -13,3 +13,7 @@ if dev_version is not None:
         __version__ += f"a{dev_version}"
     else:
         __version__ += f".dev{dev_version}"
+
+
+# Kept for compatibility reason, see https://github.com/PyCQA/pylint/issues/4399
+numversion = __version__.split(".")


### PR DESCRIPTION
There was a problem in the code given in the changelog, and we needed it in a more visible section in What's new

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Related Issue
Closes #4399

