### PR TITLE
Improve build config

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,15 @@
+recursive-exclude pylint *.rst
+prune .github
+prune doc
+prune elisp
+prune examples
+prune tests
+prune script
+exclude .*
+exclude appveyor.yml
+exclude ChangeLog
+exclude Dockerfile
+exclude README.rst
+exclude pylintrc
+exclude requirements_*.txt
+exclude tox.ini

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = pylint
-version = attr: pylint.__version__
 description = python code static checker
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
## Description
`setuptools_scm` auto-includes all files managed by git in the source distribution except for excludes specified in `MANIFEST.in`. https://github.com/pypa/setuptools_scm#file-finders-hook-makes-most-of-manifestin-unnecessary

`wheel` still adheres to the `options.packages.find` section config in `setup.cfg` for the build distribution.