### PR TITLE
Permit to lint to the end in case of crash on a file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ Release date: TBA
 ..
   Put bug fixes that should not wait for a new minor version here
 
+* pylint does not crash with a traceback anymore when a file is problematic. It
+  creates a template text file for opening an issue on the bug tracker instead.
+  The linting can go on for other non problematic files instead of being impossible.
+
 * pyreverse: Show class has-a relationships inferred from the type-hint
 
   Closes #4744

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -153,7 +153,8 @@ needed a bit more info.  We can see the second line is: ::
 
   "simplecaesar.py:1:0: C0114: Missing module docstring (missing-module-docstring)"
 
-This basically means that line 1 violates a convention ``C0114``.  It's telling me I really should have a docstring.  I agree, but what if I didn't fully understand what rule I violated.  Knowing only that I violated a convention
+This basically means that line 1 violates a convention ``C0114``.  It's telling me I really should have a docstring.
+I agree, but what if I didn't fully understand what rule I violated.  Knowing only that I violated a convention
 isn't much help if I'm a newbie. Another piece of information there is the
 message symbol between parens, ``missing-module-docstring`` here.
 

--- a/doc/whatsnew/2.10.rst
+++ b/doc/whatsnew/2.10.rst
@@ -40,6 +40,10 @@ Extensions
 Other Changes
 =============
 
+* pylint does not crash with a traceback anymore when a file is problematic. It
+  creates a template text file for opening an issue on the bug tracker instead.
+  The linting can go on for other non problematic files instead of being impossible.
+
 * Pyreverse - Show class has-a relationships inferred from type-hints
 
 * Performance of the Similarity checker has been improved.

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -3,6 +3,7 @@
 
 import collections
 import contextlib
+import datetime
 import functools
 import operator
 import os
@@ -11,8 +12,10 @@ import tokenize
 import traceback
 import warnings
 from io import TextIOWrapper
+from pathlib import Path
 
 import astroid
+from astroid import AstroidError
 
 from pylint import checkers, config, exceptions, interfaces, reporters
 from pylint.constants import MAIN_CHECKER_NAME, MSG_TYPES
@@ -1003,6 +1006,51 @@ class PyLinter(
                 self.get_ast, check_astroid_module, name, filepath, modname
             )
 
+    @staticmethod
+    def _prepare_crash_report(ex: Exception, filepath: str) -> str:
+        now = datetime.datetime.now().strftime("%Y-%m-%d-%H")
+        issue_template_path = Path(f"pylint-crash-{now}.txt")
+        with open(filepath, encoding="utf8") as f:
+            file_content = f.read()
+        template = ""
+        if not issue_template_path.exists():
+            template = """\
+First, please verify that the bug is not already filled:
+https://github.com/PyCQA/pylint/issues/
+
+Then create a new crash issue:
+https://github.com/PyCQA/pylint/issues/new?assignees=&labels=crash%2Cneeds+triage&template=BUG-REPORT.yml
+
+"""
+        template += f"""\
+
+Issue title:
+Crash ``{ex}`` (if possible, be more specific about what made pylint crash)
+Content:
+When parsing the following file:
+
+<!--
+ If sharing the code is not an option, please state so,
+ but providing only the stacktrace would still be helpful.
+ -->
+
+```python
+{file_content}
+```
+
+pylint crashed with a {ex.__class__.__name__} with the following stacktrace:
+```
+"""
+        with open(issue_template_path, "a", encoding="utf8") as f:
+            f.write(template)
+            traceback.print_exc(file=f)
+            f.write("\n```\n")
+        return (
+            f"Fatal error while checking '{filepath}'. "
+            f"Please open an issue in our bug tracker so we address this. "
+            f"There is a pre-filled template that you can use in '{issue_template_path}'."
+        )
+
     def _check_files(self, get_ast, file_descrs):
         """Check all files from file_descrs
 
@@ -1014,7 +1062,19 @@ class PyLinter(
         """
         with self._astroid_module_checker() as check_astroid_module:
             for name, filepath, modname in file_descrs:
-                self._check_file(get_ast, check_astroid_module, name, filepath, modname)
+                try:
+                    self._check_file(
+                        get_ast, check_astroid_module, name, filepath, modname
+                    )
+                except AstroidError as ex:
+                    self.add_message(
+                        "astroid-error",
+                        args=(filepath, self._prepare_crash_report(ex, filepath)),
+                    )
+                except Exception as ex:  # pylint: disable=broad-except
+                    self.add_message(
+                        "fatal", args=self._prepare_crash_report(ex, filepath)
+                    )
 
     def _check_file(self, get_ast, check_astroid_module, name, filepath, modname):
         """Check a file using the passed utility functions (get_ast and check_astroid_module)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -11,6 +11,8 @@ import tokenize
 import traceback
 import warnings
 from io import TextIOWrapper
+from pathlib import Path
+from typing import Union
 
 import astroid
 from astroid import AstroidError
@@ -170,6 +172,7 @@ class PyLinter(
     priority = 0
     level = 0
     msgs = MSGS
+    crash_file_prefix: Union[str, Path] = "pylint-crash-"
 
     @staticmethod
     def make_options():
@@ -965,7 +968,6 @@ class PyLinter(
 
         files_or_modules is either a string or list of strings presenting modules to check.
         """
-
         self.initialize()
 
         if not isinstance(files_or_modules, (list, tuple)):
@@ -1027,7 +1029,7 @@ class PyLinter(
                 except Exception as ex:  # pylint: disable=broad-except
                     error = ex
                     template_path = prepare_crash_report(
-                        error, filepath, "pylint-crash-"
+                        error, filepath, self.crash_file_prefix
                     )
                 if error is not None:
                     msg = get_fatal_error_message(filepath, template_path)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -11,8 +11,6 @@ import tokenize
 import traceback
 import warnings
 from io import TextIOWrapper
-from pathlib import Path
-from typing import Union
 
 import astroid
 from astroid import AstroidError
@@ -172,7 +170,8 @@ class PyLinter(
     priority = 0
     level = 0
     msgs = MSGS
-    crash_file_prefix: Union[str, Path] = "pylint-crash-"
+    # Will be used like this : datetime.now().strftime(crash_file_path)
+    crash_file_path: str = "pylint-crash-%Y-%m-%d-%H.txt"
 
     @staticmethod
     def make_options():
@@ -1029,7 +1028,7 @@ class PyLinter(
                 except Exception as ex:  # pylint: disable=broad-except
                     error = ex
                     template_path = prepare_crash_report(
-                        error, filepath, self.crash_file_prefix
+                        error, filepath, self.crash_file_path
                     )
                 if error is not None:
                     msg = get_fatal_error_message(filepath, template_path)

--- a/pylint/lint/utils.py
+++ b/pylint/lint/utils.py
@@ -6,6 +6,7 @@ import sys
 import traceback
 from datetime import datetime
 from pathlib import Path
+from typing import Union
 
 from pylint.lint.expand_modules import get_python_path
 
@@ -14,9 +15,10 @@ class ArgumentPreprocessingError(Exception):
     """Raised if an error occurs during argument preprocessing."""
 
 
-def prepare_crash_report(ex: Exception, filepath: str, crash_file_prefix: str) -> Path:
-    now = datetime.now().strftime("%Y-%m-%d-%H")
-    issue_template_path = Path(f"{crash_file_prefix}{now}.txt").resolve()
+def prepare_crash_report(
+    ex: Exception, filepath: str, crash_file_path: Union[Path, str]
+) -> Path:
+    issue_template_path = Path(datetime.now().strftime(str(crash_file_path))).resolve()
     with open(filepath, encoding="utf8") as f:
         file_content = f.read()
     template = ""

--- a/pylint/lint/utils.py
+++ b/pylint/lint/utils.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Union
 
+from pylint.config import PYLINT_HOME
 from pylint.lint.expand_modules import get_python_path
 
 
@@ -18,7 +19,9 @@ class ArgumentPreprocessingError(Exception):
 def prepare_crash_report(
     ex: Exception, filepath: str, crash_file_path: Union[Path, str]
 ) -> Path:
-    issue_template_path = Path(datetime.now().strftime(str(crash_file_path))).resolve()
+    issue_template_path = (
+        Path(PYLINT_HOME) / datetime.now().strftime(str(crash_file_path))
+    ).resolve()
     with open(filepath, encoding="utf8") as f:
         file_content = f.read()
     template = ""

--- a/pylint/lint/utils.py
+++ b/pylint/lint/utils.py
@@ -3,12 +3,64 @@
 
 import contextlib
 import sys
+import traceback
+from datetime import datetime
+from pathlib import Path
 
 from pylint.lint.expand_modules import get_python_path
 
 
 class ArgumentPreprocessingError(Exception):
     """Raised if an error occurs during argument preprocessing."""
+
+
+def prepare_crash_report(ex: Exception, filepath: str, crash_file_prefix: str) -> Path:
+    now = datetime.now().strftime("%Y-%m-%d-%H")
+    issue_template_path = Path(f"{crash_file_prefix}{now}.txt").resolve()
+    with open(filepath, encoding="utf8") as f:
+        file_content = f.read()
+    template = ""
+    if not issue_template_path.exists():
+        template = """\
+First, please verify that the bug is not already filled:
+https://github.com/PyCQA/pylint/issues/
+
+Then create a new crash issue:
+https://github.com/PyCQA/pylint/issues/new?assignees=&labels=crash%2Cneeds+triage&template=BUG-REPORT.yml
+
+"""
+    template += f"""\
+
+Issue title:
+Crash ``{ex}`` (if possible, be more specific about what made pylint crash)
+Content:
+When parsing the following file:
+
+<!--
+ If sharing the code is not an option, please state so,
+ but providing only the stacktrace would still be helpful.
+ -->
+
+```python
+{file_content}
+```
+
+pylint crashed with a ``{ex.__class__.__name__}`` and with the following stacktrace:
+```
+"""
+    with open(issue_template_path, "a", encoding="utf8") as f:
+        f.write(template)
+        traceback.print_exc(file=f)
+        f.write("```\n")
+    return issue_template_path
+
+
+def get_fatal_error_message(filepath: str, issue_template_path: Path) -> str:
+    return (
+        f"Fatal error while checking '{filepath}'. "
+        f"Please open an issue in our bug tracker so we address this. "
+        f"There is a pre-filled template that you can use in '{issue_template_path}'."
+    )
 
 
 def preprocess_options(args, search_for):

--- a/pylint/utils/ast_walker.py
+++ b/pylint/utils/ast_walker.py
@@ -2,6 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import collections
+import traceback
 
 from astroid import nodes
 
@@ -81,5 +82,6 @@ class ASTWalker:
             if self.exception_msg is False:
                 file = getattr(astroid.root(), "file", None)
                 print(f"Exception on node {repr(astroid)} in file '{file}'")
+                traceback.print_exc()
                 self.exception_msg = True
             raise

--- a/tests/lint/test_pylinter.py
+++ b/tests/lint/test_pylinter.py
@@ -1,0 +1,25 @@
+from unittest.mock import patch
+
+from astroid import AstroidBuildingError
+
+from pylint.utils import FileState
+
+
+def raise_exception(*args, **kwargs):
+    raise AstroidBuildingError(modname="spam")
+
+
+@patch.object(FileState, "iter_spurious_suppression_messages", raise_exception)
+def test_crash_in_file(linter, capsys, tmpdir):
+    args = linter.load_command_line_configuration([__file__])
+    linter.crash_file_prefix = tmpdir / "pylint-crash-"
+    linter.check(args)
+    out, err = capsys.readouterr()
+    assert not out
+    assert not err
+    files = tmpdir.listdir()
+    assert len(files) == 1
+    assert "pylint-crash" in str(files[0])
+    with open(files[0], encoding="utf8") as f:
+        content = f.read()
+    assert "Failed to import module spam." in content

--- a/tests/lint/test_pylinter.py
+++ b/tests/lint/test_pylinter.py
@@ -12,14 +12,14 @@ def raise_exception(*args, **kwargs):
 @patch.object(FileState, "iter_spurious_suppression_messages", raise_exception)
 def test_crash_in_file(linter, capsys, tmpdir):
     args = linter.load_command_line_configuration([__file__])
-    linter.crash_file_prefix = tmpdir / "pylint-crash-"
+    linter.crash_file_path = str(tmpdir / "pylint-crash-%Y")
     linter.check(args)
     out, err = capsys.readouterr()
     assert not out
     assert not err
     files = tmpdir.listdir()
     assert len(files) == 1
-    assert "pylint-crash" in str(files[0])
+    assert "pylint-crash-20" in str(files[0])
     with open(files[0], encoding="utf8") as f:
         content = f.read()
     assert "Failed to import module spam." in content

--- a/tests/lint/test_utils.py
+++ b/tests/lint/test_utils.py
@@ -1,0 +1,29 @@
+from pylint.lint.utils import get_fatal_error_message, prepare_crash_report
+
+
+def test_prepare_crash_report(tmp_path):
+    exception_content = "Exmessage"
+    python_file = tmp_path / "myfile.py"
+    python_content = "from shadok import MagicFaucet"
+    with open(python_file, "w", encoding="utf8") as f:
+        f.write(python_content)
+    try:
+        raise Exception(exception_content)
+    except Exception as ex:  # pylint: disable=broad-except
+        template_path = prepare_crash_report(ex, python_file, tmp_path)
+    assert str(tmp_path) in str(template_path)
+    with open(template_path, encoding="utf8") as f:
+        template_content = f.read()
+    assert python_content in template_content
+    assert exception_content in template_content
+    assert "in test_prepare_crash_report" in template_content
+    assert "raise Exception(exception_content)" in template_content
+
+
+def test_get_fatal_error_message():
+    python_path = "mypath.py"
+    crash_path = "crash.txt"
+    msg = get_fatal_error_message(python_path, crash_path)
+    assert python_path in msg
+    assert crash_path in msg
+    assert "open an issue" in msg

--- a/tests/lint/test_utils.py
+++ b/tests/lint/test_utils.py
@@ -10,7 +10,9 @@ def test_prepare_crash_report(tmp_path):
     try:
         raise Exception(exception_content)
     except Exception as ex:  # pylint: disable=broad-except
-        template_path = prepare_crash_report(ex, python_file, tmp_path)
+        template_path = prepare_crash_report(
+            ex, python_file, tmp_path / "pylint-crash-%Y.txt"
+        )
     assert str(tmp_path) in str(template_path)
     with open(template_path, encoding="utf8") as f:
         template_content = f.read()

--- a/tests/lint/unittest_expand_modules.py
+++ b/tests/lint/unittest_expand_modules.py
@@ -59,6 +59,21 @@ unittest_lint = {
     "path": str(TEST_DIRECTORY / "lint/unittest_lint.py"),
 }
 
+test_utils = {
+    "basename": "lint",
+    "basepath": INIT_PATH,
+    "isarg": False,
+    "name": "lint.test_utils",
+    "path": str(TEST_DIRECTORY / "lint/test_utils.py"),
+}
+
+test_pylinter = {
+    "basename": "lint",
+    "basepath": INIT_PATH,
+    "isarg": False,
+    "name": "lint.test_pylinter",
+    "path": str(TEST_DIRECTORY / "lint/test_pylinter.py"),
+}
 
 init_of_package = {
     "basename": "lint",
@@ -75,7 +90,13 @@ init_of_package = {
         ([__file__], [this_file]),
         (
             [Path(__file__).parent],
-            [init_of_package, this_file_from_init, unittest_lint],
+            [
+                init_of_package,
+                test_pylinter,
+                test_utils,
+                this_file_from_init,
+                unittest_lint,
+            ],
         ),
     ],
 )


### PR DESCRIPTION


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Permit to lint to the end in case of crash on a file and add a pre-filled issue template so it's easier to open an issue.
Will permit to keep using pylint when there is a crash on a code base. Also easier issue and probably more report.

Related to all the issue with a crash that are opened and completely prevent pylint from being run on a code base. I've done that prior to #4775 
