### PR TITLE
Documentation fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -61,7 +61,7 @@ Release date: TBA
   Closes #4415
 
 * Stdlib deprecated modules check is moved to stdlib checker. New deprecated
-modules are added.
+  modules are added.
 
 * Fix raising false-positive ``no-member`` on abstract properties
 
@@ -207,7 +207,7 @@ Release date: 2021-04-26
 * Pylint's tags are now the standard form ``vX.Y.Z`` and not ``pylint-X.Y.Z`` anymore.
 
 * New warning message ``deprecated-class``. This message is emitted if import or call deprecated class of the
-standard library (like ``collections.Iterable`` that will be removed in Python 3.10).
+  standard library (like ``collections.Iterable`` that will be removed in Python 3.10).
 
 Closes #4388
 

--- a/doc/user_guide/options.rst
+++ b/doc/user_guide/options.rst
@@ -133,7 +133,7 @@ prevalent naming style inside each module and enforce it on all names.
 
 Consider the following (simplified) example::
 
-   pylint --function-rgx='(?:(?P<snake>[a-z_]+)|(?P<camel>_?[A-Z]+))$' sample.py
+   pylint --function-rgx='(?:(?P<snake>[a-z_]+)|(?P<camel>[a-z]+([A-Z][a-z]*)*))$' sample.py
 
 The regular expression defines two naming styles, ``snake`` for snake-case
 names, and ``camel`` for camel-case names.

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -21,6 +21,10 @@ ignore=CVS
 # matches against base names, not paths.
 ignore-patterns=
 
+# Add files or directories matching the regex patterns to the ignore-list.
+# The regex matches against paths.
+ignore-paths=
+
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
 #init-hook=

--- a/pylint/extensions/confusing_elif.py
+++ b/pylint/extensions/confusing_elif.py
@@ -17,7 +17,7 @@ class ConfusingConsecutiveElifChecker(BaseChecker):
 
     __implements__ = IAstroidChecker
 
-    name = "confusing-elif-checker"
+    name = "confusing_elif"
     priority = -1
     msgs = {
         "R5601": (


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Write a good description on what the PR does.

## Description
A few minor documentation fixes:

- Fix regular expression for camelCase naming style example (#3747)
- Add ``ignore-paths`` to example pylintrc
- Change verbatim name of ``ConfusingConsecutiveElifChecker`` to ``confusing_elif`` so that it does not appear as "Confusing Elif Checker Checker" anymore
- Fix some improperly indented bullet points in ``ChangeLog`` so building the docs works again.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Related Issue

Closes #3747
Closes #4541

