### PR TITLE
Update name checker `consider-using-namedtuple` to include `dataclass`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -124,8 +124,8 @@ modules are added.
   Closes #4509
   Closes PyCQA/astroid#999
 
-* New checker ``consider-using-namedtuple``. Emitted when dictionary values can be replaced
-  by namedtuples.
+* New checker ``consider-using-namedtuple-or-dataclass``. Emitted when dictionary values
+  can be replaced by namedtuples or dataclass instances.
 
 
 What's New in Pylint 2.8.3?

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -31,7 +31,8 @@ New checkers
 
 * New checker ``invalid-class-object``: Emitted when a non-class is assigned to a ``__class__`` attribute.
 
-* ``consider-using-namedtuple``: Emitted when dictionary values can be replaced by namedtuples.
+* ``consider-using-namedtuple-or-dataclass``: Emitted when dictionary values
+  can be replaced by namedtuples or dataclass instances.
 
 Other Changes
 =============

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -499,7 +499,7 @@ def _has_same_layout_slots(slots, assigned_value):
     return False
 
 
-MSGS = {  # pylint: disable=consider-using-namedtuple
+MSGS = {  # pylint: disable=consider-using-namedtuple-or-dataclass
     "F0202": (
         "Unable to check methods signature (%s / %s)",
         "method-check-failed",

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -33,7 +33,7 @@ from pylint.checkers import BaseChecker
 from pylint.checkers.utils import check_messages
 from pylint.interfaces import IAstroidChecker
 
-MSGS = {  # pylint: disable=consider-using-namedtuple
+MSGS = {  # pylint: disable=consider-using-namedtuple-or-dataclass
     "R0901": (
         "Too many ancestors (%s/%s)",
         "too-many-ancestors",

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -79,7 +79,7 @@ def _is_raising(body: typing.List) -> bool:
 OVERGENERAL_EXCEPTIONS = ("BaseException", "Exception")
 BUILTINS_NAME = builtins.__name__
 
-MSGS = {  # pylint: disable=consider-using-namedtuple
+MSGS = {  # pylint: disable=consider-using-namedtuple-or-dataclass
     "E0701": (
         "Bad except clauses order (%s)",
         "bad-except-order",

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -30,7 +30,7 @@ from pylint import checkers, interfaces
 from pylint.checkers import utils
 from pylint.checkers.utils import check_messages
 
-MSGS = {  # pylint: disable=consider-using-namedtuple
+MSGS = {  # pylint: disable=consider-using-namedtuple-or-dataclass
     "W1201": (
         "Use %s formatting in logging functions",
         "logging-not-lazy",

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -356,9 +356,9 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             "The value can be accessed directly instead.",
         ),
         "R1734": (
-            "Consider using namedtuple for dictionary values",
-            "consider-using-namedtuple",
-            "Emitted when dictionary values can be replaced by namedtuples.",
+            "Consider using namedtuple or dataclass for dictionary values",
+            "consider-using-namedtuple-or-dataclass",
+            "Emitted when dictionary values can be replaced by namedtuples or dataclass instances.",
         ),
     }
     options = (
@@ -1763,7 +1763,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                             args=("1".join(value.as_string().rsplit("0", maxsplit=1)),),
                         )
 
-    @utils.check_messages("consider-using-namedtuple")
+    @utils.check_messages("consider-using-namedtuple-or-dataclass")
     def visit_dict(self, node: astroid.Dict) -> None:
         self._check_dict_consider_namedtuple(node)
 
@@ -1812,7 +1812,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             if not keys_intersection:
                 return
 
-            self.add_message("consider-using-namedtuple", node=node)
+            self.add_message("consider-using-namedtuple-or-dataclass", node=node)
             return
 
         # All dict_values are itself either list or tuple nodes
@@ -1833,5 +1833,5 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                 if all(isinstance(entry, astroid.Dict) for entry in dict_value.elts):
                     return
 
-            self.add_message("consider-using-namedtuple", node=node)
+            self.add_message("consider-using-namedtuple-or-dataclass", node=node)
             return

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -82,7 +82,7 @@ SINGLE_QUOTED_REGEX = re.compile("(%s)?'''" % "|".join(_PREFIXES))
 DOUBLE_QUOTED_REGEX = re.compile('(%s)?"""' % "|".join(_PREFIXES))
 QUOTE_DELIMITER_REGEX = re.compile("(%s)?(\"|')" % "|".join(_PREFIXES), re.DOTALL)
 
-MSGS = {  # pylint: disable=consider-using-namedtuple
+MSGS = {  # pylint: disable=consider-using-namedtuple-or-dataclass
     "E1300": (
         "Unsupported format character %r (%#02x) at index %d",
         "bad-format-character",

--- a/tests/functional/c/consider/consider_using_namedtuple.txt
+++ b/tests/functional/c/consider/consider_using_namedtuple.txt
@@ -1,5 +1,0 @@
-consider-using-namedtuple:11:12::Consider using namedtuple for dictionary values
-consider-using-namedtuple:15:12::Consider using namedtuple for dictionary values
-consider-using-namedtuple:34:23:func:Consider using namedtuple for dictionary values
-consider-using-namedtuple:41:12::Consider using namedtuple for dictionary values
-consider-using-namedtuple:53:12::Consider using namedtuple for dictionary values

--- a/tests/functional/c/consider/consider_using_namedtuple_or_dataclass.py
+++ b/tests/functional/c/consider/consider_using_namedtuple_or_dataclass.py
@@ -8,11 +8,11 @@ KEY_3 = "key_3"
 
 
 # Subdicts have at least 1 common key
-MAPPING_1 = {  # [consider-using-namedtuple]
+MAPPING_1 = {  # [consider-using-namedtuple-or-dataclass]
     "entry_1": {"key_1": 0, "key_2": 1, "key_diff_1": 2},
     "entry_2": {"key_1": 0, "key_2": 1, "key_diff_2": 3},
 }
-MAPPING_2 = {  # [consider-using-namedtuple]
+MAPPING_2 = {  # [consider-using-namedtuple-or-dataclass]
     "entry_1": {KEY_3: None, Foo.BAR: None},
     "entry_2": {KEY_3: None, Foo.BAR: None},
 }
@@ -31,14 +31,14 @@ def func():
         "entry_2": {"key_1": 0, "key_2": 1},
     }
 
-    mapping_5: Final = {  # [consider-using-namedtuple]
+    mapping_5: Final = {  # [consider-using-namedtuple-or-dataclass]
         "entry_1": {"key_1": 0, "key_2": 1},
         "entry_2": {"key_1": 0, "key_2": 1},
     }
 
 
 # lists must have the same length
-MAPPING_6 = {  # [consider-using-namedtuple]
+MAPPING_6 = {  # [consider-using-namedtuple-or-dataclass]
     "entry_1": [1, "a", set()],
     "entry_2": [2, "b", set()],
 }
@@ -50,7 +50,7 @@ MAPPING_8 = {
     "entry_1": [1],
     "entry_2": [2, "b"],
 }
-MAPPING_9 = {  # [consider-using-namedtuple]
+MAPPING_9 = {  # [consider-using-namedtuple-or-dataclass]
     "entry_1": (1, "a"),
     "entry_2": (2, "b"),
 }

--- a/tests/functional/c/consider/consider_using_namedtuple_or_dataclass.txt
+++ b/tests/functional/c/consider/consider_using_namedtuple_or_dataclass.txt
@@ -1,0 +1,5 @@
+consider-using-namedtuple-or-dataclass:11:12::Consider using namedtuple or dataclass for dictionary values
+consider-using-namedtuple-or-dataclass:15:12::Consider using namedtuple or dataclass for dictionary values
+consider-using-namedtuple-or-dataclass:34:23:func:Consider using namedtuple or dataclass for dictionary values
+consider-using-namedtuple-or-dataclass:41:12::Consider using namedtuple or dataclass for dictionary values
+consider-using-namedtuple-or-dataclass:53:12::Consider using namedtuple or dataclass for dictionary values


### PR DESCRIPTION
## Description
Followup to #4517
I realized while working on the `MsgDef` change that often `dataclasses` are also a good option instead of `dicts` or `lists`. Since we haven't release `2.9.0` yet, this wouldn't even be a breaking change.

I'm just not sure if `consider-using-namedtuple-or-dataclass` is the best name as it's pretty long. Open to suggestions if we find something better.

## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |