### PR TITLE
Multiple `output-format` support

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -491,3 +491,5 @@ contributors:
   - Added ignore_signatures to duplicate checker
 
 * Jacob Walls: contributor
+
+* ruro: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -72,6 +72,11 @@ modules are added.
 
   Closes #2309
 
+* Allow comma-separated list in ``output-format`` and separate output files for
+  each specified format.
+
+  Closes #1798
+
 
 What's New in Pylint 2.8.2?
 ===========================

--- a/doc/user_guide/output.rst
+++ b/doc/user_guide/output.rst
@@ -6,6 +6,15 @@ The default format for the output is raw text. You can change this by passing
 pylint the ``--output-format=<value>`` option. Possible values are: json,
 parseable, colorized and msvs (visual studio).
 
+Multiple output formats can be used at the same time by passing
+``--output-format`` a comma-separated list of formats. To change the output file
+for an individual format, specify it after a semicolon. For example, you can
+save a json report to ``somefile`` and print a colorized report to stdout at the
+same time with :
+::
+
+  --output-format=json:somefile,colorized
+
 Moreover you can customize the exact way information are displayed using the
 `--msg-template=<format string>` option. The `format string` uses the
 `Python new format syntax`_ and the following fields are available :

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -41,3 +41,6 @@ Other Changes
   of overridden functions. It aims to separate the functionality of ``arguments-differ``.
 
 * Fix incompatibility with Python 3.6.0 caused by ``typing.Counter`` and ``typing.NoReturn`` usage
+
+* Allow comma-separated list in ``output-format`` and separate output files for
+  each specified format.

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -43,4 +43,4 @@ Other Changes
 * Fix incompatibility with Python 3.6.0 caused by ``typing.Counter`` and ``typing.NoReturn`` usage
 
 * Allow comma-separated list in ``output-format`` and separate output files for
-  each specified format.
+  each specified format.  Each output file can be defined after a semicolon for example : ``--output-format=json:myfile.json,colorized``

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -43,13 +43,12 @@ def _read_stdin():
     return sys.stdin.read()
 
 
-def _load_reporter_by_class(reporter_class):
+def _load_reporter_by_class(reporter_class: str) -> type:
     qname = reporter_class
     module_part = astroid.modutils.get_module_part(qname)
     module = astroid.modutils.load_module_from_name(module_part)
     class_name = qname.split(".")[-1]
-    reporter_class = getattr(module, class_name)
-    return reporter_class
+    return getattr(module, class_name)
 
 
 # Python Linter class #########################################################
@@ -536,7 +535,7 @@ class PyLinter(
             if hasattr(module, "load_configuration"):
                 module.load_configuration(self)
 
-    def _load_reporters(self):
+    def _load_reporters(self) -> None:
         sub_reporters = []
         output_files = []
         with contextlib.ExitStack() as stack:
@@ -568,7 +567,7 @@ class PyLinter(
         else:
             self.set_reporter(sub_reporters[0])
 
-    def _load_reporter_by_name(self, reporter_name):
+    def _load_reporter_by_name(self, reporter_name: str) -> reporters.BaseReporter:
         name = reporter_name.lower()
         if name in self._reporters:
             return self._reporters[name]()

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -43,6 +43,15 @@ def _read_stdin():
     return sys.stdin.read()
 
 
+def _load_reporter_by_class(reporter_class):
+    qname = reporter_class
+    module_part = astroid.modutils.get_module_part(qname)
+    module = astroid.modutils.load_module_from_name(module_part)
+    class_name = qname.split(".")[-1]
+    reporter_class = getattr(module, class_name)
+    return reporter_class
+
+
 # Python Linter class #########################################################
 
 MSGS = {
@@ -451,7 +460,7 @@ class PyLinter(
         messages store / checkers / reporter / astroid manager"""
         self.msgs_store = MessageDefinitionStore()
         self.reporter = None
-        self._reporter_name = None
+        self._reporter_names = None
         self._reporters = {}
         self._checkers = collections.defaultdict(list)
         self._pragma_lineno = {}
@@ -502,7 +511,7 @@ class PyLinter(
         # Make sure to load the default reporter, because
         # the option has been set before the plugins had been loaded.
         if not self.reporter:
-            self._load_reporter()
+            self._load_reporters()
 
     def load_plugin_modules(self, modnames):
         """take a list of module names which are pylint plugins and load
@@ -527,25 +536,49 @@ class PyLinter(
             if hasattr(module, "load_configuration"):
                 module.load_configuration(self)
 
-    def _load_reporter(self):
-        name = self._reporter_name.lower()
-        if name in self._reporters:
-            self.set_reporter(self._reporters[name]())
-        else:
-            try:
-                reporter_class = self._load_reporter_class()
-            except (ImportError, AttributeError) as e:
-                raise exceptions.InvalidReporterError(name) from e
-            else:
-                self.set_reporter(reporter_class())
+    def _load_reporters(self):
+        sub_reporters = []
+        output_files = []
+        with contextlib.ExitStack() as stack:
+            for reporter_name in self._reporter_names.split(","):
+                reporter_name, *reporter_output = reporter_name.split(":")
 
-    def _load_reporter_class(self):
-        qname = self._reporter_name
-        module_part = astroid.modutils.get_module_part(qname)
-        module = astroid.modutils.load_module_from_name(module_part)
-        class_name = qname.split(".")[-1]
-        reporter_class = getattr(module, class_name)
-        return reporter_class
+                reporter = self._load_reporter_by_name(reporter_name)
+                sub_reporters.append(reporter)
+
+                if reporter_output:
+                    (reporter_output,) = reporter_output
+
+                    # pylint: disable=consider-using-with
+                    output_file = stack.enter_context(open(reporter_output, "w"))
+
+                    reporter.set_output(output_file)
+                    output_files.append(output_file)
+
+            # Extend the lifetime of all opened output files
+            close_output_files = stack.pop_all().close
+
+        if len(sub_reporters) > 1 or output_files:
+            self.set_reporter(
+                reporters.MultiReporter(
+                    sub_reporters,
+                    close_output_files,
+                )
+            )
+        else:
+            self.set_reporter(sub_reporters[0])
+
+    def _load_reporter_by_name(self, reporter_name):
+        name = reporter_name.lower()
+        if name in self._reporters:
+            return self._reporters[name]()
+
+        try:
+            reporter_class = _load_reporter_by_class(reporter_name)
+        except (ImportError, AttributeError) as e:
+            raise exceptions.InvalidReporterError(name) from e
+        else:
+            return reporter_class()
 
     def set_reporter(self, reporter):
         """set the reporter used to display messages and reports"""
@@ -575,11 +608,11 @@ class PyLinter(
                     meth(value)
                 return  # no need to call set_option, disable/enable methods do it
         elif optname == "output-format":
-            self._reporter_name = value
+            self._reporter_names = value
             # If the reporters are already available, load
             # the reporter class.
             if self._reporters:
-                self._load_reporter()
+                self._load_reporters()
 
         try:
             checkers.BaseTokenChecker.set_option(self, optname, value, action, optdict)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -540,7 +540,7 @@ class PyLinter(
         output_files = []
         with contextlib.ExitStack() as stack:
             for reporter_name in self._reporter_names.split(","):
-                reporter_name, *reporter_output = reporter_name.split(":")
+                reporter_name, *reporter_output = reporter_name.split(":", 1)
 
                 reporter = self._load_reporter_by_name(reporter_name)
                 sub_reporters.append(reporter)

--- a/pylint/reporters/__init__.py
+++ b/pylint/reporters/__init__.py
@@ -26,6 +26,7 @@ from pylint import utils
 from pylint.reporters.base_reporter import BaseReporter
 from pylint.reporters.collecting_reporter import CollectingReporter
 from pylint.reporters.json_reporter import JSONReporter
+from pylint.reporters.multi_reporter import MultiReporter
 from pylint.reporters.reports_handler_mix_in import ReportsHandlerMixIn
 
 
@@ -34,4 +35,10 @@ def initialize(linter):
     utils.register_plugins(linter, __path__[0])
 
 
-__all__ = ["BaseReporter", "ReportsHandlerMixIn", "JSONReporter", "CollectingReporter"]
+__all__ = [
+    "BaseReporter",
+    "ReportsHandlerMixIn",
+    "JSONReporter",
+    "CollectingReporter",
+    "MultiReporter",
+]

--- a/pylint/reporters/multi_reporter.py
+++ b/pylint/reporters/multi_reporter.py
@@ -1,0 +1,89 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/LICENSE
+
+
+import os
+
+from pylint.interfaces import IReporter
+
+
+class MultiReporter:
+    """Reports messages and layouts in plain text"""
+
+    __implements__ = IReporter
+    name = "_internal_multi_reporter"
+    # Note: do not register this reporter with linter.register_reporter as it is
+    #       not intended to be used directly like a regular reporter, but is
+    #       instead used to implement the
+    #       `--output-format=json:somefile.json,colorized`
+    #       multiple output formats feature
+
+    extension = ""
+
+    def __init__(self, sub_reporters, close_output_files, output=None):
+        self._sub_reporters = sub_reporters
+        self.close_output_files = close_output_files
+
+        self._path_strip_prefix = os.getcwd() + os.sep
+        self._linter = None
+
+        self.set_output(output)
+
+    def __del__(self):
+        self.close_output_files()
+
+    @property
+    def path_strip_prefix(self):
+        return self._path_strip_prefix
+
+    @path_strip_prefix.setter
+    def path_strip_prefix(self, value):
+        self._path_strip_prefix = value
+        for rep in self._sub_reporters:
+            rep.path_strip_prefix = value
+
+    @property
+    def linter(self):
+        return self._linter
+
+    @linter.setter
+    def linter(self, value):
+        self._linter = value
+        for rep in self._sub_reporters:
+            rep.linter = value
+
+    def handle_message(self, msg):
+        """Handle a new message triggered on the current file."""
+        for rep in self._sub_reporters:
+            rep.handle_message(msg)
+
+    # pylint: disable=no-self-use
+    def set_output(self, output=None):
+        """set output stream"""
+        if output is not None:
+            raise NotImplementedError("MultiReporter does not support direct output.")
+
+    def writeln(self, string=""):
+        """write a line in the output buffer"""
+        for rep in self._sub_reporters:
+            rep.writeln(string)
+
+    def display_reports(self, layout):
+        """display results encapsulated in the layout tree"""
+        for rep in self._sub_reporters:
+            rep.display_reports(layout)
+
+    def display_messages(self, layout):
+        """hook for displaying the messages of the reporter"""
+        for rep in self._sub_reporters:
+            rep.display_messages(layout)
+
+    def on_set_current_module(self, module, filepath):
+        """hook called when a module starts to be analysed"""
+        for rep in self._sub_reporters:
+            rep.on_set_current_module(module, filepath)
+
+    def on_close(self, stats, previous_stats):
+        """hook called when a module finished analyzing"""
+        for rep in self._sub_reporters:
+            rep.on_close(stats, previous_stats)

--- a/pylint/reporters/multi_reporter.py
+++ b/pylint/reporters/multi_reporter.py
@@ -48,12 +48,6 @@ class MultiReporter:
     def path_strip_prefix(self) -> str:
         return self._path_strip_prefix
 
-    @path_strip_prefix.setter
-    def path_strip_prefix(self, value: str) -> None:
-        self._path_strip_prefix = value
-        for rep in self._sub_reporters:
-            rep.path_strip_prefix = value
-
     @property
     def linter(self) -> Optional[PyLinter]:
         return self._linter
@@ -72,6 +66,9 @@ class MultiReporter:
     # pylint: disable=no-self-use
     def set_output(self, output: Optional[AnyFile] = None) -> None:
         """set output stream"""
+        # MultiReporter doesn't have it's own output. This method is only
+        # provided for API parity with BaseReporter and should not be called
+        # with non-None values for 'output'.
         if output is not None:
             raise NotImplementedError("MultiReporter does not support direct output.")
 

--- a/tests/unittest_reporting.py
+++ b/tests/unittest_reporting.py
@@ -98,7 +98,10 @@ def test_multi_format_output(tmp_path):
         linter.add_message("line-too-long", line=1, args=(1, 2))
         linter.generate_reports()
         linter.reporter.writeln("direct output")
-        del linter.reporter  # Ensure the output files are flushed and closed
+
+        # Ensure the output files are flushed and closed
+        linter.reporter.close_output_files()
+        del linter.reporter
 
     with open(json) as f:
         assert (

--- a/tests/unittest_reporting.py
+++ b/tests/unittest_reporting.py
@@ -94,7 +94,7 @@ class NopReporter(BaseReporter):
 
 
 def test_multi_format_output(tmp_path):
-    text = StringIO()
+    text = StringIO(newline=None)
     json = tmp_path / "somefile.json"
 
     source_file = tmp_path / "somemodule.py"

--- a/tests/unittest_reporting.py
+++ b/tests/unittest_reporting.py
@@ -17,6 +17,7 @@
 import warnings
 from contextlib import redirect_stdout
 from io import StringIO
+from json import dumps
 
 import pytest
 
@@ -79,6 +80,7 @@ def test_multi_format_output(tmp_path):
     json = tmp_path / "somefile.json"
     source_file = tmp_path / "somemodule.py"
     source_file.write_text('NOT_EMPTY = "This module is not empty"\n')
+    escaped_source_file = dumps(str(source_file))
     formats = ",".join(["json:" + str(json), "text"])
 
     with redirect_stdout(text):
@@ -112,7 +114,7 @@ def test_multi_format_output(tmp_path):
             '        "obj": "",\n'
             '        "line": 1,\n'
             '        "column": 0,\n'
-            f'        "path": "{source_file}",\n'
+            f'        "path": {escaped_source_file},\n'
             '        "symbol": "missing-module-docstring",\n'
             '        "message": "Missing module docstring",\n'
             '        "message-id": "C0114"\n'
@@ -123,7 +125,7 @@ def test_multi_format_output(tmp_path):
             '        "obj": "",\n'
             '        "line": 1,\n'
             '        "column": 0,\n'
-            f'        "path": "{source_file}",\n'
+            f'        "path": {escaped_source_file},\n'
             '        "symbol": "line-too-long",\n'
             '        "message": "Line too long (1/2)",\n'
             '        "message-id": "C0301"\n'

--- a/tests/unittest_reporting.py
+++ b/tests/unittest_reporting.py
@@ -14,11 +14,9 @@
 # For details: https://github.com/PyCQA/pylint/blob/master/LICENSE
 # pylint: disable=redefined-outer-name
 
-import os
 import warnings
 from contextlib import redirect_stdout
 from io import StringIO
-from tempfile import mktemp
 
 import pytest
 
@@ -76,48 +74,37 @@ def test_parseable_output_regression():
     )
 
 
-def test_multi_format_output():
+def test_multi_format_output(tmp_path):
     text = StringIO()
-    json = mktemp()
-    formats = ",".join(
-        [
-            "json:" + json,
-            "text",
-        ]
-    )
+    json = tmp_path / "somefile.json"
+    formats = ",".join(["json:" + str(json), "text"])
 
-    try:
-        with redirect_stdout(text):
-            linter = PyLinter()
-            linter.set_option("output-format", formats)
-            linter.load_default_plugins()
-            linter.open()
-            linter.set_current_module("0123")
-            linter.add_message("line-too-long", line=1, args=(1, 2))
-            linter.generate_reports()
-            linter.reporter.close_output_files()
+    with redirect_stdout(text):
+        linter = PyLinter()
+        linter.set_option("output-format", formats)
+        linter.load_default_plugins()
+        linter.open()
+        linter.set_current_module("0123")
+        linter.add_message("line-too-long", line=1, args=(1, 2))
+        linter.generate_reports()
+        linter.reporter.close_output_files()
 
-        with open(json) as f:
-            assert (
-                f.read() == "[\n"
-                "    {\n"
-                '        "type": "convention",\n'
-                '        "module": "0123",\n'
-                '        "obj": "",\n'
-                '        "line": 1,\n'
-                '        "column": 0,\n'
-                '        "path": "0123",\n'
-                '        "symbol": "line-too-long",\n'
-                '        "message": "Line too long (1/2)",\n'
-                '        "message-id": "C0301"\n'
-                "    }\n"
-                "]\n"
-            )
-    finally:
-        try:
-            os.remove(json)
-        except OSError:
-            pass
+    with open(json) as f:
+        assert (
+            f.read() == "[\n"
+            "    {\n"
+            '        "type": "convention",\n'
+            '        "module": "0123",\n'
+            '        "obj": "",\n'
+            '        "line": 1,\n'
+            '        "column": 0,\n'
+            '        "path": "0123",\n'
+            '        "symbol": "line-too-long",\n'
+            '        "message": "Line too long (1/2)",\n'
+            '        "message-id": "C0301"\n'
+            "    }\n"
+            "]\n"
+        )
 
     assert (
         text.getvalue() == "************* Module 0123\n"


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

This PR allows users to specify more than one output format by passing a comma-separated list `output-format` like this:
```sh
--output-format=text,json
```
You can also set the output file for each output format by specifying it after a colon like this:
```sh
--output-format=text:path/to/pylint-report.txt,json:different/path/to/pylint-report.json
```
Without the `:path` part, the default is to output to `stdout`.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue

Closes #1798