### PR TITLE
Remove type check from arguments-differ

### DIFF
--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -271,7 +271,6 @@ def _has_different_parameters(
     original: List[astroid.AssignName],
     overridden: List[astroid.AssignName],
     dummy_parameter_regex: Pattern,
-    counter: int,
 ) -> List[str]:
     result = []
     zipped = zip_longest(original, overridden)
@@ -280,25 +279,14 @@ def _has_different_parameters(
         if not all(params):
             return ["Number of parameters "]
 
-        # check for the arguments' type
-        original_type = original_param.parent.annotations[counter]
-        if original_type is not None:
-            overridden_type = overridden_param.parent.annotations[counter]
-            if overridden_type is not None:
-                if original_type.name != overridden_type.name:
-                    result.append(
-                        f"Parameter '{original_param.name}' was of type '{original_type.name}' and is now"
-                        + f" of type '{overridden_type.name}' in"
-                    )
-            counter += 1
-
         # check for the arguments' name
         names = [param.name for param in params]
         if any(dummy_parameter_regex.match(name) for name in names):
             continue
         if original_param.name != overridden_param.name:
             result.append(
-                f"Parameter '{original_param.name}' has been renamed to '{overridden_param.name}' in"
+                f"Parameter '{original_param.name}' has been renamed "
+                f"to '{overridden_param.name}' in"
             )
 
     return result
@@ -343,19 +331,11 @@ def _different_parameters(
             v for v in original.args.kwonlyargs if v.name in overidden_names
         ]
 
-    arguments = list(original.args.args)
-    # variable 'count' helps to check if the type of an argument has changed
-    # at the _has_different_parameters method
-    if any(arg.name == "self" for arg in arguments) and len(arguments) > 1:
-        count = 1
-    else:
-        count = 0
-
     different_positional = _has_different_parameters(
-        original_parameters, overridden_parameters, dummy_parameter_regex, count
+        original_parameters, overridden_parameters, dummy_parameter_regex
     )
     different_kwonly = _has_different_parameters(
-        original_kwonlyargs, overridden.args.kwonlyargs, dummy_parameter_regex, count
+        original_kwonlyargs, overridden.args.kwonlyargs, dummy_parameter_regex
     )
     if different_kwonly and different_positional:
         if "Number " in different_positional[0] and "Number " in different_kwonly[0]:

--- a/tests/functional/a/arguments_differ.py
+++ b/tests/functional/a/arguments_differ.py
@@ -9,7 +9,7 @@ class Parent(object):
 
 class Child(Parent):
 
-    def test(self, arg: int): #[arguments-differ]
+    def test(self, arg):  # [arguments-differ]
         pass
 
 
@@ -20,14 +20,14 @@ class ParentDefaults(object):
 
 class ChildDefaults(ParentDefaults):
 
-    def test(self, arg=None): # [arguments-differ]
+    def test(self, arg=None):  # [arguments-differ]
         pass
 
 
 class Classmethod(object):
 
     @classmethod
-    def func(cls, data: str):
+    def func(cls, data):
         return data
 
     @classmethod
@@ -38,7 +38,7 @@ class Classmethod(object):
 class ClassmethodChild(Classmethod):
 
     @staticmethod
-    def func(): # [arguments-differ]
+    def func():  # [arguments-differ]
         pass
 
     @classmethod
@@ -56,19 +56,19 @@ class Builtins(dict):
 
 class Varargs(object):
 
-    def has_kwargs(self, arg: bool, **kwargs):
+    def has_kwargs(self, arg, **kwargs):
         pass
 
-    def no_kwargs(self, args: bool):
+    def no_kwargs(self, args):
         pass
 
 
 class VarargsChild(Varargs):
 
-    def has_kwargs(self, arg: int): #[arguments-differ, arguments-differ]
+    def has_kwargs(self, arg):  # [arguments-differ]
         "Not okay to lose capabilities. Also, type has changed."
 
-    def no_kwargs(self, arg: bool, **kwargs): # [arguments-differ]
+    def no_kwargs(self, arg, **kwargs):  # [arguments-differ]
         "Addition of kwargs does not violate LSP, but first argument's name has changed."
 
 
@@ -111,14 +111,14 @@ class Sub(Super):
 class Staticmethod(object):
 
     @staticmethod
-    def func(data: int):
+    def func(data):
         return data
 
 
 class StaticmethodChild(Staticmethod):
 
     @classmethod
-    def func(cls, data: str):
+    def func(cls, data):
         return data
 
 
@@ -169,7 +169,7 @@ class FirstHasArgs(object):
 
 class SecondChangesArgs(FirstHasArgs):
 
-    def test(self, first: int, second: int, *args): # [arguments-differ]
+    def test(self, first, second, *args):  # [arguments-differ]
         pass
 
 
@@ -213,26 +213,60 @@ class MixedChild2(Mixed):
 
 class HasSpecialMethod(object):
 
-    def __getitem__(self, key: int):
+    def __getitem__(self, key):
         return key
 
 
 class OverridesSpecialMethod(HasSpecialMethod):
 
-    def __getitem__(self, cheie: int):
+    def __getitem__(self, cheie):
         # no error here, method overrides special method
         return cheie + 1
 
 
 class ParentClass(object):
 
-    def meth(self, arg: str, arg1: str):
+    def meth(self, arg, arg1):
         raise NotImplementedError
 
 
 class ChildClass(ParentClass):
 
-    def meth(self, _arg: str, dummy: str):
+    def meth(self, _arg, dummy):
         # no error here, "dummy" and "_" are being ignored if
         # spotted in a variable name (declared in dummy_parameter_regex)
+        pass
+
+
+# https://github.com/PyCQA/pylint/issues/4443
+# Some valid overwrites with type annotations
+
+import typing  # pylint: disable=wrong-import-position
+from typing import Dict  # pylint: disable=wrong-import-position
+
+class ParentT1:
+    def func(self, user_input: Dict[str, int]) -> None:
+        pass
+
+class ChildT1(ParentT1):
+    def func(self, user_input: Dict[str, int]) -> None:
+        pass
+
+class ParentT2:
+    async def func(self, user_input: typing.List) -> None:
+        pass
+
+class ChildT2(ParentT2):
+    async def func(self, user_input: typing.List) -> None:
+        pass
+
+class FooT1:
+    pass
+
+class ParentT3:
+    def func(self, user_input: FooT1) -> None:
+        pass
+
+class ChildT3(ParentT3):
+    def func(self, user_input: FooT1) -> None:
         pass

--- a/tests/functional/a/arguments_differ.txt
+++ b/tests/functional/a/arguments_differ.txt
@@ -1,7 +1,6 @@
 arguments-differ:12:4:Child.test:Number of parameters was 1 in 'Parent.test' and is now 2 in overridden 'Child.test' method
 arguments-differ:23:4:ChildDefaults.test:Number of parameters was 3 in 'ParentDefaults.test' and is now 2 in overridden 'ChildDefaults.test' method
 arguments-differ:41:4:ClassmethodChild.func:Number of parameters was 2 in 'Classmethod.func' and is now 0 in overridden 'ClassmethodChild.func' method
-arguments-differ:68:4:VarargsChild.has_kwargs:Parameter 'arg' was of type 'bool' and is now of type 'int' in overridden 'VarargsChild.has_kwargs' method
 arguments-differ:68:4:VarargsChild.has_kwargs:Variadics removed in overridden 'VarargsChild.has_kwargs' method
 arguments-differ:71:4:VarargsChild.no_kwargs:Parameter 'args' has been renamed to 'arg' in overridden 'VarargsChild.no_kwargs' method
 arguments-differ:172:4:SecondChangesArgs.test:Number of parameters was 2 in 'FirstHasArgs.test' and is now 4 in overridden 'SecondChangesArgs.test' method

--- a/tests/functional/a/arguments_differ_py3.py
+++ b/tests/functional/a/arguments_differ_py3.py
@@ -1,47 +1,47 @@
 # pylint: disable=missing-docstring,too-few-public-methods
 class AbstractFoo:
 
-    def kwonly_1(self, first: int, *, second: int, third: int):
+    def kwonly_1(self, first, *, second, third):
         "Normal positional with two positional only params."
 
-    def kwonly_2(self, *, first: str, second: str):
+    def kwonly_2(self, *, first, second):
         "Two positional only parameter."
 
-    def kwonly_3(self, *, first: str, second: str):
+    def kwonly_3(self, *, first, second):
         "Two positional only params."
 
-    def kwonly_4(self, *, first: str, second=None):
+    def kwonly_4(self, *, first, second=None):
         "One positional only and another with a default."
 
-    def kwonly_5(self, *, first: bool, **kwargs):
+    def kwonly_5(self, *, first, **kwargs):
         "Keyword only and keyword variadics."
 
-    def kwonly_6(self, first: float, second: float, *, third: int):
+    def kwonly_6(self, first, second, *, third):
         "Two positional and one keyword"
 
 
 class Foo(AbstractFoo):
 
-    def kwonly_1(self, first: int, *, second: int): # [arguments-differ]
+    def kwonly_1(self, first, *, second):  # [arguments-differ]
         "One positional and only one positional only param."
 
-    def kwonly_2(self, *, first: str): # [arguments-differ]
+    def kwonly_2(self, *, first):  # [arguments-differ]
         "Only one positional parameter instead of two positional only parameters."
 
-    def kwonly_3(self, first, second): # [arguments-differ]
+    def kwonly_3(self, first, second):  # [arguments-differ]
         "Two positional params."
 
-    def kwonly_4(self, first, second): # [arguments-differ]
+    def kwonly_4(self, first, second):  # [arguments-differ]
         "Two positional params."
 
-    def kwonly_5(self, *, first: bool): # [arguments-differ]
+    def kwonly_5(self, *, first):  # [arguments-differ]
         "Keyword only, but no variadics."
 
-    def kwonly_6(self, *args, **kwargs): # valid override
+    def kwonly_6(self, *args, **kwargs):  # valid override
         "Positional and keyword variadics to pass through parent params"
 
 
 class Foo2(AbstractFoo):
 
-    def kwonly_6(self, first, *args, **kwargs): # valid override
+    def kwonly_6(self, first, *args, **kwargs):  # valid override
         "One positional with the rest variadics to pass through parent params"


### PR DESCRIPTION
## Description

Revert part of #4422 to fix crash when checking function overwrites for `arguments-differ`.
`pylint` isn't well suited to check type annotations. That's what type checkers like `mypy` are for which already implement such a check: https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides

/CC: @Pierre-Sassoulas @ksaketou 

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #4443