### PR TITLE
Better recognize property decorators

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -164,7 +164,8 @@ Closes #4555
   Closes #1932
   Closes #2062
 
-* Better recognize property decorators. This fixes an issue when using ``cached_property`` to override ``property``.
+* Fix issue with ``cached_property`` that caused ``invalid-overridden-method`` error
+  when overriding a ``property``.
 
   Closes #4023
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -164,6 +164,10 @@ Closes #4555
   Closes #1932
   Closes #2062
 
+* Better recognize property decorators. This fixes an issue when using ``cached_property`` to override ``property``.
+
+  Closes #4023
+
 
 What's New in Pylint 2.8.3?
 ===========================

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -70,6 +70,7 @@ from typing import (
 
 import _string
 import astroid
+from astroid.bases import _is_property
 
 BUILTINS_NAME = builtins.__name__
 COMP_NODE_TYPES = (
@@ -782,15 +783,7 @@ def error_of_type(handler: astroid.ExceptHandler, error_type) -> bool:
 
 def decorated_with_property(node: astroid.FunctionDef) -> bool:
     """Detect if the given function node is decorated with a property."""
-    if not node.decorators:
-        return False
-    for decorator in node.decorators.nodes:
-        try:
-            if _is_property_decorator(decorator):
-                return True
-        except astroid.InferenceError:
-            pass
-    return False
+    return _is_property(node)
 
 
 def _is_property_kind(node, *kinds):
@@ -816,20 +809,6 @@ def is_property_deleter(node: astroid.FunctionDef) -> bool:
 def is_property_setter_or_deleter(node: astroid.FunctionDef) -> bool:
     """Check if the given node is either a property setter or a deleter"""
     return _is_property_kind(node, "setter", "deleter")
-
-
-def _is_property_decorator(decorator: astroid.Name) -> bool:
-    for inferred in decorator.infer():
-        if isinstance(inferred, astroid.ClassDef):
-            if inferred.root().name == BUILTINS_NAME and inferred.name == "property":
-                return True
-            for ancestor in inferred.ancestors():
-                if (
-                    ancestor.name == "property"
-                    and ancestor.root().name == BUILTINS_NAME
-                ):
-                    return True
-    return False
 
 
 def decorated_with(

--- a/tests/functional/c/cached_property.py
+++ b/tests/functional/c/cached_property.py
@@ -1,0 +1,23 @@
+# pylint: disable=missing-docstring,invalid-name,no-self-use
+from functools import cached_property
+
+
+# https://github.com/PyCQA/pylint/issues/4023
+# False-positive 'invalid-overridden-method' with 'cached_property'
+class Parent:
+    @property
+    def value(self):
+        return 42
+
+    def func(self):
+        return False
+
+
+class Child(Parent):
+    @cached_property
+    def value(self):
+        return 2**6
+
+    @cached_property
+    def func(self):  # [invalid-overridden-method]
+        return 42

--- a/tests/functional/c/cached_property.rc
+++ b/tests/functional/c/cached_property.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.8

--- a/tests/functional/c/cached_property.txt
+++ b/tests/functional/c/cached_property.txt
@@ -1,0 +1,1 @@
+invalid-overridden-method:22:4:Child.func:Method 'func' was expected to be 'method', found it instead as 'property'


### PR DESCRIPTION
## Description
Supersedes #4144 originally authored by @tiagohonorato

Overriding a `property` with `cached_property` currently results in an `invalid-overridden-method` error as the definition for property is too narrow. @hippo91 suggested to use `astroid.bases._is_property` which seems to work well: https://github.com/PyCQA/pylint/issues/4023#issuecomment-770197615

https://docs.python.org/3/library/functools.html#functools.cached_property

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
Closes #4023