### PR TITLE
Fix crash if a callable returning a context manager was assigned to a list or dict item

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,10 @@ Release date: TBA
 ..
   Put bug fixes that should not wait for a new minor version here
 
+* Fix crash if a callable returning a context manager was assigned to a list or dict item
+
+  Closes #4732
+
 
 What's New in Pylint 2.9.4?
 ===========================

--- a/doc/whatsnew/2.9.rst
+++ b/doc/whatsnew/2.9.rst
@@ -102,3 +102,5 @@ Other Changes
 
 * No longer emit ``consider-using-with`` for ``ThreadPoolExecutor`` and ``ProcessPoolExecutor``
   as they have legitimate use cases without a ``with`` block.
+
+* Fix crash if a callable returning a context manager was assigned to a list or dict item

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1407,7 +1407,11 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             if not isinstance(value, astroid.Call):
                 continue
             inferred = utils.safe_infer(value.func)
-            if not inferred or inferred.qname() not in CALLS_RETURNING_CONTEXT_MANAGERS:
+            if (
+                not inferred
+                or inferred.qname() not in CALLS_RETURNING_CONTEXT_MANAGERS
+                or not isinstance(assignee, (astroid.AssignName, astroid.AssignAttr))
+            ):
                 continue
             stack = self._consider_using_with_stack.get_stack_for_frame(node.frame())
             varname = (

--- a/tests/functional/c/consider/consider_using_with.py
+++ b/tests/functional/c/consider/consider_using_with.py
@@ -215,3 +215,17 @@ unused_pool, used_pool = (
 )
 with used_pool:
     pass
+
+
+def test_subscript_assignment():
+    """
+    Regression test for issue https://github.com/PyCQA/pylint/issues/4732.
+    If a context manager is assigned to a list or dict, we are not able to
+    tell if / how the context manager is used later on, as it is not assigned
+    to a variable or attribute directly.
+    In this case we can only emit the message directly.
+    """
+    job_list = [None, None]
+    job_list[0] = subprocess.Popen("ls")  # [consider-using-with]
+    job_dict = {}
+    job_dict["myjob"] = subprocess.Popen("ls")  # [consider-using-with]

--- a/tests/functional/c/consider/consider_using_with.txt
+++ b/tests/functional/c/consider/consider_using_with.txt
@@ -22,3 +22,5 @@ consider-using-with:201:4::Consider using 'with' for resource-allocating operati
 consider-using-with:202:4::Consider using 'with' for resource-allocating operations:HIGH
 consider-using-with:207:4::Consider using 'with' for resource-allocating operations:HIGH
 consider-using-with:213:4::Consider using 'with' for resource-allocating operations:HIGH
+consider-using-with:229:18:test_subscript_assignment:Consider using 'with' for resource-allocating operations:HIGH
+consider-using-with:231:24:test_subscript_assignment:Consider using 'with' for resource-allocating operations:HIGH


### PR DESCRIPTION

## Steps

- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Description
#4721 introduced a crash if a context manager was not assigned to a variable or attribute, but instead to something like a list or dictionary item.

``_append_context_managers_to_stack()`` now ignores assignments where the left hand side is not assigned to something with a name. This will lead to ``consider-using-with`` to be triggered when ``visit_call()`` is called.
Note that this would have been the same behaviour as before #4721, so this is not a step back. 

Of course it would be desirable if it is possible to properly detect if the list/dict item is extracted later on and used in a ``with`` block, like so:

```python
import subprocess

job_dict = {}
job_dict["new"] = subprocess.Popen("ls")  # will currently emit consider-using-with

# ... 

for name, job in job_dict.items():
    with job:  # we now actually use the context manager, thus it would not have been necessary to emit consider-using-with earlier
        output = job.communicate()
```

If anybody has an idea how to detect this, I'll be happy to implement this.

I'm also guessing that this would probably go in a 2.9.5? If not I'll change the ChangeLog and whatsnew entry again.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue


Closes #4732 

