### PR TITLE
[Docs] Fix errors in block disables paragraph in User Guide

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -489,3 +489,5 @@ contributors:
 
 * Aditya Gupta (adityagupta1089) : contributor
   - Added ignore_signatures to duplicate checker
+
+* Jacob Walls: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -60,6 +60,8 @@ modules are added.
 
   Closes #3619
 
+* Fix documentation errors in "Block disables" paragraph of User Guide.
+
 
 What's New in Pylint 2.8.2?
 ===========================

--- a/doc/user_guide/message-control.rst
+++ b/doc/user_guide/message-control.rst
@@ -59,7 +59,7 @@ The pragma controls can disable / enable:
             print(self.bla)
             if self.blop:
                 # pylint: enable=no-member
-                # disable all no-members for this block
+                # enable all no-members for this block
                 print(self.blip)
             else:
                 # This is affected by the scope disable
@@ -67,7 +67,7 @@ The pragma controls can disable / enable:
             # pylint: enable=no-member
             print(self.blip)
             if self.blop:
-                # pylint: enable=no-member
+                # pylint: disable=no-member
                 # disable all no-members for this block
                 print(self.blip)
             else:


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

There were two errors in the User Guide example for block disables. The code comments didn't agree with the disable commands. In one case, the disable command was wrong; in the other, the comment was wrong.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

