### PR TITLE
Fix invalid-overridden-method with nested property

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -53,6 +53,10 @@ Release date: TBA
 
   Closes #4698
 
+* Fix ``invalid-overridden-method`` with nested property
+
+  Closes #4368
+
 
 What's New in Pylint 2.9.3?
 ===========================

--- a/tests/functional/i/invalid/invalid_overridden_method.py
+++ b/tests/functional/i/invalid/invalid_overridden_method.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, too-few-public-methods
+# pylint: disable=missing-docstring,too-few-public-methods,disallowed-name,invalid-name,unused-argument
 import abc
 
 
@@ -76,3 +76,52 @@ class AbstractProperty:
     @abc.abstractmethod
     def prop(self):
         return
+
+
+# https://github.com/PyCQA/pylint/issues/4368
+# Decrator functions with a nested property decorator should still be
+# inferred as property.
+
+def my_property(func):
+    @property
+    def _wrapper(self):
+        pass
+    return _wrapper
+
+def not_a_property(func):
+    def _wrapper(self):
+        pass
+    return _wrapper
+
+def multiple_returns(func):
+    def _wrapper(self):
+        pass
+    if foobar:  # pylint: disable=undefined-variable
+        return False
+    return _wrapper
+
+class A:
+    @property
+    def foo(self):
+        return True
+
+    @property
+    def bar(self):
+        return True
+
+    @property
+    def bar2(self):
+        return True
+
+class B(A):
+    @my_property
+    def foo(self):
+        return False
+
+    @not_a_property
+    def bar(self):  # [invalid-overridden-method]
+        return False
+
+    @multiple_returns
+    def bar2(self):  # [invalid-overridden-method]
+        return False

--- a/tests/functional/i/invalid/invalid_overridden_method.txt
+++ b/tests/functional/i/invalid/invalid_overridden_method.txt
@@ -2,3 +2,5 @@ invalid-overridden-method:38:4:InvalidDerived.prop:Method 'prop' was expected to
 invalid-overridden-method:41:4:InvalidDerived.async_method:Method 'async_method' was expected to be 'async', found it instead as 'non-async'
 invalid-overridden-method:45:4:InvalidDerived.method_a:Method 'method_a' was expected to be 'method', found it instead as 'property'
 invalid-overridden-method:48:4:InvalidDerived.method_b:Method 'method_b' was expected to be 'non-async', found it instead as 'async'
+invalid-overridden-method:122:4:B.bar:Method 'bar' was expected to be 'property', found it instead as 'method'
+invalid-overridden-method:126:4:B.bar2:Method 'bar2' was expected to be 'property', found it instead as 'method'


### PR DESCRIPTION
## Description
``invalid-overridden-method`` should not be raised if decorator has a nested property function.

```py
def my_property(func):
    @property
    def _wrapper(self):
        pass

    return _wrapper


class A:
    @property
    def foo(self):
        return True

class B(A):
    @my_property
    def foo(self):
        return False
```

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
Closes #4368