### PR TITLE
Tox - update pre-commit version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skip_missing_interpreters = true
 [testenv:pylint]
 deps =
     -r {toxinidir}/requirements_test_min.txt
-    pre-commit~=2.11
+    pre-commit~=2.12
 commands =
     pre-commit run pylint --all-files
 
@@ -14,14 +14,14 @@ commands =
 basepython = python3
 deps =
     -r {toxinidir}/requirements_test_min.txt
-    pre-commit~=2.11
+    pre-commit~=2.12
 commands =
     pre-commit run --all-files
 
 [testenv:mypy]
 basepython = python3
 deps =
-    pre-commit~=2.11
+    pre-commit~=2.12
 commands =
     pre-commit run mypy --all-files
 


### PR DESCRIPTION
## Description
Update the `pre-commit` version used for `tox`. The `requirements_text.txt` file is already up to date.
https://github.com/PyCQA/pylint/blob/6b3c49895f5e1750e2cc6c4e0c4e0c5460056cd2/requirements_test.txt#L5