### PR TITLE
Moved stdlib module deprecation from imports checker to stdlib checker

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,9 @@ Release date: 2021-04-26
   Closes #4166
   Closes #4415
 
+* Stdlib deprecated modules check is moved to stdlib checker. New deprecated
+modules are added.
+
 
 What's New in Pylint 2.8.2?
 ===========================

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -309,7 +309,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
     name = "imports"
     msgs = MSGS
     priority = -2
-    default_deprecated_modules = ("optparse", "tkinter.tix")
+    default_deprecated_modules = ()
 
     options = (
         (

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -51,6 +51,17 @@ SUBPROCESS_POPEN = "subprocess.Popen"
 SUBPROCESS_RUN = "subprocess.run"
 OPEN_MODULE = "_io"
 
+
+DEPRECATED_MODULES = {
+    (0, 0, 0): {"tkinter.tix", "fpectl"},
+    (3, 2, 0): {"optparse"},
+    (3, 4, 0): {"imp"},
+    (3, 5, 0): {"formatter"},
+    (3, 6, 0): {"asynchat", "asyncore"},
+    (3, 7, 0): {"macpath"},
+    (3, 9, 0): {"lib2to3", "parser", "symbol", "binhex"},
+}
+
 DEPRECATED_ARGUMENTS = {
     (0, 0, 0): {
         "int": ((None, "x"),),
@@ -395,6 +406,10 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
         for since_vers, class_list in DEPRECATED_CLASSES.items():
             if since_vers <= sys.version_info:
                 self._deprecated_classes.update(class_list)
+        self._deprecated_modules = set()
+        for since_vers, mod_list in DEPRECATED_MODULES.items():
+            if since_vers <= sys.version_info:
+                self._deprecated_modules.update(mod_list)
 
     def _check_bad_thread_instantiation(self, node):
         if not node.kwargs and not node.keywords and len(node.args) <= 1:
@@ -572,6 +587,10 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                 self.add_message(message, node=node, args=(name, call_arg.pytype()))
         else:
             self.add_message(message, node=node, args=(name, call_arg.pytype()))
+
+    def deprecated_modules(self):
+        """Callback returning the deprecated modules."""
+        return self._deprecated_modules
 
     def deprecated_methods(self):
         return self._deprecated_methods

--- a/pylint/config/man_help_formatter.py
+++ b/pylint/config/man_help_formatter.py
@@ -1,7 +1,7 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/LICENSE
 
-import optparse
+import optparse  # pylint: disable=deprecated-module
 import sys
 import time
 

--- a/pylint/config/option.py
+++ b/pylint/config/option.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/master/LICENSE
 
 import copy
-import optparse   # pylint: disable=deprecated-module
+import optparse  # pylint: disable=deprecated-module
 import re
 
 from pylint import utils

--- a/pylint/config/option.py
+++ b/pylint/config/option.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/master/LICENSE
 
 import copy
-import optparse
+import optparse   # pylint: disable=deprecated-module
 import re
 
 from pylint import utils

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -7,7 +7,7 @@ import configparser
 import contextlib
 import copy
 import functools
-import optparse
+import optparse  # pylint: disable=deprecated-module
 import os
 import sys
 

--- a/pylint/config/option_parser.py
+++ b/pylint/config/option_parser.py
@@ -1,7 +1,7 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/LICENSE
 
-import optparse
+import optparse  # pylint: disable=deprecated-module
 
 from pylint.config.option import Option
 

--- a/pylint/config/options_provider_mixin.py
+++ b/pylint/config/options_provider_mixin.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/master/LICENSE
 
 
-import optparse
+import optparse  # pylint: disable=deprecated-module
 from typing import Any, Dict, Tuple
 
 from pylint.config.option import _validate


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

This PR moves checking of stdlib deprecated modules to stdlib checker. This is more natural place for having checks of deprecated modules and also now python version is taken into account during the checks. Imports check still has `--deprecated-modules` switch but now the default value is empty list. Moreover, multiple new deprecated modules are added.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|     | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
