### PR TITLE
Run the checks anyway when a plugin does not exists in the configuration

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -110,6 +110,11 @@ modules are added.
 
   Closes #585
 
+* Fix a crash when a plugin from the configuration could not be loaded and raise an error
+  'bad-plugin-value' instead
+
+Closes #4555
+
 * Added handling of floating point values when parsing configuration from pyproject.toml
 
   Closes #4518

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -274,6 +274,17 @@ class MessagesHandlerMixIn:
         # update stats
         msg_cat = MSG_TYPES[message_definition.msgid[0]]
         self.msg_status |= MSG_TYPES_STATUS[message_definition.msgid[0]]
+        if self.stats is None:
+            # pylint: disable=fixme
+            # TODO self.stats should make sense,
+            # class should make sense as soon as instantiated
+            # This is not true for Linter and Reporter at least
+            # pylint: enable=fixme
+            self.stats = {
+                msg_cat: 0,
+                "by_module": {self.current_name: {msg_cat: 0}},
+                "by_msg": {},
+            }
         self.stats[msg_cat] += 1
         self.stats["by_module"][self.current_name][msg_cat] += 1
         try:
@@ -291,7 +302,10 @@ class MessagesHandlerMixIn:
         else:
             module, obj = get_module_and_frameid(node)
             abspath = node.root().file
-        path = abspath.replace(self.reporter.path_strip_prefix, "", 1)
+        if abspath is not None:
+            path = abspath.replace(self.reporter.path_strip_prefix, "", 1)
+        else:
+            path = "configuration"
         # add the message
         self.reporter.handle_message(
             Message(

--- a/pylint/reporters/text.py
+++ b/pylint/reporters/text.py
@@ -133,10 +133,10 @@ class TextReporter(BaseReporter):
     def __init__(self, output=None):
         BaseReporter.__init__(self, output)
         self._modules = set()
-        self._template = None
+        self._template = self.line_format
 
     def on_set_current_module(self, module, filepath):
-        self._template = str(self.linter.config.msg_template or self.line_format)
+        self._template = str(self.linter.config.msg_template or self._template)
 
     def write_message(self, msg):
         """Convenience method to write a formatted message with class default template"""

--- a/tests/functional/p/plugin_does_not_exists.py
+++ b/tests/functional/p/plugin_does_not_exists.py
@@ -1,0 +1,5 @@
+# pylint: disable=missing-docstring
+
+from shadok import ShadokInteger  # [import-error]
+
+ShadokInteger("Buga ZoMeu")

--- a/tests/functional/p/plugin_does_not_exists.rc
+++ b/tests/functional/p/plugin_does_not_exists.rc
@@ -1,0 +1,3 @@
+[master]
+load-plugins=
+    pylint.extensions.check_does_not_exists_in_venv,

--- a/tests/functional/p/plugin_does_not_exists.txt
+++ b/tests/functional/p/plugin_does_not_exists.txt
@@ -1,0 +1,1 @@
+import-error:3:0::Unable to import 'shadok':HIGH

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -55,7 +55,7 @@ class LintModuleOutputUpdate(testutils.LintModuleTest):
     def _check_output_text(self, _, expected_output, actual_output):
         if expected_output and expected_output == actual_output:
             return
-        if not expected_output:
+        if not expected_output and not actual_output:
             if os.path.exists(self._test_file.expected_output):
                 os.remove(self._test_file.expected_output)
             return


### PR DESCRIPTION

## Description

This fix a crash when the configuration is wrong, also it fixe the update process of functional test when the expected output do not exists, it can now be created.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Related Issue

Closes #4555 

