### PR TITLE
Don't emit `unreachable` warning for empty generator functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -49,6 +49,10 @@ Release date: TBA
 
 * Clarify documentation for consider-using-from-import
 
+* Don't emit ``unreachable`` warning for empty generator functions
+
+  Closes #4698
+
 
 What's New in Pylint 2.9.3?
 ===========================

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1365,7 +1365,7 @@ class BasicChecker(_BasicChecker):
         block
         """
         self._check_unreachable(node)
-        # Is it inside final body of a try...finally bloc ?
+        # Is it inside final body of a try...finally block ?
         self._check_not_in_finally(node, "return", (astroid.FunctionDef,))
 
     @utils.check_messages("unreachable")
@@ -1384,7 +1384,7 @@ class BasicChecker(_BasicChecker):
         """
         # 1 - Is it right sibling ?
         self._check_unreachable(node)
-        # 2 - Is it inside final body of a try...finally bloc ?
+        # 2 - Is it inside final body of a try...finally block ?
         self._check_not_in_finally(node, "break", (astroid.For, astroid.While))
 
     @utils.check_messages("unreachable")
@@ -1480,12 +1480,22 @@ class BasicChecker(_BasicChecker):
         """check unreachable code"""
         unreach_stmt = node.next_sibling()
         if unreach_stmt is not None:
+            if (
+                isinstance(node, astroid.Return)
+                and isinstance(unreach_stmt, astroid.Expr)
+                and isinstance(unreach_stmt.value, astroid.Yield)
+            ):
+                # Don't add 'unreachable' for empty generators.
+                # Only add warning if 'yield' is followed by another node.
+                unreach_stmt = unreach_stmt.next_sibling()
+                if unreach_stmt is None:
+                    return
             self.add_message("unreachable", node=unreach_stmt)
 
     def _check_not_in_finally(self, node, node_name, breaker_classes=()):
         """check that a node is not inside a finally clause of a
         try...finally statement.
-        If we found before a try...finally bloc a parent which its type is
+        If we found before a try...finally block a parent which its type is
         in breaker_classes, we skip the whole check."""
         # if self._tryfinallys is empty, we're not an in try...finally block
         if not self._tryfinallys:

--- a/tests/functional/u/unreachable.py
+++ b/tests/functional/u/unreachable.py
@@ -20,3 +20,16 @@ def func3():
 def func4():
     raise Exception
     return 1 / 0 # [unreachable]
+
+
+# https://github.com/PyCQA/pylint/issues/4698
+def func5():
+    """Empty generator functions should be allowed."""
+    return
+    yield
+
+def func6():
+    """Add 'unreachable' if yield is followed by another node."""
+    return
+    yield
+    print("unreachable")  # [unreachable]

--- a/tests/functional/u/unreachable.txt
+++ b/tests/functional/u/unreachable.txt
@@ -2,3 +2,4 @@ unreachable:7:4:func1:Unreachable code
 unreachable:12:8:func2:Unreachable code
 unreachable:18:8:func3:Unreachable code
 unreachable:22:4:func4:Unreachable code
+unreachable:35:4:func6:Unreachable code


### PR DESCRIPTION
## Description
The `unreachable` code warning should not be emitted for empty generator functions.

```py
def func():
    return
    yield
```

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
Closes #4698