### PR TITLE
Fix false-positive of `unused-private-member` with class name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -60,6 +60,10 @@ Release date: TBA
 
   Closes #4673
 
+* Fix a false positive for ``unused-private-member`` with class names
+
+  Closes #4681
+
 
 What's New in Pylint 2.9.6?
 ===========================

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -992,6 +992,7 @@ a metaclass class method.",
                 )
 
             for attribute in node.nodes_of_class(astroid.Attribute):
+                # pylint: disable=too-many-boolean-expressions
                 if attribute.attrname == assign_attr.attrname and (
                     (
                         # If assigned to cls.attrib, can be accessed by cls/self
@@ -1004,6 +1005,7 @@ a metaclass class method.",
                         assign_attr.expr.name in acceptable_obj_names
                         and attribute.expr.name == "self"
                     )
+                    or (assign_attr.expr.name == attribute.expr.name == node.name)
                 ):
                     break
             else:

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -974,6 +974,7 @@ a metaclass class method.",
 
     def _check_unused_private_attributes(self, node: astroid.ClassDef) -> None:
         for assign_attr in node.nodes_of_class(astroid.AssignAttr):
+            assign_attr = cast(astroid.AssignAttr, assign_attr)
             if not is_attr_private(assign_attr.attrname):
                 continue
 
@@ -992,22 +993,29 @@ a metaclass class method.",
                 )
 
             for attribute in node.nodes_of_class(astroid.Attribute):
-                # pylint: disable=too-many-boolean-expressions
-                if attribute.attrname == assign_attr.attrname and (
-                    (
-                        # If assigned to cls.attrib, can be accessed by cls/self
-                        assign_attr.expr.name == "cls"
-                        and attribute.expr.name in ("cls", "self")
-                    )
+                attribute = cast(astroid.Attribute, attribute)
+                if attribute.attrname != assign_attr.attrname:
+                    continue
+
+                if assign_attr.expr.name == "cls" and attribute.expr.name in (
+                    "cls",
+                    "self",
+                ):
+                    # If assigned to cls.attrib, can be accessed by cls/self
+                    break
+
+                if (
+                    assign_attr.expr.name in acceptable_obj_names
+                    and attribute.expr.name == "self"
+                ):
                     # If assigned to self.attrib, can only be accessed by self
                     # Or if __new__ was used, the returned object names are acceptable
-                    or (
-                        assign_attr.expr.name in acceptable_obj_names
-                        and attribute.expr.name == "self"
-                    )
-                    or (assign_attr.expr.name == attribute.expr.name == node.name)
-                ):
                     break
+
+                if assign_attr.expr.name == attribute.expr.name == node.name:
+                    # Recognise attributes which are accessed via the class name
+                    break
+
             else:
                 args = (node.name, assign_attr.attrname)
                 self.add_message("unused-private-member", node=assign_attr, args=args)

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -203,11 +203,12 @@ class FalsePositive4673:
         return fn_to_return
 
 
-# Test cases for false-positive reported in #4681
 # https://github.com/PyCQA/pylint/issues/4681
+# Accessing attributes of the class using the class name should not result in a false positive
+# as long as it is used within the class
 class FalsePositive4681:
     __instance = None
-
+    __should_cause_error = None  # [unused-private-member]
     @staticmethod
     def instance():
         if FalsePositive4681.__instance is None:
@@ -217,6 +218,8 @@ class FalsePositive4681:
     def __init__(self):
         try:
             FalsePositive4681.__instance = 42  # This should be fine
+            FalsePositive4681.__should_cause_error = True  # [unused-private-member]
         except Exception:  # pylint: disable=broad-except
             print("Error")
             FalsePositive4681.__instance = False  # This should be fine
+            FalsePositive4681.__should_cause_error = False  # [unused-private-member]

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -201,3 +201,22 @@ class FalsePositive4673:
 
         fn_to_return = __inner_1 if flag else __inner_3(__inner_2)
         return fn_to_return
+
+
+# Test cases for false-positive reported in #4681
+# https://github.com/PyCQA/pylint/issues/4681
+class FalsePositive4681:
+    __instance = None
+
+    @staticmethod
+    def instance():
+        if FalsePositive4681.__instance is None:
+            FalsePositive4681()
+        return FalsePositive4681.__instance
+
+    def __init__(self):
+        try:
+            FalsePositive4681.__instance = 42  # This should be fine
+        except Exception:  # pylint: disable=broad-except
+            print("Error")
+            FalsePositive4681.__instance = False  # This should be fine

--- a/tests/functional/u/unused/unused_private_member.txt
+++ b/tests/functional/u/unused/unused_private_member.txt
@@ -9,3 +9,6 @@ unused-private-member:132:8:FalsePositive4657.__init__:Unused private member `Fa
 undefined-variable:137:15:FalsePositive4657.attr_c:Undefined variable 'cls':HIGH
 unused-private-member:179:8:FalsePositive4673.do_thing.__true_positive:Unused private member `FalsePositive4673.do_thing.__true_positive(in_thing)`:HIGH
 unused-private-member:199:8:FalsePositive4673.complicated_example.__inner_4:Unused private member `FalsePositive4673.complicated_example.__inner_4()`:HIGH
+unused-private-member:211:4:FalsePositive4681:Unused private member `FalsePositive4681.__should_cause_error`:HIGH
+unused-private-member:221:12:FalsePositive4681.__init__:Unused private member `FalsePositive4681.__should_cause_error`:HIGH
+unused-private-member:225:12:FalsePositive4681.__init__:Unused private member `FalsePositive4681.__should_cause_error`:HIGH


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Simple fix to avoid false-positive to check for private attributes and do not emit if it was called with the Class's name.

Done by using a boolean condition and comparing it to the node's (classdef) name


Also, added a pylint ignore as more boolean expressions are needed here

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #4681 
