### PR TITLE
Fix false-positive ``consider-using-with`` for ternary conditionals in ``with`` items

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,9 @@ Release date: TBA
 ..
   Put bug fixes that should not wait for a new minor version here
 
+* Fix false-positive ``consider-using-with`` (R1732) if a ternary conditional is used together with ``with``
+
+  Closes #4676
 
 * Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
 

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -62,6 +62,8 @@ New checkers
 Other Changes
 =============
 
+* Fix false-positive ``consider-using-with`` (R1732) if a ternary conditional is used together with ``with``
+
 * Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
 
 * Add type annotations to pyreverse dot files

--- a/tests/functional/c/consider/consider_using_with_open.py
+++ b/tests/functional/c/consider/consider_using_with_open.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring, invalid-name, import-outside-toplevel
-# pylint: disable=missing-class-docstring, too-few-public-methods, unused-variable
+# pylint: disable=missing-class-docstring, too-few-public-methods, unused-variable, multiple-statements
 """
 The functional test for the standard ``open()`` function has to be moved in a separate file,
 because PyPy has to be excluded for the tests as the ``open()`` function is uninferable in PyPy.
@@ -49,3 +49,18 @@ def test_open_outside_assignment():
 def test_open_inside_with_block():
     with open("foo") as fh:
         open("bar")  # [consider-using-with]
+
+
+def test_ternary_if_in_with_block(file1, file2, which):
+    """Regression test for issue #4676 (false positive)"""
+    with (open(file1) if which else open(file2)) as input_file:  # must not trigger
+        return input_file.read()
+
+
+def test_single_line_with(file1):
+    with open(file1): return file1.read()  # must not trigger
+
+
+def test_multiline_with_items(file1, file2, which):
+    with (open(file1) if which
+          else open(file2)) as input_file:  return input_file.read()


### PR DESCRIPTION


## Steps

- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
For details see #4676 - things like ``open`` calls inside ternary conditionals used in a ``with`` were incorrectly flagged with the ``consider-using-with``, because the check if this call happens inside the items of a ``with`` only looked at the first parent node.
This is now expanded to check all parents until we reach the enclosing frame.

I also ran ``pylint`` over a few other codebases (black, requests, pip, twine) and (luckily 😁) found no new edge cases.
But I somehow have a feeling that this won't stay the last fix of false-positives for ``consider-using-with``... 

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #4676 
