### PR TITLE
deprecated arguments

### DIFF
--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -52,7 +52,7 @@ SUBPROCESS_RUN = "subprocess.run"
 OPEN_MODULE = "_io"
 
 DEPRECATED_ARGUMENTS = {
-    (3, 7, 0): {
+    (0, 0, 0): {
         "int": ((None, "x"),),
         "bool": ((None, "x"),),
         "float": ((None, "x"),),

--- a/tests/checkers/deprecated.py
+++ b/tests/checkers/deprecated.py
@@ -1,0 +1,6 @@
+class Deprecated:
+    def deprecated_method(self):
+        pass
+
+class DeprecatedClass:
+    pass

--- a/tests/checkers/deprecated.py
+++ b/tests/checkers/deprecated.py
@@ -2,5 +2,6 @@ class Deprecated:
     def deprecated_method(self):
         pass
 
+
 class DeprecatedClass:
     pass

--- a/tests/checkers/unittest_deprecated.py
+++ b/tests/checkers/unittest_deprecated.py
@@ -15,6 +15,9 @@ class _DeprecatedChecker(DeprecatedMixin, BaseChecker):
     def deprecated_modules(self):
         return {"deprecated_module"}
 
+    def deprecated_classes(self, module):
+        return {"deprecated": "DeprecatedClass"}[module]
+
     def deprecated_arguments(self, method):
         if method == "myfunction1":
             # def myfunction1(arg1, deprecated_arg1='spam')
@@ -416,3 +419,55 @@ class TestDeprecatedChecker(CheckerTestCase):
             )
         ):
             self.checker.visit_importfrom(node)
+
+    def test_deprecated_class_import_from(self):
+        # Tests detecting deprecated class via import from
+        node = astroid.extract_node(
+            """
+        from .deprecated import DeprecatedClass
+        """
+        )
+        with self.assertAddsMessages(
+            Message(
+                msg_id="deprecated-class",
+                args=('DeprecatedClass', 'deprecated'),
+                node=node,
+                confidence=UNDEFINED,
+            )
+        ):
+            self.checker.visit_importfrom(node)
+
+    def test_deprecated_class_import(self):
+        # Tests detecting deprecated class via import
+        node = astroid.extract_node(
+            """
+        import deprecated.DeprecatedClass
+        """
+        )
+        with self.assertAddsMessages(
+            Message(
+                msg_id="deprecated-class",
+                args=('DeprecatedClass', 'deprecated'),
+                node=node,
+                confidence=UNDEFINED,
+            )
+        ):
+            self.checker.visit_import(node)
+
+    def test_deprecated_class_call(self):
+        # Tests detecting deprecated class via call
+        node = astroid.extract_node(
+            """
+        import deprecated
+        deprecated.DeprecatedClass()
+        """
+        )
+        with self.assertAddsMessages(
+            Message(
+                msg_id="deprecated-class",
+                args=('DeprecatedClass', 'deprecated'),
+                node=node,
+                confidence=UNDEFINED,
+            )
+        ):
+            self.checker.visit_call(node)

--- a/tests/checkers/unittest_deprecated.py
+++ b/tests/checkers/unittest_deprecated.py
@@ -430,7 +430,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         with self.assertAddsMessages(
             Message(
                 msg_id="deprecated-class",
-                args=('DeprecatedClass', 'deprecated'),
+                args=("DeprecatedClass", "deprecated"),
                 node=node,
                 confidence=UNDEFINED,
             )
@@ -447,7 +447,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         with self.assertAddsMessages(
             Message(
                 msg_id="deprecated-class",
-                args=('DeprecatedClass', 'deprecated'),
+                args=("DeprecatedClass", "deprecated"),
                 node=node,
                 confidence=UNDEFINED,
             )
@@ -465,7 +465,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         with self.assertAddsMessages(
             Message(
                 msg_id="deprecated-class",
-                args=('DeprecatedClass', 'deprecated'),
+                args=("DeprecatedClass", "deprecated"),
                 node=node,
                 confidence=UNDEFINED,
             )


### PR DESCRIPTION
- warn deprecated x argument of int(), bool(), float() in all python versions
- Add Deprecated Class unittests
