### PR TITLE
[test utils] No output with an expected output now fail properly

### DIFF
--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -157,7 +157,7 @@ class LintModuleTest:
         with self._open_source_file() as f:
             expected_msgs = self.get_expected_messages(f)
         if not expected_msgs:
-            return Counter(), []
+            expected_msgs = Counter()
         with self._open_expected_file() as f:
             expected_output_lines = [
                 OutputLine.from_csv(row) for row in csv.reader(f, "test")

--- a/pylint/testutils/reporter_for_tests.py
+++ b/pylint/testutils/reporter_for_tests.py
@@ -67,9 +67,12 @@ class MinimalTestReporter(BaseReporter):
     _display = None
 
 
-class FunctionalTestReporter(BaseReporter):  # pylint: disable=abstract-method
+class FunctionalTestReporter(BaseReporter):
     def on_set_current_module(self, module, filepath):
         self.messages = []
 
     def display_reports(self, layout):
         """Ignore layouts and don't call self._display()."""
+
+    def _display(self, layout):
+        pass

--- a/tests/functional/r/regression/regression_issue_4631.txt
+++ b/tests/functional/r/regression/regression_issue_4631.txt
@@ -1,2 +1,0 @@
-unused-import:9:0::Unused YTMusic imported from ytmusicapi:HIGH
-undefined-variable:16:18:get_youtube_link:Undefined variable '__query_ytmusic':HIGH


### PR DESCRIPTION
## Description

There was a problem when there was no output from pylint but an expected output in the functional tests.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

