### PR TITLE
Add exclude_lines coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,13 @@ include =
     pylint/*
 omit =
     */test/*
+exclude_lines =
+    # Re-enable default pragma
+    pragma: no cover
+
+    # Debug-only code
+    def __repr__
+
+    # Type checking code not executed during pytest runs
+    if TYPE_CHECKING:
+    @overload


### PR DESCRIPTION
## Description
Add `exclude_lines` setting to `coveragerc` file. Some lines will never be executed. We shouldn't use them to calculate coverage.

https://coverage.readthedocs.io/en/coverage-4.3.3/excluding.html#advanced-exclusion
Example Home-Assistant: [.coveragerc](https://github.com/home-assistant/core/blob/c242e56b8c9eb2b4de51aac24406e638cfa843de/.coveragerc#L1249)

--
Similar to https://github.com/PyCQA/astroid/pull/1022