### PR TITLE
Clarify documentation for consider-using-from-import

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -510,3 +510,5 @@ contributors:
   - Fixed ignored empty functions by similarities checker with "ignore-signatures" option enabled
 
 * Daniel Dorani (doranid): contributor
+
+* Will Shanks: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -47,6 +47,8 @@ Release date: TBA
 
   Closes #4664
 
+* Clarify documentation for consider-using-from-import
+
 
 What's New in Pylint 2.9.3?
 ===========================

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -223,10 +223,10 @@ MSGS = {
     "R0402": (
         "Use 'from %s import %s' instead",
         "consider-using-from-import",
-        "Emitted when a submodule/member of a package is imported and "
+        "Emitted when a submodule of a package is imported and "
         "aliased with the same name. "
-        "E.g., instead of ``import pandas.DataFrame as DataFrame`` use "
-        "``from pandas import DataFrame``",
+        "E.g., instead of ``import concurrent.futures as futures`` use "
+        "``from concurrent import futures``",
     ),
     "W0401": (
         "Wildcard import %s",


### PR DESCRIPTION
## Description

The `consider-using-from-import` checker only works on submodule imports, not member imports because, e.g., `import pandas.DataFrame` is not valid syntax (`import <member>`). This PR removes "member" from the documentation and changes the example to a submodule import.

By the way, I could not find a justification for this checker in the documentation or in the PR that created it. Is it that the `from ... import` syntax uses less characters? (Personally, I prefer `import a.b as b` to `from a import b` to avoid problems with someone later defining `b` as a member in `a.py` and that taking precedence over the submodule import but I didn't know if I was missing another advantage to the `from` syntax).

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |
