### PR TITLE
Fix IsADirectoryError in tests/lint/unittest_lint

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -527,3 +527,5 @@ contributors:
 * Eisuke Kawashima (e-kwsm): contributor
 
 * Daniel van Noord (DanielNoord): contributor
+
+* Michal Vasilek: contributor

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -643,7 +643,7 @@ def test_pylint_home():
             assert config.PYLINT_HOME == pylintd
         finally:
             try:
-                os.remove(pylintd)
+                rmtree(pylintd)
             except FileNotFoundError:
                 pass
     finally:


### PR DESCRIPTION
pylintd is a directory, so os.remove throws IsADirectoryError

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
-->

Do I have to add myself CONTRIBUTORS for a small change like this? Should I add the fix to the changelog?

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #4780
