### PR TITLE
Add new checker `invalid-all-format`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -127,6 +127,9 @@ modules are added.
 * New checker ``consider-using-namedtuple``. Emitted when dictionary values can be replaced
   by namedtuples.
 
+* New checker ``invalid-all-format``. Emitted when ``__all__`` has an invalid format,
+  i.e. isn't a ``tuple`` or ``list``.
+
 
 What's New in Pylint 2.8.3?
 ===========================

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -33,6 +33,9 @@ New checkers
 
 * ``consider-using-namedtuple``: Emitted when dictionary values can be replaced by namedtuples.
 
+* ``invalid-all-format``: Emitted when ``__all__`` has an invalid format,
+  i.e. isn't a ``tuple`` or ``list``.
+
 Other Changes
 =============
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -391,6 +391,11 @@ MSGS = {
         "invalid-all-object",
         "Used when an invalid (non-string) object occurs in __all__.",
     ),
+    "E0605": (
+        "Invalid format for __all__, must be tuple or list",
+        "invalid-all-format",
+        "Used when __all__ has an invalid format.",
+    ),
     "E0611": (
         "No name %r in module %r",
         "no-name-in-module",
@@ -737,6 +742,7 @@ class VariablesChecker(BaseChecker):
         "redefined-builtin",
         "undefined-all-variable",
         "invalid-all-object",
+        "invalid-all-format",
         "unused-variable",
     )
     def leave_module(self, node):
@@ -1960,6 +1966,10 @@ class VariablesChecker(BaseChecker):
     def _check_all(self, node, not_consumed):
         assigned = next(node.igetattr("__all__"))
         if assigned is astroid.Uninferable:
+            return
+
+        if not isinstance(assigned, (astroid.Tuple, astroid.List)):
+            self.add_message("invalid-all-format", node=assigned)
             return
 
         for elt in getattr(assigned, "elts", ()):

--- a/tests/functional/i/invalid/invalid_all_format.py
+++ b/tests/functional/i/invalid/invalid_all_format.py
@@ -1,0 +1,7 @@
+"""Test invalid __all__ format.
+
+Tuples with one element MUST contain a comma! Otherwise it's a string.
+"""
+__all__ = ("CONST")  # [invalid-all-format]
+
+CONST = 42

--- a/tests/functional/i/invalid/invalid_all_format.txt
+++ b/tests/functional/i/invalid/invalid_all_format.txt
@@ -1,0 +1,1 @@
+invalid-all-format:5:11::Invalid format for __all__, must be tuple or list

--- a/tests/functional/i/invalid/invalid_all_format_valid_1.py
+++ b/tests/functional/i/invalid/invalid_all_format_valid_1.py
@@ -1,0 +1,4 @@
+"""Test valid __all__ format."""
+__all__ = ("CONST", )
+
+CONST = 42

--- a/tests/functional/i/invalid/invalid_all_format_valid_2.py
+++ b/tests/functional/i/invalid/invalid_all_format_valid_2.py
@@ -1,0 +1,4 @@
+"""Test valid __all__ format."""
+__all__ = ["CONST"]
+
+CONST = 42


### PR DESCRIPTION
## Description
New checker to catch a common beginner mistake when writing `__all__` as a tuple: missing the trailing comma.

```py
# wrong
__all__ = ("CONST")  # this is evaluated as a string, not a tuple

# correct
__all__ = ("CONST", )

CONST = 42
```

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |