### PR TITLE
Fix issues with Python 3.6.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -40,6 +40,10 @@ modules are added.
 
 * Don't emit ``import-error`` if import guarded behind ``if sys.version_info >= (x, x)``
 
+* Fix incompatibility with Python 3.6.0 caused by ``typing.Counter`` and ``typing.NoReturn`` usage
+
+  Closes #4412
+
 
 What's New in Pylint 2.8.2?
 ===========================

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -26,3 +26,5 @@ Other Changes
 * The output messages for ``arguments-differ`` error message have been customized based on the different error cases.
 
 * New option ``--fail-on=<msg ids>`` to return non-zero exit codes regardless of ``fail-under`` value.
+
+* Fix incompatibility with Python 3.6.0 caused by ``typing.Counter`` and ``typing.NoReturn`` usage

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -38,13 +38,16 @@ import collections
 import numbers
 import re
 import tokenize
-from typing import Counter, Iterable
+from typing import TYPE_CHECKING, Iterable
 
 import astroid
 
 from pylint.checkers import BaseChecker, BaseTokenChecker, utils
 from pylint.checkers.utils import check_messages
 from pylint.interfaces import IAstroidChecker, IRawChecker, ITokenChecker
+
+if TYPE_CHECKING:
+    from typing import Counter  # typing.Counter added in Python 3.6.1
 
 _AST_NODE_STR_TYPES = ("__builtin__.unicode", "__builtin__.str", "builtins.str")
 # Prefixes for both strings and bytes literals per
@@ -750,7 +753,8 @@ class StringConstantChecker(BaseTokenChecker):
         Args:
           tokens: The tokens to be checked against for consistent usage.
         """
-        string_delimiters: Counter[str] = collections.Counter()
+        # typing.Counter added in Python 3.6.1 so this type hint must be a comment
+        string_delimiters = collections.Counter()  # type: Counter[str]
 
         # First, figure out which quote character predominates in the module
         for tok_type, token, _, _, _ in tokens:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 -r requirements_test_min.txt
 coveralls~=3.0
 coverage~=5.5
-pre-commit~=2.12
+pre-commit~=2.12;python_full_version>="3.6.2"
 pyenchant~=3.2
 pytest-cov~=2.11
 pytest-profiling~=1.7

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,7 +1,7 @@
 autoflake==1.4
-black==21.5b1
+black==21.5b1;python_full_version>="3.6.2"
 flake8==3.9.2
 isort==5.8.0
 mypy==0.812
-pyupgrade==2.15.0
+pyupgrade==2.15.0;python_full_version>="3.6.1"
 black-disable-checker==1.0.1

--- a/tests/functional/i/inconsistent/inconsistent_returns.py
+++ b/tests/functional/i/inconsistent/inconsistent_returns.py
@@ -336,59 +336,6 @@ def bug_pylint_3873_2():
         nothing_to_do()
     return False
 
-import typing  # pylint: disable=wrong-import-position
-
-def parser_error(msg) -> typing.NoReturn:  #pylint:disable=unused-argument
-    sys.exit(1)
-
-def parser_error_nortype(msg):  #pylint:disable=unused-argument
-    sys.exit(2)
-
-
-from typing import NoReturn  # pylint: disable=wrong-import-position
-
-def parser_error_name(msg) -> NoReturn:  #pylint:disable=unused-argument
-    sys.exit(3)
-
-def bug_pylint_4122(s):
-    """
-    Every returns is consistent because parser_error has type hints
-    indicating it never returns
-    """
-    try:
-        n = int(s)
-        if n < 1:
-            raise ValueError()
-        return n
-    except ValueError:
-        parser_error('parser error')
-
-def bug_pylint_4122_wrong(s): # [inconsistent-return-statements]
-    """
-    Every returns is not consistent because parser_error_nortype has no type hints
-    """
-    try:
-        n = int(s)
-        if n < 1:
-            raise ValueError()
-        return n
-    except ValueError:
-        parser_error_nortype('parser error')
-
-def bug_pylint_4122_bis(s):
-    """
-    Every returns is consistent because parser_error has type hints
-    indicating it never returns
-    """
-    try:
-        n = int(s)
-        if n < 1:
-            raise ValueError()
-        return n
-    except ValueError:
-        parser_error_name('parser error')
-
-
 # https://github.com/PyCQA/pylint/issues/4019
 def bug_pylint_4019(x):
     """

--- a/tests/functional/i/inconsistent/inconsistent_returns.txt
+++ b/tests/functional/i/inconsistent/inconsistent_returns.txt
@@ -14,5 +14,4 @@ inconsistent-return-statements:262:8:bug_1794_inner_func_in_if_counter_example_3
 inconsistent-return-statements:267:0:bug_3468:Either all return statements in a function should return an expression, or none of them should.
 inconsistent-return-statements:277:0:bug_3468_variant:Either all return statements in a function should return an expression, or none of them should.
 inconsistent-return-statements:322:0:bug_pylint_3873_1:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:366:0:bug_pylint_4122_wrong:Either all return statements in a function should return an expression, or none of them should.
-inconsistent-return-statements:402:0:bug_pylint_4019_wrong:Either all return statements in a function should return an expression, or none of them should.
+inconsistent-return-statements:349:0:bug_pylint_4019_wrong:Either all return statements in a function should return an expression, or none of them should.

--- a/tests/functional/i/inconsistent/inconsistent_returns_noreturn.py
+++ b/tests/functional/i/inconsistent/inconsistent_returns_noreturn.py
@@ -1,0 +1,55 @@
+"""Testing inconsistent returns involving typing.NoReturn annotations."""
+# pylint: disable=missing-docstring, invalid-name
+
+import sys
+import typing
+
+def parser_error(msg) -> typing.NoReturn:  # pylint: disable=unused-argument
+    sys.exit(1)
+
+def parser_error_nortype(msg):  # pylint: disable=unused-argument
+    sys.exit(2)
+
+
+from typing import NoReturn  # pylint: disable=wrong-import-position
+
+def parser_error_name(msg) -> NoReturn:  # pylint: disable=unused-argument
+    sys.exit(3)
+
+def bug_pylint_4122(s):
+    """
+    Every returns is consistent because parser_error has type hints
+    indicating it never returns
+    """
+    try:
+        n = int(s)
+        if n < 1:
+            raise ValueError()
+        return n
+    except ValueError:
+        parser_error('parser error')
+
+def bug_pylint_4122_wrong(s):  # [inconsistent-return-statements]
+    """
+    Every returns is not consistent because parser_error_nortype has no type hints
+    """
+    try:
+        n = int(s)
+        if n < 1:
+            raise ValueError()
+        return n
+    except ValueError:
+        parser_error_nortype('parser error')
+
+def bug_pylint_4122_bis(s):
+    """
+    Every returns is consistent because parser_error has type hints
+    indicating it never returns
+    """
+    try:
+        n = int(s)
+        if n < 1:
+            raise ValueError()
+        return n
+    except ValueError:
+        parser_error_name('parser error')

--- a/tests/functional/i/inconsistent/inconsistent_returns_noreturn.rc
+++ b/tests/functional/i/inconsistent/inconsistent_returns_noreturn.rc
@@ -1,0 +1,5 @@
+[testoptions]
+min_pyver=3.6.2
+
+[REFACTORING]
+never-returning-functions=sys.exit,sys.getdefaultencoding

--- a/tests/functional/i/inconsistent/inconsistent_returns_noreturn.txt
+++ b/tests/functional/i/inconsistent/inconsistent_returns_noreturn.txt
@@ -1,0 +1,1 @@
+inconsistent-return-statements:32:0:bug_pylint_4122_wrong:Either all return statements in a function should return an expression, or none of them should.


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

This PR fixes compatibility with Python 3.6.0, mainly due to `typing`:

- `typing.Counter` is added in Python 3.6.1, so make the import conditional on TYPE_CHECKING.
- `typing.NoReturn` is added in Python 3.6.2, split the inconsistent_returns tests that need this to it's own file.
- `black`, `pre-commit` and `pyupgrade` require Python 3.6.1 (or later), add `python_full_version` markers so `tox -e py36` works

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #4412 