### PR TITLE
Keep __pkginfo__.numversion a tuple

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,9 +2,21 @@
 Pylint's ChangeLog
 ------------------
 
-What's New in Pylint 2.8.1?
+What's New in Pylint 2.8.2?
 ===========================
 Release date: TBA
+
+..
+  Put new features and bugfixes here and also in 'doc/whatsnew/2.9.rst'
+
+* Keep ``__pkginfo__.numversion`` a tuple to avoid breaking pylint-django.
+
+  Closes #4405
+
+
+What's New in Pylint 2.8.1?
+===========================
+Release date: 2021-04-25
 
 ..
   Put new features and bugfixes here and also in 'doc/whatsnew/2.9.rst'

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -16,4 +16,4 @@ if dev_version is not None:
 
 
 # Kept for compatibility reason, see https://github.com/PyCQA/pylint/issues/4399
-numversion = __version__.split(".")
+numversion = tuple(__version__.split("."))


### PR DESCRIPTION
## Description

After 2.8.1 `__pkginfo__.numversion` was now a list which broke pylint-django. See #4405 
This avoids breaking pylint-django like described here https://github.com/PyCQA/pylint-django/issues/323

Not sure if it would make sense to fix here or downstream

## Type of Changes


|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #4405 
