### PR TITLE
[unused-private-member] add logic to check for obj attributes when using ``__new__``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -67,7 +67,6 @@ Release date: TBA
   Closes #4668
 
 
-
 What's New in Pylint 2.9.3?
 ===========================
 Release date: 2021-07-01

--- a/ChangeLog
+++ b/ChangeLog
@@ -62,6 +62,11 @@ Release date: TBA
 
   Closes #4368
 
+* Fix false-positive of ``unused-private-member`` when using ``__new__`` in a class
+
+  Closes #4668
+
+
 
 What's New in Pylint 2.9.3?
 ===========================

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -964,15 +964,14 @@ a metaclass class method.",
             # Logic for checking false positive when using __new__,
             # Get the returned object names of the __new__ magic function
             # Then check if the attribute was consumed in other instance methods
-            acceptable_obj_names = ["self"]
-            if (
-                isinstance(assign_attr.scope(), astroid.FunctionDef)
-                and assign_attr.scope().name == "__new__"
-            ):
+            acceptable_obj_names: List[str] = ["self"]
+            scope = assign_attr.scope()
+            if isinstance(scope, astroid.FunctionDef) and scope.name == "__new__":
                 acceptable_obj_names.extend(
                     [
-                        n.value.name
-                        for n in assign_attr.scope().nodes_of_class(astroid.Return)
+                        return_node.value.name
+                        for return_node in scope.nodes_of_class(astroid.Return)
+                        if isinstance(return_node.value, astroid.Name)
                     ]
                 )
 

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -135,3 +135,26 @@ class FalsePositive4657:
     def attr_c(self):
         """Get c."""
         return cls.__attr_c  # [undefined-variable]
+
+# Test cases for false-positive reported in #4668
+# https://github.com/PyCQA/pylint/issues/4668
+
+class FalsePositive4668:
+    # pylint: disable=protected-access, no-member
+
+    def __new__(cls, func, *args):
+        if args:
+            true_obj = super(FalsePositive4668, cls).__new__(cls)
+            true_obj.func = func
+            true_obj.__args = args  # Do not emit message here
+            return true_obj
+
+        false_obj = super(FalsePositive4668, cls).__new__(cls)
+        false_obj.func = func
+        false_obj.__args = args  # Do not emit message here
+        false_obj.__secret_bool = False
+        return false_obj
+
+    def exec(self):
+        print(self.__secret_bool)
+        return self.func(*self.__args)

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -136,11 +136,11 @@ class FalsePositive4657:
         """Get c."""
         return cls.__attr_c  # [undefined-variable]
 
+
 # Test cases for false-positive reported in #4668
 # https://github.com/PyCQA/pylint/issues/4668
-
 class FalsePositive4668:
-    # pylint: disable=protected-access, no-member
+    # pylint: disable=protected-access, no-member, unreachable
 
     def __new__(cls, func, *args):
         if args:
@@ -154,6 +154,8 @@ class FalsePositive4668:
         false_obj.__args = args  # Do not emit message here
         false_obj.__secret_bool = False
         return false_obj
+        # unreachable but non-Name return value
+        return 3+4
 
     def exec(self):
         print(self.__secret_bool)


### PR DESCRIPTION
## Steps

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
Fix false positive when using ``__new__`` in a class, this is done by performing the following:

1. If the current method is ``__new__``, get all returned object names by the method
2. Check and do not emit when the current expression of the attribute is in this list of object names, and a ``self.attribute`` of the same attribute was consumed in other methods of the same class

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
Closes #4668 

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
