### PR TITLE
Fix ``similarity`` checker fails with ``ignore-signatures`` option enabled on function with docstring-only body

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,9 @@ Release date: TBA
 
   Closes #4648
 
+* The ``similarity`` checker no longer add three trailing whitespaces for
+  empty lines in its report.
+
 
 What's New in Pylint 2.9.2?
 ===========================

--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,10 @@ Release date: TBA
 ..
   Put bug fixes that should not wait for a new minor version here
 
+* Fix a crash that happened when analysing empty function with docstring
+  using in the ``similarity`` checker.
+
+  Closes #4648
 
 
 What's New in Pylint 2.9.2?

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -112,27 +112,30 @@ class Similar:
 
     def _display_sims(self, similarities: List[Tuple]) -> None:
         """Display computed similarities on stdout"""
-        duplicated_line_number = 0
+        report = self._get_similarity_report(similarities)
+        print(report)
+
+    def _get_similarity_report(self, similarities: List[Tuple]) -> str:
+        """Create a report from similarities"""
+        report: str = ""
+        duplicated_line_number: int = 0
         for number, files in similarities:
-            print()
-            print(number, "similar lines in", len(files), "files")
+            report += f"\n{number} similar lines in {len(files)} files\n"
             files = sorted(files)
-            lineset = idx = None
-            for lineset, idx in files:
-                print(f"=={lineset.name}:{idx}")
-            if lineset:
-                for line in lineset._real_lines[idx : idx + number]:
-                    print("  ", line.rstrip())
+            line_set = idx = None
+            for line_set, idx in files:
+                report += f"=={line_set.name}:{idx}\n"
+            if line_set:
+                for line in line_set._real_lines[idx : idx + number]:
+                    report += f"   {line.rstrip()}\n"
             duplicated_line_number += number * (len(files) - 1)
-        total_line_number = sum(len(lineset) for lineset in self.linesets)
-        print(
-            "TOTAL lines=%s duplicates=%s percent=%.2f"
-            % (
-                total_line_number,
-                duplicated_line_number,
-                duplicated_line_number * 100.0 / total_line_number,
-            )
+        total_line_number: int = sum(len(lineset) for lineset in self.linesets)
+        report += "TOTAL lines={} duplicates={} percent={:.2f}\n".format(
+            total_line_number,
+            duplicated_line_number,
+            duplicated_line_number * 100.0 / total_line_number,
         )
+        return report
 
     def _find_common(self, lineset1, lineset2):
         """find similarities in the two given linesets"""

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -127,7 +127,7 @@ class Similar:
                 report += f"=={line_set.name}:{idx}\n"
             if line_set:
                 for line in line_set._real_lines[idx : idx + number]:
-                    report += f"   {line.rstrip()}\n"
+                    report += f"   {line.rstrip()}\n" if line.rstrip() else "\n"
             duplicated_line_number += number * (len(files) - 1)
         total_line_number: int = sum(len(lineset) for lineset in self.linesets)
         report += "TOTAL lines={} duplicates={} percent={:.2f}\n".format(

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -34,7 +34,7 @@ from collections import defaultdict
 from getopt import getopt
 from io import TextIOWrapper
 from itertools import chain, groupby
-from typing import List
+from typing import List, Tuple
 
 import astroid
 
@@ -86,7 +86,7 @@ class Similar:
         except UnicodeDecodeError:
             pass
 
-    def run(self):
+    def run(self) -> None:
         """start looking for similarities and display results on stdout"""
         self._display_sims(self._compute_sims())
 
@@ -110,7 +110,7 @@ class Similar:
         sims.reverse()
         return sims
 
-    def _display_sims(self, similarities):
+    def _display_sims(self, similarities: List[Tuple]) -> None:
         """Display computed similarities on stdout"""
         duplicated_line_number = 0
         for number, files in similarities:

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -218,7 +218,13 @@ def stripped_lines(
             if isinstance(n, (astroid.FunctionDef, astroid.AsyncFunctionDef))
         ]
         signature_lines = set(
-            chain(*(range(func.fromlineno, func.body[0].lineno) for func in functions))
+            chain(
+                *(
+                    range(func.fromlineno, func.body[0].lineno)
+                    for func in functions
+                    if func.body
+                )
+            )
         )
 
     strippedlines = []

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -110,27 +110,27 @@ class Similar:
         sims.reverse()
         return sims
 
-    def _display_sims(self, sims):
-        """display computed similarities on stdout"""
-        nb_lignes_dupliquees = 0
-        for num, couples in sims:
+    def _display_sims(self, similarities):
+        """Display computed similarities on stdout"""
+        duplicated_line_number = 0
+        for number, files in similarities:
             print()
-            print(num, "similar lines in", len(couples), "files")
-            couples = sorted(couples)
+            print(number, "similar lines in", len(files), "files")
+            files = sorted(files)
             lineset = idx = None
-            for lineset, idx in couples:
+            for lineset, idx in files:
                 print(f"=={lineset.name}:{idx}")
             if lineset:
-                for line in lineset._real_lines[idx : idx + num]:
+                for line in lineset._real_lines[idx : idx + number]:
                     print("  ", line.rstrip())
-            nb_lignes_dupliquees += num * (len(couples) - 1)
-        nb_total_lignes = sum(len(lineset) for lineset in self.linesets)
+            duplicated_line_number += number * (len(files) - 1)
+        total_line_number = sum(len(lineset) for lineset in self.linesets)
         print(
             "TOTAL lines=%s duplicates=%s percent=%.2f"
             % (
-                nb_total_lignes,
-                nb_lignes_dupliquees,
-                nb_lignes_dupliquees * 100.0 / nb_total_lignes,
+                total_line_number,
+                duplicated_line_number,
+                duplicated_line_number * 100.0 / total_line_number,
             )
         )
 

--- a/tests/checkers/unittest_similar.py
+++ b/tests/checkers/unittest_similar.py
@@ -164,8 +164,8 @@ def test_ignore_signatures_fail():
     assert (
         output.getvalue().strip()
         == (
-            """
-7 similar lines in 2 files
+            '''
+10 similar lines in 2 files
 ==%s:1
 ==%s:8
        arg1: int = 3,
@@ -175,8 +175,11 @@ def test_ignore_signatures_fail():
        arg5: int = 5
    ) -> Ret1:
        pass
-TOTAL lines=23 duplicates=7 percent=30.43
-"""
+   
+   def example():
+       """Valid function definition with docstring only."""
+TOTAL lines=29 duplicates=10 percent=34.48
+'''
             % (SIMILAR5, SIMILAR6)
         ).strip()
     )
@@ -190,7 +193,7 @@ def test_ignore_signatures_pass():
     assert (
         output.getvalue().strip()
         == """
-TOTAL lines=23 duplicates=0 percent=0.00
+TOTAL lines=29 duplicates=0 percent=0.00
 """.strip()
     )
 

--- a/tests/checkers/unittest_similar.py
+++ b/tests/checkers/unittest_similar.py
@@ -175,7 +175,7 @@ def test_ignore_signatures_fail():
        arg5: int = 5
    ) -> Ret1:
        pass
-   
+
    def example():
        """Valid function definition with docstring only."""
 TOTAL lines=29 duplicates=10 percent=34.48

--- a/tests/input/similar5
+++ b/tests/input/similar5
@@ -6,3 +6,6 @@ def func1(
     arg5: int = 5
 ) -> Ret1:
     pass
+
+def example():
+    """Valid function definition with docstring only."""

--- a/tests/input/similar6
+++ b/tests/input/similar6
@@ -13,3 +13,6 @@ async def func2(
     arg5: int = 5
 ) -> Ret1:
     pass
+
+def example():
+    """Valid function definition with docstring only."""


### PR DESCRIPTION
## Description

Fix a crash caused by the newly introduced ignore-signatures option for similarities checker fails for functions with an empty body with docstring only. Also include some refactor necessary so pre-commit works (trailing whitespace added in report).

## Type of Changes


|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Related Issue

Closes #4648 

