### PR TITLE
Fix deprecated methods from #4620

### DIFF
--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -202,9 +202,7 @@ DEPRECATED_METHODS = {
         },
         (3, 6, 0): {
             "importlib._bootstrap_external.FileLoader.load_module",
-            "ssl.RAND_pseudo_bytes",
-            "ssl.SSLSocket.read",
-            "SSLSocket.write",
+            "_ssl.RAND_pseudo_bytes",
         },
         (3, 7, 0): {
             "sys.set_coroutine_wrapper",
@@ -241,8 +239,6 @@ DEPRECATED_METHODS = {
             "zipimport.zipimporter.load_module",
             "zipimport.zipimporter.find_module",
             "zipimport.zipimporter.find_loader",
-            "sqlite3.enable_shared_cache",
-            "pathlib.Path.link_to",
             "threading.currentThread",
             "threading.activeCount",
             "threading.Condition.notifyAll",
@@ -252,7 +248,6 @@ DEPRECATED_METHODS = {
             "threading.Thread.isDaemon",
             "threading.Thread.setDaemon",
             "cgi.log",
-            "SSLSocket.selected_npn_protocol",
         },
     },
 }


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/master/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

Fixes several issues in #4620:

* Remove duplicates
* Remove SSLSocket methods - the methods cannot be inferred when created by factory SSLContext.wrap_socket
* `ssl.RAND_pseudo_bytes`  -> `_ssl.RAND_pseudo_bytes`

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
