### PR TITLE
Remove deprecated `astroid.Index` and `astroid.ExtSlice` nodes

### DIFF
--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -174,8 +174,6 @@ class RecommendationChecker(checkers.BaseChecker):
                     continue
 
                 value = subscript.slice
-                if isinstance(value, astroid.Index):
-                    value = value.value
                 if not isinstance(value, astroid.Name):
                     continue
                 if subscript.value.scope() != node.scope():
@@ -215,8 +213,6 @@ class RecommendationChecker(checkers.BaseChecker):
                     continue
 
                 value = subscript.slice
-                if isinstance(value, astroid.Index):
-                    value = value.value
                 if (
                     not isinstance(value, astroid.Name)
                     or value.name != node.target.name
@@ -256,8 +252,6 @@ class RecommendationChecker(checkers.BaseChecker):
                     continue
 
                 value = subscript.slice
-                if isinstance(value, astroid.Index):
-                    value = value.value
                 if (
                     not isinstance(value, astroid.Name)
                     or value.name != node.target.name

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -632,10 +632,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             return False
 
         # The subscript's slice needs to be the same as the test variable.
-        # Python 3.9 we no longer have the `Index` node.
         slice_value = stmt.value.slice
-        if isinstance(slice_value, astroid.Index):
-            slice_value = slice_value.value
         if not (
             self._type_and_name_are_equal(stmt.value.value, node.test.ops[0][1])
             and self._type_and_name_are_equal(slice_value, node.test.left)
@@ -1684,8 +1681,6 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                         continue
 
                     value = subscript.slice
-                    if isinstance(value, astroid.Index):
-                        value = value.value
 
                     if isinstance(node, astroid.For) and (
                         isinstance(subscript.parent, astroid.Assign)
@@ -1742,10 +1737,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                             continue
 
                         # check if subscripted by 0 (key)
-                        subscript_val = value.slice
-                        if isinstance(subscript_val, astroid.Index):
-                            subscript_val = subscript_val.value
-                        inferred = utils.safe_infer(subscript_val)
+                        inferred = utils.safe_infer(value.slice)
                         if (
                             not isinstance(inferred, astroid.Const)
                             or inferred.value != 0

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1775,11 +1775,7 @@ accessed. Python regular expressions are accepted.",
 
         if isinstance(node.value, astroid.Dict):
             # Assert dict key is hashable
-            if isinstance(node.slice, astroid.Index):
-                # In Python 3.9 the Index node is no longer in use
-                inferred = safe_infer(node.slice.value)
-            else:
-                inferred = safe_infer(node.slice)
+            inferred = safe_infer(node.slice)
             if inferred not in (None, astroid.Uninferable):
                 try:
                     hash_fn = next(inferred.igetattr("__hash__"))

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1530,18 +1530,13 @@ def get_iterating_dictionary_name(
 
 def get_subscript_const_value(node: astroid.Subscript) -> astroid.Const:
     """
-    Returns the value (subscript.slice) of a Subscript node,
-    also supports python <3.9 windows where node.slice might be an Index
-    node
+    Returns the value 'subscript.slice' of a Subscript node.
 
     :param node: Subscript Node to extract value from
     :returns: Const Node containing subscript value
     :raises InferredTypeError: if the subscript node cannot be inferred as a Const
     """
-    value = node.slice
-    if isinstance(value, astroid.Index):
-        value = value.value
-    inferred = safe_infer(value)
+    inferred = safe_infer(node.slice)
     if not isinstance(inferred, astroid.Const):
         raise InferredTypeError(
             "Subscript.slice cannot be inferred as an astroid.Const"


### PR DESCRIPTION
## Description
Remove all references of `astroid.Index` and `astroid.ExtSlice` nodes.
https://github.com/PyCQA/astroid/pull/1026

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |