### PR TITLE
Fix false positive `unused-private-member` if class member is assigned/mutated with `cls`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,11 @@ Release date: TBA
 ..
   Put bug fixes that should not wait for a new minor version here
 
+* Fix a false positive for ``unused-private-member`` when mutating a private attribute
+  with ``cls``
+
+  Closes #4657
+
 
 What's New in Pylint 2.9.3?
 ===========================

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -961,9 +961,14 @@ a metaclass class method.",
             if not is_attr_private(assign_attr.attrname):
                 continue
             for attribute in node.nodes_of_class(astroid.Attribute):
-                if (
-                    attribute.attrname == assign_attr.attrname
-                    and attribute.expr.name == assign_attr.expr.name
+                if attribute.attrname == assign_attr.attrname and (
+                    (
+                        # If assigned to cls.attrib, can be accessed by cls/self
+                        assign_attr.expr.name == "cls"
+                        and attribute.expr.name in ["cls", "self"]
+                    )
+                    # If assigned to self.attrib, can only be accessed by self
+                    or (assign_attr.expr.name == attribute.expr.name == "self")
                 ):
                     break
             else:

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -103,3 +103,35 @@ class Klass:
 k = Klass()
 print(k.twentyone)
 print(k.ninetyfive)
+
+
+class FalsePositive4657:
+    """False positivie tests for 4657"""
+    __attr_a = None
+    __attr_b = 'b'
+
+    @classmethod
+    def load_attrs(cls):
+        """Load attributes."""
+        cls.__attr_a = 'a'
+
+    @property
+    def attr_a(self):
+        """Get a."""
+        return self.__attr_a
+
+    @property
+    def attr_b(self):
+        """Get b."""
+        return self.__attr_b
+
+    # Test cases where we assign self.attr, but try to
+    # access cls.attr
+
+    def __init__(self):
+        self.__attr_c = "this is an unused private instance attribute"  # [unused-private-member]
+
+    @property
+    def attr_c(self):
+        """Get c."""
+        return cls.__attr_c  # [undefined-variable]

--- a/tests/functional/u/unused/unused_private_member.txt
+++ b/tests/functional/u/unused/unused_private_member.txt
@@ -1,7 +1,9 @@
-unused-private-member:4:4:AnotherClass.__test:Unused private member `AnotherClass.__test(self)`
-unused-private-member:8:4:HasUnusedInClass:Unused private member `HasUnusedInClass.__my_secret`
-unused-private-member:12:4:HasUnusedInClass.__private_class_method_unused:Unused private member `HasUnusedInClass.__private_class_method_unused(cls)`
-unused-private-member:20:4:HasUnusedInClass.__private_static_method_unused:Unused private member `HasUnusedInClass.__private_static_method_unused()`
-unused-private-member:28:8:HasUnusedInClass.__init__:Unused private member `HasUnusedInClass.__instance_secret`
-unused-private-member:34:4:HasUnusedInClass.__test:Unused private member `HasUnusedInClass.__test(self, x, y, z)`
-unused-private-member:55:4:HasUnusedInClass.__test_recursive:Unused private member `HasUnusedInClass.__test_recursive(self)`
+unused-private-member:4:4:AnotherClass.__test:Unused private member `AnotherClass.__test(self)`:HIGH
+unused-private-member:8:4:HasUnusedInClass:Unused private member `HasUnusedInClass.__my_secret`:HIGH
+unused-private-member:12:4:HasUnusedInClass.__private_class_method_unused:Unused private member `HasUnusedInClass.__private_class_method_unused(cls)`:HIGH
+unused-private-member:20:4:HasUnusedInClass.__private_static_method_unused:Unused private member `HasUnusedInClass.__private_static_method_unused()`:HIGH
+unused-private-member:28:8:HasUnusedInClass.__init__:Unused private member `HasUnusedInClass.__instance_secret`:HIGH
+unused-private-member:34:4:HasUnusedInClass.__test:Unused private member `HasUnusedInClass.__test(self, x, y, z)`:HIGH
+unused-private-member:55:4:HasUnusedInClass.__test_recursive:Unused private member `HasUnusedInClass.__test_recursive(self)`:HIGH
+unused-private-member:132:8:FalsePositive4657.__init__:Unused private member `FalsePositive4657.__attr_c`:HIGH
+undefined-variable:137:15:FalsePositive4657.attr_c:Undefined variable 'cls':HIGH


### PR DESCRIPTION
Handle case where private class attributes are assigned/mutated with: `cls.attrib = ...`

This was forgotten during the initial implementation.
## Steps

- [x] Add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #4657 

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
