### PR TITLE
Fix false positive useless type annotation for pep484 typing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,12 @@ Release date: TBA
 
 * astroid has been upgraded to 2.6.0
 
+* Fix false positive ``useless-type-doc`` on ignored argument using ``pylint.extensions.docparams``
+  when a function was typed using pep484 but not inside the docstring.
+
+  Closes #4117
+  Closes #4593
+
 * ``setuptools_scm`` has been removed and replaced by ``tbump`` in order to not
   have hidden runtime dependencies to setuptools
 

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -72,3 +72,6 @@ Other Changes
 * ``ignore-paths`` configuration directive has been added. Defined regex patterns are matched against file path.
 
 * Added handling of floating point values when parsing configuration from pyproject.toml
+
+* Fix false positive ``useless-type-doc`` on ignored argument using ``pylint.extensions.docparams`` when a function
+  was typed using pep484 but not inside the docstring.

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -203,6 +203,9 @@ class Docstring:
         doc = doc or ""
         self.doc = doc.expandtabs()
 
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}:'''{self.doc}'''>"
+
     def is_valid(self):
         return False
 

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -25,6 +25,7 @@ import re
 from typing import List
 
 import astroid
+from astroid import AssignName
 
 from pylint.checkers import utils
 
@@ -205,6 +206,9 @@ class Docstring:
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}:'''{self.doc}'''>"
+
+    def arg_is_documented(self, arg_name: AssignName) -> bool:
+        return arg_name.name in self.doc
 
     def is_valid(self):
         return False

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -25,7 +25,6 @@ import re
 from typing import List
 
 import astroid
-from astroid import AssignName
 
 from pylint.checkers import utils
 
@@ -206,9 +205,6 @@ class Docstring:
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}:'''{self.doc}'''>"
-
-    def arg_is_documented(self, arg_name: AssignName) -> bool:
-        return arg_name.name in self.doc
 
     def is_valid(self):
         return False

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -23,12 +23,14 @@
 """Pylint plugin for checking in Sphinx, Google, or Numpy style docstrings
 """
 import re
+from typing import Optional
 
 import astroid
 
 from pylint.checkers import BaseChecker
 from pylint.checkers import utils as checker_utils
 from pylint.extensions import _check_docs_utils as utils
+from pylint.extensions._check_docs_utils import Docstring
 from pylint.interfaces import IAstroidChecker
 from pylint.utils import get_global_option
 
@@ -460,7 +462,11 @@ class DocstringParameterChecker(BaseChecker):
             )
 
     def check_arguments_in_docstring(
-        self, doc, arguments_node, warning_node, accept_no_param_doc=None
+        self,
+        doc: Docstring,
+        arguments_node: astroid.Arguments,
+        warning_node: astroid.NodeNG,
+        accept_no_param_doc: Optional[bool] = None,
     ):
         """Check that all parameters in a function, method or class constructor
         on the one hand and the parameters mentioned in the parameter
@@ -541,10 +547,12 @@ class DocstringParameterChecker(BaseChecker):
             )
 
         for index, arg_name in enumerate(arguments_node.args):
-            if arguments_node.annotations[index]:
+            if arguments_node.annotations[index] and doc.arg_is_documented(arg_name):
                 params_with_type.add(arg_name.name)
         for index, arg_name in enumerate(arguments_node.kwonlyargs):
-            if arguments_node.kwonlyargs_annotations[index]:
+            if arguments_node.kwonlyargs_annotations[index] and doc.arg_is_documented(
+                arg_name
+            ):
                 params_with_type.add(arg_name.name)
 
         if not tolerate_missing_params:

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -531,7 +531,6 @@ class DocstringParameterChecker(BaseChecker):
             expected_argument_names.add(arguments_node.kwarg)
             not_needed_type_in_docstring.add(arguments_node.kwarg)
         params_with_doc, params_with_type = doc.match_param_docs()
-
         # Tolerate no parameter documentation at all.
         if not params_with_doc and not params_with_type and accept_no_param_doc:
             tolerate_missing_params = True
@@ -546,13 +545,20 @@ class DocstringParameterChecker(BaseChecker):
                 warning_node,
             )
 
+        # This is before the update of param_with_type because this must check only
+        # the type documented in a docstring, not the one using pep484
+        # See #4117 and #4593
+        self._compare_ignored_args(
+            params_with_type,
+            "useless-type-doc",
+            expected_but_ignored_argument_names,
+            warning_node,
+        )
         for index, arg_name in enumerate(arguments_node.args):
-            if arguments_node.annotations[index] and doc.arg_is_documented(arg_name):
+            if arguments_node.annotations[index]:
                 params_with_type.add(arg_name.name)
         for index, arg_name in enumerate(arguments_node.kwonlyargs):
-            if arguments_node.kwonlyargs_annotations[index] and doc.arg_is_documented(
-                arg_name
-            ):
+            if arguments_node.kwonlyargs_annotations[index]:
                 params_with_type.add(arg_name.name)
 
         if not tolerate_missing_params:
@@ -581,12 +587,6 @@ class DocstringParameterChecker(BaseChecker):
         self._compare_ignored_args(
             params_with_doc,
             "useless-param-doc",
-            expected_but_ignored_argument_names,
-            warning_node,
-        )
-        self._compare_ignored_args(
-            params_with_type,
-            "useless-type-doc",
             expected_but_ignored_argument_names,
             warning_node,
         )

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -2236,8 +2236,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
             Message(msg_id="useless-type-doc", node=node, args=("_",)),
+            Message(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -2260,8 +2260,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
             Message(msg_id="useless-type-doc", node=node, args=("_",)),
+            Message(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -2290,8 +2290,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
             Message(msg_id="useless-type-doc", node=node, args=("_",)),
+            Message(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
         ):
             self.checker.visit_functiondef(node)
 

--- a/tests/functional/u/useless/useless_type_doc.py
+++ b/tests/functional/u/useless/useless_type_doc.py
@@ -1,0 +1,51 @@
+"""demonstrate FP with useless-type-doc"""
+# line-too-long
+
+
+def function(public_param: int, _some_private_param: bool = False) -> None:
+    """does things
+
+    Args:
+        public_param: an ordinary parameter
+    """
+    for _ in range(public_param):
+        ...
+    if _some_private_param:
+        ...
+    else:
+        ...
+
+
+# +1: [useless-type-doc,useless-param-doc]
+def function_useless_doc(public_param: int, _some_private_param: bool = False) -> None:
+    """does things
+
+    Args:
+        public_param: an ordinary parameter
+        _some_private_param (bool): private param
+
+    """
+    for _ in range(public_param):
+        ...
+    if _some_private_param:
+        ...
+    else:
+        ...
+
+
+def test(_new: str) -> str:  # We don't expect useless-type-doc here
+    """foobar
+
+    :return: comment
+    """
+    return ""
+
+
+# +1: [useless-type-doc,useless-param-doc]
+def test_two(_new: str) -> str:  # We don't expect useless-type-doc here
+    """foobar
+
+    :param str _new:
+    :return: comment
+    """
+    return ""

--- a/tests/functional/u/useless/useless_type_doc.py
+++ b/tests/functional/u/useless/useless_type_doc.py
@@ -1,9 +1,22 @@
 """demonstrate FP with useless-type-doc"""
-# line-too-long
 
 
 def function(public_param: int, _some_private_param: bool = False) -> None:
     """does things
+
+    Args:
+        public_param: an ordinary parameter
+    """
+    for _ in range(public_param):
+        ...
+    if _some_private_param:
+        ...
+    else:
+        ...
+
+
+def smart_function(public_param: int, _some_private_param: bool = False) -> None:
+    """We're speaking about _some_private_param without really documenting it.
 
     Args:
         public_param: an ordinary parameter
@@ -33,7 +46,7 @@ def function_useless_doc(public_param: int, _some_private_param: bool = False) -
         ...
 
 
-def test(_new: str) -> str:  # We don't expect useless-type-doc here
+def test(_new: str) -> str:
     """foobar
 
     :return: comment
@@ -41,8 +54,16 @@ def test(_new: str) -> str:  # We don't expect useless-type-doc here
     return ""
 
 
+def smarter_test(_new: str) -> str:
+    """We're speaking about _new without really documenting it.
+
+    :return: comment
+    """
+    return ""
+
+
 # +1: [useless-type-doc,useless-param-doc]
-def test_two(_new: str) -> str:  # We don't expect useless-type-doc here
+def test_two(_new: str) -> str:
     """foobar
 
     :param str _new:

--- a/tests/functional/u/useless/useless_type_doc.rc
+++ b/tests/functional/u/useless/useless_type_doc.rc
@@ -1,0 +1,8 @@
+[MASTER]
+load-plugins=pylint.extensions.docparams,
+
+[PARAMETER_DOCUMENTATION]
+accept-no-param-doc=no
+accept-no-raise-doc=no
+accept-no-return-doc=no
+accept-no-yields-doc=no

--- a/tests/functional/u/useless/useless_type_doc.txt
+++ b/tests/functional/u/useless/useless_type_doc.txt
@@ -1,0 +1,4 @@
+useless-param-doc:33:0:function_useless_doc:"""_some_private_param"" useless ignored parameter documentation":HIGH
+useless-type-doc:33:0:function_useless_doc:"""_some_private_param"" useless ignored parameter type documentation":HIGH
+useless-param-doc:66:0:test_two:"""_new"" useless ignored parameter documentation":HIGH
+useless-type-doc:66:0:test_two:"""_new"" useless ignored parameter type documentation":HIGH


### PR DESCRIPTION
## Description

Fix false positive ``useless-type-doc`` on ignored argument using ``pylint.extensions.docparams``
  when a function was typed using pep484 but not inside the docstring.


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

  Closes #4117
  Closes #4593