### PR TITLE
Add ``OutputLine`` tests and typing on ``handle_message``

### DIFF
--- a/pylint/interfaces.py
+++ b/pylint/interfaces.py
@@ -91,7 +91,7 @@ class IAstroidChecker(IChecker):
 class IReporter(Interface):
     """reporter collect messages and display results encapsulated in a layout"""
 
-    def handle_message(self, msg):
+    def handle_message(self, msg) -> None:
         """Handle the given message object."""
 
     def display_reports(self, layout):

--- a/pylint/reporters/base_reporter.py
+++ b/pylint/reporters/base_reporter.py
@@ -3,6 +3,9 @@
 
 import os
 import sys
+from typing import List
+
+from pylint.message import Message
 
 
 class BaseReporter:
@@ -19,11 +22,13 @@ class BaseReporter:
         self.out = None
         self.out_encoding = None
         self.set_output(output)
+        self.messages: List[Message] = []
         # Build the path prefix to strip to get relative paths
         self.path_strip_prefix = os.getcwd() + os.sep
 
-    def handle_message(self, msg):
+    def handle_message(self, msg: Message) -> None:
         """Handle a new message triggered on the current file."""
+        self.messages.append(msg)
 
     def set_output(self, output=None):
         """set output stream"""

--- a/pylint/reporters/collecting_reporter.py
+++ b/pylint/reporters/collecting_reporter.py
@@ -1,6 +1,5 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/LICENSE
-
 from pylint.reporters.base_reporter import BaseReporter
 
 
@@ -12,9 +11,6 @@ class CollectingReporter(BaseReporter):
     def __init__(self):
         BaseReporter.__init__(self)
         self.messages = []
-
-    def handle_message(self, msg):
-        self.messages.append(msg)
 
     def reset(self):
         self.messages = []

--- a/pylint/reporters/json_reporter.py
+++ b/pylint/reporters/json_reporter.py
@@ -24,9 +24,9 @@ class JSONReporter(BaseReporter):
     name = "json"
     extension = "json"
 
-    def handle_message(self, msg):
-        """Manage message of different type and in the context of path."""
-        self.messages.append(
+    def display_messages(self, layout):
+        """Launch layouts display"""
+        json_dumpable = [
             {
                 "type": msg.category,
                 "module": msg.module,
@@ -38,11 +38,9 @@ class JSONReporter(BaseReporter):
                 "message": msg.msg or "",
                 "message-id": msg.msg_id,
             }
-        )
-
-    def display_messages(self, layout):
-        """Launch layouts display"""
-        print(json.dumps(self.messages, indent=4), file=self.out)
+            for msg in self.messages
+        ]
+        print(json.dumps(json_dumpable, indent=4), file=self.out)
 
     def display_reports(self, layout):
         """Don't do anything in this reporter."""

--- a/pylint/reporters/json_reporter.py
+++ b/pylint/reporters/json_reporter.py
@@ -12,7 +12,6 @@
 
 """JSON reporter"""
 import json
-import sys
 
 from pylint.interfaces import IReporter
 from pylint.reporters.base_reporter import BaseReporter
@@ -24,10 +23,6 @@ class JSONReporter(BaseReporter):
     __implements__ = IReporter
     name = "json"
     extension = "json"
-
-    def __init__(self, output=None):
-        BaseReporter.__init__(self, output or sys.stdout)
-        self.messages = []
 
     def handle_message(self, msg):
         """Manage message of different type and in the context of path."""

--- a/pylint/reporters/multi_reporter.py
+++ b/pylint/reporters/multi_reporter.py
@@ -6,6 +6,7 @@ import os
 from typing import IO, Any, AnyStr, Callable, List, Mapping, Optional, Union
 
 from pylint.interfaces import IReporter
+from pylint.message import Message
 from pylint.reporters.base_reporter import BaseReporter
 from pylint.reporters.ureports.nodes import BaseLayout
 
@@ -58,7 +59,7 @@ class MultiReporter:
         for rep in self._sub_reporters:
             rep.linter = value
 
-    def handle_message(self, msg: str) -> None:
+    def handle_message(self, msg: Message) -> None:
         """Handle a new message triggered on the current file."""
         for rep in self._sub_reporters:
             rep.handle_message(msg)

--- a/pylint/reporters/text.py
+++ b/pylint/reporters/text.py
@@ -27,6 +27,7 @@ import warnings
 
 from pylint import utils
 from pylint.interfaces import IReporter
+from pylint.message import Message
 from pylint.reporters import BaseReporter
 from pylint.reporters.ureports.text_writer import TextWriter
 
@@ -141,7 +142,7 @@ class TextReporter(BaseReporter):
         """Convenience method to write a formatted message with class default template"""
         self.writeln(msg.format(self._template))
 
-    def handle_message(self, msg):
+    def handle_message(self, msg: Message) -> None:
         """manage message of different type and in the context of path"""
         if msg.module not in self._modules:
             if msg.module:
@@ -217,7 +218,7 @@ class ColorizedTextReporter(TextReporter):
         except KeyError:
             return None, None
 
-    def handle_message(self, msg):
+    def handle_message(self, msg: Message) -> None:
         """manage message of different types, and colorize output
         using ansi escape codes
         """

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -2,6 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/master/LICENSE
 
 import collections
+from typing import Any, NamedTuple
 
 from pylint import interfaces
 from pylint.constants import PY38_PLUS
@@ -54,11 +55,14 @@ Try updating it with: 'python tests/test_functional.py {UPDATE_OPTION}'"""
         Exception.__init__(self, msg)
 
 
-class OutputLine(
-    collections.namedtuple(
-        "OutputLine", ["symbol", "lineno", "column", "object", "msg", "confidence"]
-    )
-):
+class OutputLine(NamedTuple):
+    symbol: str
+    lineno: int
+    column: int
+    object: Any
+    msg: str
+    confidence: str
+
     @classmethod
     def from_msg(cls, msg):
         column = cls.get_column(msg.column)

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -36,10 +36,13 @@ class MalformedOutputLineException(Exception):
         ]
         reconstructed_row = ""
         i = 0
-        for i, column in enumerate(row):
-            reconstructed_row += f"\t{expected[i]}='{column}' ?\n"
-        for missing in expected[i + 1 :]:
-            reconstructed_row += f"\t{missing}= Nothing provided !\n"
+        try:
+            for i, column in enumerate(row):
+                reconstructed_row += f"\t{expected[i]}='{column}' ?\n"
+            for missing in expected[i + 1 :]:
+                reconstructed_row += f"\t{missing}= Nothing provided !\n"
+        except IndexError:
+            pass
         raw = ":".join(row)
         msg = f"""\
 {exception}
@@ -73,7 +76,7 @@ class OutputLine(
     @classmethod
     def get_column(cls, column):
         if not PY38_PLUS:
-            return ""
+            return ""  # pragma: no cover
         return str(column)
 
     @classmethod

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -89,6 +89,4 @@ class OutputLine(
             raise MalformedOutputLineException(row, e) from e
 
     def to_csv(self):
-        if self.confidence == interfaces.HIGH.name:
-            return self[:-1]
-        return self
+        return tuple(self)

--- a/pylint/testutils/reporter_for_tests.py
+++ b/pylint/testutils/reporter_for_tests.py
@@ -3,8 +3,10 @@
 
 from io import StringIO
 from os import getcwd, linesep, sep
+from typing import Dict, List
 
 from pylint import interfaces
+from pylint.message import Message
 from pylint.reporters import BaseReporter
 
 
@@ -14,21 +16,20 @@ class GenericTestReporter(BaseReporter):
     __implements__ = interfaces.IReporter
 
     def __init__(self):  # pylint: disable=super-init-not-called
-
-        self.message_ids = {}
         self.reset()
-        self.path_strip_prefix = getcwd() + sep
 
     def reset(self):
+        self.message_ids: Dict = {}
         self.out = StringIO()
-        self.messages = []
+        self.path_strip_prefix: str = getcwd() + sep
+        self.messages: List[str] = []
 
-    def handle_message(self, msg):
+    def handle_message(self, msg: Message) -> None:
         """manage message of different type and in the context of path"""
         obj = msg.obj
         line = msg.line
         msg_id = msg.msg_id
-        msg = msg.msg
+        str_message: str = msg.msg
         self.message_ids[msg_id] = 1
         if obj:
             obj = ":%s" % obj
@@ -36,8 +37,8 @@ class GenericTestReporter(BaseReporter):
         if linesep != "\n":
             # 2to3 writes os.linesep instead of using
             # the previously used line separators
-            msg = msg.replace("\r\n", "\n")
-        self.messages.append(f"{sigle}:{line:>3}{obj}: {msg}")
+            str_message = str_message.replace("\r\n", "\n")
+        self.messages.append(f"{sigle}:{line:>3}{obj}: {str_message}")
 
     def finalize(self):
         self.messages.sort()
@@ -60,9 +61,6 @@ class GenericTestReporter(BaseReporter):
 
 
 class MinimalTestReporter(BaseReporter):
-    def handle_message(self, msg):
-        self.messages.append(msg)
-
     def on_set_current_module(self, module, filepath):
         self.messages = []
 
@@ -70,9 +68,6 @@ class MinimalTestReporter(BaseReporter):
 
 
 class FunctionalTestReporter(BaseReporter):  # pylint: disable=abstract-method
-    def handle_message(self, msg):
-        self.messages.append(msg)
-
     def on_set_current_module(self, module, filepath):
         self.messages = []
 

--- a/tests/extensions/test_broad_try_clause.py
+++ b/tests/extensions/test_broad_try_clause.py
@@ -20,9 +20,6 @@ from pylint.reporters import BaseReporter
 
 
 class BroadTryClauseTestReporter(BaseReporter):
-    def handle_message(self, msg):
-        self.messages.append(msg)
-
     def on_set_current_module(self, module, filepath):
         self.messages = []
 

--- a/tests/extensions/test_comparetozero.py
+++ b/tests/extensions/test_comparetozero.py
@@ -21,9 +21,6 @@ from pylint.reporters import BaseReporter
 
 
 class CompareToZeroTestReporter(BaseReporter):
-    def handle_message(self, msg):
-        self.messages.append(msg)
-
     def on_set_current_module(self, module, filepath):
         self.messages = []
 

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -57,6 +57,7 @@ import pytest
 from pylint import modify_sys_path
 from pylint.constants import MAIN_CHECKER_NAME, MSG_TYPES_STATUS
 from pylint.lint import Run
+from pylint.message import Message
 from pylint.reporters import JSONReporter
 from pylint.reporters.text import BaseReporter, ColorizedTextReporter, TextReporter
 from pylint.utils import utils
@@ -104,7 +105,7 @@ class MultiReporter(BaseReporter):
         for rep in self._reporters:
             rep.on_set_current_module(*args, **kwargs)
 
-    def handle_message(self, msg):
+    def handle_message(self, msg: Message) -> None:
         for rep in self._reporters:
             rep.handle_message(msg)
 

--- a/tests/testutils/test_output_line.py
+++ b/tests/testutils/test_output_line.py
@@ -5,6 +5,7 @@
 
 import pytest
 
+from pylint.constants import PY38_PLUS
 from pylint.interfaces import HIGH, INFERENCE
 from pylint.message import Message
 from pylint.testutils.output_line import MalformedOutputLineException, OutputLine
@@ -53,7 +54,15 @@ def test_output_line_from_message(message):
 def test_output_line_to_csv(confidence, message):
     output_line = OutputLine.from_msg(message(confidence))
     csv = output_line.to_csv()
-    assert csv == ("missing-docstring", "line", "column", "obj", "msg", confidence.name)
+    expected_column = "column" if PY38_PLUS else ""
+    assert csv == (
+        "missing-docstring",
+        "line",
+        expected_column,
+        "obj",
+        "msg",
+        confidence.name,
+    )
 
 
 def test_output_line_from_csv_error():
@@ -70,9 +79,9 @@ def test_output_line_from_csv_error():
 
 
 @pytest.mark.parametrize(
-    "confidence,expected", [[None, "HIGH"], ["INFERENCE", "INFERENCE"]]
+    "confidence,expected_confidence", [[None, "HIGH"], ["INFERENCE", "INFERENCE"]]
 )
-def test_output_line_from_csv(confidence, expected):
+def test_output_line_from_csv(confidence, expected_confidence):
     proper_csv = (
         "missing-docstring",
         "1",
@@ -83,11 +92,12 @@ def test_output_line_from_csv(confidence, expected):
     if confidence is not None:
         proper_csv += (confidence,)
     output_line = OutputLine.from_csv(proper_csv)
+    expected_column = "2" if PY38_PLUS else ""
     assert output_line == OutputLine(
         symbol="missing-docstring",
         lineno=1,
-        column="2",
+        column=expected_column,
         object="obj",
         msg="msg",
-        confidence=expected,
+        confidence=expected_confidence,
     )

--- a/tests/testutils/test_output_line.py
+++ b/tests/testutils/test_output_line.py
@@ -1,0 +1,89 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/master/LICENSE
+
+# pylint: disable=redefined-outer-name
+
+import pytest
+
+from pylint.interfaces import HIGH
+from pylint.message import Message
+from pylint.testutils.output_line import MalformedOutputLineException, OutputLine
+
+
+@pytest.fixture()
+def message():
+    return Message(
+        symbol="missing-docstring",
+        msg_id="C0123",
+        location=[
+            "abspath",
+            "path",
+            "module",
+            "obj",
+            "line",
+            "column",
+        ],
+        msg="msg",
+        confidence=HIGH,
+    )
+
+
+def test_output_line():
+    output_line = OutputLine(
+        symbol="missing-docstring",
+        lineno=0,
+        column=0,
+        object="",
+        msg="Missing docstring's bad.",
+        confidence=HIGH,
+    )
+    assert output_line.symbol == "missing-docstring"
+
+
+def test_output_line_from_message(message):
+    output_line = OutputLine.from_msg(message)
+    assert output_line.symbol == "missing-docstring"
+    assert output_line.msg == "msg"
+
+
+def test_output_line_to_csv(message):
+    output_line = OutputLine.from_msg(message)
+    csv = output_line.to_csv()
+    assert csv == ("missing-docstring", "line", "column", "obj", "msg")
+
+
+def test_output_line_from_csv_error():
+    with pytest.raises(
+        MalformedOutputLineException,
+        match="msg-symbolic-name:42:27:MyClass.my_function:The message",
+    ):
+        OutputLine.from_csv("'missing-docstring', 'line', 'column', 'obj', 'msg'")
+    with pytest.raises(
+        MalformedOutputLineException, match="symbol='missing-docstring' ?"
+    ):
+        csv = ("missing-docstring", "line", "column", "obj", "msg")
+        OutputLine.from_csv(csv)
+
+
+@pytest.mark.parametrize(
+    "confidence,expected", [[None, "HIGH"], ["INFERENCE", "INFERENCE"]]
+)
+def test_output_line_from_csv(confidence, expected):
+    proper_csv = (
+        "missing-docstring",
+        "1",
+        "2",
+        "obj",
+        "msg",
+    )
+    if confidence is not None:
+        proper_csv += (confidence,)
+    output_line = OutputLine.from_csv(proper_csv)
+    assert output_line == OutputLine(
+        symbol="missing-docstring",
+        lineno=1,
+        column="2",
+        object="obj",
+        msg="msg",
+        confidence=expected,
+    )


### PR DESCRIPTION

## Description

We lacked coverage on this and this prevented proper typing.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

