### PR TITLE
Add a regression test for AttributeError for Subscript object

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,11 @@ Release date: TBA
 ..
   Put bug fixes that should not wait for a new minor version here
 
+* Fix a crash when there would be a 'TypeError object does not support
+  item assignment' in the code we parse.
+
+  Closes #4439
+
 * Fix crash if a callable returning a context manager was assigned to a list or dict item
 
   Closes #4732

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,4 +1,4 @@
 -e .
-astroid==2.6.4  # Pinned to a specific version for tests
+astroid==2.6.5  # Pinned to a specific version for tests
 pytest~=6.2
 pytest-benchmark~=3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    astroid>=2.6.4,<2.7 # (You should also upgrade requirements_test_min.txt)
+    astroid>=2.6.5,<2.7 # (You should also upgrade requirements_test_min.txt)
     isort>=4.2.5,<6
     mccabe>=0.6,<0.7
     toml>=0.7.1

--- a/tests/functional/r/regression/regression_4439.py
+++ b/tests/functional/r/regression/regression_4439.py
@@ -1,0 +1,13 @@
+"""AttributeError: 'Subscript' object has no attribute 'name' """
+# pylint: disable=missing-docstring
+
+from typing import Optional
+
+from attr import attrib, attrs
+
+
+@attrs()
+class User:
+    name: str = attrib()
+    age: int = attrib()
+    occupation = Optional[str] = attrib(default=None) # [unsupported-assignment-operation]

--- a/tests/functional/r/regression/regression_4439.txt
+++ b/tests/functional/r/regression/regression_4439.txt
@@ -1,0 +1,1 @@
+unsupported-assignment-operation:13:17:User:'Optional' does not support item assignment:HIGH


### PR DESCRIPTION
## Description

Add a regression test for AttributeError for Subscript object (#4439)


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #4439
