### PR TITLE
Remove deprecated `astroid.Ellipsis` node

### DIFF
--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1205,9 +1205,7 @@ class BasicChecker(_BasicChecker):
         # warn W0106 if we have any underlying function call (we can't predict
         # side effects), else pointless-statement
         if (
-            isinstance(
-                expr, (astroid.Yield, astroid.Await, astroid.Ellipsis, astroid.Call)
-            )
+            isinstance(expr, (astroid.Yield, astroid.Await, astroid.Call))
             or (
                 isinstance(node.parent, astroid.TryExcept)
                 and node.parent.body == [node]

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -632,9 +632,10 @@ class FormatChecker(BaseTokenChecker):
             return
 
         # Function overloads that use ``Ellipsis`` are exempted.
-        if isinstance(node, nodes.Expr) and (
-            isinstance(node.value, nodes.Ellipsis)
-            or (isinstance(node.value, nodes.Const) and node.value.value is Ellipsis)
+        if (
+            isinstance(node, nodes.Expr)
+            and isinstance(node.value, nodes.Const)
+            and node.value.value is Ellipsis
         ):
             frame = node.frame()
             if is_overload_stub(frame) or is_protocol_class(node_frame_class(frame)):


### PR DESCRIPTION
## Description

Remove all references to the `astroid.Ellipsis` node.
https://github.com/PyCQA/astroid/pull/1025

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |