### PR TITLE
Add new warning ``deprecated-class`` #4388

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  skip: [pylint]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -478,3 +478,5 @@ contributors:
 * manderj: contributor
 
 * qwiddle: contributor
+
+* Jiajunsu (victor): contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -18,9 +18,9 @@ Release date: 2021-04-26
 * Pylint's tags are now the standard form ``vX.Y.Z`` and not ``pylint-X.Y.Z`` anymore.
 
 * New warning message ``deprecated-class``. This message is emitted if import or call deprecated class of the
-__standard library (like ``collections.Iterable`` that will be removed in Python 3.10).
+standard library (like ``collections.Iterable`` that will be removed in Python 3.10).
 
-__Closes #4388
+Closes #4388
 
 
 What's New in Pylint 2.8.1?

--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,11 @@ Release date: 2021-04-26
 
 * Pylint's tags are now the standard form ``vX.Y.Z`` and not ``pylint-X.Y.Z`` anymore.
 
+* New warning message ``deprecated-class``. This message is emitted if import or call deprecated class of the
+__standard library (like ``collections.Iterable`` that will be removed in Python 3.10).
+
+__Closes #4388
+
 
 What's New in Pylint 2.8.1?
 ===========================

--- a/doc/whatsnew/2.8.rst
+++ b/doc/whatsnew/2.8.rst
@@ -39,6 +39,7 @@ New checkers
   (For example, 'typing.Dict' can be replaced by 'dict', and 'typing.Unions' by '|', etc.)
   Make sure to check the config options if you plan on using it!
 
+* Add ``deprecated-class`` check for deprecated classes.
 
 Other Changes
 =============

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -196,7 +196,7 @@ class DeprecatedMixin:
                 )
 
     def check_deprecated_class_in_call(self, node):
-        """Check if call the deprecated class"""
+        """Checks if call the deprecated class"""
         if isinstance(node.func, astroid.Attribute) and isinstance(
             node.func.expr, astroid.Name
         ):

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -52,11 +52,12 @@ class DeprecatedMixin:
     def visit_call(self, node: astroid.Call) -> None:
         """Called when a :class:`.astroid.node_classes.Call` node is visited."""
         try:
+            self.check_deprecated_class_in_call(node)
             for inferred in node.func.infer():
                 # Calling entry point for deprecation check logic.
                 self.check_deprecated_method(node, inferred)
         except astroid.InferenceError:
-            self.check_deprecated_class_in_call(node)
+            pass
 
     @utils.check_messages(
         "deprecated-module",
@@ -197,6 +198,7 @@ class DeprecatedMixin:
 
     def check_deprecated_class_in_call(self, node):
         """Checks if call the deprecated class"""
+
         if isinstance(node.func, astroid.Attribute) and isinstance(
             node.func.expr, astroid.Name
         ):

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -434,7 +434,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                         self._check_for_check_kw_in_run(node)
                 self.check_deprecated_method(node, inferred)
         except astroid.InferenceError:
-            pass
+            return
 
     @utils.check_messages("boolean-datetime")
     def visit_unaryop(self, node):

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -433,7 +433,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                         self._check_for_check_kw_in_run(node)
                 self.check_deprecated_method(node, inferred)
         except astroid.InferenceError:
-            self.check_deprecated_class(node)
+            self.check_deprecated_class_in_call(node)
 
     @utils.check_messages("boolean-datetime")
     def visit_unaryop(self, node):

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -410,6 +410,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
     def visit_call(self, node):
         """Visit a Call node."""
         try:
+            self.check_deprecated_class_in_call(node)
             for inferred in node.func.infer():
                 if inferred is astroid.Uninferable:
                     continue
@@ -433,7 +434,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                         self._check_for_check_kw_in_run(node)
                 self.check_deprecated_method(node, inferred)
         except astroid.InferenceError:
-            self.check_deprecated_class_in_call(node)
+            pass
 
     @utils.check_messages("boolean-datetime")
     def visit_unaryop(self, node):

--- a/tests/functional/d/deprecated/deprecated_class_py33.py
+++ b/tests/functional/d/deprecated/deprecated_class_py33.py
@@ -1,5 +1,5 @@
 """Test deprecated classes from Python 3.3."""
-# pylint: disable=unused-import,import-error,no-name-in-module
+# pylint: disable=unused-import,import-error,no-name-in-module,abstract-class-instantiated
 
 from collections import Iterable  # [deprecated-class]
 

--- a/tests/functional/d/deprecated/deprecated_class_py33.py
+++ b/tests/functional/d/deprecated/deprecated_class_py33.py
@@ -1,4 +1,4 @@
-"""Test deprecated modules from Python 3.3."""
+"""Test deprecated classes from Python 3.3."""
 # pylint: disable=unused-import,import-error,no-name-in-module
 
 from collections import Iterable  # [deprecated-class]

--- a/tests/functional/d/deprecated/deprecated_class_py33.py
+++ b/tests/functional/d/deprecated/deprecated_class_py33.py
@@ -1,0 +1,11 @@
+"""Test deprecated modules from Python 3.3."""
+# pylint: disable=unused-import,import-error,no-name-in-module
+
+from collections import Iterable  # [deprecated-class]
+
+import collections.Set  # [deprecated-class]
+
+import collections
+
+
+_ = collections.Awaitable()  # [deprecated-class]

--- a/tests/functional/d/deprecated/deprecated_class_py33.rc
+++ b/tests/functional/d/deprecated/deprecated_class_py33.rc
@@ -1,0 +1,3 @@
+[testoptions]
+min_pyver=3.3
+max_pyver=3.10

--- a/tests/functional/d/deprecated/deprecated_class_py33.txt
+++ b/tests/functional/d/deprecated/deprecated_class_py33.txt
@@ -1,3 +1,3 @@
-deprecated-class:4:::Using deprecated class Iterable of module collections
-deprecated-class:6:::Using deprecated class Set of module collections
+deprecated-class:4:0::Using deprecated class Iterable of module collections
+deprecated-class:6:0::Using deprecated class Set of module collections
 deprecated-class:11:4::Using deprecated class Awaitable of module collections

--- a/tests/functional/d/deprecated/deprecated_class_py33.txt
+++ b/tests/functional/d/deprecated/deprecated_class_py33.txt
@@ -1,0 +1,3 @@
+deprecated-class:4:::Using deprecated class Iterable of module collections
+deprecated-class:6:::Using deprecated class Set of module collections
+deprecated-class:11:4::Using deprecated class Awaitable of module collections


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
According to Python documentation of module `collections`[1], classes in `_collections_abc`[2] will be moved from `collections` to `collections.abc`. And now Pylint hasn't checked it.

This PR add ``deprecated-class`` to check deprecated class that be imported or called, and could check the deprecation above.

**Unsupport scenario**
I haven't found a proper method that could detect the code below. Maybe it could be implemented in future.

```
import collections


isinstance(None, collections.Iterable)
```

[1]https://docs.python.org/3/library/collections.html
[2]https://github.com/python/cpython/blob/3.9/Lib/_collections_abc.py#L18


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #
-->
Closes #4388
