### PR TITLE
Add cached infer_all helper function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -158,6 +158,8 @@ Release date: TBA
 
   Closes #4653
 
+* Improve performance when inferring ``Call`` nodes, by utilizing caching.
+
 
 What's New in Pylint 2.9.6?
 ===========================

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -75,6 +75,7 @@ from pylint import checkers, exceptions, interfaces
 from pylint import utils as lint_utils
 from pylint.checkers import utils
 from pylint.checkers.utils import (
+    infer_all,
     is_overload_stub,
     is_property_deleter,
     is_property_setter,
@@ -782,11 +783,8 @@ class BasicErrorChecker(_BasicChecker):
         """Check instantiating abstract class with
         abc.ABCMeta as metaclass.
         """
-        try:
-            for inferred in node.func.infer():
-                self._check_inferred_class_is_abstract(inferred, node)
-        except astroid.InferenceError:
-            return
+        for inferred in infer_all(node.func):
+            self._check_inferred_class_is_abstract(inferred, node)
 
     def _check_inferred_class_is_abstract(self, inferred, node):
         if not isinstance(inferred, nodes.ClassDef):

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -9,7 +9,7 @@ import astroid
 from astroid import nodes
 
 from pylint.checkers import utils
-from pylint.checkers.utils import get_import_name, safe_infer
+from pylint.checkers.utils import get_import_name, infer_all, safe_infer
 
 ACCEPTABLE_NODES = (
     astroid.BoundMethod,
@@ -58,14 +58,11 @@ class DeprecatedMixin:
         "deprecated-class",
     )
     def visit_call(self, node: nodes.Call) -> None:
-        """Called when a :class:`.astroid.Call` node is visited."""
-        try:
-            self.check_deprecated_class_in_call(node)
-            for inferred in node.func.infer():
-                # Calling entry point for deprecation check logic.
-                self.check_deprecated_method(node, inferred)
-        except astroid.InferenceError:
-            pass
+        """Called when a :class:`nodes.Call` node is visited."""
+        self.check_deprecated_class_in_call(node)
+        for inferred in infer_all(node.func):
+            # Calling entry point for deprecation check logic.
+            self.check_deprecated_method(node, inferred)
 
     @utils.check_messages(
         "deprecated-module",

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1176,7 +1176,7 @@ def _get_python_type_of_node(node):
     return None
 
 
-@lru_cache(maxsize=8192)
+@lru_cache(maxsize=1024)
 def safe_infer(node: nodes.NodeNG, context=None) -> Optional[nodes.NodeNG]:
     """Return the inferred value for the given node.
 
@@ -1205,7 +1205,7 @@ def safe_infer(node: nodes.NodeNG, context=None) -> Optional[nodes.NodeNG]:
     return value if len(inferred_types) <= 1 else None
 
 
-@lru_cache(maxsize=2048)
+@lru_cache(maxsize=512)
 def infer_all(
     node: nodes.NodeNG, context: InferenceContext = None
 ) -> List[nodes.NodeNG]:

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -74,6 +74,7 @@ import _string
 import astroid
 import astroid.objects
 from astroid import TooManyLevelsError, nodes
+from astroid.context import InferenceContext
 
 COMP_NODE_TYPES = (
     nodes.ListComp,
@@ -1205,9 +1206,11 @@ def safe_infer(node: nodes.NodeNG, context=None) -> Optional[nodes.NodeNG]:
 
 
 @lru_cache(maxsize=1024)
-def infer_all(node: nodes.NodeNG) -> List[nodes.NodeNG]:
+def infer_all(
+    node: nodes.NodeNG, context: InferenceContext = None
+) -> List[nodes.NodeNG]:
     try:
-        return list(node.infer())
+        return list(node.infer(context=context))
     except astroid.InferenceError:
         return []
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1176,7 +1176,7 @@ def _get_python_type_of_node(node):
     return None
 
 
-@lru_cache(maxsize=1024)
+@lru_cache(maxsize=8192)
 def safe_infer(node: nodes.NodeNG, context=None) -> Optional[nodes.NodeNG]:
     """Return the inferred value for the given node.
 
@@ -1205,7 +1205,7 @@ def safe_infer(node: nodes.NodeNG, context=None) -> Optional[nodes.NodeNG]:
     return value if len(inferred_types) <= 1 else None
 
 
-@lru_cache(maxsize=1024)
+@lru_cache(maxsize=2048)
 def infer_all(
     node: nodes.NodeNG, context: InferenceContext = None
 ) -> List[nodes.NodeNG]:

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1204,6 +1204,14 @@ def safe_infer(node: nodes.NodeNG, context=None) -> Optional[nodes.NodeNG]:
     return value if len(inferred_types) <= 1 else None
 
 
+@lru_cache(maxsize=1024)
+def infer_all(node: nodes.NodeNG) -> List[nodes.NodeNG]:
+    try:
+        return list(node.infer())
+    except astroid.InferenceError:
+        return []
+
+
 def has_known_bases(klass: nodes.ClassDef, context=None) -> bool:
     """Return true if all base classes of a class could be inferred."""
     try:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
While looking at the pylint call graph https://github.com/PyCQA/astroid/issues/1115#issuecomment-890961827, I noticed that some parts aren't properly utilizing caching. This seems to be especially the case for `Call` nodes, which often use
```py
try:
    for inferred in node.func.infer():
        ...
except astroid.InferenceError:
    pass
```

We can't use `safe_infer` for that as it will only return one value. Thus I've created a new helper function for it, that will also be cached.

--
Difficult to say if that will significantly improve performance, but it might be worth a try.
@robin-wayve Would you be able to test these changes?