### PR TITLE
Add support for checking deprecated class arguments.

### DIFF
--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -13,6 +13,7 @@ ACCEPTABLE_NODES = (
     astroid.BoundMethod,
     astroid.UnboundMethod,
     astroid.FunctionDef,
+    astroid.ClassDef,
 )
 
 

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -63,6 +63,11 @@ DEPRECATED_ARGUMENTS = {
         "asyncio.subprocess.create_subprocess_shell": ((4, "loop"),),
         "gettext.translation": ((5, "codeset"),),
         "gettext.install": ((2, "codeset"),),
+        "functools.partialmethod": ((None, "func"),),
+        "weakref.finalize": (
+            (None, "func"),
+            (None, "obj")
+        ),
         "profile.Profile.runcall": ((None, "func"),),
         "cProfile.Profile.runcall": ((None, "func"),),
         "bdb.Bdb.runcall": ((None, "func"),),
@@ -78,6 +83,7 @@ DEPRECATED_ARGUMENTS = {
             (None, "c"),
             (None, "typeid"),
         ),
+
     },
     (3, 9, 0): {"random.Random.shuffle": ((1, "random"),)},
 }

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -64,10 +64,7 @@ DEPRECATED_ARGUMENTS = {
         "gettext.translation": ((5, "codeset"),),
         "gettext.install": ((2, "codeset"),),
         "functools.partialmethod": ((None, "func"),),
-        "weakref.finalize": (
-            (None, "func"),
-            (None, "obj")
-        ),
+        "weakref.finalize": ((None, "func"), (None, "obj")),
         "profile.Profile.runcall": ((None, "func"),),
         "cProfile.Profile.runcall": ((None, "func"),),
         "bdb.Bdb.runcall": ((None, "func"),),
@@ -83,7 +80,6 @@ DEPRECATED_ARGUMENTS = {
             (None, "c"),
             (None, "typeid"),
         ),
-
     },
     (3, 9, 0): {"random.Random.shuffle": ((1, "random"),)},
 }

--- a/tests/checkers/unittest_deprecated.py
+++ b/tests/checkers/unittest_deprecated.py
@@ -34,6 +34,9 @@ class _DeprecatedChecker(DeprecatedMixin, BaseChecker):
         if method == ".MyClass.mymethod3":
             # def mymethod1(self, arg1, *, deprecated_arg1=None)
             return ((None, "deprecated_arg1"),)
+        if method == ".MyClass":
+            # def __init__(self, deprecated_arg=None)
+            return ((0, "deprecated_arg"),)
         return ()
 
 
@@ -356,6 +359,27 @@ class TestDeprecatedChecker(CheckerTestCase):
                 node=node,
                 confidence=UNDEFINED,
             ),
+        ):
+            self.checker.visit_call(node)
+
+    def test_class_deprecated_arguments(self):
+
+        node = astroid.extract_node(
+            """
+        class MyClass:
+            def __init__(self, deprecated_arg=None):
+                pass
+
+        MyClass(5)
+        """
+        )
+        with self.assertAddsMessages(
+            Message(
+                msg_id="deprecated-argument",
+                args=("deprecated_arg", "MyClass"),
+                node=node,
+                confidence=UNDEFINED,
+            )
         ):
             self.checker.visit_call(node)
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

This PR adds support for checking deprecated class arguments. Hence, we can check deprecated arguments of `functools.partialmethod` even it is defined as a class.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|     | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
