### PR TITLE
Add ``possible-f-string-as-string`` checker

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -68,6 +68,10 @@ Release date: TBA
 
   Closes #4681
 
+* Added ``possible-f-string-as-string``: Emitted when variables are used in normal strings in between "{}"
+
+  Closes #2507
+
 
 What's New in Pylint 2.9.6?
 ===========================

--- a/doc/whatsnew/2.10.rst
+++ b/doc/whatsnew/2.10.rst
@@ -28,6 +28,10 @@ New checkers
 
   Closes #3692
 
+* Added ``possible-f-string-as-string``: Emitted when variables are used in normal strings in between "{}"
+
+  Closes #2507
+
 
 Extensions
 ==========

--- a/tests/functional/p/possible_f_string_as_string.py
+++ b/tests/functional/p/possible_f_string_as_string.py
@@ -1,0 +1,12 @@
+# pylint: disable=missing-module-docstring, invalid-name
+var = "string"
+var_two = "extra string"
+
+x = f"This is a {var} which should be a f-string"
+x = "This is a {var} used twice, see {var}"
+x = "This is a {var} which should be a f-string"  # [possible-f-string-as-string]
+x = "This is a {var} and {var_two} which should be a f-string"  # [possible-f-string-as-string]
+x1, x2, x3 = (1, 2, "This is a {var} which should be a f-string")  # [possible-f-string-as-string]
+
+y = "This is a {var} used for formatting later"
+z = y.format(var="string")

--- a/tests/functional/p/possible_f_string_as_string.txt
+++ b/tests/functional/p/possible_f_string_as_string.txt
@@ -1,0 +1,3 @@
+possible-f-string-as-string:7:4::Using an string which should probably be a f-string:HIGH
+possible-f-string-as-string:8:4::Using an string which should probably be a f-string:HIGH
+possible-f-string-as-string:9:20::Using an string which should probably be a f-string:HIGH


### PR DESCRIPTION
To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

This checks if text in strings in between `{}`'s are variables.
The var the string is assigned to is also checked for a format() call.
If this does not happen, the string should probably be a f-string and a message is emitted.
This closes #2507

## Reason for this PR being a draft

Ideally I would also add a check for the following code:
```python
x = "This is a calculation {1 + 1}" # bad

x = f"This is a calculation {1 + 1}" # good
```
Can we check that  `1 + 1` is a calculation without calling `eval`?

