### PR TITLE
Fixed minor doc formatting in doc/whatsnew/2.9.rst

### DIFF
--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -25,7 +25,7 @@ New checkers
 
 * ``consider-using-from-import``: Emitted when a submodule/member of a package is imported and aliased with the same name.
 
-* New checker ``unused-private-member``. Emitted when a private member (i.e., starts with ``__``) of a class is defined but not used.
+* New checker ``unused-private-member``: Emitted when a private member (i.e., starts with ``__``) of a class is defined but not used.
 
 Other Changes
 =============


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Write a good description on what the PR does.

## Description

A small formatting oversight for my previous PRs made for the ``unused-private-member`` checker -- sorry about that :sweat: 

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |


