### PR TITLE
Implemented new check ``consider-using-from-import``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -67,7 +67,7 @@ modules are added.
 
   Closes #4470
 
-* New checker``consider-using-from-import``. Emitted when a module/member of a package is imported and aliased
+* New checker``consider-using-from-import``. Emitted when a submodule/member of a package is imported and aliased
   with the same name.
 
   Closes #2309

--- a/ChangeLog
+++ b/ChangeLog
@@ -67,7 +67,7 @@ modules are added.
 
   Closes #4470
 
-* New checker``consider-use-from-import``. Emitted when a module/member of a package is imported and aliased
+* New checker``consider-using-from-import``. Emitted when a module/member of a package is imported and aliased
   with the same name.
 
   Closes #2309

--- a/ChangeLog
+++ b/ChangeLog
@@ -67,8 +67,10 @@ modules are added.
 
   Closes #4470
 
-* New checker``use-from-import``. Emitted when an lower-level module/member of a package is imported and aliaised
+* New checker``consider-use-from-import``. Emitted when a module/member of a package is imported and aliased
   with the same name.
+
+  Closes #2309
 
 
 What's New in Pylint 2.8.2?

--- a/ChangeLog
+++ b/ChangeLog
@@ -67,6 +67,9 @@ modules are added.
 
   Closes #4470
 
+* New checker``use-from-import``. Emitted when an lower-level module/member of a package is imported and aliaised
+  with the same name.
+
 
 What's New in Pylint 2.8.2?
 ===========================

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -23,6 +23,8 @@ New checkers
 * ``unnecessary-dict-index-lookup``: Emitted when iterating over dictionary items
   (key-value pairs) and accessing the value by index lookup.
 
+* ``use-from-import``: Emitted when an lower-level module/member of a package is imported and aliaised with the same name.
+
 Other Changes
 =============
 

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -23,7 +23,7 @@ New checkers
 * ``unnecessary-dict-index-lookup``: Emitted when iterating over dictionary items
   (key-value pairs) and accessing the value by index lookup.
 
-* ``consider-use-from-import``: Emitted when a module/member of a package is imported and aliased with the same name.
+* ``consider-using-from-import``: Emitted when a module/member of a package is imported and aliased with the same name.
 
 Other Changes
 =============

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -23,7 +23,7 @@ New checkers
 * ``unnecessary-dict-index-lookup``: Emitted when iterating over dictionary items
   (key-value pairs) and accessing the value by index lookup.
 
-* ``use-from-import``: Emitted when an lower-level module/member of a package is imported and aliaised with the same name.
+* ``consider-use-from-import``: Emitted when a module/member of a package is imported and aliased with the same name.
 
 Other Changes
 =============

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -23,7 +23,7 @@ New checkers
 * ``unnecessary-dict-index-lookup``: Emitted when iterating over dictionary items
   (key-value pairs) and accessing the value by index lookup.
 
-* ``consider-using-from-import``: Emitted when a module/member of a package is imported and aliased with the same name.
+* ``consider-using-from-import``: Emitted when a submodule/member of a package is imported and aliased with the same name.
 
 Other Changes
 =============

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -239,9 +239,9 @@ MSGS = {
     "R0402": (
         "Use 'from %s import %s' instead",
         "consider-using-from-import",
-        "Emitted when a module/member of a package is imported and "
+        "Emitted when a submodule/member of a package is imported and "
         "aliased with the same name. "
-        "e.g ``import pandas.DataFrame as DataFrame`` instead of "
+        "E.g., instead of ``import pandas.DataFrame as DataFrame`` use "
         "``from pandas import DataFrame``",
     ),
     "W0401": (
@@ -893,7 +893,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
                 self.add_message(
                     "consider-using-from-import",
                     node=node,
-                    args=(splitted_packages[0], aliased_name),
+                    args=(splitted_packages[0], import_name),
                 )
 
     def _check_reimport(self, node, basename=None, level=None):

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -238,7 +238,7 @@ MSGS = {
     ),
     "R0402": (
         "Use 'from %s import %s' instead",
-        "consider-use-from-import",
+        "consider-using-from-import",
         "Emitted when a module/member of a package is imported and "
         "aliased with the same name. "
         "e.g ``import pandas.DataFrame as DataFrame`` instead of "
@@ -891,7 +891,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
                 self.add_message("useless-import-alias", node=node)
             elif len(splitted_packages) == 2:
                 self.add_message(
-                    "consider-use-from-import",
+                    "consider-using-from-import",
                     node=node,
                     args=(splitted_packages[0], aliased_name),
                 )

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -236,6 +236,14 @@ MSGS = {
         "cyclic-import",
         "Used when a cyclic import between two or more modules is detected.",
     ),
+    "R0402": (
+        "Use 'from %s import %s' instead",
+        "consider-use-from-import",
+        "Emitted when a module/member of a package is imported and "
+        "aliased with the same name. "
+        "e.g ``import pandas.DataFrame as DataFrame`` instead of "
+        "``from pandas import DataFrame``",
+    ),
     "W0401": (
         "Wildcard import %s",
         "wildcard-import",
@@ -299,14 +307,6 @@ MSGS = {
         "import-outside-toplevel",
         "Used when an import statement is used anywhere other than the module "
         "toplevel. Move this import to the top of the file.",
-    ),
-    "C0416": (
-        "Use 'from %s import %s' instead",
-        "use-from-import",
-        "Emitted when an lower-level module/member of a package is imported and "
-        "aliaised with the same name. "
-        "e.g ``import pandas.DataFrame as DataFrame`` instead of "
-        "``from pandas import DataFrame``",
     ),
 }
 
@@ -881,20 +881,19 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             if not all(name):
                 return
 
-            real_name = name[0]
-            splitted_packages = real_name.rsplit(".", 1)
-            real_name = splitted_packages[-1]
-            imported_name = name[1]
-            if real_name != imported_name:
+            splitted_packages = name[0].rsplit(".", maxsplit=1)
+            import_name = splitted_packages[-1]
+            aliased_name = name[1]
+            if import_name != aliased_name:
                 continue
 
             if len(splitted_packages) == 1:
                 self.add_message("useless-import-alias", node=node)
             elif len(splitted_packages) == 2:
                 self.add_message(
-                    "use-from-import",
+                    "consider-use-from-import",
                     node=node,
-                    args=(splitted_packages[0], imported_name),
+                    args=(splitted_packages[0], aliased_name),
                 )
 
     def _check_reimport(self, node, basename=None, level=None):

--- a/tests/extensions/test_empty_comment.py
+++ b/tests/extensions/test_empty_comment.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-import pylint.extensions.empty_comment as empty_comment
+from pylint.extensions import empty_comment
 
 
 @pytest.fixture(scope="module")

--- a/tests/functional/i/import_aliasing.py
+++ b/tests/functional/i/import_aliasing.py
@@ -1,13 +1,13 @@
 # pylint: disable=unused-import, missing-docstring, invalid-name, reimported, import-error, wrong-import-order, no-name-in-module, relative-beyond-top-level
 # Functional tests for import aliasing
 # 1. useless-import-alias
-# 2. use-from-import
+# 2. consider-use-from-import
 
 from collections import OrderedDict as OrderedDict # [useless-import-alias]
 from collections import OrderedDict as o_dict
-import os.path as path  # [use-from-import]
+import os.path as path  # [consider-use-from-import]
 import os.path as p
-import foo.bar.foobar as foobar  # [use-from-import]
+import foo.bar.foobar as foobar  # [consider-use-from-import]
 import os
 import os as OS
 from sys import version

--- a/tests/functional/i/import_aliasing.py
+++ b/tests/functional/i/import_aliasing.py
@@ -1,9 +1,13 @@
 # pylint: disable=unused-import, missing-docstring, invalid-name, reimported, import-error, wrong-import-order, no-name-in-module, relative-beyond-top-level
+# Functional tests for import aliasing
+# 1. useless-import-alias
+# 2. use-from-import
+
 from collections import OrderedDict as OrderedDict # [useless-import-alias]
 from collections import OrderedDict as o_dict
-import os.path as path
+import os.path as path  # [use-from-import]
 import os.path as p
-import foo.bar.foobar as foobar
+import foo.bar.foobar as foobar  # [use-from-import]
 import os
 import os as OS
 from sys import version

--- a/tests/functional/i/import_aliasing.py
+++ b/tests/functional/i/import_aliasing.py
@@ -1,13 +1,13 @@
 # pylint: disable=unused-import, missing-docstring, invalid-name, reimported, import-error, wrong-import-order, no-name-in-module, relative-beyond-top-level
 # Functional tests for import aliasing
 # 1. useless-import-alias
-# 2. consider-use-from-import
+# 2. consider-using-from-import
 
 from collections import OrderedDict as OrderedDict # [useless-import-alias]
 from collections import OrderedDict as o_dict
-import os.path as path  # [consider-use-from-import]
+import os.path as path  # [consider-using-from-import]
 import os.path as p
-import foo.bar.foobar as foobar  # [consider-use-from-import]
+import foo.bar.foobar as foobar  # [consider-using-from-import]
 import os
 import os as OS
 from sys import version

--- a/tests/functional/i/import_aliasing.txt
+++ b/tests/functional/i/import_aliasing.txt
@@ -1,0 +1,9 @@
+useless-import-alias:6:0::Import alias does not rename original package
+use-from-import:8:0::Use 'from os import path' instead
+use-from-import:10:0::Use 'from foo.bar import foobar' instead
+useless-import-alias:14:0::Import alias does not rename original package
+useless-import-alias:17:0::Import alias does not rename original package
+useless-import-alias:18:0::Import alias does not rename original package
+useless-import-alias:20:0::Import alias does not rename original package
+useless-import-alias:21:0::Import alias does not rename original package
+useless-import-alias:23:0::Import alias does not rename original package

--- a/tests/functional/i/import_aliasing.txt
+++ b/tests/functional/i/import_aliasing.txt
@@ -1,6 +1,6 @@
 useless-import-alias:6:0::Import alias does not rename original package
-consider-use-from-import:8:0::Use 'from os import path' instead
-consider-use-from-import:10:0::Use 'from foo.bar import foobar' instead
+consider-using-from-import:8:0::Use 'from os import path' instead
+consider-using-from-import:10:0::Use 'from foo.bar import foobar' instead
 useless-import-alias:14:0::Import alias does not rename original package
 useless-import-alias:17:0::Import alias does not rename original package
 useless-import-alias:18:0::Import alias does not rename original package

--- a/tests/functional/i/import_aliasing.txt
+++ b/tests/functional/i/import_aliasing.txt
@@ -1,6 +1,6 @@
 useless-import-alias:6:0::Import alias does not rename original package
-use-from-import:8:0::Use 'from os import path' instead
-use-from-import:10:0::Use 'from foo.bar import foobar' instead
+consider-use-from-import:8:0::Use 'from os import path' instead
+consider-use-from-import:10:0::Use 'from foo.bar import foobar' instead
 useless-import-alias:14:0::Import alias does not rename original package
 useless-import-alias:17:0::Import alias does not rename original package
 useless-import-alias:18:0::Import alias does not rename original package

--- a/tests/functional/u/useless/useless-import-alias.txt
+++ b/tests/functional/u/useless/useless-import-alias.txt
@@ -1,7 +1,0 @@
-useless-import-alias:2:0::Import alias does not rename original package
-useless-import-alias:10:0::Import alias does not rename original package
-useless-import-alias:13:0::Import alias does not rename original package
-useless-import-alias:14:0::Import alias does not rename original package
-useless-import-alias:16:0::Import alias does not rename original package
-useless-import-alias:17:0::Import alias does not rename original package
-useless-import-alias:19:0::Import alias does not rename original package


### PR DESCRIPTION
## Steps

- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Implemented this new check to check for instances where
```python
import x.y.z as z
```
could be refactored to 
```python
from x.y import z
```
Also refactored some doc/ code to use typehints
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Related Issue
Closes #2309
#2402
#2423 -> should I name it instead to ``consider-use-from-import`` as some styleguides might suggest otherwise?
<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
