### PR TITLE
Handle floats when parsing pyproject.toml (#4518)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -499,3 +499,5 @@ contributors:
 * Bernard Nauwelaerts: contributor
 
 * Fabian Damken: contributor
+
+* Markus Siebenhaar: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -105,6 +105,9 @@ modules are added.
 
   Closes #585
 
+* Added handling of floating point values when parsing configuration from pyproject.toml
+
+  Closes #4518
 
 What's New in Pylint 2.8.2?
 ===========================

--- a/ChangeLog
+++ b/ChangeLog
@@ -109,6 +109,7 @@ modules are added.
 
   Closes #4518
 
+
 What's New in Pylint 2.8.2?
 ===========================
 Release date: 2021-04-26

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -55,3 +55,5 @@ Other Changes
   like ``[]`` and ``[1, 2, 3]``.
 
 * ``ignore-paths`` configuration directive has been added. Defined regex patterns are matched against file path.
+
+* Added handling of floating point values when parsing configuration from pyproject.toml

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -281,7 +281,7 @@ class OptionsManagerMixIn:
                         for option, value in values.items():
                             if isinstance(value, bool):
                                 values[option] = "yes" if value else "no"
-                            elif isinstance(value, int):
+                            elif isinstance(value, (int, float)):
                                 values[option] = str(value)
                             elif isinstance(value, list):
                                 values[option] = ",".join(value)


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Cast floats to string so ``ConfigParser`` can handle them, just like ints.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #4518
