### PR TITLE
Handle the 'call' use case of unused_private_member

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,10 @@ Release date: TBA
 ..
   Put bug fixes that should not wait for a new minor version here
 
+* Fix a crash that happened when analysing code using ``type(self)`` to access
+  a class attribute in the ``unused-private-member`` checker.
+
+  Closes #4638
 
 
 What's New in Pylint 2.9.1?

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -905,7 +905,6 @@ a metaclass class method.",
         # Check for unused private functions
         for function_def in node.nodes_of_class(astroid.FunctionDef):
             function_def = cast(astroid.FunctionDef, function_def)
-            found = False
             if not is_attr_private(function_def.name):
                 continue
             for attribute in node.nodes_of_class(astroid.Attribute):
@@ -915,16 +914,13 @@ a metaclass class method.",
                     and attribute.scope() != function_def  # We ignore recursive calls
                     and attribute.expr.name in ("self", node.name)
                 ):
-                    found = True
                     break
-            if not found:
+            else:
+                function_repr = f"{function_def.name}({function_def.args.as_string()})"
                 self.add_message(
                     "unused-private-member",
                     node=function_def,
-                    args=(
-                        node.name,
-                        f"{function_def.name}({function_def.args.as_string()})",
-                    ),
+                    args=(node.name, function_repr),
                 )
 
         # Check for unused private variables

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -46,7 +46,7 @@
 """
 import collections
 from itertools import chain, zip_longest
-from typing import List, Pattern
+from typing import List, Pattern, cast
 
 import astroid
 
@@ -904,10 +904,12 @@ a metaclass class method.",
     def _check_unused_private_members(self, node: astroid.ClassDef) -> None:
         # Check for unused private functions
         for function_def in node.nodes_of_class(astroid.FunctionDef):
+            function_def = cast(astroid.FunctionDef, function_def)
             found = False
             if not is_attr_private(function_def.name):
                 continue
             for attribute in node.nodes_of_class(astroid.Attribute):
+                attribute = cast(astroid.Attribute, attribute)
                 if (
                     attribute.attrname == function_def.name
                     and attribute.scope() != function_def  # We ignore recursive calls

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -909,14 +909,29 @@ a metaclass class method.",
                 continue
             for attribute in node.nodes_of_class(astroid.Attribute):
                 attribute = cast(astroid.Attribute, attribute)
-                if attribute.expr is None:  # attribute.expr is probably not really an Optional ?
+                if attribute.expr is None:
+                    # attribute.expr is an Optional[NodeNG] it can be None
                     continue
                 if (
-                    attribute.attrname == function_def.name
-                    and attribute.scope() != function_def  # We ignore recursive calls
-                    and attribute.expr.name in ("self", node.name)
+                    attribute.attrname != function_def.name
+                    or attribute.scope() == function_def
                 ):
+                    # We ignore recursive calls
+                    continue
+                if isinstance(attribute.expr, astroid.Name) and attribute.expr.name in (
+                    "self",
+                    node.name,
+                ):
+                    # self.__attrname / node_name.__attrname
                     break
+                if isinstance(attribute.expr, astroid.Call):
+                    # type(self).__attrname
+                    inferred = safe_infer(attribute.expr)
+                    if (
+                        isinstance(inferred, astroid.ClassDef)
+                        and inferred.name == node.name
+                    ):
+                        break
             else:
                 function_repr = f"{function_def.name}({function_def.args.as_string()})"
                 self.add_message(

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -909,6 +909,8 @@ a metaclass class method.",
                 continue
             for attribute in node.nodes_of_class(astroid.Attribute):
                 attribute = cast(astroid.Attribute, attribute)
+                if attribute.expr is None:  # attribute.expr is probably not really an Optional ?
+                    continue
                 if (
                     attribute.attrname == function_def.name
                     and attribute.scope() != function_def  # We ignore recursive calls

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -909,14 +909,10 @@ a metaclass class method.",
                 continue
             for attribute in node.nodes_of_class(astroid.Attribute):
                 attribute = cast(astroid.Attribute, attribute)
-                if attribute.expr is None:
-                    # attribute.expr is an Optional[NodeNG] it can be None
-                    continue
                 if (
                     attribute.attrname != function_def.name
-                    or attribute.scope() == function_def
+                    or attribute.scope() == function_def  # We ignore recursive calls
                 ):
-                    # We ignore recursive calls
                     continue
                 if isinstance(attribute.expr, astroid.Name) and attribute.expr.name in (
                     "self",

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -66,3 +66,14 @@ class MyCls:
     @classmethod
     def get_class_var(cls):
         return cls.__class_var
+
+
+class Bla:
+    """Regression test for issue 4638"""
+
+    def __init__(self):
+        type(self).__a()
+
+    @classmethod
+    def __a(cls):
+        pass

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -73,7 +73,17 @@ class Bla:
 
     def __init__(self):
         type(self).__a()
+        self.__b()
+        Bla.__c()
 
     @classmethod
     def __a(cls):
+        pass
+
+    @classmethod
+    def __b(cls):
+        pass
+
+    @classmethod
+    def __c(cls):
         pass


### PR DESCRIPTION
## Description

We can have something else than node with expr.name attribute in this context.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #4638