### PR TITLE
[undefined-variable] Fix crash when metaclass was parsed as an attribute

### DIFF
--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2109,7 +2109,6 @@ class VariablesChecker(BaseChecker):
 
         consumed = []  # [(scope_locals, consumed_key)]
         metaclass = klass.metaclass()
-
         name = None
         if isinstance(klass._metaclass, astroid.Name):
             name = klass._metaclass.name
@@ -2130,18 +2129,17 @@ class VariablesChecker(BaseChecker):
                 if found:
                     consumed.append((scope_locals, name))
                     break
-        if found is None and not metaclass:
-            current_expr = klass._metaclass
-            while isinstance(current_expr, astroid.Attribute):
-                current_expr = current_expr.expr
-            name = current_expr.name
-            if not (
+        if (
+            found is None
+            and not metaclass
+            and not (
                 name in astroid.Module.scope_attrs
                 or utils.is_builtin(name)
                 or name in self.config.additional_builtins
                 or name in parent_node.locals
-            ):
-                self.add_message("undefined-variable", node=klass, args=(name,))
+            )
+        ):
+            self.add_message("undefined-variable", node=klass, args=(name,))
 
         return consumed
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2139,8 +2139,10 @@ class VariablesChecker(BaseChecker):
                 isinstance(klass._metaclass, astroid.Attribute)
                 and klass._metaclass.expr
             ):
-                name = klass._metaclass.expr.name
-
+                if isinstance(klass._metaclass.expr, astroid.Name):
+                    name = klass._metaclass.expr.name
+                elif isinstance(klass._metaclass.expr, astroid.Attribute):
+                    name = klass._metaclass.expr.attrname
             if name is not None:
                 if not (
                     name in astroid.Module.scope_attrs

--- a/tests/functional/r/regression/regression_4680.py
+++ b/tests/functional/r/regression/regression_4680.py
@@ -1,17 +1,17 @@
-# pylint: disable=missing-docstring,too-few-public-methods,undefined-variable
+# pylint: disable=missing-docstring,too-few-public-methods
 
 import pkg.sub  # [import-error]
 
 
-class Failed(metaclass=pkg.sub.Metaclass):
+class Failed(metaclass=pkg.sub.Metaclass):  # [undefined-variable]
     pass
 
 
-class FailedTwo(metaclass=ab.ABCMeta):
+class FailedTwo(metaclass=ab.ABCMeta):  # [undefined-variable]
     pass
 
 
-class FailedThree(metaclass=pkg.sob.Metaclass):
+class FailedThree(metaclass=pkg.sob.Metaclass):  # [undefined-variable]
     pass
 
 

--- a/tests/functional/r/regression/regression_4680.py
+++ b/tests/functional/r/regression/regression_4680.py
@@ -1,0 +1,18 @@
+# pylint: disable=missing-docstring,too-few-public-methods,undefined-variable
+
+import pkg.sub  # [import-error]
+
+
+class Failed(metaclass=pkg.sub.Metaclass):
+    pass
+
+
+class FailedTwo(metaclass=ab.ABCMeta):
+    pass
+
+
+class FailedThree(metaclass=pkg.sob.Metaclass):
+    pass
+
+
+assert pkg.sub.value is None

--- a/tests/functional/r/regression/regression_4680.py
+++ b/tests/functional/r/regression/regression_4680.py
@@ -3,7 +3,7 @@
 import pkg.sub  # [import-error]
 
 
-class Failed(metaclass=pkg.sub.Metaclass):  # [undefined-variable]
+class Failed(metaclass=pkg.sub.Metaclass):
     pass
 
 
@@ -11,7 +11,7 @@ class FailedTwo(metaclass=ab.ABCMeta):  # [undefined-variable]
     pass
 
 
-class FailedThree(metaclass=pkg.sob.Metaclass):  # [undefined-variable]
+class FailedThree(metaclass=pkg.sob.Metaclass):
     pass
 
 

--- a/tests/functional/r/regression/regression_4680.txt
+++ b/tests/functional/r/regression/regression_4680.txt
@@ -1,4 +1,2 @@
 import-error:3:0::Unable to import 'pkg.sub':HIGH
-undefined-variable:6:0:Failed:Undefined variable 'sub':HIGH
 undefined-variable:10:0:FailedTwo:Undefined variable 'ab':HIGH
-undefined-variable:14:0:FailedThree:Undefined variable 'sob':HIGH

--- a/tests/functional/r/regression/regression_4680.txt
+++ b/tests/functional/r/regression/regression_4680.txt
@@ -1,0 +1,1 @@
+import-error:3:0::Unable to import 'pkg.sub':HIGH

--- a/tests/functional/r/regression/regression_4680.txt
+++ b/tests/functional/r/regression/regression_4680.txt
@@ -1,1 +1,4 @@
 import-error:3:0::Unable to import 'pkg.sub':HIGH
+undefined-variable:6:0:Failed:Undefined variable 'sub':HIGH
+undefined-variable:10:0:FailedTwo:Undefined variable 'ab':HIGH
+undefined-variable:14:0:FailedThree:Undefined variable 'sob':HIGH


### PR DESCRIPTION
## Description

I have a feeling there could be an easier way to get the name of the metaclass node but for now we'll just fix the crash.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #4680
