### PR TITLE
Omit no-member error if guarded behind if stmt

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,12 @@ Release date: TBA
 
   Close #4120
 
+* Don't emit ``no-member`` error if guarded behind if statement.
+
+  Ref #1162
+  Closes #1990
+  Closes #4168
+
 
 What's New in Pylint 2.9.6?
 ===========================

--- a/doc/whatsnew/2.10.rst
+++ b/doc/whatsnew/2.10.rst
@@ -24,5 +24,12 @@ Other Changes
 * Performance of the Similarity checker has been improved.
 
 * Added ``time.clock`` to deprecated functions/methods for python 3.3
+
 * Added ``ignored-parents`` option to the design checker to ignore specific
   classes from the ``too-many-ancestors`` check (R0901).
+
+* Don't emit ``no-member`` error if guarded behind if statement.
+
+  Ref #1162
+  Closes #1990
+  Closes #4168

--- a/tests/functional/n/no/no_member_if_statements.py
+++ b/tests/functional/n/no/no_member_if_statements.py
@@ -1,5 +1,6 @@
 # pylint: disable=invalid-name,missing-docstring,pointless-statement
 from datetime import datetime
+from typing import Union
 
 value = "Hello World"
 value.isoformat()  # [no-member]
@@ -26,10 +27,10 @@ res = value.isoformat() if isinstance(value, datetime) else value
 
 
 class Base:
-    _attr_state: str | float | datetime = "Unknown"
+    _attr_state: Union[str, datetime] = "Unknown"
 
     @property
-    def state(self) -> str | float | datetime:
+    def state(self) -> Union[str, datetime]:
         return self._attr_state
 
     def some_function(self) -> str:

--- a/tests/functional/n/no/no_member_if_statements.py
+++ b/tests/functional/n/no/no_member_if_statements.py
@@ -1,0 +1,78 @@
+# pylint: disable=invalid-name,missing-docstring,pointless-statement
+from datetime import datetime
+
+value = "Hello World"
+value.isoformat()  # [no-member]
+
+
+if isinstance(value, datetime):
+    value.isoformat()
+else:
+    value.isoformat()  # [no-member]
+
+
+def func():
+    if hasattr(value, "load"):
+        value.load()
+
+    if getattr(value, "load", None):
+        value.load
+
+
+if value.none_existent():  # [no-member]
+    pass
+
+res = value.isoformat() if isinstance(value, datetime) else value
+
+
+class Base:
+    _attr_state: str | float | datetime = "Unknown"
+
+    @property
+    def state(self) -> str | float | datetime:
+        return self._attr_state
+
+    def some_function(self) -> str:
+        state = self.state
+        if isinstance(state, datetime):
+            return state.isoformat()
+        return str(state)
+
+
+# https://github.com/PyCQA/pylint/issues/1990
+# Attribute access after 'isinstance' should not cause 'no-member' error
+import subprocess  # pylint: disable=wrong-import-position  # noqa: E402
+
+try:
+    subprocess.check_call(['ls', '-'])  # Deliberately made error in this line
+except Exception as err:
+    if isinstance(err, subprocess.CalledProcessError):
+        print(f'Subprocess error occured. Return code: {err.returncode}')
+    else:
+        print(f'An error occured: {str(err)}')
+    raise
+
+
+# https://github.com/PyCQA/pylint/issues/4168
+# 'encode' for 'arg' should not cause 'no-member' error
+mixed_tuple = (b"a", b"b", b"c", b"d")
+byte_tuple = [arg.encode('utf8') if isinstance(arg, str) else arg for arg in mixed_tuple]
+
+for arg in mixed_tuple:
+    if isinstance(arg, str):
+        print(arg.encode('utf8'))
+    else:
+        print(arg)
+
+
+# https://github.com/PyCQA/pylint/issues/1162
+# Attribute access after 'isinstance' should not cause 'no-member' error
+class FoobarException(Exception):
+    foobar = None
+
+try:  # noqa: E305
+    pass
+except Exception as ex:
+    if isinstance(ex, FoobarException):
+        ex.foobar
+    raise

--- a/tests/functional/n/no/no_member_if_statements.txt
+++ b/tests/functional/n/no/no_member_if_statements.txt
@@ -1,3 +1,3 @@
-no-member:5:0::Instance of 'str' has no 'isoformat' member:INFERENCE
-no-member:11:4::Instance of 'str' has no 'isoformat' member:INFERENCE
-no-member:22:3::Instance of 'str' has no 'none_existent' member:INFERENCE
+no-member:6:0::Instance of 'str' has no 'isoformat' member:INFERENCE
+no-member:12:4::Instance of 'str' has no 'isoformat' member:INFERENCE
+no-member:23:3::Instance of 'str' has no 'none_existent' member:INFERENCE

--- a/tests/functional/n/no/no_member_if_statements.txt
+++ b/tests/functional/n/no/no_member_if_statements.txt
@@ -1,0 +1,3 @@
+no-member:5:0::Instance of 'str' has no 'isoformat' member:INFERENCE
+no-member:11:4::Instance of 'str' has no 'isoformat' member:INFERENCE
+no-member:22:3::Instance of 'str' has no 'none_existent' member:INFERENCE


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Omit `no-member` errors if attribute / method access is guarded behind if statement.

This change doesn't implement `control-flow` logic. Instead I chose to check for an `IF` / `IFExp` node in the node parents and evaluate it. That doesn't solve all issue, especially not those with `assert` #4693, but I would never the less consider it an improvement.

As this is a larger change, I would like to target `2.10` for it.

### Example
```py
from datetime import datetime

value = "Hello World"
value.isoformat()  # [no-member]

if isinstance(value, datetime):
    value.isoformat()  # This is now fixed and doesn't emit 'no-member' anymore
```

--
Ref #1162 (not closed, but issue would be addressed)
Closes #1990
Closes #4168