### PR TITLE
``pyreverse``: Move creation of label from ``DiagramWriter`` to ``Printer`` 

### DIFF
--- a/pylint/pyreverse/dot_printer.py
+++ b/pylint/pyreverse/dot_printer.py
@@ -41,6 +41,7 @@ class DotPrinter(Printer):
         layout: Optional[Layout] = None,
         use_automatic_namespace: Optional[bool] = None,
     ):
+        layout = layout or Layout.BOTTOM_TO_TOP
         self.charset = "utf-8"
         self.node_style = "solid"
         super().__init__(title, layout, use_automatic_namespace)

--- a/pylint/pyreverse/main.py
+++ b/pylint/pyreverse/main.py
@@ -27,8 +27,10 @@ from typing import Iterable
 from pylint.config import ConfigurationMixIn
 from pylint.pyreverse import writer
 from pylint.pyreverse.diadefslib import DiadefsHandler
+from pylint.pyreverse.dot_printer import DotPrinter
 from pylint.pyreverse.inspector import Linker, project_from_files
 from pylint.pyreverse.utils import check_graphviz_availability, insert_default_options
+from pylint.pyreverse.vcg_printer import VCGPrinter
 
 OPTIONS = (
     (
@@ -207,11 +209,8 @@ class Run(ConfigurationMixIn):
             diadefs = handler.get_diadefs(project, linker)
         finally:
             sys.path.pop(0)
-
-        if self.config.output_format == "vcg":
-            writer.VCGWriter(self.config).write(diadefs)
-        else:
-            writer.DotWriter(self.config).write(diadefs)
+        printer_class = VCGPrinter if self.config.output_format == "vcg" else DotPrinter
+        writer.DiagramWriter(self.config, printer_class).write(diadefs)
         return 0
 
 

--- a/pylint/pyreverse/printer.py
+++ b/pylint/pyreverse/printer.py
@@ -10,6 +10,8 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import List, NamedTuple, Optional
 
+import astroid
+
 
 class NodeType(Enum):
     CLASS = "class"
@@ -33,9 +35,10 @@ class Layout(Enum):
 
 class NodeProperties(NamedTuple):
     label: str
+    attrs: Optional[List[str]] = None
+    methods: Optional[List[astroid.FunctionDef]] = None
     color: Optional[str] = None
     fontcolor: Optional[str] = None
-    body: Optional[str] = None
 
 
 class Printer(ABC):

--- a/pylint/pyreverse/vcg_printer.py
+++ b/pylint/pyreverse/vcg_printer.py
@@ -237,19 +237,22 @@ class VCGPrinter(Printer):
     def _build_label_for_node(properties: NodeProperties) -> str:
         fontcolor = "\f09" if properties.fontcolor == "red" else ""
         label = rf"\fb{fontcolor}{properties.label}\fn"
-        if label and properties.attrs is not None and properties.methods is not None:
-            attrs = properties.attrs
-            methods = [func.name for func in properties.methods]
-            # box width for UML like diagram
-            maxlen = max(len(name) for name in [properties.label] + methods + attrs)
-            line = "_" * (maxlen + 2)
+        if properties.attrs is None and properties.methods is None:
+            # return a compact form which only displays the classname in a box
+            return label
+        attrs = properties.attrs or []
+        methods = properties.methods or []
+        method_names = [func.name for func in methods]
+        # box width for UML like diagram
+        maxlen = max(len(name) for name in [properties.label] + method_names + attrs)
+        line = "_" * (maxlen + 2)
+        label = fr"{label}\n\f{line}"
+        for attr in attrs:
+            label = fr"{label}\n\f08{attr}"
+        if attrs:
             label = fr"{label}\n\f{line}"
-            for attr in attrs:
-                label = fr"{label}\n\f08{attr}"
-            if attrs:
-                label = fr"{label}\n\f{line}"
-            for func in methods:
-                label = fr"{label}\n\f10{func}()"
+        for func in method_names:
+            label = fr"{label}\n\f10{func}()"
         return label
 
     def emit_edge(

--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -18,20 +18,16 @@
 """Utilities for creating VCG and Dot diagrams"""
 
 import os
-from typing import List
-
-import astroid
 
 from pylint.pyreverse.diagrams import (
     ClassDiagram,
     ClassEntity,
-    DiagramEntity,
     PackageDiagram,
     PackageEntity,
 )
 from pylint.pyreverse.dot_printer import DotPrinter
 from pylint.pyreverse.printer import EdgeType, Layout, NodeProperties, NodeType
-from pylint.pyreverse.utils import get_annotation_label, is_exception
+from pylint.pyreverse.utils import is_exception
 from pylint.pyreverse.vcg_printer import VCGPrinter
 
 
@@ -111,10 +107,6 @@ class DiagramWriter:
         """set printer"""
         raise NotImplementedError
 
-    def get_title(self, obj: DiagramEntity) -> str:
-        """get project title"""
-        raise NotImplementedError
-
     def get_package_properties(self, obj: PackageEntity) -> NodeProperties:
         """get label and shape for packages."""
         raise NotImplementedError
@@ -136,14 +128,10 @@ class DotWriter(DiagramWriter):
         self.printer = DotPrinter(basename, layout=Layout.BOTTOM_TO_TOP)
         self.file_name = file_name
 
-    def get_title(self, obj: DiagramEntity) -> str:
-        """get project title"""
-        return obj.title
-
     def get_package_properties(self, obj: PackageEntity) -> NodeProperties:
         """get label and shape for packages."""
         return NodeProperties(
-            label=self.get_title(obj),
+            label=obj.title,
             color="black",
         )
 
@@ -152,38 +140,10 @@ class DotWriter(DiagramWriter):
 
         The label contains all attributes and methods
         """
-        label = obj.title
-        if not self.config.only_classnames:
-            label = r"{}|{}\l|".format(label, r"\l".join(obj.attrs))
-            for func in obj.methods:
-                return_type = (
-                    f": {get_annotation_label(func.returns)}" if func.returns else ""
-                )
-
-                if func.args.args:
-                    arguments: List[astroid.AssignName] = [
-                        arg for arg in func.args.args if arg.name != "self"
-                    ]
-                else:
-                    arguments = []
-
-                annotations = dict(zip(arguments, func.args.annotations[1:]))
-                for arg in arguments:
-                    annotation_label = ""
-                    ann = annotations.get(arg)
-                    if ann:
-                        annotation_label = get_annotation_label(ann)
-                    annotations[arg] = annotation_label
-
-                args = ", ".join(
-                    f"{arg.name}: {ann}" if ann else f"{arg.name}"
-                    for arg, ann in annotations.items()
-                )
-
-                label = fr"{label}{func.name}({args}){return_type}\l"
-            label = "{%s}" % label
         properties = NodeProperties(
-            label=label,
+            label=obj.title,
+            attrs=obj.attrs if not self.config.only_classnames else None,
+            methods=obj.methods if not self.config.only_classnames else None,
             fontcolor="red" if is_exception(obj.node) else "black",
             color="black",
         )
@@ -198,14 +158,11 @@ class VCGWriter(DiagramWriter):
         self.file_name = file_name
         self.printer = VCGPrinter(basename)
 
-    def get_title(self, obj: DiagramEntity) -> str:
-        """get project title in vcg format"""
-        return r"\fb%s\fn" % obj.title
-
     def get_package_properties(self, obj: PackageEntity) -> NodeProperties:
         """get label and shape for packages."""
         return NodeProperties(
-            label=self.get_title(obj),
+            label=obj.title,
+            color="black",
         )
 
     def get_class_properties(self, obj: ClassEntity) -> NodeProperties:
@@ -213,21 +170,10 @@ class VCGWriter(DiagramWriter):
 
         The label contains all attributes and methods
         """
-        if is_exception(obj.node):
-            label = r"\fb\f09%s\fn" % obj.title
-        else:
-            label = r"\fb%s\fn" % obj.title
-        if not self.config.only_classnames:
-            attrs = obj.attrs
-            methods = [func.name for func in obj.methods]
-            # box width for UML like diagram
-            maxlen = max(len(name) for name in [obj.title] + methods + attrs)
-            line = "_" * (maxlen + 2)
-            label = fr"{label}\n\f{line}"
-            for attr in attrs:
-                label = fr"{label}\n\f08{attr}"
-            if attrs:
-                label = fr"{label}\n\f{line}"
-            for func in methods:
-                label = fr"{label}\n\f10{func}()"
-        return NodeProperties(label=label)
+        return NodeProperties(
+            label=obj.title,
+            attrs=obj.attrs if not self.config.only_classnames else None,
+            methods=obj.methods if not self.config.only_classnames else None,
+            fontcolor="red" if is_exception(obj.node) else "black",
+            color="black",
+        )

--- a/tests/unittest_pyreverse_writer.py
+++ b/tests/unittest_pyreverse_writer.py
@@ -30,9 +30,11 @@ import astroid
 import pytest
 
 from pylint.pyreverse.diadefslib import DefaultDiadefGenerator, DiadefsHandler
+from pylint.pyreverse.dot_printer import DotPrinter
 from pylint.pyreverse.inspector import Linker, project_from_files
 from pylint.pyreverse.utils import get_annotation, get_visibility, infer_node
-from pylint.pyreverse.writer import DotWriter, VCGWriter
+from pylint.pyreverse.vcg_printer import VCGPrinter
+from pylint.pyreverse.writer import DiagramWriter
 
 _DEFAULTS = {
     "all_ancestors": None,
@@ -89,7 +91,7 @@ VCG_FILES = ["packages_No_Name.vcg", "classes_No_Name.vcg"]
 @pytest.fixture(scope="module")
 def setup_dot():
     config = Config()
-    writer = DotWriter(config)
+    writer = DiagramWriter(config, printer_class=DotPrinter)
     yield from _setup(config, writer)
 
 
@@ -97,7 +99,7 @@ def setup_dot():
 def setup_vcg():
     config = Config()
     config.output_format = "vcg"
-    writer = VCGWriter(config)
+    writer = DiagramWriter(config, printer_class=VCGPrinter)
     yield from _setup(config, writer)
 
 


### PR DESCRIPTION
## Description


Currently the logic to create diagrams is split between the ``Printer`` classes and the ``DiagramWriter`` classes.
In my opinion the responsibilities should be:
- ``DiagramWriter`` defines WHAT elements should be included in the diagram
- ``Printer`` handles HOW this needs to be translated into a format the desired tool (``dot``/Graphviz or ``vcg``, later on also PlantUML) understands

With the current implementation the ``DiagramWriter`` subclasses also hold a lot of logic how to construct the ``label`` of individual nodes (i.e. to include attributes and methods of the classes). However, how this label needs to be constructed is an implementation detail of the backend and thus should reside in the ``Printer`` classes.

This MR moves the logic inside the ``Printer`` classes.
Please note that this eliminates the need for specialized ``DiagramWriter`` subclasses - they now only differ in the ``set_printer`` method, and the ``Printer`` class could now be passed directly in the constructor.
To ease the review I did not include this change just yet, so it is easier to see what parts of the current logic were moved.
We can open a new MR for this, or after these first changes are reviewed I just make another push on this MR and request a new review.


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

