### PR TITLE
Add new checker ``consider-using-namedtuple``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -124,6 +124,9 @@ modules are added.
   Closes #4509
   Closes PyCQA/astroid#999
 
+* New checker ``consider-using-namedtuple``. Emitted when dictionary values can be replaced
+  by namedtuples.
+
 
 What's New in Pylint 2.8.2?
 ===========================

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -31,6 +31,8 @@ New checkers
 
 * New checker ``invalid-class-object``: Emitted when a non-class is assigned to a ``__class__`` attribute.
 
+* ``consider-using-namedtuple``: Emitted when dictionary values can be replaced by namedtuples.
+
 Other Changes
 =============
 

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -499,7 +499,7 @@ def _has_same_layout_slots(slots, assigned_value):
     return False
 
 
-MSGS = {
+MSGS = {  # pylint: disable=consider-using-namedtuple
     "F0202": (
         "Unable to check methods signature (%s / %s)",
         "method-check-failed",

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -33,7 +33,7 @@ from pylint.checkers import BaseChecker
 from pylint.checkers.utils import check_messages
 from pylint.interfaces import IAstroidChecker
 
-MSGS = {
+MSGS = {  # pylint: disable=consider-using-namedtuple
     "R0901": (
         "Too many ancestors (%s/%s)",
         "too-many-ancestors",

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -79,7 +79,7 @@ def _is_raising(body: typing.List) -> bool:
 OVERGENERAL_EXCEPTIONS = ("BaseException", "Exception")
 BUILTINS_NAME = builtins.__name__
 
-MSGS = {
+MSGS = {  # pylint: disable=consider-using-namedtuple
     "E0701": (
         "Bad except clauses order (%s)",
         "bad-except-order",

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -30,7 +30,7 @@ from pylint import checkers, interfaces
 from pylint.checkers import utils
 from pylint.checkers.utils import check_messages
 
-MSGS = {
+MSGS = {  # pylint: disable=consider-using-namedtuple
     "W1201": (
         "Use %s formatting in logging functions",
         "logging-not-lazy",

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -6,14 +6,15 @@ import copy
 import itertools
 import tokenize
 from functools import reduce
-from typing import List, Optional, Tuple, Union, cast
+from typing import List, Optional, Set, Tuple, Type, Union, cast
 
 import astroid
+from astroid.node_classes import NodeNG
 
 from pylint import checkers, interfaces
 from pylint import utils as lint_utils
 from pylint.checkers import utils
-from pylint.checkers.utils import node_frame_class
+from pylint.checkers.utils import node_frame_class, safe_infer
 
 KNOWN_INFINITE_ITERATORS = {"itertools.count"}
 BUILTIN_EXIT_FUNCS = frozenset(("quit", "exit"))
@@ -353,6 +354,11 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             "Emitted when iterating over the dictionary items (key-item pairs) and accessing the "
             "value by index lookup. "
             "The value can be accessed directly instead.",
+        ),
+        "R1734": (
+            "Consider using namedtuple for dictionary values",
+            "consider-using-namedtuple",
+            "Emitted when dictionary values can be replaced by namedtuples.",
         ),
     }
     options = (
@@ -1756,3 +1762,76 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                             node=subscript,
                             args=("1".join(value.as_string().rsplit("0", maxsplit=1)),),
                         )
+
+    @utils.check_messages("consider-using-namedtuple")
+    def visit_dict(self, node: astroid.Dict) -> None:
+        self._check_dict_consider_namedtuple(node)
+
+    def _check_dict_consider_namedtuple(self, node: astroid.Dict) -> None:
+        """Check if dictionary values can be replaced by Namedtuple."""
+        if not (
+            isinstance(node.parent, (astroid.Assign, astroid.AnnAssign))
+            and isinstance(node.parent.parent, astroid.Module)
+            or isinstance(node.parent, astroid.AnnAssign)
+            and utils.is_assign_name_annotated_with(node.parent.target, "Final")
+        ):
+            # If dict is not part of an 'Assign' or 'AnnAssign' node in
+            # a module context OR 'AnnAssign' with 'Final' annotation, skip check.
+            return
+
+        # All dict_values are itself dict nodes
+        if len(node.items) > 1 and all(
+            isinstance(dict_value, astroid.Dict) for _, dict_value in node.items
+        ):
+            KeyTupleT = Tuple[Type[NodeNG], str]
+
+            # Makes sure all keys are 'Const' string nodes
+            keys_checked: Set[KeyTupleT] = set()
+            for _, dict_value in node.items:
+                for key, _ in dict_value.items:
+                    key_tuple = (type(key), key.as_string())
+                    if key_tuple in keys_checked:
+                        continue
+                    inferred = safe_infer(key)
+                    if not (
+                        isinstance(inferred, astroid.Const)
+                        and inferred.pytype() == "builtins.str"
+                    ):
+                        return
+                    keys_checked.add(key_tuple)
+
+            # Makes sure all subdicts have at least 1 common key
+            key_tuples: List[Tuple[KeyTupleT, ...]] = []
+            for _, dict_value in node.items:
+                key_tuples.append(
+                    tuple((type(key), key.as_string()) for key, _ in dict_value.items)
+                )
+            keys_intersection: Set[KeyTupleT] = set(key_tuples[0])
+            for sub_key_tuples in key_tuples[1:]:
+                keys_intersection.intersection_update(sub_key_tuples)
+            if not keys_intersection:
+                return
+
+            self.add_message("consider-using-namedtuple", node=node)
+            return
+
+        # All dict_values are itself either list or tuple nodes
+        if len(node.items) > 1 and all(
+            isinstance(dict_value, (astroid.List, astroid.Tuple))
+            for _, dict_value in node.items
+        ):
+            # Make sure all sublists have the same length > 0
+            list_length = len(node.items[0][1].elts)
+            if list_length == 0:
+                return
+            for _, dict_value in node.items[1:]:
+                if len(dict_value.elts) != list_length:
+                    return
+
+            # Make sure at least one list entry isn't a dict
+            for _, dict_value in node.items:
+                if all(isinstance(entry, astroid.Dict) for entry in dict_value.elts):
+                    return
+
+            self.add_message("consider-using-namedtuple", node=node)
+            return

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -82,7 +82,7 @@ SINGLE_QUOTED_REGEX = re.compile("(%s)?'''" % "|".join(_PREFIXES))
 DOUBLE_QUOTED_REGEX = re.compile('(%s)?"""' % "|".join(_PREFIXES))
 QUOTE_DELIMITER_REGEX = re.compile("(%s)?(\"|')" % "|".join(_PREFIXES), re.DOTALL)
 
-MSGS = {
+MSGS = {  # pylint: disable=consider-using-namedtuple
     "E1300": (
         "Unsupported format character %r (%#02x) at index %d",
         "bad-format-character",

--- a/tests/functional/c/consider/consider_using_namedtuple.py
+++ b/tests/functional/c/consider/consider_using_namedtuple.py
@@ -1,0 +1,74 @@
+# pylint: disable=missing-docstring,too-few-public-methods,unused-variable,no-name-in-module
+from typing import Final
+
+class Foo:
+    BAR = "bar"
+
+KEY_3 = "key_3"
+
+
+# Subdicts have at least 1 common key
+MAPPING_1 = {  # [consider-using-namedtuple]
+    "entry_1": {"key_1": 0, "key_2": 1, "key_diff_1": 2},
+    "entry_2": {"key_1": 0, "key_2": 1, "key_diff_2": 3},
+}
+MAPPING_2 = {  # [consider-using-namedtuple]
+    "entry_1": {KEY_3: None, Foo.BAR: None},
+    "entry_2": {KEY_3: None, Foo.BAR: None},
+}
+
+# ints are not valid fieldnames for namedtuples
+MAPPING_3 = {
+    "entry_1": {0: None, 1: None},
+    "entry_2": {0: None, 1: None},
+}
+
+
+def func():
+    # Not in module scope
+    mapping_4 = {
+        "entry_1": {"key_1": 0, "key_2": 1},
+        "entry_2": {"key_1": 0, "key_2": 1},
+    }
+
+    mapping_5: Final = {  # [consider-using-namedtuple]
+        "entry_1": {"key_1": 0, "key_2": 1},
+        "entry_2": {"key_1": 0, "key_2": 1},
+    }
+
+
+# lists must have the same length
+MAPPING_6 = {  # [consider-using-namedtuple]
+    "entry_1": [1, "a", set()],
+    "entry_2": [2, "b", set()],
+}
+MAPPING_7 = {
+    "entry_1": [],
+    "entry_2": [],
+}
+MAPPING_8 = {
+    "entry_1": [1],
+    "entry_2": [2, "b"],
+}
+MAPPING_9 = {  # [consider-using-namedtuple]
+    "entry_1": (1, "a"),
+    "entry_2": (2, "b"),
+}
+
+# No entry can't contain only dicts
+MAPPING_10 = {
+    "entry_1": [
+        {"key_1": None, "key_2": None},
+    ],
+    "entry_2": [None]
+}
+
+# No either dict, tuple, or list as dict values
+MAPPING_11 = {
+    "entry_1": 1,
+    "entry_2": 2,
+}
+MAPPING_12 = {
+    "entry_1": "",
+    "entry_2": "",
+}

--- a/tests/functional/c/consider/consider_using_namedtuple.txt
+++ b/tests/functional/c/consider/consider_using_namedtuple.txt
@@ -1,0 +1,5 @@
+consider-using-namedtuple:11:12::Consider using namedtuple for dictionary values
+consider-using-namedtuple:15:12::Consider using namedtuple for dictionary values
+consider-using-namedtuple:34:23:func:Consider using namedtuple for dictionary values
+consider-using-namedtuple:41:12::Consider using namedtuple for dictionary values
+consider-using-namedtuple:53:12::Consider using namedtuple for dictionary values


### PR DESCRIPTION
## Description
Add a new checker to suggest the use of `namedtuples` for constant dictionary values, instead of sub-dicts or lists.
Module level dicts are most often used as mappings and thus don't change. Namedtuples provide some (minor) performance benefits but most importantly will make code more readable in most cases.

Some requirements:
- All dict values must either be dicts or lists. They must all be of the same type
- If the dict values are dicts itself, all dict values must have at least one common key and the current keys of the `sub-dict` must be strings (e.g., ints are no valid fieldnames for namedtuples).
- If all dict values are lists, they must all have the same number of elements > 0 and any dict value can't contain only dicts.

I added the requirements to prevent most false-positives, but it isn't perfect. For example, the checker assumes that all module level dicts are constant. This is recommended but not always a given. For the cases where this isn't true, it might be best to add a `pylint: disable` manually.

**Example**
```py
# Either import from 'collections' or 'typing'
from collections import namedtuple
from typing import NamedTuple

SERVICE_JOIN = "join"
SERVICE_UNJOIN = "unjoin"

SERVICE_TO_METHOD = {
    SERVICE_JOIN: {"method": "async_join", "schema": 0},
    SERVICE_UNJOIN: {"method": "async_unjoin", "schema": 1},
}

method_val = SERVICE_TO_METHOD[SERVICE_JOIN]["method"]


# new

class ServiceMethod(NamedTuple):
    method: str
    schema: int

SERVICE_TO_METHOD_2 = {
    SERVICE_JOIN: ServiceMethod("async_join", 0),
    SERVICE_UNJOIN: ServiceMethod("asnyc_unjoin", 1),
}

method_val = SERVICE_TO_METHOD_2[SERVICE_JOIN].method
```

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |