### PR TITLE
Refactor ``--list-msgs`` & ``--list-msgs-enabled``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -75,6 +75,10 @@ Release date: TBA
   Closes #3608
   Closes #4346
 
+* Refactor of ``--list-msgs`` & ``--list-msgs-enabled``: both options now show whether messages are emittable with the current interpreter.
+
+  Closes #4778
+
 
 What's New in Pylint 2.9.6?
 ===========================

--- a/doc/whatsnew/2.10.rst
+++ b/doc/whatsnew/2.10.rst
@@ -61,3 +61,7 @@ Other Changes
   Closes #3249
   Closes #3608
   Closes #4346
+
+* Refactor of ``--list-msgs`` & ``--list-msgs-enabled``: both options now show whether messages are emittable with the current interpreter.
+
+  Closes #4778

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -775,25 +775,23 @@ class PyLinter(
         self._python3_porting_mode = True
 
     def list_messages_enabled(self):
+        emittable, non_emittable = self.msgs_store.find_emittable_messages()
         enabled = []
         disabled = []
-        non_emittable = []
-        for message in self.msgs_store.messages:
-            if not message.may_be_emitted():
-                non_emittable.append(f"  {message.symbol} ({message.msgid})")
-            elif self.is_message_enabled(message.msgid):
+        for message in emittable:
+            if self.is_message_enabled(message.msgid):
                 enabled.append(f"  {message.symbol} ({message.msgid})")
             else:
                 disabled.append(f"  {message.symbol} ({message.msgid})")
         print("Enabled messages:")
-        for msg in sorted(enabled):
+        for msg in enabled:
             print(msg)
         print("\nDisabled messages:")
-        for msg in sorted(disabled):
+        for msg in disabled:
             print(msg)
         print("\nNon-emittable messages with current interpreter:")
-        for msg in sorted(non_emittable):
-            print(msg)
+        for msg in non_emittable:
+            print(f"  {msg.symbol} ({msg.msgid})")
         print("")
 
     # block level option handling #############################################

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -775,21 +775,24 @@ class PyLinter(
         self._python3_porting_mode = True
 
     def list_messages_enabled(self):
-        enabled = [
-            f"  {message.symbol} ({message.msgid})"
-            for message in self.msgs_store.messages
-            if self.is_message_enabled(message.msgid)
-        ]
-        disabled = [
-            f"  {message.symbol} ({message.msgid})"
-            for message in self.msgs_store.messages
-            if not self.is_message_enabled(message.msgid)
-        ]
+        enabled = []
+        disabled = []
+        non_emittable = []
+        for message in self.msgs_store.messages:
+            if not message.may_be_emitted():
+                non_emittable.append(f"  {message.symbol} ({message.msgid})")
+            elif self.is_message_enabled(message.msgid):
+                enabled.append(f"  {message.symbol} ({message.msgid})")
+            else:
+                disabled.append(f"  {message.symbol} ({message.msgid})")
         print("Enabled messages:")
         for msg in sorted(enabled):
             print(msg)
         print("\nDisabled messages:")
         for msg in sorted(disabled):
+            print(msg)
+        print("\nNon-emittable messages with current interpreter:")
+        for msg in sorted(non_emittable):
             print(msg)
         print("")
 

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -156,7 +156,8 @@ group are mutually exclusive.",
                         "callback": self.cb_list_messages,
                         "group": "Commands",
                         "level": 1,
-                        "help": "Generate pylint's messages.",
+                        "help": "Display a list of all pylint's messages divided by whether "
+                        "they are emittable with the given interpreter.",
                     },
                 ),
                 (
@@ -167,8 +168,8 @@ group are mutually exclusive.",
                         "callback": self.cb_list_messages_enabled,
                         "group": "Commands",
                         "level": 1,
-                        "help": "Display a list of what messages are enabled "
-                        "and disabled with the given configuration.",
+                        "help": "Display a list of what messages are enabled, "
+                        "disabled and non-emittable with the given configuration.",
                     },
                 ),
                 (

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import collections
-from typing import Dict, List, ValuesView
+from typing import Dict, List, Tuple, ValuesView
 
 from pylint.exceptions import UnknownMessageError
 from pylint.message.message_definition import MessageDefinition
@@ -73,18 +73,25 @@ class MessageDefinitionStore:
 
     def list_messages(self) -> None:
         """Output full messages list documentation in ReST format."""
+        emittable, non_emittable = self.find_emittable_messages()
+        print("Emittable messages with current interpreter:")
+        for msg in emittable:
+            print(msg.format_help(checkerref=False))
+        print("\nNon-emittable messages with current interpreter:")
+        for msg in non_emittable:
+            print(msg.format_help(checkerref=False))
+        print("")
+
+    def find_emittable_messages(
+        self,
+    ) -> Tuple[List[MessageDefinition], List[MessageDefinition]]:
+        """Finds all emittable and non-emittable messages"""
         messages = sorted(self._messages_definitions.values(), key=lambda m: m.msgid)
         emittable = []
         non_emittable = []
         for message in messages:
             if message.may_be_emitted():
-                emittable.append(message.format_help(checkerref=False))
+                emittable.append(message)
             else:
-                non_emittable.append(message.format_help(checkerref=False))
-        print("Emittable messages with current interpreter:")
-        for msg in emittable:
-            print(msg)
-        print("\nNon-emittable messages with current interpreter:")
-        for msg in non_emittable:
-            print(msg)
-        print("")
+                non_emittable.append(message)
+        return emittable, non_emittable

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -74,8 +74,17 @@ class MessageDefinitionStore:
     def list_messages(self) -> None:
         """Output full messages list documentation in ReST format."""
         messages = sorted(self._messages_definitions.values(), key=lambda m: m.msgid)
+        emittable = []
+        non_emittable = []
         for message in messages:
-            if not message.may_be_emitted():
-                continue
-            print(message.format_help(checkerref=False))
+            if message.may_be_emitted():
+                emittable.append(message.format_help(checkerref=False))
+            else:
+                non_emittable.append(message.format_help(checkerref=False))
+        print("Emittable messages with current interpreter:")
+        for msg in emittable:
+            print(msg)
+        print("\nNon-emittable messages with current interpreter:")
+        for msg in non_emittable:
+            print(msg)
         print("")


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

Both options now show which messages can't be emitted with the current interpreter. This makes function more like their name implies. Code clearly shows in which order/format the messages are emitted.
This closes #4778