### PR TITLE
Implemented ``unused-protected-member`` checker

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -79,7 +79,7 @@ modules are added.
 
 * Make ``using-constant-test`` detect constant tests consisting of list literals like ``[]`` and
   ``[1, 2, 3]``.
-  
+
 * New checker ``unused-protected-member``. Emitted when a protected member (i.e., starts with ``_``) of a class
   is defined but not used.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -79,6 +79,11 @@ modules are added.
 
 * Make ``using-constant-test`` detect constant tests consisting of list literals like ``[]`` and
   ``[1, 2, 3]``.
+  
+* New checker ``unused-protected-member``. Emitted when a protected member (i.e., starts with ``_``) of a class
+  is defined but not used.
+
+  Closes #4483
 
 
 What's New in Pylint 2.8.2?

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -25,6 +25,8 @@ New checkers
 
 * ``consider-using-from-import``: Emitted when a submodule/member of a package is imported and aliased with the same name.
 
+* New checker ``unused-protected-member``. Emitted when a protected member (i.e., starts with ``_``) of a class is defined but not used.
+
 Other Changes
 =============
 

--- a/tests/checkers/unittest_classes.py
+++ b/tests/checkers/unittest_classes.py
@@ -61,7 +61,22 @@ class TestVariablesChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message("protected-access", node=node.body[-1].value, args="_teta")
+            Message(
+                "unused-protected-member",
+                node=node.body[0],
+                args=("Protected", "_meta"),
+            ),
+            Message(
+                "unused-protected-member",
+                node=node.body[0],
+                args=("Protected", "_manager"),
+            ),
+            Message(
+                "unused-protected-member",
+                node=node.body[0],
+                args=("Protected", "_teta"),
+            ),
+            Message("protected-access", node=node.body[-1].value, args="_teta"),
         ):
             self.walk(node.root())
 
@@ -152,6 +167,11 @@ class TestVariablesChecker(CheckerTestCase):
             Message("protected-access", node=attribute_in_eq, args="_protected"),
             Message("protected-access", node=attribute_in_fake_1, args="_protected"),
             Message("protected-access", node=attribute_in_fake_2, args="__private"),
+            Message(
+                "unused-protected-member",
+                node=classdef,
+                args=("Protected", "_fake_special_(self, other)"),
+            ),
         ):
             self.walk(node.root())
 
@@ -186,6 +206,11 @@ class TestVariablesChecker(CheckerTestCase):
         with self.assertAddsMessages(
             Message("protected-access", node=attribute_in_fake_1, args="_protected"),
             Message("protected-access", node=attribute_in_fake_2, args="__private"),
+            Message(
+                "unused-protected-member",
+                node=classdef,
+                args=("Protected", "_fake_special_(self, other)"),
+            ),
         ):
             self.walk(node.root())
 

--- a/tests/extensions/data/redefined.py
+++ b/tests/extensions/data/redefined.py
@@ -1,6 +1,6 @@
 """Checks variable types aren't redefined within a method or a function"""
 
-# pylint: disable=too-few-public-methods,missing-docstring,unused-variable,invalid-name, useless-object-inheritance
+# pylint: disable=too-few-public-methods,missing-docstring,unused-variable,invalid-name, useless-object-inheritance, unused-protected-member
 
 _OK = True
 

--- a/tests/functional/a/access/access_attr_before_def_false_positive.py
+++ b/tests/functional/a/access/access_attr_before_def_false_positive.py
@@ -1,5 +1,5 @@
 # pylint: disable=invalid-name,too-many-public-methods,attribute-defined-outside-init
-# pylint: disable=no-absolute-import, useless-object-inheritance,too-few-public-methods
+# pylint: disable=no-absolute-import, useless-object-inheritance,too-few-public-methods, unused-protected-member
 """This module demonstrates a possible problem of pyLint with calling __init__ s
 from inherited classes.
 Initializations done there are not considered, which results in Error E0203 for

--- a/tests/functional/a/access/access_member_before_definition.py
+++ b/tests/functional/a/access/access_member_before_definition.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-docstring,too-few-public-methods,invalid-name
-# pylint: disable=attribute-defined-outside-init, useless-object-inheritance
+# pylint: disable=attribute-defined-outside-init, useless-object-inheritance, unused-protected-member
 
 class Aaaa(object):
     """class with attributes defined in wrong order"""

--- a/tests/functional/a/access/access_to_protected_members.py
+++ b/tests/functional/a/access/access_to_protected_members.py
@@ -1,5 +1,5 @@
 # pylint: disable=too-few-public-methods, super-init-not-called, print-statement
-# pylint: disable=no-classmethod-decorator,useless-object-inheritance
+# pylint: disable=no-classmethod-decorator,useless-object-inheritance, unused-protected-member
 """Test external access to protected class members."""
 from __future__ import print_function
 

--- a/tests/functional/a/arguments_differ.py
+++ b/tests/functional/a/arguments_differ.py
@@ -1,5 +1,5 @@
 """Test that we are emitting arguments-differ when the arguments are different."""
-# pylint: disable=missing-docstring, too-few-public-methods, unused-argument,useless-super-delegation, useless-object-inheritance
+# pylint: disable=missing-docstring, too-few-public-methods, unused-argument,useless-super-delegation, useless-object-inheritance, unused-protected-member
 
 class Parent(object):
 

--- a/tests/functional/a/assigning_non_slot.py
+++ b/tests/functional/a/assigning_non_slot.py
@@ -1,7 +1,7 @@
 """ Checks assigning attributes not found in class slots
 will trigger assigning-non-slot warning.
 """
-# pylint: disable=too-few-public-methods, no-init, missing-docstring, no-absolute-import, import-error, useless-object-inheritance
+# pylint: disable=too-few-public-methods, no-init, missing-docstring, no-absolute-import, import-error, useless-object-inheritance, unused-protected-member
 from collections import deque
 
 from missing import Unknown

--- a/tests/functional/c/class_attributes.py
+++ b/tests/functional/c/class_attributes.py
@@ -1,6 +1,6 @@
 """Test that valid class attribute doesn't trigger errors"""
 __revision__ = 'sponge bob'
-# pylint: disable=useless-object-inheritance
+# pylint: disable=useless-object-inheritance, unused-protected-member
 
 class Clazz(object):
     "dummy class"

--- a/tests/functional/c/classes_protected_member_access.py
+++ b/tests/functional/c/classes_protected_member_access.py
@@ -3,7 +3,7 @@
 """
 __revision__ = 1
 
-# pylint: disable=no-classmethod-decorator, no-staticmethod-decorator, useless-object-inheritance
+# pylint: disable=no-classmethod-decorator, no-staticmethod-decorator, useless-object-inheritance, unused-protected-member
 class A3123(object):
     """oypuee"""
     _protected = 1

--- a/tests/functional/m/member/member_checks.py
+++ b/tests/functional/m/member/member_checks.py
@@ -1,4 +1,4 @@
-# pylint: disable=print-statement,missing-docstring,no-self-use,too-few-public-methods,bare-except,broad-except, useless-object-inheritance
+# pylint: disable=print-statement,missing-docstring,no-self-use,too-few-public-methods,bare-except,broad-except, useless-object-inheritance, unused-protected-member
 # pylint: disable=using-constant-test,expression-not-assigned, assigning-non-slot, unused-variable,pointless-statement, wrong-import-order, wrong-import-position,import-outside-toplevel
 from __future__ import print_function
 class Provider(object):

--- a/tests/functional/m/member/member_checks_hints.py
+++ b/tests/functional/m/member/member_checks_hints.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, too-few-public-methods, pointless-statement, useless-object-inheritance
+# pylint: disable=missing-docstring, too-few-public-methods, pointless-statement, useless-object-inheritance, unused-protected-member
 
 
 class Parent(object):

--- a/tests/functional/m/member/member_checks_no_hints.py
+++ b/tests/functional/m/member/member_checks_no_hints.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, too-few-public-methods, pointless-statement, useless-object-inheritance
+# pylint: disable=missing-docstring, too-few-public-methods, pointless-statement, useless-object-inheritance, unused-protected-member
 
 
 class Parent(object):

--- a/tests/functional/m/metaclass_attr_access.py
+++ b/tests/functional/m/metaclass_attr_access.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-few-public-methods, metaclass-assignment, useless-object-inheritance
+# pylint: disable=too-few-public-methods, metaclass-assignment, useless-object-inheritance, unused-protected-member
 """test attribute access on metaclass"""
 
 

--- a/tests/functional/m/method_hidden.py
+++ b/tests/functional/m/method_hidden.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-few-public-methods,print-statement, useless-object-inheritance,missing-docstring
+# pylint: disable=too-few-public-methods,print-statement, useless-object-inheritance,missing-docstring, unused-protected-member
 """check method hidding ancestor attribute
 """
 from __future__ import print_function

--- a/tests/functional/m/missing/missing_docstring.py
+++ b/tests/functional/m/missing/missing_docstring.py
@@ -1,5 +1,5 @@
 # [missing-module-docstring]
-# pylint: disable=too-few-public-methods, useless-object-inheritance
+# pylint: disable=too-few-public-methods, useless-object-inheritance, unused-protected-member
 
 def public_documented():
     """It has a docstring."""

--- a/tests/functional/m/missing/missing_kwoa_py3.py
+++ b/tests/functional/m/missing/missing_kwoa_py3.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring,unused-argument,too-few-public-methods
+# pylint: disable=missing-docstring,unused-argument,too-few-public-methods, unused-protected-member
 import typing
 
 

--- a/tests/functional/n/name/name_styles.py
+++ b/tests/functional/n/name/name_styles.py
@@ -1,5 +1,5 @@
 """Test for the invalid-name warning."""
-# pylint: disable=no-absolute-import, useless-object-inheritance, unnecessary-pass, unnecessary-comprehension
+# pylint: disable=no-absolute-import, useless-object-inheritance, unnecessary-pass, unnecessary-comprehension, unused-protected-member
 from __future__ import print_function
 import abc
 import collections

--- a/tests/functional/n/no/no_classmethod_decorator.py
+++ b/tests/functional/n/no/no_classmethod_decorator.py
@@ -2,7 +2,7 @@
 scope and if classmethod's argument is a member of the class
 """
 
-# pylint: disable=too-few-public-methods, using-constant-test, no-self-argument, useless-object-inheritance
+# pylint: disable=too-few-public-methods, using-constant-test, no-self-argument, useless-object-inheritance, unused-protected-member
 
 class MyClass(object):
     """Some class"""

--- a/tests/functional/n/no/no_staticmethod_decorator.py
+++ b/tests/functional/n/no/no_staticmethod_decorator.py
@@ -2,7 +2,7 @@
 scope and if static method's argument is a member of the class
 """
 
-# pylint: disable=too-few-public-methods, using-constant-test, no-method-argument, useless-object-inheritance
+# pylint: disable=too-few-public-methods, using-constant-test, no-method-argument, useless-object-inheritance, unused-protected-member
 
 class MyClass(object):
     """Some class"""

--- a/tests/functional/r/recursion/recursion_error_2861.py
+++ b/tests/functional/r/recursion/recursion_error_2861.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-docstring,redefined-builtin,unsubscriptable-object
-# pylint: disable=invalid-name,too-few-public-methods,attribute-defined-outside-init
+# pylint: disable=invalid-name,too-few-public-methods,attribute-defined-outside-init, unused-protected-member
 class Repository:
     def _transfer(self, bytes=-1):
         self._bytesTransfered = 0

--- a/tests/functional/s/self/self_cls_assignment.py
+++ b/tests/functional/s/self/self_cls_assignment.py
@@ -1,6 +1,6 @@
 """Warning about assigning self/cls variable."""
 from __future__ import print_function
-# pylint: disable=too-few-public-methods, useless-object-inheritance
+# pylint: disable=too-few-public-methods, useless-object-inheritance, unused-protected-member
 
 class Foo(object):
     """Class with methods that check for self/cls assignment"""

--- a/tests/functional/s/slots_checks.py
+++ b/tests/functional/s/slots_checks.py
@@ -1,7 +1,7 @@
 """ Checks that classes uses valid __slots__ """
 
 # pylint: disable=too-few-public-methods, missing-docstring, no-absolute-import, useless-object-inheritance
-# pylint: disable=using-constant-test, wrong-import-position, no-else-return, line-too-long
+# pylint: disable=using-constant-test, wrong-import-position, no-else-return, line-too-long, unused-protected-member
 from collections import deque
 
 def func():

--- a/tests/functional/t/too/too_few_public_methods.py
+++ b/tests/functional/t/too/too_few_public_methods.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, useless-object-inheritance
+# pylint: disable=missing-docstring, useless-object-inheritance, unused-protected-member
 from __future__ import print_function
 
 

--- a/tests/functional/t/too/too_many_instance_attributes.py
+++ b/tests/functional/t/too/too_many_instance_attributes.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, too-few-public-methods, useless-object-inheritance
+# pylint: disable=missing-docstring, too-few-public-methods, useless-object-inheritance, unused-protected-member
 
 class Aaaa(object): # [too-many-instance-attributes]
 

--- a/tests/functional/t/too/too_many_public_methods.py
+++ b/tests/functional/t/too/too_many_public_methods.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, useless-object-inheritance
+# pylint: disable=missing-docstring, useless-object-inheritance, unused-protected-member
 
 class Aaaa(object): # [too-many-public-methods]
 

--- a/tests/functional/u/unused/unused_protected_member.py
+++ b/tests/functional/u/unused/unused_protected_member.py
@@ -1,0 +1,31 @@
+# pylint: disable=missing-docstring, invalid-name, too-few-public-methods, no-self-use, line-too-long
+
+class HasUnusedInClass():  # [unused-protected-member,unused-protected-member,unused-protected-member,unused-protected-member]
+
+    _my_secret = "I have no secrets"  # this is unused (1/4)
+
+    def __init__(self):  # Will not trigger as it begins with __ and ends with __
+        self._instance_secret = "I will never be initialized"  # this is unused (2/4)
+        self._another_secret = "hello world"
+
+    def __str__(self):  # Will not trigger as it begins with __ and ends with __
+        return "hello"
+
+    def _test(self, x, y, z):  # this is unused (3/4)
+        pass
+
+    def _my_print(self, string):
+        print(self._another_secret + string)
+
+    def hey(self):  # Will not trigger as it does not begin with _
+        self._my_print("!")
+
+    def _test_fn_as_var(self):
+        pass
+
+    def assign_fn_to_var(self):
+        fn = self._test_fn_as_var
+        fn()
+
+    def _test_recursive(self):  # will trigger, unused recursive method (4/4)
+        self._test_recursive()

--- a/tests/functional/u/unused/unused_protected_member.txt
+++ b/tests/functional/u/unused/unused_protected_member.txt
@@ -1,0 +1,4 @@
+unused-protected-member:3:0:HasUnusedInClass:"Unused protected member of class HasUnusedInClass: _instance_secret"
+unused-protected-member:3:0:HasUnusedInClass:"Unused protected member of class HasUnusedInClass: _my_secret"
+unused-protected-member:3:0:HasUnusedInClass:"Unused protected member of class HasUnusedInClass: _test(self, x, y, z)"
+unused-protected-member:3:0:HasUnusedInClass:"Unused protected member of class HasUnusedInClass: _test_recursive(self)"


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Implemented a new checker, ``unused-protected-member``, which is emitted when a private member (i.e., begins with ``_``) is defined within a class and unused

Check includes:
- protected functions
- protected class variables
- protected instance attributes

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue
Closes #4483 
<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
