### PR TITLE
Remove classes.dot after testing #4762

### DIFF
--- a/tests/test_pylint_runners.py
+++ b/tests/test_pylint_runners.py
@@ -9,12 +9,14 @@ from pylint import run_epylint, run_pylint, run_pyreverse, run_symilar
 
 
 @pytest.mark.parametrize(
-    "runner", [run_pylint, run_epylint, run_pyreverse, run_symilar]
+    "runner", [run_epylint, run_pylint, run_pyreverse, run_symilar]
 )
-def test_runner(runner):
+def test_runner(runner, tmpdir):
+    print(os.path.abspath(__file__))
     filepath = os.path.abspath(__file__)
     testargs = ["", filepath]
-    with patch.object(sys, "argv", testargs):
-        with pytest.raises(SystemExit) as err:
-            runner()
-        assert err.value.code == 0
+    with tmpdir.as_cwd():
+        with patch.object(sys, "argv", testargs):
+            with pytest.raises(SystemExit) as err:
+                runner()
+            assert err.value.code == 0


### PR DESCRIPTION

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This makes test_pylint_runners use a tmpdir for any output files.
As a result the classes.dot file created during testing will now be
removed after testing has finished.
This closes #4762


## Questions

Does this need a mention in the changelog? Does not seem relevant for end-users.