### PR TITLE
Document the release process

### DIFF
--- a/doc/release.md
+++ b/doc/release.md
@@ -7,10 +7,21 @@ So, you want to release the `X.Y.Z` version of pylint ?
 1. Check if the dependencies of the package are correct, make sure that astroid is
    pinned to the latest version.
 2. Install the release dependencies `pip3 install pre-commit tbump`
-3. Bump the version and release by using `tbump X.Y.Z --no-push`.
-4. Check the result.
-5. Push the tag.
-6. Go to GitHub, click on "Releases" then on the `vX.Y.Z` tag, choose edit tag, and copy
+3. Bump the version by using `tbump X.Y.Z --no-tag --no-push`
+4. Check the result
+5. Move back to a dev version for pylint with `tbump`:
+
+```bash
+tbump X.Y.Z+1-dev0 --no-tag --no-push # You can interrupt during copyrite
+git commit -am "Move back to a dev version following X.Y.Z release"
+```
+
+4. Check the result
+5. Open a merge request with the two commits (no one can push directly on `main`)
+6. After the merge recover the merged commits and tag the first one (the version should
+   be `X.Y.Z`) as `vX.Y.Z`
+7. Push the tag
+8. Go to GitHub, click on "Releases" then on the `vX.Y.Z` tag, choose edit tag, and copy
    past the changelog in the description. This will trigger the release to pypi.
 
 ## Post release
@@ -32,17 +43,8 @@ git push
 We move issue that were not done in the next milestone and block release only if it's an
 issue labelled as blocker.
 
-### Back to a dev version
-
-1. Unpin the version of astroid, so it's possible to install a dev version during
-   development
-2. Move back to a dev version for pylint with `tbump`:
-
-```bash
-tbump X.Y.Z-dev0 --no-tag --no-push # You can interrupt during copyrite
-```
-
-Check the result and then upgrade the main branch
+- Close milestone `X.Y.Z`
+- Create the milestones for `X.Y.Z+1`, (or `X.Y+1.0`, and `X+1.0.0` if applicable)
 
 #### Whatsnew
 


### PR DESCRIPTION
## Description

Documenting the release process. @cdce8p would you like to release the next version so you can have an opinion on how to make this better ? I'm not really satisfied with the way we have to launch tbump two times and interrupt it the second time. We could also unprotect the main branch like in astroid so we can push directly on it as maintainers (?).

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |
