### PR TITLE
[duplicate-code] Fix ignored empty functions by similarities checker with ignore-signatures option enabled

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -505,3 +505,6 @@ contributors:
 * Lorena Buciu (lorena-b): contributor
 
 * Sergei Lebedev (superbobry): contributor
+
+* Maksym Humetskyi (mhumetskyi): contributor
+  - Fixed ignored empty functions by similarities checker with "ignore-signatures" option enabled

--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,10 @@ Release date: TBA
 
   Closes #4657
 
+* Fix ignored empty functions by similarities checker with "ignore-signatures" option enabled
+
+  Closes #4652
+
 
 What's New in Pylint 2.9.3?
 ===========================

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -223,9 +223,11 @@ def stripped_lines(
         signature_lines = set(
             chain(
                 *(
-                    range(func.fromlineno, func.body[0].lineno)
+                    range(
+                        func.fromlineno,
+                        func.body[0].lineno if func.body else func.tolineno + 1,
+                    )
                     for func in functions
-                    if func.body
                 )
             )
         )

--- a/tests/checkers/unittest_similar.py
+++ b/tests/checkers/unittest_similar.py
@@ -35,6 +35,8 @@ SIMILAR3 = str(INPUT / "similar3")
 SIMILAR4 = str(INPUT / "similar4")
 SIMILAR5 = str(INPUT / "similar5")
 SIMILAR6 = str(INPUT / "similar6")
+EMPTY_FUNCTION_1 = str(INPUT / "similar_empty_func_1.py")
+EMPTY_FUNCTION_2 = str(INPUT / "similar_empty_func_2.py")
 MULTILINE = str(INPUT / "multiline-import")
 HIDE_CODE_WITH_IMPORTS = str(INPUT / "hide_code_with_imports.py")
 
@@ -195,6 +197,44 @@ def test_ignore_signatures_pass():
         output.getvalue().strip()
         == """
 TOTAL lines=29 duplicates=0 percent=0.00
+""".strip()
+    )
+
+
+def test_ignore_signatures_empty_functions_fail():
+    output = StringIO()
+    with redirect_stdout(output), pytest.raises(SystemExit) as ex:
+        similar.Run([EMPTY_FUNCTION_1, EMPTY_FUNCTION_2])
+    assert ex.value.code == 0
+    assert (
+        output.getvalue().strip()
+        == (
+            '''
+6 similar lines in 2 files
+==%s:1
+==%s:1
+       arg1: int = 1,
+       arg2: str = "2",
+       arg3: int = 3,
+       arg4: bool = True,
+   ) -> None:
+       """Valid function definition with docstring only."""
+TOTAL lines=14 duplicates=6 percent=42.86
+'''
+            % (EMPTY_FUNCTION_1, EMPTY_FUNCTION_2)
+        ).strip()
+    )
+
+
+def test_ignore_signatures_empty_functions_pass():
+    output = StringIO()
+    with redirect_stdout(output), pytest.raises(SystemExit) as ex:
+        similar.Run(["--ignore-signatures", EMPTY_FUNCTION_1, EMPTY_FUNCTION_2])
+    assert ex.value.code == 0
+    assert (
+        output.getvalue().strip()
+        == """
+TOTAL lines=14 duplicates=0 percent=0.00
 """.strip()
     )
 

--- a/tests/input/similar_empty_func_1.py
+++ b/tests/input/similar_empty_func_1.py
@@ -1,0 +1,7 @@
+def func1(
+    arg1: int = 1,
+    arg2: str = "2",
+    arg3: int = 3,
+    arg4: bool = True,
+) -> None:
+    """Valid function definition with docstring only."""

--- a/tests/input/similar_empty_func_2.py
+++ b/tests/input/similar_empty_func_2.py
@@ -1,0 +1,7 @@
+def func2(
+    arg1: int = 1,
+    arg2: str = "2",
+    arg3: int = 3,
+    arg4: bool = True,
+) -> None:
+    """Valid function definition with docstring only."""


### PR DESCRIPTION
## Description

Similarities checker with "ignore-signatures" option enabled ignores functions with empty bodies.
This PR fixes this bug.

## Type of Changes

|       | Type                   |
| --- | --------------- |
| ✓   | :bug: Bug fix     |

## Related Issue

Closes #4652