### PR TITLE
Improve traceback for pytest runs

### DIFF
--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -76,6 +76,9 @@ class LintModuleTest:
             if sys.platform.lower() in platforms:
                 pytest.skip("Test cannot run on platform %r" % sys.platform)
 
+    def runTest(self):
+        self._runTest()
+
     def _should_be_skipped_due_to_version(self):
         return (
             sys.version_info < self._test_file.options["min_pyver"]
@@ -175,6 +178,7 @@ class LintModuleTest:
         return received_msgs, received_output_lines
 
     def _runTest(self):
+        __tracebackhide__ = True  # pylint: disable=unused-variable
         modules_to_check = [self._test_file.source]
         self._linter.check(modules_to_check)
         expected_messages, expected_output = self._get_expected()

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -96,12 +96,13 @@ TEST_WITH_EXPECTED_DEPRECATION = [
 
 @pytest.mark.parametrize("test_file", TESTS, ids=TESTS_NAMES)
 def test_functional(test_file, recwarn, pytestconfig):
+    __tracebackhide__ = True  # pylint: disable=unused-variable
     if UPDATE_FILE.exists():
         lint_test = LintModuleOutputUpdate(test_file, pytestconfig)
     else:
         lint_test = testutils.LintModuleTest(test_file, pytestconfig)
     lint_test.setUp()
-    lint_test._runTest()
+    lint_test.runTest()
     warning = None
     try:
         # Catch <unknown>:x: DeprecationWarning: invalid escape sequence


### PR DESCRIPTION
## Description
Use `__tracebackhide__ = True` to hide functions from pytest traceback. This is especially useful for the functional test output. https://docs.pytest.org/en/latest/example/simple.html?highlight=tracebackhide
Unfortunately, it isn't possible to hide it for all functions in the call stack. Therefore I've added a helper to keep it at least as short as possible.


**Before**
```
======================================================== FAILURES ========================================================
______________________________________ test_functional[typing_consider_using_alias] ______________________________________

test_file = FunctionalTest:typing_consider_using_alias, recwarn = WarningsRecorder(record=True)
pytestconfig = <_pytest.config.Config object at 0x109b6ab00>

    @pytest.mark.parametrize("test_file", TESTS, ids=TESTS_NAMES)
    def test_functional(test_file, recwarn, pytestconfig):
        if UPDATE_FILE.exists():
            lint_test = LintModuleOutputUpdate(test_file, pytestconfig)
        else:
            lint_test = testutils.LintModuleTest(test_file, pytestconfig)
        lint_test.setUp()
>       lint_test._runTest()

tests/test_functional.py:104: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <pylint.testutils.lint_module_test.LintModuleTest object at 0x10ba15600>

    def _runTest(self):
        modules_to_check = [self._test_file.source]
        self._linter.check(modules_to_check)
        expected_messages, expected_output = self._get_expected()
        actual_messages, actual_output = self._get_actual()
>       assert (
            expected_messages == actual_messages
        ), self.error_msg_for_unequal_messages(
            actual_messages, expected_messages, actual_output
        )
E       AssertionError: Wrong results for file "typing_consider_using_alias":
E       
E       Expected in testdata:
E         17: consider-using-alias

pylint/testutils/lint_module_test.py:182: AssertionError
```

**After**
```
======================================================== FAILURES ========================================================
______________________________________ test_functional[typing_consider_using_alias] ______________________________________

self = <pylint.testutils.lint_module_test.LintModuleTest object at 0x10fe1d630>

    def runTest(self):
>       self._runTest()
E       AssertionError: Wrong results for file "typing_consider_using_alias":
E       
E       Expected in testdata:
E         17: consider-using-alias

pylint/testutils/lint_module_test.py:80: AssertionError
```