### PR TITLE
Fix a crash when a test function is decorated with ``@pytest.fixture``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,11 @@ Release date: TBA
 * ``setuptools_scm`` has been removed and replaced by ``tbump`` in order to not
   have hidden runtime dependencies to setuptools
 
+* Fix a crash when a test function is decorated with ``@pytest.fixture`` and astroid can't
+  infer the name of the decorator when using ``open`` without ``with``.
+
+  Closes #4612
+
 * Appveyor is no longer used in the continuous integration
 
 * Added ``deprecated-decorator``: Emitted when deprecated decorator is used.

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -810,8 +810,9 @@ def decorated_with(
             decorator_node = decorator_node.func
         try:
             if any(
-                i is not None and i.qname() in qnames or i.name in qnames
+                i.name in qnames or i.qname() in qnames
                 for i in decorator_node.infer()
+                if i is not None and i != astroid.Uninferable
             ):
                 return True
         except astroid.InferenceError:

--- a/tests/functional/r/regression/regression_4612_crash_pytest_fixture.py
+++ b/tests/functional/r/regression/regression_4612_crash_pytest_fixture.py
@@ -1,0 +1,9 @@
+# pylint: disable=missing-docstring,consider-using-with,redefined-outer-name
+
+import pytest
+
+
+@pytest.fixture
+def qm_file():
+    qm_file = open("src/test/resources/example_qm_file.csv").read()
+    return qm_file


### PR DESCRIPTION
## Description

And astroid can't infer the name of the decorator when using ``open`` without ``with`` inside the function.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

Closes #4612