### PR TITLE
Added `time.clock` to deprecated functions/methods for python 3.3.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -517,3 +517,5 @@ contributors:
 
 * Marco Gorelli: contributor
   - Documented Jupyter integration
+
+* Yilei Yang: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,8 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.10.rst'
 
+* Added `time.clock` to deprecated functions/methods for python 3.3
+
 
 What's New in Pylint 2.9.4?
 ===========================

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,7 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.10.rst'
 
-* Added `time.clock` to deprecated functions/methods for python 3.3
+* Added ``time.clock`` to deprecated functions/methods for python 3.3
 
 
 What's New in Pylint 2.9.4?

--- a/doc/whatsnew/2.10.rst
+++ b/doc/whatsnew/2.10.rst
@@ -17,4 +17,4 @@ New checkers
 Other Changes
 =============
 
-* Added `time.clock` to deprecated functions/methods for python 3.3
+* Added ``time.clock`` to deprecated functions/methods for python 3.3

--- a/doc/whatsnew/2.10.rst
+++ b/doc/whatsnew/2.10.rst
@@ -16,3 +16,5 @@ New checkers
 
 Other Changes
 =============
+
+* Added `time.clock` to deprecated functions/methods for python 3.3

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -184,6 +184,7 @@ DEPRECATED_METHODS = {
             "nntplib._NNTPBase.xpath",
             "platform.popen",
             "sqlite3.OptimizedUnicode",
+            "time.clock",
         },
         (3, 4, 0): {
             "importlib.find_loader",


### PR DESCRIPTION
It was deprecated in 3.3 and removed in 3.8.

<!--

Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/PyCQA/pylint/blob/main/doc/development_guide/contribute.rst#repository
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
