### PR TITLE
Improvements `consider-using-tuple`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -120,6 +120,12 @@ Release date: TBA
 
 * Added ``use-sequence-for-iteration``: Emitted when iterating over an in-place defined ``set``.
 
+* ``CodeStyleChecker``
+
+  * Limit ``consider-using-tuple`` to be emitted only for in-place defined ``lists``.
+
+  * Emit ``consider-using-tuple`` even if list contains a ``starred`` expression.
+
 
 What's New in Pylint 2.9.6?
 ===========================

--- a/doc/whatsnew/2.10.rst
+++ b/doc/whatsnew/2.10.rst
@@ -31,6 +31,16 @@ New checkers
 * Added ``use-sequence-for-iteration``: Emitted when iterating over an in-place defined ``set``.
 
 
+Extensions
+==========
+
+* ``CodeStyleChecker``
+
+  * Limit ``consider-using-tuple`` to be emitted only for in-place defined ``lists``.
+
+  * Emit ``consider-using-tuple`` even if list contains a ``starred`` expression.
+
+
 Other Changes
 =============
 

--- a/pylint/extensions/code_style.py
+++ b/pylint/extensions/code_style.py
@@ -36,7 +36,7 @@ class CodeStyleChecker(BaseChecker):
             "Emitted when dictionary values can be replaced by namedtuples or dataclass instances.",
         ),
         "R6102": (
-            "Consider using an in-place tuple%s",
+            "Consider using an in-place tuple instead of list",
             "consider-using-tuple",
             "Emitted when an in-place defined list or set can be "
             "replaced by a slightly faster tuple.",
@@ -53,11 +53,11 @@ class CodeStyleChecker(BaseChecker):
 
     @check_messages("consider-using-tuple")
     def visit_for(self, node: astroid.For) -> None:
-        self._check_inplace_defined_list_set(node)
+        self._check_inplace_defined_list(node)
 
     @check_messages("consider-using-tuple")
     def visit_comprehension(self, node: astroid.Comprehension) -> None:
-        self._check_inplace_defined_list_set(node)
+        self._check_inplace_defined_list(node)
 
     def _check_dict_consider_namedtuple_dataclass(self, node: astroid.Dict) -> None:
         """Check if dictionary values can be replaced by Namedtuple or Dataclass."""
@@ -133,18 +133,12 @@ class CodeStyleChecker(BaseChecker):
             self.add_message("consider-using-namedtuple-or-dataclass", node=node)
             return
 
-    def _check_inplace_defined_list_set(
+    def _check_inplace_defined_list(
         self, node: Union[astroid.For, astroid.Comprehension]
     ) -> None:
-        """Check if inplace defined list / set can be replaced by a tuple."""
-        if isinstance(node.iter, (astroid.List, astroid.Set)) and not any(
-            isinstance(item, astroid.Starred) for item in node.iter.elts
-        ):
-            self.add_message(
-                "consider-using-tuple",
-                node=node.iter,
-                args=(f" instead of {node.iter.__class__.__qualname__.lower()}",),
-            )
+        """Check if in-place defined list can be replaced by a tuple."""
+        if isinstance(node.iter, astroid.List):
+            self.add_message("consider-using-tuple", node=node.iter)
 
 
 def register(linter: PyLinter) -> None:

--- a/pylint/extensions/code_style.py
+++ b/pylint/extensions/code_style.py
@@ -38,8 +38,9 @@ class CodeStyleChecker(BaseChecker):
         "R6102": (
             "Consider using an in-place tuple instead of list",
             "consider-using-tuple",
-            "Emitted when an in-place defined list or set can be "
-            "replaced by a slightly faster tuple.",
+            "Only for style consistency! "
+            "Emitted where an in-place defined ``list`` can be replaced by a ``tuple``. "
+            "Due to optimizations by CPython, there is no performance benefit from it.",
         ),
     }
 

--- a/tests/functional/ext/code_style/code_style_consider_using_tuple.py
+++ b/tests/functional/ext/code_style/code_style_consider_using_tuple.py
@@ -12,18 +12,20 @@ for x in [1, 2, 3]:  # [consider-using-tuple]
 (x for x in var)
 (x for x in (1, 2, 3))
 (x for x in [1, 2, 3])  # [consider-using-tuple]
-(x for x in {1, 2, 3})  # [consider-using-tuple,use-sequence-for-iteration]
 
 [x for x in var]
 [x for x in (1, 2, 3)]
 [x for x in [1, 2, 3]]  # [consider-using-tuple]
 
 
-# list/set can't be replaced if tuple unpacking is used
-for x in [*var]:
+for x in [*var]:  # [consider-using-tuple]
     pass
-for x in [2, *var]:
+for x in [2, *var]:  # [consider-using-tuple]
     pass
 
-[x for x in [*var, 2]]
+[x for x in [*var, 2]]  # [consider-using-tuple]
+
+
+# Don't emit warning for sets as this is handled by builtin checker
+(x for x in {1, 2, 3})  # [use-sequence-for-iteration]
 [x for x in {*var, 2}]  # [use-sequence-for-iteration]

--- a/tests/functional/ext/code_style/code_style_consider_using_tuple.txt
+++ b/tests/functional/ext/code_style/code_style_consider_using_tuple.txt
@@ -1,6 +1,8 @@
 consider-using-tuple:9:9::Consider using an in-place tuple instead of list
 consider-using-tuple:14:12::Consider using an in-place tuple instead of list
-consider-using-tuple:15:12::Consider using an in-place tuple instead of set
-use-sequence-for-iteration:15:12::Use a sequence type when iterating over values
-consider-using-tuple:19:12::Consider using an in-place tuple instead of list
-use-sequence-for-iteration:29:12::Use a sequence type when iterating over values
+consider-using-tuple:18:12::Consider using an in-place tuple instead of list
+consider-using-tuple:21:9::Consider using an in-place tuple instead of list
+consider-using-tuple:23:9::Consider using an in-place tuple instead of list
+consider-using-tuple:26:12::Consider using an in-place tuple instead of list
+use-sequence-for-iteration:30:12::Use a sequence type when iterating over values
+use-sequence-for-iteration:31:12::Use a sequence type when iterating over values


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description
Followup to https://github.com/PyCQA/pylint/pull/4835#issuecomment-898052028

* Add additional typing to `CodeStyleChecker`
* Limit `consider-using-tuple` to in-place defined lists to prevent double warnings.
* Emit `consider-using-tuple` even for starred expressions as they can be replaced as well.
```py
var = (1, 2, 3)

# old
[*var]

# new
(*var,)  # trailing comma is important
```