### PR TITLE
Rename refs from `master` to `main`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,2 +1,2 @@
 Please read the
-[contribute doc](https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst).
+[contribute doc](https://github.com/PyCQA/pylint/blob/main/doc/development_guide/contribute.rst).

--- a/.github/ISSUE_TEMPLATE/2_Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_Feature_request.md
@@ -7,7 +7,7 @@ about: Suggest an idea for this project
   Hi there! Thank you for wanting to make pylint better.
 
   Before you submit this, make sure that this feature wasn't
-  already requested or if it is not already implemented in the master branch.
+  already requested or if it is not already implemented in the main branch.
 -->
 
 ### Is your feature request related to a problem? Please describe

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Thank you for submitting a PR to pylint!
 To ease the process of reviewing your PR, do make sure to complete the following boxes.
 
 You can also read more about contributing to pylint in this document:
-https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
+https://github.com/PyCQA/pylint/blob/main/doc/development_guide/contribute.rst#repository
 -->
 
 ## Steps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - 2.*
   pull_request: ~
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: "44 16 * * 4"
 

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@
 README for Pylint - https://pylint.pycqa.org/
 =============================================
 
-.. image:: https://github.com/PyCQA/pylint/actions/workflows/ci.yaml/badge.svg?branch=master
+.. image:: https://github.com/PyCQA/pylint/actions/workflows/ci.yaml/badge.svg?branch=main
     :target: https://github.com/PyCQA/pylint/actions
 
-.. image:: https://coveralls.io/repos/github/PyCQA/pylint/badge.svg?branch=master
-    :target: https://coveralls.io/github/PyCQA/pylint?branch=master
+.. image:: https://coveralls.io/repos/github/PyCQA/pylint/badge.svg?branch=main
+    :target: https://coveralls.io/github/PyCQA/pylint?branch=main
 
 
 .. image:: https://img.shields.io/pypi/v/pylint.svg
@@ -20,11 +20,11 @@ README for Pylint - https://pylint.pycqa.org/
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/ambv/black
 
-.. image:: https://results.pre-commit.ci/badge/github/PyCQA/pylint/master.svg
-   :target: https://results.pre-commit.ci/latest/github/PyCQA/pylint/master
+.. image:: https://results.pre-commit.ci/badge/github/PyCQA/pylint/main.svg
+   :target: https://results.pre-commit.ci/latest/github/PyCQA/pylint/main
    :alt: pre-commit.ci status
 
-.. |tideliftlogo| image:: https://raw.githubusercontent.com/PyCQA/pylint/master/doc/media/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White.png
+.. |tideliftlogo| image:: https://raw.githubusercontent.com/PyCQA/pylint/main/doc/media/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White.png
    :width: 75
    :height: 60
    :alt: Tidelift
@@ -162,9 +162,9 @@ For more detailed information, check the documentation.
 License
 -------
 
-pylint is, with a few exceptions listed below, `GPLv2 <https://github.com/PyCQA/pylint/blob/master/LICENSE>`_.
+pylint is, with a few exceptions listed below, `GPLv2 <https://github.com/PyCQA/pylint/blob/main/LICENSE>`_.
 
 The icon files are licensed under the `CC BY-SA 4.0 <https://creativecommons.org/licenses/by-sa/4.0/>`_ license:
 
-- `doc/logo.png <https://raw.githubusercontent.com/PyCQA/pylint/master/doc/logo.png>`_
-- `doc/logo.svg <https://raw.githubusercontent.com/PyCQA/pylint/master/doc/logo.svg>`_
+- `doc/logo.png <https://raw.githubusercontent.com/PyCQA/pylint/main/doc/logo.png>`_
+- `doc/logo.svg <https://raw.githubusercontent.com/PyCQA/pylint/main/doc/logo.svg>`_

--- a/doc/how_tos/custom_checkers.rst
+++ b/doc/how_tos/custom_checkers.rst
@@ -3,11 +3,11 @@
 How to Write a Checker
 ======================
 You can find some simple examples in the distribution
-(`custom.py <https://github.com/PyCQA/pylint/blob/master/examples/custom.py>`_
+(`custom.py <https://github.com/PyCQA/pylint/blob/main/examples/custom.py>`_
 ,
-`custom_raw.py <https://github.com/PyCQA/pylint/blob/master/examples/custom_raw.py>`_
+`custom_raw.py <https://github.com/PyCQA/pylint/blob/main/examples/custom_raw.py>`_
 and
-`deprecation_checker.py <https://github.com/PyCQA/pylint/blob/master/examples/deprecation_checker.py>`_).
+`deprecation_checker.py <https://github.com/PyCQA/pylint/blob/main/examples/deprecation_checker.py>`_).
 
 .. TODO Create custom_token.py
 

--- a/doc/how_tos/transform_plugins.rst
+++ b/doc/how_tos/transform_plugins.rst
@@ -105,4 +105,4 @@ an example, any code transformation can be done by plugins.
 See `astroid/brain`_ for real life examples of transform plugins.
 
 .. _`warnings.py`: https://hg.python.org/cpython/file/2.7/Lib/warnings.py
-.. _`astroid/brain`: https://github.com/PyCQA/astroid/tree/master/astroid/brain
+.. _`astroid/brain`: https://github.com/PyCQA/astroid/tree/main/astroid/brain

--- a/doc/release.md
+++ b/doc/release.md
@@ -15,14 +15,14 @@ So, you want to release the `X.Y.Z` version of pylint ?
 
 ## Post release
 
-### Merge tags in master for pre-commit
+### Merge tags in main for pre-commit
 
 If the tag you just made is not part of the main branch, merge the tag `vX.Y.Z` in the
 main branch by doing a history only merge. It's done in order to signal that this is an
 official release tag, and for `pre-commit autoupdate` to works.
 
 ```bash
-git checkout master
+git checkout main
 git merge --no-edit --strategy=ours vX.Y.Z
 git push
 ```
@@ -42,7 +42,7 @@ issue labelled as blocker.
 tbump X.Y.Z-dev0 --no-tag --no-push # You can interrupt during copyrite
 ```
 
-Check the result and then upgrade the master branch
+Check the result and then upgrade the main branch
 
 #### Whatsnew
 


### PR DESCRIPTION
## Description

Rename references from `master` branch to `main`. Should only be applied **after** the branch has been renamed.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Related Issue
https://github.com/PyCQA/astroid/pull/1079
