### PR TITLE
VariableChecker now accounts for attribute lookups in type comments

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -503,3 +503,5 @@ contributors:
 * Markus Siebenhaar: contributor
 
 * Lorena Buciu (lorena-b): contributor
+
+* Sergei Lebedev (superbobry): contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -171,6 +171,11 @@ Closes #4555
 
   Closes #4023
 
+* Fix ``unused-import`` false positive for imported modules referenced in
+  attribute lookups in type comments.
+
+  Closes #4603
+
 
 What's New in Pylint 2.8.3?
 ===========================

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1826,6 +1826,10 @@ class VariablesChecker(BaseChecker):
             self._type_annotation_names.append(type_annotation.name)
             return
 
+        if isinstance(type_annotation, astroid.Attribute):
+            self._store_type_annotation_node(type_annotation.expr)
+            return
+
         if not isinstance(type_annotation, astroid.Subscript):
             return
 

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -1,6 +1,7 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/master/LICENSE
 
+import platform
 import sys
 
 import astroid
@@ -11,6 +12,7 @@ PY38_PLUS = sys.version_info[:2] >= (3, 8)
 PY39_PLUS = sys.version_info[:2] >= (3, 9)
 PY310_PLUS = sys.version_info[:2] >= (3, 10)
 
+IS_PYPY = platform.python_implementation() == "PyPy"
 
 PY_EXTS = (".py", ".pyc", ".pyo", ".pyw", ".so", ".dll")
 

--- a/tests/checkers/unittest_variables.py
+++ b/tests/checkers/unittest_variables.py
@@ -22,7 +22,6 @@ import os
 import re
 import sys
 import unittest
-import platform
 from pathlib import Path
 
 import astroid
@@ -207,7 +206,8 @@ class TestVariablesChecker(CheckerTestCase):
         a = ... # type: foo.Bar
         b = ... # type: foo.Bar[Boo]
         c = ... # type: Bar.Boo
-        """)
+        """
+        )
         with self.assertNoMessages():
             self.walk(module)
 

--- a/tests/checkers/unittest_variables.py
+++ b/tests/checkers/unittest_variables.py
@@ -21,11 +21,14 @@
 import os
 import re
 import sys
+import unittest
+import platform
 from pathlib import Path
 
 import astroid
 
 from pylint.checkers import variables
+from pylint.constants import IS_PYPY
 from pylint.interfaces import UNDEFINED
 from pylint.testutils import CheckerTestCase, Message, linter, set_config
 
@@ -188,6 +191,23 @@ class TestVariablesChecker(CheckerTestCase):
                 pass
         """
         )
+        with self.assertNoMessages():
+            self.walk(module)
+
+    @unittest.skipIf(IS_PYPY, "PyPy does not parse type comments")
+    def test_attribute_in_type_comment(self):
+        """Ensure attribute lookups in type comments are accounted for.
+
+        https://github.com/PyCQA/pylint/issues/4603
+        """
+        module = astroid.parse(
+            """
+        import foo
+        from foo import Bar, Boo
+        a = ... # type: foo.Bar
+        b = ... # type: foo.Bar[Boo]
+        c = ... # type: Bar.Boo
+        """)
         with self.assertNoMessages():
             self.walk(module)
 


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.

## Description

Prior to this commit `VariableChecker` did not recurse into attribute lookups in type comments. This lead to false positive `unused-import messages` in e.g.

    import collections
    d = ...  # type: collections.OrderedDict

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Fixes #4603.

