### PR TITLE
Remove references to `astroid.scoped_nodes`

### DIFF
--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -70,6 +70,7 @@ import sys
 from typing import Pattern
 
 import astroid
+import astroid.bases
 
 from pylint import checkers, exceptions, interfaces
 from pylint import utils as lint_utils
@@ -1111,7 +1112,7 @@ class BasicChecker(_BasicChecker):
     def _check_using_constant_test(self, node, test):
         const_nodes = (
             astroid.Module,
-            astroid.scoped_nodes.GeneratorExp,
+            astroid.GeneratorExp,
             astroid.Lambda,
             astroid.FunctionDef,
             astroid.ClassDef,

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -49,6 +49,7 @@ from itertools import chain, zip_longest
 from typing import List, Pattern, cast
 
 import astroid
+import astroid.scoped_nodes
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import (

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1203,7 +1203,7 @@ accessed. Python regular expressions are accepted.",
         # Check for called function being an object instance function
         # If so, ignore the initial 'self' argument in the signature
         try:
-            is_classdef = isinstance(called.parent, astroid.scoped_nodes.ClassDef)
+            is_classdef = isinstance(called.parent, astroid.ClassDef)
             if is_classdef and called_param_names[0] == "self":
                 called_param_names = called_param_names[1:]
         except IndexError:

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -71,6 +71,7 @@ from typing import (
 
 import _string
 import astroid
+import astroid.scoped_nodes
 
 BUILTINS_NAME = builtins.__name__
 COMP_NODE_TYPES = (
@@ -306,7 +307,7 @@ def is_super(node: astroid.node_classes.NodeNG) -> bool:
     return False
 
 
-def is_error(node: astroid.scoped_nodes.FunctionDef) -> bool:
+def is_error(node: astroid.FunctionDef) -> bool:
     """Return true if the given function node only raises an exception"""
     return len(node.body) == 1 and isinstance(node.body[0], astroid.Raise)
 
@@ -430,7 +431,7 @@ def is_func_decorator(node: astroid.node_classes.NodeNG) -> bool:
             (
                 astroid.Lambda,
                 astroid.scoped_nodes.ComprehensionScope,
-                astroid.scoped_nodes.ListComp,
+                astroid.ListComp,
             ),
         ):
             break

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -58,6 +58,7 @@ import re
 from functools import lru_cache
 
 import astroid
+import astroid.scoped_nodes
 
 from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import is_postponed_evaluation_enabled
@@ -1871,7 +1872,7 @@ class VariablesChecker(BaseChecker):
             scope = node.scope().parent.scope()
 
         if not (
-            isinstance(scope, astroid.scoped_nodes.FunctionDef)
+            isinstance(scope, astroid.FunctionDef)
             and scope.is_method()
             and "builtins.staticmethod" not in scope.decoratornames()
         ):

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -209,7 +209,7 @@ class DocstringParameterChecker(BaseChecker):
         """Called for function and method definitions (def).
 
         :param node: Node for a function or method definition in the AST
-        :type node: :class:`astroid.scoped_nodes.Function`
+        :type node: :class:`astroid.Function`
         """
         node_doc = utils.docstringify(node.doc, self.config.default_docstring_type)
 
@@ -380,7 +380,7 @@ class DocstringParameterChecker(BaseChecker):
         :type expected_argument_names: set
 
         :param warning_node: The node to be analyzed
-        :type warning_node: :class:`astroid.scoped_nodes.Node`
+        :type warning_node: :class:`astroid.NodeNG`
         """
         missing_argument_names = (
             expected_argument_names - found_argument_names
@@ -416,7 +416,7 @@ class DocstringParameterChecker(BaseChecker):
         :type expected_argument_names: set
 
         :param warning_node: The node to be analyzed
-        :type warning_node: :class:`astroid.scoped_nodes.Node`
+        :type warning_node: :class:`astroid.NodeNG`
         """
         differing_argument_names = (
             (expected_argument_names ^ found_argument_names)
@@ -451,7 +451,7 @@ class DocstringParameterChecker(BaseChecker):
         :type ignored_argument_names: set
 
         :param warning_node: The node to be analyzed
-        :type warning_node: :class:`astroid.scoped_nodes.Node`
+        :type warning_node: :class:`astroid.NodeNG`
         """
         existing_ignored_argument_names = ignored_argument_names & found_argument_names
 
@@ -492,10 +492,10 @@ class DocstringParameterChecker(BaseChecker):
 
         :param arguments_node: Arguments node for the function, method or
             class constructor.
-        :type arguments_node: :class:`astroid.scoped_nodes.Arguments`
+        :type arguments_node: :class:`astroid.Arguments`
 
         :param warning_node: The node to assign the warnings to
-        :type warning_node: :class:`astroid.scoped_nodes.Node`
+        :type warning_node: :class:`astroid.NodeNG`
 
         :param accept_no_param_doc: Whether or not to allow no parameters
             to be documented.

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -344,7 +344,7 @@ class TestParamDocChecker(CheckerTestCase):
         """Visit all methods of a class node
 
         :param node: class node
-        :type node: :class:`astroid.scoped_nodes.Class`
+        :type node: :class:`astroid.ClassDef`
         """
         for body_item in node.body:
             if isinstance(body_item, astroid.FunctionDef) and hasattr(


### PR DESCRIPTION
## Description
Remove references to `astroid.scoped_nodes` in preparation for astroid refactoring.

**TODO**: Some symbols aren't yet available to import from just `astroid`:
- `function_to_method`
- `ComprehensionScope`
- `LocalsDictNodeNG`

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Related Issue
https://github.com/PyCQA/astroid/pull/1057