### PR TITLE
Fix false positive ``unused-private-member`` if class member is accessed via ``self``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,11 @@ Release date: TBA
 
   Closes #4638
 
+* Fix a false positive for ``unused-private-member`` when accessing a private variable
+  with ``self``
+
+  Closes #4644
+
 
 What's New in Pylint 2.9.1?
 ===========================

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -949,7 +949,7 @@ a metaclass class method.",
                 if (
                     isinstance(child, astroid.Attribute)
                     and child.attrname == assign_name.name
-                    and child.expr.name in ("cls", node.name)
+                    and child.expr.name in ("self", "cls", node.name)
                 ):
                     break
             else:

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -898,11 +898,12 @@ a metaclass class method.",
         check that instance attributes are defined in __init__ and check
         access to existent members
         """
-        self._check_unused_private_members(node)
+        self._check_unused_private_functions(node)
+        self._check_unused_private_variables(node)
+        self._check_unused_private_attributes(node)
         self._check_attribute_defined_outside_init(node)
 
-    def _check_unused_private_members(self, node: astroid.ClassDef) -> None:
-        # Check for unused private functions
+    def _check_unused_private_functions(self, node: astroid.ClassDef) -> None:
         for function_def in node.nodes_of_class(astroid.FunctionDef):
             function_def = cast(astroid.FunctionDef, function_def)
             if not is_attr_private(function_def.name):
@@ -936,7 +937,7 @@ a metaclass class method.",
                     args=(node.name, function_repr),
                 )
 
-        # Check for unused private variables
+    def _check_unused_private_variables(self, node: astroid.ClassDef) -> None:
         for assign_name in node.nodes_of_class(astroid.AssignName):
             found = False
             if isinstance(assign_name.parent, astroid.Arguments):
@@ -960,7 +961,7 @@ a metaclass class method.",
                     args=(node.name, assign_name.name),
                 )
 
-        # Check for unused private attributes
+    def _check_unused_private_attributes(self, node: astroid.ClassDef) -> None:
         for assign_attr in node.nodes_of_class(astroid.AssignAttr):
             found = False
             if not is_attr_private(assign_attr.attrname):

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -87,3 +87,19 @@ class Bla:
     @classmethod
     def __c(cls):
         pass
+
+
+class Klass:
+    """Regression test for 4644"""
+
+    __seventyseven = 77
+    __ninetyone = 91
+
+    def __init__(self):
+        self.twentyone = 21 * (1 / (self.__seventyseven + 33)) % 100
+        self.ninetyfive = Klass.__ninetyone + 4
+
+
+k = Klass()
+print(k.twentyone)
+print(k.ninetyfive)


### PR DESCRIPTION
## Description

The self was forgotten. Also made some small refactor around it following comment made in #4642 

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Related Issue

Closes #4644 
