### PR TITLE
Added suggestion in helptext for ``unnecessary-comprehension`` checker

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -80,6 +80,10 @@ modules are added.
 * Make ``using-constant-test`` detect constant tests consisting of list literals like ``[]`` and
   ``[1, 2, 3]``.
 
+* Improved error message of ``unnecessary-comprehension`` checker by providing code suggestion.
+
+  Closes #4499
+
 
 What's New in Pylint 2.8.2?
 ===========================

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -6,7 +6,7 @@ import copy
 import itertools
 import tokenize
 from functools import reduce
-from typing import List, Union, cast
+from typing import List, Optional, Tuple, Union, cast
 
 import astroid
 
@@ -1393,17 +1393,18 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         else:
             return
         if expr_list == target_list != []:
-            args = None
+            args: Optional[Tuple[str]] = None
+            inferred = utils.safe_infer(node.iter)
             if isinstance(node.parent, astroid.DictComp) and isinstance(
-                utils.safe_infer(node.iter), astroid.objects.DictItems
+                inferred, astroid.objects.DictItems
             ):
                 args = (f"{node.iter.func.expr.as_string()}",)
-            if (
+            elif (
                 isinstance(node.parent, astroid.ListComp)
-                and isinstance(utils.safe_infer(node.iter), astroid.List)
+                and isinstance(inferred, astroid.List)
             ) or (
                 isinstance(node.parent, astroid.SetComp)
-                and isinstance(utils.safe_infer(node.iter), astroid.Set)
+                and isinstance(inferred, astroid.Set)
             ):
                 args = (f"{node.iter.as_string()}",)
             if args:

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1393,15 +1393,11 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         else:
             return
         if expr_list == target_list != []:
+            args = None
             if isinstance(node.parent, astroid.DictComp) and isinstance(
                 utils.safe_infer(node.iter), astroid.objects.DictItems
             ):
-                self.add_message(
-                    "unnecessary-comprehension",
-                    node=node,
-                    args=(f"{node.iter.func.expr.as_string()}",),
-                )
-                return
+                args = (f"{node.iter.func.expr.as_string()}",)
             if (
                 isinstance(node.parent, astroid.ListComp)
                 and isinstance(utils.safe_infer(node.iter), astroid.List)
@@ -1409,11 +1405,9 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                 isinstance(node.parent, astroid.SetComp)
                 and isinstance(utils.safe_infer(node.iter), astroid.Set)
             ):
-                self.add_message(
-                    "unnecessary-comprehension",
-                    node=node,
-                    args=(f"{node.iter.as_string()}",),
-                )
+                args = (f"{node.iter.as_string()}",)
+            if args:
+                self.add_message("unnecessary-comprehension", node=node, args=args)
                 return
 
             if isinstance(node.parent, astroid.DictComp):

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1393,12 +1393,37 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         else:
             return
         if expr_list == target_list != []:
+            if isinstance(node.parent, astroid.DictComp) and isinstance(
+                utils.safe_infer(node.iter), astroid.objects.DictItems
+            ):
+                self.add_message(
+                    "unnecessary-comprehension",
+                    node=node,
+                    args=(f"{node.iter.func.expr.as_string()}",),
+                )
+                return
+            if (
+                isinstance(node.parent, astroid.ListComp)
+                and isinstance(utils.safe_infer(node.iter), astroid.List)
+            ) or (
+                isinstance(node.parent, astroid.SetComp)
+                and isinstance(utils.safe_infer(node.iter), astroid.Set)
+            ):
+                self.add_message(
+                    "unnecessary-comprehension",
+                    node=node,
+                    args=(f"{node.iter.as_string()}",),
+                )
+                return
+
             if isinstance(node.parent, astroid.DictComp):
                 func = "dict"
             elif isinstance(node.parent, astroid.ListComp):
                 func = "list"
-            else:
+            elif isinstance(node.parent, astroid.SetComp):
                 func = "set"
+            else:
+                return
 
             self.add_message(
                 "unnecessary-comprehension",

--- a/tests/functional/u/unnecessary/unnecessary_comprehension.py
+++ b/tests/functional/u/unnecessary/unnecessary_comprehension.py
@@ -1,4 +1,4 @@
-# pylint: disable=undefined-variable, pointless-statement, missing-docstring, line-too-long
+# pylint: disable=undefined-variable, pointless-statement, missing-docstring, line-too-long, expression-not-assigned
 # For name-reference see https://docs.python.org/3/reference/expressions.html#displays-for-lists-sets-and-dictionaries
 
 # List comprehensions
@@ -12,6 +12,9 @@
 [y for x in iterable for y in x]  # exclude nested comprehensions
 [2 * x for x in iterable]  # exclude useful comprehensions
 [(x, y, 1) for x, y in iterable]  # exclude useful comprehensions
+# Test case for issue #4499
+a_dict = dict()
+[(k, v) for k, v in a_dict.items()]  # [unnecessary-comprehension]
 
 # Set comprehensions
 {x for x in iterable}  # [unnecessary-comprehension]

--- a/tests/functional/u/unnecessary/unnecessary_comprehension.py
+++ b/tests/functional/u/unnecessary/unnecessary_comprehension.py
@@ -37,3 +37,13 @@ a_dict = dict()
 {y: z for x in iterable for y, z in x}  # exclude nested comprehensions
 {x: 1 for x in iterable}  # expression != target_list
 {2 * x: 3 + x for x in iterable}  # exclude useful comprehensions
+
+# Some additional tests on helptext -- when object is already a list/set/dict
+my_list = list()
+my_dict = dict()
+my_set = set()
+
+[elem for elem in my_list]  # [unnecessary-comprehension]
+{k: v for k, v in my_dict.items()} # [unnecessary-comprehension]
+{k: my_dict[k] for k in my_dict} # [consider-using-dict-items]
+{elem for elem in my_set}  # [unnecessary-comprehension]

--- a/tests/functional/u/unnecessary/unnecessary_comprehension.txt
+++ b/tests/functional/u/unnecessary/unnecessary_comprehension.txt
@@ -7,3 +7,7 @@ unnecessary-comprehension:23:0::Unnecessary use of a comprehension, use set(iter
 unnecessary-comprehension:24:0::Unnecessary use of a comprehension, use set(iterable) instead.
 unnecessary-comprehension:32:0::Unnecessary use of a comprehension, use dict(iterable) instead.
 unnecessary-comprehension:34:0::Unnecessary use of a comprehension, use dict(iterable) instead.
+unnecessary-comprehension:46:0::Unnecessary use of a comprehension, use my_list instead.
+unnecessary-comprehension:47:0::Unnecessary use of a comprehension, use my_dict instead.
+consider-using-dict-items:48:0::Consider iterating with .items()
+unnecessary-comprehension:49:0::Unnecessary use of a comprehension, use my_set instead.

--- a/tests/functional/u/unnecessary/unnecessary_comprehension.txt
+++ b/tests/functional/u/unnecessary/unnecessary_comprehension.txt
@@ -1,8 +1,9 @@
-unnecessary-comprehension:5:0::Unnecessary use of a comprehension
-unnecessary-comprehension:8:0::Unnecessary use of a comprehension
-unnecessary-comprehension:9:0::Unnecessary use of a comprehension
-unnecessary-comprehension:17:0::Unnecessary use of a comprehension
-unnecessary-comprehension:20:0::Unnecessary use of a comprehension
-unnecessary-comprehension:21:0::Unnecessary use of a comprehension
-unnecessary-comprehension:29:0::Unnecessary use of a comprehension
-unnecessary-comprehension:31:0::Unnecessary use of a comprehension
+unnecessary-comprehension:5:0::Unnecessary use of a comprehension, use list(iterable) instead.
+unnecessary-comprehension:8:0::Unnecessary use of a comprehension, use list(iterable) instead.
+unnecessary-comprehension:9:0::Unnecessary use of a comprehension, use list(iterable) instead.
+unnecessary-comprehension:17:0::Unnecessary use of a comprehension, use list(a_dict.items()) instead.
+unnecessary-comprehension:20:0::Unnecessary use of a comprehension, use set(iterable) instead.
+unnecessary-comprehension:23:0::Unnecessary use of a comprehension, use set(iterable) instead.
+unnecessary-comprehension:24:0::Unnecessary use of a comprehension, use set(iterable) instead.
+unnecessary-comprehension:32:0::Unnecessary use of a comprehension, use dict(iterable) instead.
+unnecessary-comprehension:34:0::Unnecessary use of a comprehension, use dict(iterable) instead.


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Improved help text for ``unnecessary-comprehension`` -- now provides suggestion of what could be used instead.

E.g:
```python
a_dict = dict()
[(k, v) for k, v in a_dict.items()]  # [unnecessary-comprehension]
```

Help text:
```
unnecessary-comprehension:17:0::Unnecessary use of a comprehension, use list(a_dict.items()) instead.
```


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :memo:  Documentation   |
| ✓   | :hammer: Refactoring   |

## Related Issue

Closes #4499

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
