### PR TITLE
Fix false-positive ``consider-using-with`` when using ``contextlib.ExitStack``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,10 @@ Release date: TBA
 ..
   Put bug fixes that should not wait for a new minor version here
 
+* Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
+
+  Closes #4654
+
 
 What's New in Pylint 2.9.3?
 ===========================

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,10 +9,6 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.10.rst'
 
-* Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
-
-  Closes #4654
-
 
 What's New in Pylint 2.9.4?
 ===========================
@@ -20,6 +16,10 @@ Release date: TBA
 
 ..
   Put bug fixes that should not wait for a new minor version here
+
+* Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
+
+  Closes #4654
 
 
 What's New in Pylint 2.9.3?

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,10 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.10.rst'
 
+* Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
+
+  Closes #4654
+
 
 What's New in Pylint 2.9.4?
 ===========================
@@ -16,10 +20,6 @@ Release date: TBA
 
 ..
   Put bug fixes that should not wait for a new minor version here
-
-* Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
-
-  Closes #4654
 
 
 What's New in Pylint 2.9.3?

--- a/doc/whatsnew/2.10.rst
+++ b/doc/whatsnew/2.10.rst
@@ -16,3 +16,5 @@ New checkers
 
 Other Changes
 =============
+
+* Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method

--- a/doc/whatsnew/2.10.rst
+++ b/doc/whatsnew/2.10.rst
@@ -16,5 +16,3 @@ New checkers
 
 Other Changes
 =============
-
-* Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -62,7 +62,6 @@ New checkers
 Other Changes
 =============
 
-
 * Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
 
 * Add type annotations to pyreverse dot files

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -62,6 +62,9 @@ New checkers
 Other Changes
 =============
 
+
+* Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
+
 * Add type annotations to pyreverse dot files
 
 * Pylint's tags are now the standard form ``vX.Y.Z`` and not ``pylint-X.Y.Z`` anymore.

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -63,6 +63,8 @@ Other Changes
 =============
 
 
+* Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
+
 * Add type annotations to pyreverse dot files
 
 * Pylint's tags are now the standard form ``vX.Y.Z`` and not ``pylint-X.Y.Z`` anymore.

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -63,8 +63,6 @@ Other Changes
 =============
 
 
-* Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
-
 * Add type annotations to pyreverse dot files
 
 * Pylint's tags are now the standard form ``vX.Y.Z`` and not ``pylint-X.Y.Z`` anymore.

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -103,7 +103,7 @@ def _is_trailing_comma(tokens: List[tokenize.TokenInfo], index: int) -> bool:
     return False
 
 
-def _is_inside_context_manager(node):
+def _is_inside_context_manager(node: astroid.Call) -> bool:
     frame = node.frame()
     if not isinstance(
         frame, (astroid.FunctionDef, astroid.BoundMethod, astroid.UnboundMethod)
@@ -112,6 +112,21 @@ def _is_inside_context_manager(node):
     return frame.name == "__enter__" or utils.decorated_with(
         frame, "contextlib.contextmanager"
     )
+
+
+def _will_be_released_automatically(node: astroid.Call) -> bool:
+    """Checks if a call that could be used in a ``with`` statement is used in an alternative
+    construct which would ensure that its __exit__ method is called."""
+    callables_taking_care_of_exit = frozenset(
+        ("contextlib._BaseExitStack.enter_context",)
+    )
+    parent = node.parent
+    if not isinstance(parent, astroid.Call):
+        return False
+    func = utils.safe_infer(parent.func)
+    if not func:
+        return False
+    return func.qname() in callables_taking_care_of_exit
 
 
 class RefactoringChecker(checkers.BaseTokenChecker):
@@ -1299,7 +1314,9 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                 and not isinstance(node.parent, astroid.With)
             )
         )
-        if could_be_used_in_with and not _is_inside_context_manager(node):
+        if could_be_used_in_with and not (
+            _is_inside_context_manager(node) or _will_be_released_automatically(node)
+        ):
             self.add_message("consider-using-with", node=node)
 
     def _check_consider_using_join(self, aug_assign):

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -123,10 +123,9 @@ def _will_be_released_automatically(node: astroid.Call) -> bool:
             "contextlib.ExitStack.enter_context",  # necessary for Python 3.6 compatibility
         )
     )
-    parent = node.parent
-    if not isinstance(parent, astroid.Call):
+    if not isinstance(node.parent, astroid.Call):
         return False
-    func = utils.safe_infer(parent.func)
+    func = utils.safe_infer(node.parent.func)
     if not func:
         return False
     return func.qname() in callables_taking_care_of_exit

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -118,7 +118,10 @@ def _will_be_released_automatically(node: astroid.Call) -> bool:
     """Checks if a call that could be used in a ``with`` statement is used in an alternative
     construct which would ensure that its __exit__ method is called."""
     callables_taking_care_of_exit = frozenset(
-        ("contextlib._BaseExitStack.enter_context",)
+        (
+            "contextlib._BaseExitStack.enter_context",
+            "contextlib.ExitStack.enter_context",  # necessary for Python 3.6 compatibility
+        )
     )
     parent = node.parent
     if not isinstance(parent, astroid.Call):

--- a/tests/functional/c/consider/consider_using_with.py
+++ b/tests/functional/c/consider/consider_using_with.py
@@ -154,3 +154,11 @@ def test_popen():
     _ = subprocess.Popen("sh")  # [consider-using-with]
     with subprocess.Popen("sh"):
         pass
+
+
+def test_suppress_in_exit_stack():
+    """Regression test for issue #4654 (false positive)"""
+    with contextlib.ExitStack() as stack:
+        _ = stack.enter_context(
+            open("/sys/firmware/devicetree/base/hwid,location", "r")
+        )  # must not trigger


### PR DESCRIPTION

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/main/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
The ``contextlib.ExitStack`` class provides a method to automatically call ``__exit__`` on context managers added to its stack when leaving a ``with contextlib.ExitStack() as stack`` block.
If a callable that could be used in a ``with`` block was added to the stack, no R1732 ``consider-using-with`` message should be triggered:

```python
with contextlib.ExitStack() as stack:
    _ = stack.enter_context(
        open("/sys/firmware/devicetree/base/hwid,location", "r")
    )  # must not trigger
```

While ``contextlib.AsyncExitStack`` should theoretically also be covered (as it can be used with synchronous context managers as well), it is currently not possible to implement this, as trying to infer the ``stack.enter_context`` returns ``Uninferable`` in this case...

I also noticed that the whole ``consider-using-with`` check does not check asynchronous context managers at all. 
But I guess this would exceed the scope of this PR, and should probably get its own message (e.g. ``consider-using-async-with``).

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #4654 
