### PR TITLE
Fix error with slice as subscript for dict

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -146,6 +146,7 @@ modules are added.
   * New checker ``consider-using-namedtuple-or-dataclass``. Emitted when dictionary values
     can be replaced by namedtuples or dataclass instances.
 
+* Fix error that occurred when using ``slice`` as subscript for dict.
 
 
 What's New in Pylint 2.8.3?

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1775,8 +1775,8 @@ accessed. Python regular expressions are accepted.",
 
         if isinstance(node.value, astroid.Dict):
             # Assert dict key is hashable
-            if isinstance(node.slice, (astroid.Index, astroid.Slice)):
-                # In Python 3.9 the Index, Slice and ExtSlice nodes are no longer in use
+            if isinstance(node.slice, astroid.Index):
+                # In Python 3.9 the Index node is no longer in use
                 inferred = safe_infer(node.slice.value)
             else:
                 inferred = safe_infer(node.slice)

--- a/tests/functional/u/unhashable_dict_key.py
+++ b/tests/functional/u/unhashable_dict_key.py
@@ -7,5 +7,6 @@ class Unhashable(object):
 {}[[1, 2, 3]] # [unhashable-dict-key]
 {}[{}] # [unhashable-dict-key]
 {}[Unhashable()] # [unhashable-dict-key]
+{}[1:2]  # [unhashable-dict-key]
 {'foo': 'bar'}['foo']
 {'foo': 'bar'}[42]

--- a/tests/functional/u/unhashable_dict_key.txt
+++ b/tests/functional/u/unhashable_dict_key.txt
@@ -1,3 +1,4 @@
 unhashable-dict-key:7:0::Dict key is unhashable
 unhashable-dict-key:8:0::Dict key is unhashable
 unhashable-dict-key:9:0::Dict key is unhashable
+unhashable-dict-key:10:0::Dict key is unhashable


### PR DESCRIPTION
## Description
Fix `AttributeError` that occurred when trying to use slice as subscript for dict with Python < 3.9
Instead emit `unhashable-dict-key` error.

```py
{}[1:2]

# This will result in:
# TypeError: unhashable type: 'slice'
```

```
# pylint result

Traceback (most recent call last):
  ...
  File "/.../pylint/pylint/checkers/typecheck.py", line 1780, in visit_subscript
    inferred = safe_infer(node.slice.value)
AttributeError: 'Slice' object has no attribute 'value'
```


## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |