### PR TITLE
Add sys.version_info guard to import-error

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,8 @@ modules are added.
 
   Closes #3389
 
+* Don't emit ``import-error`` if import guarded behind ``if sys.version_info >= (x, x)``
+
 
 What's New in Pylint 2.8.2?
 ===========================

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -135,6 +135,19 @@ def _ignore_import_failure(node, modname, ignored_modules):
         if submodule in ignored_modules:
             return True
 
+    # ignore import failure if guarded by `sys.version_info` test
+    if isinstance(node.parent, astroid.If) and isinstance(
+        node.parent.test, astroid.Compare
+    ):
+        value = node.parent.test.left
+        if isinstance(value, astroid.Subscript):
+            value = value.value
+        if (
+            isinstance(value, astroid.Attribute)
+            and value.as_string() == "sys.version_info"
+        ):
+            return True
+
     return node_ignores_exception(node, ImportError)
 
 

--- a/tests/functional/i/import_error.py
+++ b/tests/functional/i/import_error.py
@@ -26,3 +26,12 @@ except ImportError:
 
 # pylint: disable=no-name-in-module
 from functional.s.syntax_error import toto # [syntax-error]
+
+# Don't emit import-error if guarded behind `sys.version_info`
+import sys
+
+if sys.version_info >= (3, 9):
+    import zoneinfo
+
+if sys.version_info[:2] >= (3, 9):
+    import zoneinfo


### PR DESCRIPTION
## Description
Suggested by @KapJI here: https://github.com/home-assistant/core/pull/50444#discussion_r630266002

Don't emit an `import-error` if import is guarded behind `if sys.version_info`. Since pylint can only check the python version it's executed with, this often results in a false-positive.

The current suggestion doesn't account for imports that are truly missing, since the `if` statement can't (yet) be inferred. Implementing this would be possible, but probably not worth it.

**Examples**
```py
import sys

if sys.version_info >= (3, 9):
    import zoneinfo

if sys.version_info[:2] >= (3, 9):
    import zoneinfo
```
If tested with `pylint <= 3.8`, this would have resulted in an `import-error` without this change.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |