### PR TITLE
Remove references to `astroid.node_classes`

### DIFF
--- a/examples/custom.py
+++ b/examples/custom.py
@@ -46,12 +46,12 @@ class MyAstroidChecker(BaseChecker):
     )
 
     def visit_call(self, node):
-        """Called when a :class:`.astroid.node_classes.Call` node is visited.
+        """Called when a :class:`.astroid.Call` node is visited.
 
         See :mod:`astroid` for the description of available nodes.
 
         :param node: The node to check.
-        :type node: astroid.node_classes.Call
+        :type node: astroid.Call
         """
         if not (
             isinstance(node.func, astroid.Attribute)

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -2491,7 +2491,7 @@ class ComparisonChecker(_BasicChecker):
     def _check_logical_tautology(self, node):
         """Check if identifier is compared against itself.
         :param node: Compare node
-        :type node: astroid.node_classes.Compare
+        :type node: astroid.Compare
         :Example:
         val = 786
         if val == val:  # [comparison-with-itself]

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -1639,7 +1639,7 @@ a metaclass class method.",
                 self.add_message("protected-access", node=node, args=attrname)
 
     @staticmethod
-    def _is_called_inside_special_method(node: astroid.node_classes.NodeNG) -> bool:
+    def _is_called_inside_special_method(node: astroid.NodeNG) -> bool:
         """
         Returns true if the node is located inside a special (aka dunder) method
         """

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -57,7 +57,7 @@ class DeprecatedMixin:
         "deprecated-class",
     )
     def visit_call(self, node: astroid.Call) -> None:
-        """Called when a :class:`.astroid.node_classes.Call` node is visited."""
+        """Called when a :class:`.astroid.Call` node is visited."""
         try:
             self.check_deprecated_class_in_call(node)
             for inferred in node.func.infer():

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -432,8 +432,8 @@ class ExceptionsChecker(checkers.BaseChecker):
     def _check_try_except_raise(self, node):
         def gather_exceptions_from_handler(
             handler,
-        ) -> typing.Optional[typing.List[astroid.node_classes.NodeNG]]:
-            exceptions: typing.List[astroid.node_classes.NodeNG] = []
+        ) -> typing.Optional[typing.List[astroid.NodeNG]]:
+            exceptions: typing.List[astroid.NodeNG] = []
             if handler.type:
                 exceptions_in_handler = utils.safe_infer(handler.type)
                 if isinstance(exceptions_in_handler, astroid.Tuple):

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -300,7 +300,7 @@ class LoggingChecker(checkers.BaseChecker):
         """Checks that function call is not format_string.format().
 
         Args:
-          node (astroid.node_classes.Call):
+          node (astroid.Call):
             Call AST node to be checked.
         """
         func = utils.safe_infer(node.func)
@@ -319,7 +319,7 @@ class LoggingChecker(checkers.BaseChecker):
         """Checks that format string tokens match the supplied arguments.
 
         Args:
-          node (astroid.node_classes.NodeNG): AST node to be checked.
+          node (astroid.NodeNG): AST node to be checked.
           format_arg (int): Index of the format string in the node arguments.
         """
         num_args = _count_supplied_tokens(node.args[format_arg + 1 :])
@@ -376,7 +376,7 @@ def is_complex_format_str(node):
     """Checks if node represents a string with complex formatting specs.
 
     Args:
-        node (astroid.node_classes.NodeNG): AST node to check
+        node (astroid.NodeNG): AST node to check
     Returns:
         bool: True if inferred string uses complex formatting, False otherwise
     """

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1040,7 +1040,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         If the next value has a default value, then do not add message.
 
         :param node: Check to see if this Call node is a next function
-        :type node: :class:`astroid.node_classes.Call`
+        :type node: :class:`astroid.Call`
         """
 
         def _looks_like_infinite_iterator(param):
@@ -1348,8 +1348,8 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         return (
             isinstance(node, astroid.Assign)
             and len(node.targets) == 1
-            and isinstance(node.targets[0], astroid.node_classes.AssignName)
-            and isinstance(node.value, astroid.node_classes.Name)
+            and isinstance(node.targets[0], astroid.AssignName)
+            and isinstance(node.value, astroid.Name)
         )
 
     def _check_swap_variables(self, node):
@@ -1727,11 +1727,11 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         # if no handlers handle the exception then it's ok
         return True
 
-    def _is_node_return_ended(self, node: astroid.node_classes.NodeNG) -> bool:
+    def _is_node_return_ended(self, node: astroid.NodeNG) -> bool:
         """Check if the node ends with an explicit return statement.
 
         Args:
-            node (astroid.node_classes.NodeNG): node to be checked.
+            node (astroid.NodeNG): node to be checked.
 
         Returns:
             bool: True if the node ends with an explicit statement, False otherwise.
@@ -1776,7 +1776,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         return any(self._is_node_return_ended(_child) for _child in node.get_children())
 
     @staticmethod
-    def _has_return_in_siblings(node: astroid.node_classes.NodeNG) -> bool:
+    def _has_return_in_siblings(node: astroid.NodeNG) -> bool:
         """
         Returns True if there is at least one return in the node's siblings
         """

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1150,7 +1150,7 @@ accessed. Python regular expressions are accepted.",
 
         # Check the left hand side of the assignment is <something>.__name__
         lhs = node.targets[0]
-        if not isinstance(lhs, astroid.node_classes.AssignAttr):
+        if not isinstance(lhs, astroid.AssignAttr):
             return
         if not lhs.attrname == "__name__":
             return
@@ -1845,7 +1845,7 @@ accessed. Python regular expressions are accepted.",
 
     @check_messages("dict-items-missing-iter")
     def visit_for(self, node):
-        if not isinstance(node.target, astroid.node_classes.Tuple):
+        if not isinstance(node.target, astroid.Tuple):
             # target is not a tuple
             return
         if not len(node.target.elts) == 2:
@@ -1853,14 +1853,14 @@ accessed. Python regular expressions are accepted.",
             return
 
         iterable = node.iter
-        if not isinstance(iterable, astroid.node_classes.Name):
+        if not isinstance(iterable, astroid.Name):
             # it's not a bare variable
             return
 
         inferred = safe_infer(iterable)
         if not inferred:
             return
-        if not isinstance(inferred, astroid.node_classes.Dict):
+        if not isinstance(inferred, astroid.Dict):
             # the iterable is not a dict
             return
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -282,7 +282,7 @@ class InferredTypeError(Exception):
     pass
 
 
-def is_inside_lambda(node: astroid.node_classes.NodeNG) -> bool:
+def is_inside_lambda(node: astroid.NodeNG) -> bool:
     """Return true if given node is inside lambda"""
     parent = node.parent
     while parent is not None:
@@ -292,9 +292,7 @@ def is_inside_lambda(node: astroid.node_classes.NodeNG) -> bool:
     return False
 
 
-def get_all_elements(
-    node: astroid.node_classes.NodeNG,
-) -> Iterable[astroid.node_classes.NodeNG]:
+def get_all_elements(node: astroid.NodeNG) -> Iterable[astroid.NodeNG]:
     """Recursively returns all atoms in nested lists and tuples."""
     if isinstance(node, (astroid.Tuple, astroid.List)):
         for child in node.elts:
@@ -303,7 +301,7 @@ def get_all_elements(
         yield node
 
 
-def is_super(node: astroid.node_classes.NodeNG) -> bool:
+def is_super(node: astroid.NodeNG) -> bool:
     """return True if the node is referencing the "super" builtin function"""
     if getattr(node, "name", None) == "super" and node.root().name == BUILTINS:
         return True
@@ -319,7 +317,7 @@ builtins = builtins.__dict__.copy()  # type: ignore
 SPECIAL_BUILTINS = ("__builtins__",)  # '__path__', '__file__')
 
 
-def is_builtin_object(node: astroid.node_classes.NodeNG) -> bool:
+def is_builtin_object(node: astroid.NodeNG) -> bool:
     """Returns True if the given node is an object from the __builtin__ module."""
     return node and node.root().name == BUILTINS
 
@@ -330,9 +328,7 @@ def is_builtin(name: str) -> bool:
 
 
 def is_defined_in_scope(
-    var_node: astroid.node_classes.NodeNG,
-    varname: str,
-    scope: astroid.node_classes.NodeNG,
+    var_node: astroid.NodeNG, varname: str, scope: astroid.NodeNG
 ) -> bool:
     if isinstance(scope, astroid.If):
         for node in scope.body:
@@ -407,8 +403,7 @@ def is_defined_before(var_node: astroid.Name) -> bool:
 
 
 def is_default_argument(
-    node: astroid.node_classes.NodeNG,
-    scope: Optional[astroid.node_classes.NodeNG] = None,
+    node: astroid.NodeNG, scope: Optional[astroid.NodeNG] = None
 ) -> bool:
     """return true if the given Name node is used in function or lambda
     default argument's value
@@ -423,7 +418,7 @@ def is_default_argument(
     return False
 
 
-def is_func_decorator(node: astroid.node_classes.NodeNG) -> bool:
+def is_func_decorator(node: astroid.NodeNG) -> bool:
     """return true if the name is used in function decorator"""
     parent = node.parent
     while parent is not None:
@@ -442,9 +437,7 @@ def is_func_decorator(node: astroid.node_classes.NodeNG) -> bool:
     return False
 
 
-def is_ancestor_name(
-    frame: astroid.ClassDef, node: astroid.node_classes.NodeNG
-) -> bool:
+def is_ancestor_name(frame: astroid.ClassDef, node: astroid.NodeNG) -> bool:
     """return True if `frame` is an astroid.Class node with `node` in the
     subtree of its bases attribute
     """
@@ -456,12 +449,12 @@ def is_ancestor_name(
     return False
 
 
-def is_being_called(node: astroid.node_classes.NodeNG) -> bool:
+def is_being_called(node: astroid.NodeNG) -> bool:
     """return True if node is the function being called in a Call node"""
     return isinstance(node.parent, astroid.Call) and node.parent.func is node
 
 
-def assign_parent(node: astroid.node_classes.NodeNG) -> astroid.node_classes.NodeNG:
+def assign_parent(node: astroid.NodeNG) -> astroid.NodeNG:
     """return the higher parent which is not an AssignName, Tuple or List node"""
     while node and isinstance(node, (astroid.AssignName, astroid.Tuple, astroid.List)):
         node = node.parent
@@ -653,7 +646,7 @@ def is_attr_protected(attrname: str) -> bool:
     )
 
 
-def node_frame_class(node: astroid.node_classes.NodeNG) -> Optional[astroid.ClassDef]:
+def node_frame_class(node: astroid.NodeNG) -> Optional[astroid.ClassDef]:
     """Return the class that is wrapping the given node
 
     The function returns a class for a method node (or a staticmethod or a
@@ -661,7 +654,7 @@ def node_frame_class(node: astroid.node_classes.NodeNG) -> Optional[astroid.Clas
     """
     klass = node.frame()
     nodes_to_check = (
-        astroid.node_classes.NodeNG,
+        astroid.NodeNG,
         astroid.UnboundMethod,
         astroid.BaseInstance,
     )
@@ -716,7 +709,7 @@ def get_argument_from_call(
     raise NoSuchArgumentError
 
 
-def inherit_from_std_ex(node: astroid.node_classes.NodeNG) -> bool:
+def inherit_from_std_ex(node: astroid.NodeNG) -> bool:
     """
     Return true if the given class node is subclass of
     exceptions.Exception.
@@ -846,7 +839,7 @@ def decorated_with(
 @lru_cache(maxsize=1024)
 def unimplemented_abstract_methods(
     node: astroid.ClassDef, is_abstract_cb: astroid.FunctionDef = None
-) -> Dict[str, astroid.node_classes.NodeNG]:
+) -> Dict[str, astroid.NodeNG]:
     """
     Get the unimplemented abstract methods for the given *node*.
 
@@ -860,7 +853,7 @@ def unimplemented_abstract_methods(
     """
     if is_abstract_cb is None:
         is_abstract_cb = partial(decorated_with, qnames=ABC_METHODS)
-    visited: Dict[str, astroid.node_classes.NodeNG] = {}
+    visited: Dict[str, astroid.NodeNG] = {}
     try:
         mro = reversed(node.mro())
     except NotImplementedError:
@@ -904,7 +897,7 @@ def unimplemented_abstract_methods(
 
 
 def find_try_except_wrapper_node(
-    node: astroid.node_classes.NodeNG,
+    node: astroid.NodeNG,
 ) -> Optional[Union[astroid.ExceptHandler, astroid.TryExcept]]:
     """Return the ExceptHandler or the TryExcept node in which the node is."""
     current = node
@@ -918,7 +911,7 @@ def find_try_except_wrapper_node(
 
 
 def find_except_wrapper_node_in_scope(
-    node: astroid.node_classes.NodeNG,
+    node: astroid.NodeNG,
 ) -> Optional[Union[astroid.ExceptHandler, astroid.TryExcept]]:
     """Return the ExceptHandler in which the node is, without going out of scope."""
     current = node
@@ -935,7 +928,7 @@ def find_except_wrapper_node_in_scope(
     return None
 
 
-def is_from_fallback_block(node: astroid.node_classes.NodeNG) -> bool:
+def is_from_fallback_block(node: astroid.NodeNG) -> bool:
     """Check if the given node is from a fallback import block."""
     context = find_try_except_wrapper_node(node)
     if not context:
@@ -966,7 +959,7 @@ def _except_handlers_ignores_exception(
 
 
 def get_exception_handlers(
-    node: astroid.node_classes.NodeNG, exception=Exception
+    node: astroid.NodeNG, exception=Exception
 ) -> Optional[List[astroid.ExceptHandler]]:
     """Return the collections of handlers handling the exception in arguments.
 
@@ -1000,9 +993,7 @@ def is_node_inside_try_except(node: astroid.Raise) -> bool:
     return isinstance(context, astroid.TryExcept)
 
 
-def node_ignores_exception(
-    node: astroid.node_classes.NodeNG, exception=Exception
-) -> bool:
+def node_ignores_exception(node: astroid.NodeNG, exception=Exception) -> bool:
     """Check if the node is in a TryExcept which handles the given exception.
 
     If the exception is not given, the function is going to look for bare
@@ -1036,7 +1027,7 @@ def class_is_abstract(node: astroid.ClassDef) -> bool:
     return False
 
 
-def _supports_protocol_method(value: astroid.node_classes.NodeNG, attr: str) -> bool:
+def _supports_protocol_method(value: astroid.NodeNG, attr: str) -> bool:
     try:
         attributes = value.getattr(attr)
     except astroid.NotFoundError:
@@ -1049,7 +1040,7 @@ def _supports_protocol_method(value: astroid.node_classes.NodeNG, attr: str) -> 
     return True
 
 
-def is_comprehension(node: astroid.node_classes.NodeNG) -> bool:
+def is_comprehension(node: astroid.NodeNG) -> bool:
     comprehensions = (
         astroid.ListComp,
         astroid.SetComp,
@@ -1059,35 +1050,35 @@ def is_comprehension(node: astroid.node_classes.NodeNG) -> bool:
     return isinstance(node, comprehensions)
 
 
-def _supports_mapping_protocol(value: astroid.node_classes.NodeNG) -> bool:
+def _supports_mapping_protocol(value: astroid.NodeNG) -> bool:
     return _supports_protocol_method(
         value, GETITEM_METHOD
     ) and _supports_protocol_method(value, KEYS_METHOD)
 
 
-def _supports_membership_test_protocol(value: astroid.node_classes.NodeNG) -> bool:
+def _supports_membership_test_protocol(value: astroid.NodeNG) -> bool:
     return _supports_protocol_method(value, CONTAINS_METHOD)
 
 
-def _supports_iteration_protocol(value: astroid.node_classes.NodeNG) -> bool:
+def _supports_iteration_protocol(value: astroid.NodeNG) -> bool:
     return _supports_protocol_method(value, ITER_METHOD) or _supports_protocol_method(
         value, GETITEM_METHOD
     )
 
 
-def _supports_async_iteration_protocol(value: astroid.node_classes.NodeNG) -> bool:
+def _supports_async_iteration_protocol(value: astroid.NodeNG) -> bool:
     return _supports_protocol_method(value, AITER_METHOD)
 
 
-def _supports_getitem_protocol(value: astroid.node_classes.NodeNG) -> bool:
+def _supports_getitem_protocol(value: astroid.NodeNG) -> bool:
     return _supports_protocol_method(value, GETITEM_METHOD)
 
 
-def _supports_setitem_protocol(value: astroid.node_classes.NodeNG) -> bool:
+def _supports_setitem_protocol(value: astroid.NodeNG) -> bool:
     return _supports_protocol_method(value, SETITEM_METHOD)
 
 
-def _supports_delitem_protocol(value: astroid.node_classes.NodeNG) -> bool:
+def _supports_delitem_protocol(value: astroid.NodeNG) -> bool:
     return _supports_protocol_method(value, DELITEM_METHOD)
 
 
@@ -1099,7 +1090,7 @@ def _is_abstract_class_name(name: str) -> bool:
     return is_mixin or is_abstract or is_base
 
 
-def is_inside_abstract_class(node: astroid.node_classes.NodeNG) -> bool:
+def is_inside_abstract_class(node: astroid.NodeNG) -> bool:
     while node is not None:
         if isinstance(node, astroid.ClassDef):
             if class_is_abstract(node):
@@ -1112,7 +1103,7 @@ def is_inside_abstract_class(node: astroid.node_classes.NodeNG) -> bool:
 
 
 def _supports_protocol(
-    value: astroid.node_classes.NodeNG, protocol_callback: astroid.FunctionDef
+    value: astroid.NodeNG, protocol_callback: astroid.FunctionDef
 ) -> bool:
     if isinstance(value, astroid.ClassDef):
         if not has_known_bases(value):
@@ -1141,7 +1132,7 @@ def _supports_protocol(
     return False
 
 
-def is_iterable(value: astroid.node_classes.NodeNG, check_async: bool = False) -> bool:
+def is_iterable(value: astroid.NodeNG, check_async: bool = False) -> bool:
     if check_async:
         protocol_check = _supports_async_iteration_protocol
     else:
@@ -1149,18 +1140,16 @@ def is_iterable(value: astroid.node_classes.NodeNG, check_async: bool = False) -
     return _supports_protocol(value, protocol_check)
 
 
-def is_mapping(value: astroid.node_classes.NodeNG) -> bool:
+def is_mapping(value: astroid.NodeNG) -> bool:
     return _supports_protocol(value, _supports_mapping_protocol)
 
 
-def supports_membership_test(value: astroid.node_classes.NodeNG) -> bool:
+def supports_membership_test(value: astroid.NodeNG) -> bool:
     supported = _supports_protocol(value, _supports_membership_test_protocol)
     return supported or is_iterable(value)
 
 
-def supports_getitem(
-    value: astroid.node_classes.NodeNG, node: astroid.node_classes.NodeNG
-) -> bool:
+def supports_getitem(value: astroid.NodeNG, node: astroid.NodeNG) -> bool:
     if isinstance(value, astroid.ClassDef):
         if _supports_protocol_method(value, CLASS_GETITEM_METHOD):
             return True
@@ -1169,11 +1158,11 @@ def supports_getitem(
     return _supports_protocol(value, _supports_getitem_protocol)
 
 
-def supports_setitem(value: astroid.node_classes.NodeNG, *_: Any) -> bool:
+def supports_setitem(value: astroid.NodeNG, *_: Any) -> bool:
     return _supports_protocol(value, _supports_setitem_protocol)
 
 
-def supports_delitem(value: astroid.node_classes.NodeNG, *_: Any) -> bool:
+def supports_delitem(value: astroid.NodeNG, *_: Any) -> bool:
     return _supports_protocol(value, _supports_delitem_protocol)
 
 
@@ -1185,9 +1174,7 @@ def _get_python_type_of_node(node):
 
 
 @lru_cache(maxsize=1024)
-def safe_infer(
-    node: astroid.node_classes.NodeNG, context=None
-) -> Optional[astroid.node_classes.NodeNG]:
+def safe_infer(node: astroid.NodeNG, context=None) -> Optional[astroid.NodeNG]:
     """Return the inferred value for the given node.
 
     Return None if inference failed or if there is some ambiguity (more than
@@ -1234,7 +1221,7 @@ def has_known_bases(klass: astroid.ClassDef, context=None) -> bool:
     return True
 
 
-def is_none(node: astroid.node_classes.NodeNG) -> bool:
+def is_none(node: astroid.NodeNG) -> bool:
     return (
         node is None
         or (isinstance(node, astroid.Const) and node.value is None)
@@ -1242,7 +1229,7 @@ def is_none(node: astroid.node_classes.NodeNG) -> bool:
     )
 
 
-def node_type(node: astroid.node_classes.NodeNG) -> Optional[type]:
+def node_type(node: astroid.NodeNG) -> Optional[type]:
     """Return the inferred type for `node`
 
     If there is more than one possible type, or if inferred type is Uninferable or None,
@@ -1296,7 +1283,7 @@ def is_registered_in_singledispatch_function(node: astroid.FunctionDef) -> bool:
     return False
 
 
-def get_node_last_lineno(node: astroid.node_classes.NodeNG) -> int:
+def get_node_last_lineno(node: astroid.NodeNG) -> int:
     """
     Get the last lineno of the given node. For a simple statement this will just be node.lineno,
     but for a node that has child statements (e.g. a method) this will be the lineno of the last
@@ -1319,14 +1306,14 @@ def get_node_last_lineno(node: astroid.node_classes.NodeNG) -> int:
     return node.lineno
 
 
-def is_postponed_evaluation_enabled(node: astroid.node_classes.NodeNG) -> bool:
+def is_postponed_evaluation_enabled(node: astroid.NodeNG) -> bool:
     """Check if the postponed evaluation of annotations is enabled"""
     module = node.root()
     return "annotations" in module.future_imports
 
 
 def is_class_subscriptable_pep585_with_postponed_evaluation_enabled(
-    value: astroid.ClassDef, node: astroid.node_classes.NodeNG
+    value: astroid.ClassDef, node: astroid.NodeNG
 ) -> bool:
     """Check if class is subscriptable with PEP 585 and
     postponed evaluation enabled.
@@ -1338,7 +1325,7 @@ def is_class_subscriptable_pep585_with_postponed_evaluation_enabled(
     )
 
 
-def is_node_in_type_annotation_context(node: astroid.node_classes.NodeNG) -> bool:
+def is_node_in_type_annotation_context(node: astroid.NodeNG) -> bool:
     """Check if node is in type annotation context.
 
     Check for 'AnnAssign', function 'Arguments',
@@ -1388,7 +1375,7 @@ def is_subclass_of(child: astroid.ClassDef, parent: astroid.ClassDef) -> bool:
 
 
 @lru_cache(maxsize=1024)
-def is_overload_stub(node: astroid.node_classes.NodeNG) -> bool:
+def is_overload_stub(node: astroid.NodeNG) -> bool:
     """Check if a node if is a function stub decorated with typing.overload.
 
     :param node: Node to check.
@@ -1398,7 +1385,7 @@ def is_overload_stub(node: astroid.node_classes.NodeNG) -> bool:
     return bool(decorators and decorated_with(node, ["typing.overload", "overload"]))
 
 
-def is_protocol_class(cls: astroid.node_classes.NodeNG) -> bool:
+def is_protocol_class(cls: astroid.NodeNG) -> bool:
     """Check if the given node represents a protocol class
 
     :param cls: The node to check
@@ -1412,7 +1399,7 @@ def is_protocol_class(cls: astroid.node_classes.NodeNG) -> bool:
     return any(parent.qname() in TYPING_PROTOCOLS for parent in cls.ancestors())
 
 
-def is_call_of_name(node: astroid.node_classes.NodeNG, name: str) -> bool:
+def is_call_of_name(node: astroid.NodeNG, name: str) -> bool:
     """Checks if node is a function call with the given name"""
     return (
         isinstance(node, astroid.Call)
@@ -1422,8 +1409,7 @@ def is_call_of_name(node: astroid.node_classes.NodeNG, name: str) -> bool:
 
 
 def is_test_condition(
-    node: astroid.node_classes.NodeNG,
-    parent: Optional[astroid.node_classes.NodeNG] = None,
+    node: astroid.NodeNG, parent: Optional[astroid.NodeNG] = None
 ) -> bool:
     """Returns true if the given node is being tested for truthiness"""
     parent = parent or node.parent

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -928,8 +928,7 @@ class VariablesChecker(BaseChecker):
                 assign_nodes = []
 
             not_defined_locally_by_import = not any(
-                isinstance(local, astroid.node_classes.Import)
-                for local in locals_.get(name, ())
+                isinstance(local, astroid.Import) for local in locals_.get(name, ())
             )
             if not assign_nodes and not_defined_locally_by_import:
                 self.add_message("global-variable-not-assigned", args=name, node=node)
@@ -1324,7 +1323,7 @@ class VariablesChecker(BaseChecker):
 
     @staticmethod
     def _in_lambda_or_comprehension_body(
-        node: astroid.node_classes.NodeNG, frame: astroid.node_classes.NodeNG
+        node: astroid.NodeNG, frame: astroid.NodeNG
     ) -> bool:
         """return True if node within a lambda/comprehension body (or similar) and thus should not have access to class attributes in frame"""
         child = node
@@ -1335,10 +1334,7 @@ class VariablesChecker(BaseChecker):
             if isinstance(parent, astroid.Lambda) and child is not parent.args:
                 # Body of lambda should not have access to class attributes.
                 return True
-            if (
-                isinstance(parent, astroid.node_classes.Comprehension)
-                and child is not parent.iter
-            ):
+            if isinstance(parent, astroid.Comprehension) and child is not parent.iter:
                 # Only iter of list/set/dict/generator comprehension should have access.
                 return True
             if isinstance(parent, astroid.scoped_nodes.ComprehensionScope) and not (
@@ -1391,7 +1387,7 @@ class VariablesChecker(BaseChecker):
             if not forbid_lookup and defframe.root().lookup(name)[1]:
                 maybee0601 = False
                 use_outer_definition = stmt == defstmt and not isinstance(
-                    defnode, astroid.node_classes.Comprehension
+                    defnode, astroid.Comprehension
                 )
             # check if we have a nonlocal
             elif name in defframe.locals:
@@ -1941,7 +1937,7 @@ class VariablesChecker(BaseChecker):
         target_assign_names = (
             target.name
             for target in node.targets
-            if isinstance(target, astroid.node_classes.AssignName)
+            if isinstance(target, astroid.AssignName)
         )
         if self_cls_name in target_assign_names:
             self.add_message("self-cls-assignment", node=node, args=(self_cls_name,))

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -126,7 +126,7 @@ def possible_exc_types(node):
 
 
     :param node: The raise node to find exception types for.
-    :type node: astroid.node_classes.NodeNG
+    :type node: astroid.NodeNG
 
     :returns: A list of exception types possibly raised by :param:`node`.
     :rtype: set(str)

--- a/pylint/extensions/broad_try_clause.py
+++ b/pylint/extensions/broad_try_clause.py
@@ -9,8 +9,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 """Looks for try/except statements with too much code in the try clause."""
-
-from astroid.node_classes import For, If, While, With
+import astroid
 
 from pylint import checkers, interfaces
 
@@ -53,7 +52,9 @@ class BroadTryClauseChecker(checkers.BaseChecker):
         statement_count = len(try_node.body)
 
         for body_node in try_node.body:
-            if isinstance(body_node, (For, If, While, With)):
+            if isinstance(
+                body_node, (astroid.For, astroid.If, astroid.While, astroid.With)
+            ):
                 statement_count += self._count_statements(body_node)
 
         return statement_count

--- a/pylint/extensions/code_style.py
+++ b/pylint/extensions/code_style.py
@@ -1,7 +1,6 @@
 from typing import List, Set, Tuple, Type, Union, cast
 
 import astroid
-from astroid.node_classes import NodeNG
 
 from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import check_messages, safe_infer
@@ -77,7 +76,7 @@ class CodeStyleChecker(BaseChecker):
         if len(node.items) > 1 and all(
             isinstance(dict_value, astroid.Dict) for _, dict_value in node.items
         ):
-            KeyTupleT = Tuple[Type[NodeNG], str]
+            KeyTupleT = Tuple[Type[astroid.NodeNG], str]
 
             # Makes sure all keys are 'Const' string nodes
             keys_checked: Set[KeyTupleT] = set()

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -612,7 +612,7 @@ class DocstringParameterChecker(BaseChecker):
         :type missing_excs: set(str)
 
         :param node: The node show the message on.
-        :type node: astroid.node_classes.NodeNG
+        :type node: astroid.NodeNG
         """
         if node.is_abstract():
             try:

--- a/pylint/extensions/typing.py
+++ b/pylint/extensions/typing.py
@@ -3,7 +3,6 @@ from typing import Dict, List, NamedTuple, Set, Union
 
 import astroid
 import astroid.bases
-import astroid.node_classes
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import (

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -51,7 +51,7 @@ def interfaces(node, herited=True, handler_func=_iface_hdlr):
         return
     found = set()
     missing = False
-    for iface in astroid.node_classes.unpack_infer(implements):
+    for iface in astroid.unpack_infer(implements):
         if iface is astroid.Uninferable:
             missing = True
             continue

--- a/tests/functional/g/generated_members.py
+++ b/tests/functional/g/generated_members.py
@@ -1,7 +1,9 @@
 """Test the generated-members config option."""
 # pylint: disable=pointless-statement, invalid-name, useless-object-inheritance
 from __future__ import print_function
-from astroid import node_classes
+
+import astroid
+
 from pylint import checkers
 
 class Klass(object):
@@ -11,7 +13,7 @@ print(Klass().DoesNotExist)
 print(Klass().aBC_set1)
 print(Klass().ham.does.not_.exist)
 print(Klass().spam.does.not_.exist)  # [no-member]
-node_classes.Tuple.does.not_.exist
+astroid.Tuple.does.not_.exist
 checkers.base.doesnotexist()
 
 session = Klass()

--- a/tests/functional/g/generated_members.txt
+++ b/tests/functional/g/generated_members.txt
@@ -1,1 +1,1 @@
-no-member:13:6::Instance of 'Klass' has no 'spam' member:INFERENCE
+no-member:15:6::Instance of 'Klass' has no 'spam' member:INFERENCE


### PR DESCRIPTION
## Description
Remove references to `astroid.node_classes` in preparation for astroid refactoring.
All symbols are available through import from `astroid` itself.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Related Issue
https://github.com/PyCQA/astroid/pull/1057