### PR TITLE
Extended `consider-using-tuple` check to cover `in` comparisons

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -36,6 +36,10 @@ Release date: TBA
 
   Closes #3878
 
+* ``CodeStyleChecker``
+
+  * Extended ``consider-using-tuple`` check to cover ``in`` comparisons.
+
 
 What's New in Pylint 2.9.6?
 ===========================

--- a/doc/whatsnew/2.10.rst
+++ b/doc/whatsnew/2.10.rst
@@ -17,6 +17,14 @@ New checkers
   Closes #3826
 
 
+Extensions
+==========
+
+* ``CodeStyleChecker``
+
+  * Extended ``consider-using-tuple`` check to cover ``in`` comparisons.
+
+
 Other Changes
 =============
 

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -981,7 +981,7 @@ a metaclass class method.",
                     (
                         # If assigned to cls.attrib, can be accessed by cls/self
                         assign_attr.expr.name == "cls"
-                        and attribute.expr.name in ["cls", "self"]
+                        and attribute.expr.name in ("cls", "self")
                     )
                     # If assigned to self.attrib, can only be accessed by self
                     # Or if __new__ was used, the returned object names are acceptable

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -156,7 +156,7 @@ def _in_iterating_context(node):
     elif (
         isinstance(parent, astroid.Compare)
         and len(parent.ops) == 1
-        and parent.ops[0][0] in ["in", "not in"]
+        and parent.ops[0][0] in ("in", "not in")
     ):
         return True
     # Also if it's an `yield from`, that's fair

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -943,7 +943,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                 # remove square brackets '[]'
                 inside_comp = node.args[0].as_string()[1:-1]
                 call_name = node.func.name
-                if call_name in ["any", "all"]:
+                if call_name in ("any", "all"):
                     self.add_message(
                         "use-a-generator",
                         node=node,

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -558,7 +558,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
             isinstance(infer, astroid.BoundMethod)
             and node.args
             and isinstance(node.args[0], astroid.Const)
-            and infer.name in ["assertTrue", "assertFalse"]
+            and infer.name in ("assertTrue", "assertFalse")
         ):
             self.add_message(
                 "redundant-unittest-assert",

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -518,7 +518,7 @@ def _emit_no_member(node, owner, owner_name, ignored_mixins=True, ignored_none=T
         and isinstance(owner.parent, astroid.ClassDef)
         and owner.parent.name == "EnumMeta"
         and owner_name == "__members__"
-        and node.attrname in ["items", "values", "keys"]
+        and node.attrname in ("items", "values", "keys")
     ):
         # Avoid false positive on Enum.__members__.{items(), values, keys}
         # See https://github.com/PyCQA/pylint/issues/4123
@@ -1781,7 +1781,7 @@ accessed. Python regular expressions are accepted.",
             return
 
         op, right = node.ops[0]
-        if op in ["in", "not in"]:
+        if op in ("in", "not in"):
             self._check_membership_test(right)
 
     @check_messages(

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -717,7 +717,7 @@ class PyLinter(
     def disable_noerror_messages(self):
         for msgcat, msgids in self.msgs_store._msgs_by_category.items():
             # enable only messages with 'error' severity and above ('fatal')
-            if msgcat in ["E", "F"]:
+            if msgcat in ("E", "F"):
                 for msgid in msgids:
                     self.enable(msgid)
             else:

--- a/script/bump_changelog.py
+++ b/script/bump_changelog.py
@@ -136,7 +136,7 @@ def do_checks(content, next_version, version, version_type):
     wn_next_version = get_whats_new(next_version)
     wn_this_version = get_whats_new(version)
     # There is only one field where the release date is TBA
-    if version_type in [VersionType.MAJOR, VersionType.MINOR]:
+    if version_type in (VersionType.MAJOR, VersionType.MINOR):
         assert (
             content.count(RELEASE_DATE_TEXT) <= 1
         ), f"There should be only one release date 'TBA' ({version}) {err}"

--- a/tests/functional/ext/code_style/code_style_consider_using_tuple.py
+++ b/tests/functional/ext/code_style/code_style_consider_using_tuple.py
@@ -27,3 +27,30 @@ for x in [2, *var]:
 
 [x for x in [*var, 2]]
 [x for x in {*var, 2}]
+
+
+# -----
+# Suggest tuple for `in` comparisons
+x in var
+x in (1, 2, 3)
+x in [1, 2, 3]  # [consider-using-tuple]
+
+if x in var:
+    pass
+if x in (1, 2, 3):
+    pass
+if x in [1, 2, 3]:  # [consider-using-tuple]
+    pass
+if x in {1, 2, 3}:  # [consider-using-tuple]
+    pass
+
+42 if x in [1, 2, 3] else None  # [consider-using-tuple]
+assert x in [1, 2, 3]  # [consider-using-tuple]
+(x for x in var if x in [1, 2, 3])  # [consider-using-tuple]
+while x in [1, 2, 3]:  # [consider-using-tuple]
+    break
+
+# Stacked operators, rightmost pair is evaluated first
+# Doesn't make much sense in practice since `in` will only return `bool`
+True == x in [1, 2, 3]  # [consider-using-tuple]  # noqa: E712
+1 >= x in [1, 2, 3]  # [consider-using-tuple]  # noqa: E712

--- a/tests/functional/ext/code_style/code_style_consider_using_tuple.txt
+++ b/tests/functional/ext/code_style/code_style_consider_using_tuple.txt
@@ -1,4 +1,13 @@
-consider-using-tuple:9:9::Consider using an in-place tuple instead of list
-consider-using-tuple:14:12::Consider using an in-place tuple instead of list
-consider-using-tuple:15:12::Consider using an in-place tuple instead of set
-consider-using-tuple:19:12::Consider using an in-place tuple instead of list
+consider-using-tuple:9:9::Consider using an in-place tuple instead of list:HIGH
+consider-using-tuple:14:12::Consider using an in-place tuple instead of list:HIGH
+consider-using-tuple:15:12::Consider using an in-place tuple instead of set:HIGH
+consider-using-tuple:19:12::Consider using an in-place tuple instead of list:HIGH
+consider-using-tuple:36:5::Consider using an in-place tuple instead of list:HIGH
+consider-using-tuple:42:8::Consider using an in-place tuple instead of list:HIGH
+consider-using-tuple:44:8::Consider using an in-place tuple instead of set:HIGH
+consider-using-tuple:47:11::Consider using an in-place tuple instead of list:HIGH
+consider-using-tuple:48:12::Consider using an in-place tuple instead of list:HIGH
+consider-using-tuple:49:24::Consider using an in-place tuple instead of list:HIGH
+consider-using-tuple:50:11::Consider using an in-place tuple instead of list:HIGH
+consider-using-tuple:55:13::Consider using an in-place tuple instead of list:HIGH
+consider-using-tuple:56:10::Consider using an in-place tuple instead of list:HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description
Extend `consider-using-tuple` check from the `CodeStyleChecker` extension to recognize lists / sets in `in` comparisons.

**Some examples**
```py
x in [1, 2, 3]  # [consider-using-tuple]

if x in [1, 2, 3]:  # [consider-using-tuple]
    pass

assert x in {1, 2, 3}  # [consider-using-tuple]
```

Previously the check was only used inside `For` looks and `Comprehensions`.