### PR TITLE
Ensure --fail-on always returns a non-zero exit code when issue is matched

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -512,3 +512,5 @@ contributors:
 * Daniel Dorani (doranid): contributor
 
 * Will Shanks: contributor
+
+* Mark Bell: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,9 @@ Release date: TBA
 
 * Fix bug in which --fail-on can return a zero exit code even when the specified issue is present
 
+  Closes #4296 
+  Closes #3363 
+
 * Fix hard failure when handling missing attribute in a class with duplicated bases
 
   Closes #4687

--- a/ChangeLog
+++ b/ChangeLog
@@ -19,8 +19,8 @@ Release date: TBA
 
 * Fix bug in which --fail-on can return a zero exit code even when the specified issue is present
 
-  Closes #4296 
-  Closes #3363 
+  Closes #4296
+  Closes #3363
 
 * Fix hard failure when handling missing attribute in a class with duplicated bases
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,8 @@ Release date: TBA
 ..
   Put bug fixes that should not wait for a new minor version here
 
+* Fix bug in which --fail-on can return a zero exit code even when the specified issue is present
+
 * Fix hard failure when handling missing attribute in a class with duplicated bases
 
   Closes #4687

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -707,7 +707,9 @@ class PyLinter(
                         self.fail_on_symbols.append(msg.symbol)
 
     def any_fail_on_issues(self):
-        return any(x in self.fail_on_symbols for x in self.stats["by_msg"])
+        return self.stats is not None and any(
+            x in self.fail_on_symbols for x in self.stats["by_msg"]
+        )
 
     def disable_noerror_messages(self):
         for msgcat, msgids in self.msgs_store._msgs_by_category.items():

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -394,14 +394,13 @@ group are mutually exclusive.",
         if exit:
             if linter.config.exit_zero:
                 sys.exit(0)
+            elif linter.any_fail_on_issues():
+                # We need to make sure we return a failing exit code in this case.
+                # So we use self.linter.msg_status if that is non-zero, otherwise we just return 1.
+                sys.exit(self.linter.msg_status or 1)
+            elif score_value and score_value >= linter.config.fail_under:
+                sys.exit(0)
             else:
-                if (
-                    score_value
-                    and score_value >= linter.config.fail_under
-                    # detected messages flagged by --fail-on prevent non-zero exit code
-                    and not linter.any_fail_on_issues()
-                ):
-                    sys.exit(0)
                 sys.exit(self.linter.msg_status)
 
     def version_asked(self, _, __):

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -398,7 +398,7 @@ group are mutually exclusive.",
                 # We need to make sure we return a failing exit code in this case.
                 # So we use self.linter.msg_status if that is non-zero, otherwise we just return 1.
                 sys.exit(self.linter.msg_status or 1)
-            elif score_value and score_value >= linter.config.fail_under:
+            elif score_value >= linter.config.fail_under:
                 sys.exit(0)
             else:
                 sys.exit(self.linter.msg_status)

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -398,7 +398,7 @@ group are mutually exclusive.",
                 # We need to make sure we return a failing exit code in this case.
                 # So we use self.linter.msg_status if that is non-zero, otherwise we just return 1.
                 sys.exit(self.linter.msg_status or 1)
-            elif score_value >= linter.config.fail_under:
+            elif score_value is not None and score_value >= linter.config.fail_under:
                 sys.exit(0)
             else:
                 sys.exit(self.linter.msg_status)

--- a/tests/regrtest_data/fail_on.py
+++ b/tests/regrtest_data/fail_on.py
@@ -1,0 +1,12 @@
+"""
+    Pylint score:  -1.67
+"""
+import nonexistent
+# pylint: disable=broad-except
+
+
+def loop():
+    count = 0
+    for _ in range(5):
+        count += 1
+    print(count)

--- a/tests/regrtest_data/fail_on_info_only.py
+++ b/tests/regrtest_data/fail_on_info_only.py
@@ -1,0 +1,11 @@
+"""
+    Pylint score:  -1.67
+"""
+# pylint: disable=broad-except
+
+def loop():
+    """Run a loop."""
+    count = 0
+    for _ in range(5):
+        count += 1
+    print(count)

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1136,34 +1136,40 @@ class TestRunTC:
         output_file = "thisdirectorydoesnotexit/output.txt"
         self._runtest([path, f"--output={output_file}"], code=32)
 
-    @pytest.mark.parametrize("args, expected", [
-        ([], 0),
-        (["--enable=C"], 0),
-        (["--fail-on=superfluous-parens"], 0),
-        (["--fail-on=import-error"], 6),
-        (["--fail-on=unused-import"], 6),
-        (["--fail-on=unused-import", "--enable=C"], 22),
-        (["--fail-on=missing-function-docstring"], 22),
-        (["--fail-on=useless-suppression"], 6),
-        (["--fail-on=useless-suppression", "--enable=C"], 22),
-        ])
+    @pytest.mark.parametrize(
+        "args, expected",
+        [
+            ([], 0),
+            (["--enable=C"], 0),
+            (["--fail-on=superfluous-parens"], 0),
+            (["--fail-on=import-error"], 6),
+            (["--fail-on=unused-import"], 6),
+            (["--fail-on=unused-import", "--enable=C"], 22),
+            (["--fail-on=missing-function-docstring"], 22),
+            (["--fail-on=useless-suppression"], 6),
+            (["--fail-on=useless-suppression", "--enable=C"], 22),
+        ],
+    )
     def test_fail_on_exit_code(self, args, expected):
         path = join(HERE, "regrtest_data", "fail_on.py")
         # We set fail-under to be something very low so that even with the warnings
         # and errors that are generated they don't affect the exit code.
         self._runtest([path, "--fail-under=-10"] + args, code=expected)
 
-    @pytest.mark.parametrize("args, expected", [
-        ([], 0),
-        (["--enable=C"], 0),
-        (["--fail-on=superfluous-parens"], 0),
-        (["--fail-on=import-error"], 0),
-        (["--fail-on=unused-import"], 0),
-        (["--fail-on=unused-import", "--enable=C"], 0),
-        (["--fail-on=missing-function-docstring"], 0),
-        (["--fail-on=useless-suppression"], 1),
-        (["--fail-on=useless-suppression", "--enable=C"], 1),
-        ])
+    @pytest.mark.parametrize(
+        "args, expected",
+        [
+            ([], 0),
+            (["--enable=C"], 0),
+            (["--fail-on=superfluous-parens"], 0),
+            (["--fail-on=import-error"], 0),
+            (["--fail-on=unused-import"], 0),
+            (["--fail-on=unused-import", "--enable=C"], 0),
+            (["--fail-on=missing-function-docstring"], 0),
+            (["--fail-on=useless-suppression"], 1),
+            (["--fail-on=useless-suppression", "--enable=C"], 1),
+        ],
+    )
     def test_fail_on_info_only_exit_code(self, args, expected):
         path = join(HERE, "regrtest_data", "fail_on_info_only.py")
         self._runtest([path] + args, code=expected)

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1136,6 +1136,38 @@ class TestRunTC:
         output_file = "thisdirectorydoesnotexit/output.txt"
         self._runtest([path, f"--output={output_file}"], code=32)
 
+    @pytest.mark.parametrize("args, expected", [
+        ([], 0),
+        (["--enable=C"], 0),
+        (["--fail-on=superfluous-parens"], 0),
+        (["--fail-on=import-error"], 6),
+        (["--fail-on=unused-import"], 6),
+        (["--fail-on=unused-import", "--enable=C"], 22),
+        (["--fail-on=missing-function-docstring"], 22),
+        (["--fail-on=useless-suppression"], 6),
+        (["--fail-on=useless-suppression", "--enable=C"], 22),
+        ])
+    def test_fail_on_exit_code(self, args, expected):
+        path = join(HERE, "regrtest_data", "fail_on.py")
+        # We set fail-under to be something very low so that even with the warnings
+        # and errors that are generated they don't affect the exit code.
+        self._runtest([path, "--fail-under=-10"] + args, code=expected)
+
+    @pytest.mark.parametrize("args, expected", [
+        ([], 0),
+        (["--enable=C"], 0),
+        (["--fail-on=superfluous-parens"], 0),
+        (["--fail-on=import-error"], 0),
+        (["--fail-on=unused-import"], 0),
+        (["--fail-on=unused-import", "--enable=C"], 0),
+        (["--fail-on=missing-function-docstring"], 0),
+        (["--fail-on=useless-suppression"], 1),
+        (["--fail-on=useless-suppression", "--enable=C"], 1),
+        ])
+    def test_fail_on_info_only_exit_code(self, args, expected):
+        path = join(HERE, "regrtest_data", "fail_on_info_only.py")
+        self._runtest([path] + args, code=expected)
+
     @pytest.mark.parametrize(
         "output_format, expected_output",
         [


### PR DESCRIPTION
## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

This fixes a bug in which pylint can still return a zero exit code when using --fail-on even if the specified issue occurs when the issues matched are all of info type.

Without this patch, running: `pylint --fail-on=useless-suppression a.py` when `a.py` contains:
```
"""Test file to trigger an useless-suppression error msg"""
# pylint: disable=broad-except
pass
```
returns exit code 0 despite matching the useless-suppression (info) issue.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

This is related to Issue #4296 and #3363. However although it will provides some other options for these issues, I don't think it will fully resolve them.