### PR TITLE
Fix false-positive used-before-assignment with := in Return node

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -114,6 +114,10 @@ Release date: TBA
 
   Closes #3839
 
+* Fix false-positive ``used-before-assignment`` with an assignment expression in a ``Return`` node
+
+  Closes #4828
+
 
 What's New in Pylint 2.9.6?
 ===========================

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1464,6 +1464,7 @@ class VariablesChecker(BaseChecker):
                             astroid.AnnAssign,
                             astroid.AugAssign,
                             astroid.Expr,
+                            astroid.Return,
                         ),
                     )
                     and isinstance(defstmt.value, astroid.IfExp)

--- a/tests/functional/a/assign/assignment_expression.py
+++ b/tests/functional/a/assign/assignment_expression.py
@@ -84,3 +84,8 @@ l3 += (
 def func2():
     return f'The number {(count := 4)} ' \
            f'is equal to {count}'
+
+
+# https://github.com/PyCQA/pylint/issues/4828
+def func3():
+    return bar if (bar := "") else ""


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

```py
def foo() -> str:
    return bar if (bar := "") else ""
```

Closes #4828
