### PR TITLE
Fix crash for `unused-private-member` when there are nested attributes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -60,6 +60,10 @@ Release date: TBA
 
   Closes #4673
 
+* Fix crash for ``unused-private-member`` that occurs when there is a presence of nested attributes
+
+  Closes #4755
+
 
 What's New in Pylint 2.9.6?
 ===========================

--- a/ChangeLog
+++ b/ChangeLog
@@ -60,7 +60,7 @@ Release date: TBA
 
   Closes #4673
 
-* Fix crash for ``unused-private-member`` that occurs when there is a presence of nested attributes
+* Fix crash for ``unused-private-member`` that occurred with nested attributes.
 
   Closes #4755
 

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -978,6 +978,7 @@ a metaclass class method.",
                 assign_attr.expr, astroid.Name
             ):
                 continue
+
             # Logic for checking false positive when using __new__,
             # Get the returned object names of the __new__ magic function
             # Then check if the attribute was consumed in other instance methods

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -974,9 +974,10 @@ a metaclass class method.",
 
     def _check_unused_private_attributes(self, node: astroid.ClassDef) -> None:
         for assign_attr in node.nodes_of_class(astroid.AssignAttr):
-            if not is_attr_private(assign_attr.attrname):
+            if not is_attr_private(assign_attr.attrname) or not isinstance(
+                assign_attr.expr, astroid.Name
+            ):
                 continue
-
             # Logic for checking false positive when using __new__,
             # Get the returned object names of the __new__ magic function
             # Then check if the attribute was consumed in other instance methods

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -220,7 +220,7 @@ class Crash4755Command:
         for message in self.context.__messages:
             print(message)
 
-            
+
 # https://github.com/PyCQA/pylint/issues/4681
 # Accessing attributes of the class using the class name should not result in a false positive
 # as long as it is used within the class

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -104,7 +104,8 @@ k = Klass()
 print(k.twentyone)
 print(k.ninetyfive)
 
-
+# https://github.com/PyCQA/pylint/issues/4657
+# Mutation of class member with cls should not fire a false-positive
 class FalsePositive4657:
     """False positivie tests for 4657"""
     __attr_a = None
@@ -137,8 +138,8 @@ class FalsePositive4657:
         return cls.__attr_c  # [undefined-variable]
 
 
-# Test cases for false-positive reported in #4668
 # https://github.com/PyCQA/pylint/issues/4668
+# Attributes assigned within __new__() has to be processed as part of the class
 class FalsePositive4668:
     # pylint: disable=protected-access, no-member, unreachable
 
@@ -153,6 +154,7 @@ class FalsePositive4668:
         false_obj.func = func
         false_obj.__args = args  # Do not emit message here
         false_obj.__secret_bool = False
+        false_obj.__unused = None  # [unused-private-member]
         return false_obj
         # unreachable but non-Name return value
         return 3+4
@@ -162,8 +164,8 @@ class FalsePositive4668:
         return self.func(*self.__args)
 
 
-# Test cases for false-positive reported in #4673
 # https://github.com/PyCQA/pylint/issues/4673
+# Nested functions shouldn't cause a false positive if they are properly used
 class FalsePositive4673:
     """ The testing class """
 
@@ -203,8 +205,8 @@ class FalsePositive4673:
         return fn_to_return
 
 
-# Test cases for crash reported in #4755
 # https://github.com/PyCQA/pylint/issues/4755
+# Nested attributes shouldn't cause crash
 class Crash4755Context:
     def __init__(self):
         self.__messages = None  # [unused-private-member]

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -104,6 +104,7 @@ k = Klass()
 print(k.twentyone)
 print(k.ninetyfive)
 
+
 # https://github.com/PyCQA/pylint/issues/4657
 # Mutation of class member with cls should not fire a false-positive
 class FalsePositive4657:

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -104,7 +104,6 @@ k = Klass()
 print(k.twentyone)
 print(k.ninetyfive)
 
-
 # https://github.com/PyCQA/pylint/issues/4657
 # Mutation of class member with cls should not fire a false-positive
 class FalsePositive4657:

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -201,3 +201,19 @@ class FalsePositive4673:
 
         fn_to_return = __inner_1 if flag else __inner_3(__inner_2)
         return fn_to_return
+
+
+# Test cases for crash reported in #4755
+# https://github.com/PyCQA/pylint/issues/4755
+class Crash4755Context:
+    def __init__(self):
+        self.__messages = None  # [unused-private-member]
+
+class Crash4755Command:
+    def __init__(self):
+        self.context = Crash4755Context()
+
+    def method(self):
+        self.context.__messages = []
+        for message in self.context.__messages:
+            print(message)

--- a/tests/functional/u/unused/unused_private_member.txt
+++ b/tests/functional/u/unused/unused_private_member.txt
@@ -11,10 +11,6 @@ unused-private-member:157:8:FalsePositive4668.__new__:Unused private member `Fal
 unused-private-member:181:8:FalsePositive4673.do_thing.__true_positive:Unused private member `FalsePositive4673.do_thing.__true_positive(in_thing)`:HIGH
 unused-private-member:201:8:FalsePositive4673.complicated_example.__inner_4:Unused private member `FalsePositive4673.complicated_example.__inner_4()`:HIGH
 unused-private-member:212:8:Crash4755Context.__init__:Unused private member `Crash4755Context.__messages`:HIGH
-unused-private-member:132:8:FalsePositive4657.__init__:Unused private member `FalsePositive4657.__attr_c`:HIGH
-undefined-variable:137:15:FalsePositive4657.attr_c:Undefined variable 'cls':HIGH
-unused-private-member:179:8:FalsePositive4673.do_thing.__true_positive:Unused private member `FalsePositive4673.do_thing.__true_positive(in_thing)`:HIGH
-unused-private-member:199:8:FalsePositive4673.complicated_example.__inner_4:Unused private member `FalsePositive4673.complicated_example.__inner_4()`:HIGH
-unused-private-member:211:4:FalsePositive4681:Unused private member `FalsePositive4681.__should_cause_error`:HIGH
-unused-private-member:221:12:FalsePositive4681.__init__:Unused private member `FalsePositive4681.__should_cause_error`:HIGH
-unused-private-member:225:12:FalsePositive4681.__init__:Unused private member `FalsePositive4681.__should_cause_error`:HIGH
+unused-private-member:229:4:FalsePositive4681:Unused private member `FalsePositive4681.__should_cause_error`:HIGH
+unused-private-member:239:12:FalsePositive4681.__init__:Unused private member `FalsePositive4681.__should_cause_error`:HIGH
+unused-private-member:243:12:FalsePositive4681.__init__:Unused private member `FalsePositive4681.__should_cause_error`:HIGH

--- a/tests/functional/u/unused/unused_private_member.txt
+++ b/tests/functional/u/unused/unused_private_member.txt
@@ -9,3 +9,4 @@ unused-private-member:132:8:FalsePositive4657.__init__:Unused private member `Fa
 undefined-variable:137:15:FalsePositive4657.attr_c:Undefined variable 'cls':HIGH
 unused-private-member:179:8:FalsePositive4673.do_thing.__true_positive:Unused private member `FalsePositive4673.do_thing.__true_positive(in_thing)`:HIGH
 unused-private-member:199:8:FalsePositive4673.complicated_example.__inner_4:Unused private member `FalsePositive4673.complicated_example.__inner_4()`:HIGH
+unused-private-member:210:8:Crash4755Context.__init__:Unused private member `Crash4755Context.__messages`:HIGH

--- a/tests/functional/u/unused/unused_private_member.txt
+++ b/tests/functional/u/unused/unused_private_member.txt
@@ -5,8 +5,9 @@ unused-private-member:20:4:HasUnusedInClass.__private_static_method_unused:Unuse
 unused-private-member:28:8:HasUnusedInClass.__init__:Unused private member `HasUnusedInClass.__instance_secret`:HIGH
 unused-private-member:34:4:HasUnusedInClass.__test:Unused private member `HasUnusedInClass.__test(self, x, y, z)`:HIGH
 unused-private-member:55:4:HasUnusedInClass.__test_recursive:Unused private member `HasUnusedInClass.__test_recursive(self)`:HIGH
-unused-private-member:132:8:FalsePositive4657.__init__:Unused private member `FalsePositive4657.__attr_c`:HIGH
-undefined-variable:137:15:FalsePositive4657.attr_c:Undefined variable 'cls':HIGH
-unused-private-member:179:8:FalsePositive4673.do_thing.__true_positive:Unused private member `FalsePositive4673.do_thing.__true_positive(in_thing)`:HIGH
-unused-private-member:199:8:FalsePositive4673.complicated_example.__inner_4:Unused private member `FalsePositive4673.complicated_example.__inner_4()`:HIGH
-unused-private-member:210:8:Crash4755Context.__init__:Unused private member `Crash4755Context.__messages`:HIGH
+unused-private-member:133:8:FalsePositive4657.__init__:Unused private member `FalsePositive4657.__attr_c`:HIGH
+undefined-variable:138:15:FalsePositive4657.attr_c:Undefined variable 'cls':HIGH
+unused-private-member:157:8:FalsePositive4668.__new__:Unused private member `FalsePositive4668.__unused`:HIGH
+unused-private-member:181:8:FalsePositive4673.do_thing.__true_positive:Unused private member `FalsePositive4673.do_thing.__true_positive(in_thing)`:HIGH
+unused-private-member:201:8:FalsePositive4673.complicated_example.__inner_4:Unused private member `FalsePositive4673.complicated_example.__inner_4()`:HIGH
+unused-private-member:212:8:Crash4755Context.__init__:Unused private member `Crash4755Context.__messages`:HIGH


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :page_facing_up:  Documentation          |

## Description
Added logic to prevent checking attributes of attributes, and only check for the first level of attributes.

Closes #4755 
