### PR TITLE
Fix a crash with ``StopIteration`` when using ``limit-inference-results=0``

### DIFF
--- a/tests/functional/r/regression/regression_issue_4631.py
+++ b/tests/functional/r/regression/regression_issue_4631.py
@@ -1,0 +1,10 @@
+# pylint: disable=missing-function-docstring
+
+"""
+Regression tests for StopIteration raised when using limit-inference-results=0
+"""
+
+
+def get_youtube_link(song_name: str, song_artists):
+    with open("possible errors.txt", "ab") as file:
+        file.write(f"{', '.join(song_artists)} - {song_name}".encode())

--- a/tests/functional/r/regression/regression_issue_4631.rc
+++ b/tests/functional/r/regression/regression_issue_4631.rc
@@ -1,0 +1,2 @@
+[testoptions]
+limit-inference-results=0

--- a/tests/functional/r/regression/regression_issue_4631.txt
+++ b/tests/functional/r/regression/regression_issue_4631.txt
@@ -1,0 +1,2 @@
+unused-import:9:0::Unused YTMusic imported from ytmusicapi:HIGH
+undefined-variable:16:18:get_youtube_link:Undefined variable '__query_ytmusic':HIGH


### PR DESCRIPTION
## Description

Fux an issue with StopIteration when using ``limit-inference-results=0``

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #4631 
Closes https://github.com/PyCQA/astroid/issues/1080
