### PR TITLE
Catch MRO error when applying missing hints feature.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -508,3 +508,6 @@ contributors:
 
 * Maksym Humetskyi (mhumetskyi): contributor
   - Fixed ignored empty functions by similarities checker with "ignore-signatures" option enabled
+
+* Daniel Dorani (doranid): contributor
+

--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,10 @@ Release date: TBA
 ..
   Put bug fixes that should not wait for a new minor version here
 
+* Fix hard failure when parsing missing attribute in a class with duplicated bases
+
+  Closes #4687
+
 * Fix false-positive ``consider-using-with`` (R1732) if a ternary conditional is used together with ``with``
 
   Closes #4676

--- a/ChangeLog
+++ b/ChangeLog
@@ -17,7 +17,7 @@ Release date: TBA
 ..
   Put bug fixes that should not wait for a new minor version here
 
-* Fix hard failure when parsing missing attribute in a class with duplicated bases
+* Fix hard failure when handling missing attribute in a class with duplicated bases
 
   Closes #4687
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -185,7 +185,7 @@ def _(node):
 
     try:
         mro = node.mro()[1:]
-    except (NotImplementedError, TypeError):
+    except (NotImplementedError, TypeError, astroid.MroError):
         mro = node.ancestors()
 
     other_values = [value for cls in mro for value in _node_names(cls)]

--- a/tests/functional/r/regression/regression_4688_duplicated_bases_member_hints.py
+++ b/tests/functional/r/regression/regression_4688_duplicated_bases_member_hints.py
@@ -1,0 +1,7 @@
+# pylint: disable=missing-docstring, pointless-statement, useless-object-inheritance
+# pylint: disable=duplicate-bases, too-few-public-methods
+
+
+class Klass(object, object):
+    def get(self):
+        self._non_existent_attribute # [no-member]

--- a/tests/functional/r/regression/regression_4688_duplicated_bases_member_hints.txt
+++ b/tests/functional/r/regression/regression_4688_duplicated_bases_member_hints.txt
@@ -1,0 +1,1 @@
+no-member:7::Klass.get:Instance of 'Klass' has no '_non_existent_attribute' member:INFERENCE

--- a/tests/functional/r/regression/regression_4688_duplicated_bases_member_hints.txt
+++ b/tests/functional/r/regression/regression_4688_duplicated_bases_member_hints.txt
@@ -1,1 +1,1 @@
-no-member:7::Klass.get:Instance of 'Klass' has no '_non_existent_attribute' member:INFERENCE
+no-member:7:8:Klass.get:Instance of 'Klass' has no '_non_existent_attribute' member:INFERENCE


### PR DESCRIPTION
<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/main/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

This fixes #4687.
Missing type hints won't fail hard anymore when applied to an instance with an MRO with duplicated names.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

Closes #4687 
