### PR TITLE
Fix broken tests

### DIFF
--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1077,20 +1077,24 @@ class TestRunTC:
                 code=0,
             )
 
-    def test_can_list_directories_without_dunder_init(self, tmpdir):
+    @staticmethod
+    def test_can_list_directories_without_dunder_init(tmpdir):
         test_directory = tmpdir / "test_directory"
         test_directory.mkdir()
         spam_module = test_directory / "spam.py"
         spam_module.write("'Empty'")
 
-        with tmpdir.as_cwd():
-            self._runtest(
-                [
-                    "--disable=missing-docstring, missing-final-newline",
-                    "test_directory",
-                ],
-                code=0,
-            )
+        subprocess.check_output(
+            [
+                sys.executable,
+                "-m",
+                "pylint",
+                "--disable=missing-docstring, missing-final-newline",
+                "test_directory",
+            ],
+            cwd=str(tmpdir),
+            stderr=subprocess.PIPE,
+        )
 
     def test_jobs_score(self):
         path = join(HERE, "regrtest_data", "unused_variable.py")


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
The last python updates (`3.8.10` and `3.9.5`) seem to have broken a test. Unfortunately, I wasn't able to determine the exact issue. The best I got is that it's probably some kind of global state. It occurred when `test_parallel_execution_missing_arguments` and `test_can_list_directories_without_dunder_init` where executed after one another.

https://github.com/PyCQA/pylint/blob/7167442a294bd9dac498724557f0d737bfad9b58/tests/test_self.py#L303-L304

https://github.com/PyCQA/pylint/blob/7167442a294bd9dac498724557f0d737bfad9b58/tests/test_self.py#L1080-L1093

Anyway, this change should fix the test.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |