### PR TITLE
Change rebase-strategy dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     labels:
       - "dependency"
     open-pull-requests-limit: 10
+    rebase-strategy: "disabled"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,3 +16,4 @@ updates:
     labels:
       - "dependency"
     open-pull-requests-limit: 10
+    rebase-strategy: "disabled"


### PR DESCRIPTION
## Description
Prevent `dependabot` from rebasing MRs after the branch was updated (e.g., because another MR was merged).
https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#rebase-strategy