### PR TITLE
Clarify documentation for `typing` extension

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -135,6 +135,10 @@ modules are added.
 
 * New checker ``await-outside-async``. Emitted when await is used outside an async function.
 
+* Clarify documentation for ``typing`` extension.
+
+  Closes #4545
+
 
 What's New in Pylint 2.8.3?
 ===========================

--- a/pylint/extensions/typing.py
+++ b/pylint/extensions/typing.py
@@ -124,10 +124,10 @@ class TypingChecker(BaseChecker):
                 "type": "yn",
                 "metavar": "<y_or_n>",
                 "help": (
-                    "Set to ``no`` if the app / libary does NOT need to "
-                    "support runtime introspection of type "
-                    "annotations. Only applies to Python version "
-                    "3.7 - 3.9"
+                    "Set to ``no`` if the app / library does NOT need to "
+                    "support runtime introspection of type annotations. "
+                    "Only change it if you understand what that means. "
+                    "Applies to Python version 3.7 - 3.9"
                 ),
             },
         ),

--- a/pylint/extensions/typing.py
+++ b/pylint/extensions/typing.py
@@ -124,10 +124,13 @@ class TypingChecker(BaseChecker):
                 "type": "yn",
                 "metavar": "<y_or_n>",
                 "help": (
-                    "Set to ``no`` if the app / library does NOT need to "
+                    "Set to ``no`` if the app / library does **NOT** need to "
                     "support runtime introspection of type annotations. "
-                    "Only change it if you understand what that means. "
-                    "Applies to Python version 3.7 - 3.9"
+                    "If you use type annotations **exclusively** for type checking "
+                    "of an application, you're probably fine. For libraries, "
+                    "evaluate if some users what to access the type hints "
+                    "at runtime first, e.g., through ``typing.get_type_hints``. "
+                    "Applies to Python versions 3.7 - 3.9"
                 ),
             },
         ),


### PR DESCRIPTION
## Description
Clarify documentation for `typing` extension.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Related Issue
Closes #4545 
