### PR TITLE
Fix false-positive assigning-non-slot with typing.Generic base

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -119,6 +119,11 @@ modules are added.
 
   Closes PyCQA/astroid#942
 
+* Fix ``assigning-non-slot`` false-positive with base that inherits from ``typing.Generic``
+
+  Closes #4509
+  Closes PyCQA/astroid#999
+
 
 What's New in Pylint 2.8.2?
 ===========================

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -1417,6 +1417,13 @@ a metaclass class method.",
         if "__slots__" not in klass.locals or not klass.newstyle:
             return
 
+        # If 'typing.Generic' is a base of bases of klass, the cached version
+        # of 'slots()' might have been evaluated incorrectly, thus deleted cache entry.
+        if any(base.qname() == "typing.Generic" for base in klass.mro()):
+            cache = getattr(klass, "__cache", None)
+            if cache and cache.get(klass.slots) is not None:
+                del cache[klass.slots]
+
         slots = klass.slots()
         if slots is None:
             return

--- a/tests/functional/a/assign/assigning_non_slot_4509.py
+++ b/tests/functional/a/assign/assigning_non_slot_4509.py
@@ -1,0 +1,18 @@
+# pylint: disable=invalid-name,missing-docstring,too-few-public-methods
+
+# Slots with base that inherits from 'Generic'
+# https://github.com/PyCQA/pylint/issues/4509
+# https://github.com/PyCQA/astroid/issues/999
+
+from typing import Generic, TypeVar
+T = TypeVar("T")
+
+class Base(Generic[T]):
+    __slots__ = ()
+
+class Foo(Base[T]):
+    __slots__ = ['_value']
+
+    def __init__(self, value: T):
+        self._value = value
+        self._bar = value  # [assigning-non-slot]

--- a/tests/functional/a/assign/assigning_non_slot_4509.rc
+++ b/tests/functional/a/assign/assigning_non_slot_4509.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.7

--- a/tests/functional/a/assign/assigning_non_slot_4509.txt
+++ b/tests/functional/a/assign/assigning_non_slot_4509.txt
@@ -1,0 +1,1 @@
+assigning-non-slot:18:8:Foo.__init__:Assigning to attribute '_bar' not defined in class slots


### PR DESCRIPTION
## Description
Fix a false-positive for `assigning-non-slot` with base that inherits from `typing.Generic`.

```py
from typing import Generic, TypeVar
T = TypeVar("T")

class Base(Generic[T]):
    __slots__ = ()

class Foo(Base[T]):
    __slots__ = ['_value']

    def __init__(self, value: T):
        self._value = value
```
The reason for the issue is that `slots()` is evaluated and cached before any inference tips from astroid are applied.
For classes that directly inherit from `Generic` this is fixed by `astroid`, everything else needs to be handled by `pylint` at least for now. -> [astroid fix](https://github.com/PyCQA/astroid/pull/931/files#diff-bad42d2444679b996b2e5e6d3d1f157ecdd286279465d0cda99d3bd772862f82R169-R173)


## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes https://github.com/PyCQA/pylint/issues/4509
Closes https://github.com/PyCQA/astroid/issues/999
