### PR TITLE
Add additional documenation for typing extension

### DIFF
--- a/pylint/extensions/typing.rst
+++ b/pylint/extensions/typing.rst
@@ -1,0 +1,1 @@
+Find issue specifically related to type annotations.


### PR DESCRIPTION
## Description
Didn't know that the checker class docstring wasn't used for the documenation.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |