### PR TITLE
Add regression test for no-member with generic base class

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -115,6 +115,10 @@ modules are added.
 * ``logging-format-interpolation`` and ``logging-not-lazy``, now works on logger
   class created from renamed logging import following an upgrade in astroid.
 
+* Fix false-positive ``no-member`` with generic base class
+
+  Closes PyCQA/astroid#942
+
 
 What's New in Pylint 2.8.2?
 ===========================

--- a/tests/functional/t/typing_generic.py
+++ b/tests/functional/t/typing_generic.py
@@ -2,7 +2,7 @@
 
 # https://github.com/PyCQA/pylint/issues/2822
 # Base should be subscriptable, even with ABCMeta as metaclass
-from abc import ABCMeta
+from abc import ABC, ABCMeta
 from typing import Generic, TypeVar
 
 T = TypeVar("T")
@@ -12,3 +12,21 @@ class Base(Generic[T], metaclass=ABCMeta):
 
 class Impl(Base[str]):
     """Impl"""
+
+
+# https://github.com/PyCQA/astroid/issues/942
+Anything = TypeVar("Anything")
+MoreSpecific = TypeVar("MoreSpecific", str, int)
+
+class A(ABC, Generic[Anything]):
+    def a_method(self) -> None:  # pylint: disable=no-self-use
+        print("hello")
+
+class B(A[MoreSpecific]):
+    pass
+
+class C(B[str]):
+    pass
+
+c = C()
+c.a_method()  # should NOT emit `no-member` error


### PR DESCRIPTION
## Description
Add regression test. This is fixed with the current `astroid` master branch.
```py
from abc import ABC
from typing import Generic, TypeVar

Anything = TypeVar("Anything")
MoreSpecific = TypeVar("MoreSpecific", str, int)

class A(ABC, Generic[Anything]):
    def a_method(self) -> None:
        print("hello")

class B(A[MoreSpecific]):
    pass

class C(B[str]):
    pass

c = C()
c.a_method()  # should NOT emit no-member error
```

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
Closes https://github.com/PyCQA/astroid/issues/942