### PR TITLE
Use scm setuptools for auto-versionning

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,8 @@ Release date: TBA
 
 * scm_setuptools has been added to the packaging.
 
+* Pylint's tags are now the standard form ``vX.Y.Z`` and not ``pylint-X.Y.Z`` anymore.
+
 
 What's New in Pylint 2.8.1?
 ===========================

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,8 @@ Release date: TBA
 
   Closes #4405
 
+* scm_setuptools has been added to the packaging.
+
 
 What's New in Pylint 2.8.1?
 ===========================

--- a/doc/release.md
+++ b/doc/release.md
@@ -7,11 +7,8 @@ So, you want to release the `X.Y.Z` version of pylint ?
 1. Run the acceptance tests to see if everything is alright with this release. We don't
    run them on CI: `pytest -m acceptance`
 2. Check if the dependencies of the package are correct
-3. Update `__version__` in `pylint/__pkginfo__.py`, `dev_version` should be `None` when
-   you tag, except if it's an alpha release.
-4. Put the version numbers, and the release date into the changelog
-5. Put the release date into the `What's new` section.
-6. Generate the new copyright notices for this release:
+3. Put the release date into the changelog and `What's new` section.
+4. Generate the new copyright notices for this release:
 
 ```bash
 pip3 install copyrite
@@ -21,17 +18,17 @@ git --aliases=.copyrite_aliases . --jobs=8
 # automatically
 ```
 
-7. Submit your changes in a merge request.
+5. Submit your changes in a merge request.
 
-8. Make sure the tests are passing on Travis/GithubActions:
+6. Make sure the tests are passing on Travis/GithubActions:
    https://travis-ci.org/PyCQA/pylint/
 
-9. Do the actual release by tagging the master with `pylint-X.Y.Z` (ie `pylint-1.6.12`
-   for example). Travis should deal with the release process once the tag is pushed with
-   `git push origin --tags`
+7. Do the actual release by tagging the master with `pylint-X.Y.Z` (ie `pylint-1.6.12`
+   or `pylint-4.0.0a1` for example). Travis should deal with the release process once
+   the tag is pushed with `git push origin --tags`
 
-10. Go to github, click on "Releases" then on the `pylint-X.Y.Z` tag, choose edit tag,
-    and copy past the changelog in the description.
+8. Go to github, click on "Releases" then on the `pylint-X.Y.Z` tag, choose edit tag,
+   and copy past the changelog in the description.
 
 ## Manual Release
 
@@ -77,8 +74,3 @@ known at that time, we should use `Undefined`.
 
 If it's a major release, create a new `What's new in Pylint X.Y+1` document Take a look
 at the examples from `doc/whatsnew`.
-
-### Versions
-
-Update `__version__` to `X.Y+1.0` or `X.Y.Z+1` in `__pkginfo__`. `dev_version` should
-also be back to an integer after the tag.

--- a/doc/release.md
+++ b/doc/release.md
@@ -23,12 +23,12 @@ git --aliases=.copyrite_aliases . --jobs=8
 6. Make sure the tests are passing on Travis/GithubActions:
    https://travis-ci.org/PyCQA/pylint/
 
-7. Do the actual release by tagging the master with `pylint-X.Y.Z` (ie `pylint-1.6.12`
-   or `pylint-4.0.0a1` for example). Travis should deal with the release process once
-   the tag is pushed with `git push origin --tags`
+7. Do the actual release by tagging the master with `vX.Y.Z` (ie `v1.6.12` or `v2.5.3a1`
+   for example). Travis should deal with the release process once the tag is pushed with
+   `git push origin --tags`
 
-8. Go to github, click on "Releases" then on the `pylint-X.Y.Z` tag, choose edit tag,
-   and copy past the changelog in the description.
+8. Go to github, click on "Releases" then on the `vX.Y.Z` tag, choose edit tag, and copy
+   past the changelog in the description.
 
 ## Manual Release
 
@@ -45,13 +45,13 @@ twine upload dist/*
 
 ### Merge tags in master for pre-commit
 
-If the tag you just made is not part of the main branch, merge the tag `X.Y.Z` in the
+If the tag you just made is not part of the main branch, merge the tag `vX.Y.Z` in the
 main branch by doing a history only merge. It's done in order to signal that this is an
 official release tag, and for `pre-commit autoupdate` to works.
 
 ```bash
 git checkout master
-git merge --no-edit --strategy=ours pylint-X.Y.Z
+git merge --no-edit --strategy=ours vX.Y.Z
 git push
 ```
 

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -14,3 +14,5 @@ New checkers
 
 Other Changes
 =============
+
+* Pylint's tags are now the standard form ``vX.Y.Z`` and not ``pylint-X.Y.Z`` anymore.

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -1,19 +1,12 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/LICENSE
 
-from typing import Optional
+from pkg_resources import DistributionNotFound, get_distribution
 
-__version__ = "2.8.1"
-# For an official release, use 'alpha_version = False' and 'dev_version = None'
-alpha_version: bool = False  # Release will be an alpha version if True (ex: '1.2.3a6')
-dev_version: Optional[int] = None
-
-if dev_version is not None:
-    if alpha_version:
-        __version__ += f"a{dev_version}"
-    else:
-        __version__ += f".dev{dev_version}"
-
+try:
+    __version__ = get_distribution("pylint").version
+except DistributionNotFound:
+    __version__ = "2.8.2+"
 
 # Kept for compatibility reason, see https://github.com/PyCQA/pylint/issues/4399
 numversion = tuple(__version__.split("."))

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,8 @@ install_requires =
     mccabe>=0.6,<0.7
     toml>=0.7.1
     colorama;sys_platform=="win32"
+setup_requires =
+  setuptools_scm
 python_requires = ~=3.6
 
 [options.packages.find]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup()
+setup(use_scm_version=True)


### PR DESCRIPTION
## Description

Move to scm_setuptools for easier release. Update the release doc.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Related Issue

#4399 #4400 
