### PR TITLE
Add regression test for Pattern Matching 3.10

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -130,6 +130,9 @@ modules are added.
 * New checker ``invalid-all-format``. Emitted when ``__all__`` has an invalid format,
   i.e. isn't a ``tuple`` or ``list``.
 
+* Fix false positive ``unused-variable`` and ``undefined-variable`` with
+  Pattern Matching in Python 3.10
+
 
 What's New in Pylint 2.8.3?
 ===========================

--- a/tests/functional/p/pattern_matching.py
+++ b/tests/functional/p/pattern_matching.py
@@ -1,0 +1,24 @@
+# pylint: disable=missing-docstring,invalid-name,too-few-public-methods
+
+class Point2D:
+    __match_args__ = ("x", "y")
+
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+
+# Don't emit false-positive 'unused-variable' and 'undefined-varibable'
+var = 42
+match var:
+    case [*rest1]:
+        print(rest1)
+    case {**rest2}:
+        print(rest2)
+    case Point2D(0, a):
+        print(a)
+    case Point2D(x=0, y=b) as new_point:
+        print(b)
+        print(new_point)
+    case new_var:
+        print(new_var)

--- a/tests/functional/p/pattern_matching.rc
+++ b/tests/functional/p/pattern_matching.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.10


### PR DESCRIPTION
## Description
Add basic regression test for Pattern Matching to catch `unused-variable` and `undefined-variable` errors.
Requires: https://github.com/PyCQA/astroid/pull/1010

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |