### PR TITLE
Remove appveyor.yml replaced by github actions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,8 @@ Release date: TBA
 ..
   Put new features and bugfixes here and also in 'doc/whatsnew/2.9.rst'
 
+* Appveyor is no longer used in the continuous integration
+
 * Added ``deprecated-decorator``: Emitted when deprecated decorator is used.
 
   Closes #4429

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,6 @@ prune examples
 prune tests
 prune script
 exclude .*
-exclude appveyor.yml
 exclude ChangeLog
 exclude Dockerfile
 exclude README.rst

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,0 @@
-version: "{branch}-{build}"
-build: off
-
-test_script:
-  - echo "Skip"


### PR DESCRIPTION
## Description

Appveyor is not used anymore and can be removed.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
