### PR TITLE
[#3791] propose a fix

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,4 +1,4 @@
-Contributors
+﻿Contributors
 ------------
 
 Current team:

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,4 +1,4 @@
-﻿Contributors
+Contributors
 ------------
 
 Current team:
@@ -519,3 +519,5 @@ contributors:
   - Documented Jupyter integration
 
 * Yilei Yang: contributor
+
+* Marcin Kurczewski (rr-): contributor

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -945,6 +945,8 @@ class VariablesChecker(BaseChecker):
 
     def visit_name(self, node):
         """Check that a name is defined in the current scope"""
+        # refactoring this block is a pain.
+        # pylint: disable=too-many-nested-blocks,too-many-branches
         stmt = node.statement()
         if stmt.fromlineno is None:
             # name node from an astroid built from live code, skip
@@ -964,7 +966,7 @@ class VariablesChecker(BaseChecker):
 
         # iterates through parent scopes, from the inner to the outer
         base_scope_type = self._to_consume[start_index].scope_type
-        # pylint: disable=too-many-nested-blocks; refactoring this block is a pain.
+
         for i in range(start_index, -1, -1):
             current_consumer = self._to_consume[i]
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -44,6 +44,7 @@
 # Copyright (c) 2021 Lorena B <46202743+lorena-b@users.noreply.github.com>
 # Copyright (c) 2021 haasea <44787650+haasea@users.noreply.github.com>
 # Copyright (c) 2021 Alexander Kapshuna <kapsh@kap.sh>
+# Copyright (c) 2021 Marcin Kurczewski <rr-@sakuya.pl>
 
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
@@ -1013,6 +1014,12 @@ class VariablesChecker(BaseChecker):
                 defnode = utils.assign_parent(current_consumer.consumed[name][0])
                 self._check_late_binding_closure(node, defnode)
                 self._loopvar_name(node, name)
+                break
+
+            # the name has already been consumed, skip decorators
+            if name in current_consumer.consumed and utils.is_func_decorator(
+                current_consumer.node
+            ):
                 break
 
             found_node = current_consumer.get_next_to_consume(node)

--- a/tests/functional/u/undefined/undefined_variable.py
+++ b/tests/functional/u/undefined/undefined_variable.py
@@ -319,3 +319,12 @@ def decorated1(x):
 @decorator(x * x for x in range(3))
 def decorated2(x):
     print(x)
+
+@decorator(x)  # [undefined-variable]
+@decorator(x * x for x in range(3))
+def decorated3(x):
+    print(x)
+
+@decorator(x * x * y for x in range(3))  # [undefined-variable]
+def decorated4(x):
+    print(x)

--- a/tests/functional/u/undefined/undefined_variable.py
+++ b/tests/functional/u/undefined/undefined_variable.py
@@ -309,3 +309,13 @@ bigger = [
     ]
     for item in lst
 ]
+
+
+# 3791
+@decorator(x for x in range(3))
+def decorated1(x):
+    print(x)
+
+@decorator(x * x for x in range(3))
+def decorated2(x):
+    print(x)

--- a/tests/functional/u/undefined/undefined_variable.txt
+++ b/tests/functional/u/undefined/undefined_variable.txt
@@ -28,3 +28,5 @@ used-before-assignment:254:26:func_should_fail:Using variable 'datetime' before 
 undefined-variable:281:18:not_using_loop_variable_accordingly:Undefined variable 'iteree'
 undefined-variable:292:27:undefined_annotation:Undefined variable 'x'
 used-before-assignment:293:7:undefined_annotation:Using variable 'x' before assignment
+undefined-variable:323:11:decorated3:Undefined variable 'x'
+undefined-variable:328:19:decorated4:Undefined variable 'y'


### PR DESCRIPTION
## Steps

- [X] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [X] Write a good description on what the PR does.

## Description

This is a proposed fix for an issue where defining a function decorated with a list comprehension that shares argument name, and the argument is used twice in the list comprehension, it shows an undefined-variable error.

To put it in code:

```python3
def decorator(seq):
    return lambda f: f

@decorator(x * x for x in "123")
def func(x):
    pass
```

This wrongfully shows an `undefined-variable` error since version at least 2.7.

```python3
def decorator(seq):
    return lambda f: f

@decorator(x for x in "123")
def func(x):
   pass
```

This is rightfully OK on the current `main`.

This probably will need changes, but I am not familiar enough with the codebase to go better about it.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #3791