### PR TITLE
[duplicate-code] Ignore decorators lines by similarities checker when ignore signatures flag enabled

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -508,6 +508,7 @@ contributors:
 
 * Maksym Humetskyi (mhumetskyi): contributor
   - Fixed ignored empty functions by similarities checker with "ignore-signatures" option enabled
+  - Ignore function decorators signatures as well by similarities checker with "ignore-signatures" option enabled
 
 * Daniel Dorani (doranid): contributor
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -125,6 +125,10 @@ Release date: TBA
   * Limit ``consider-using-tuple`` to be emitted only for in-place defined ``lists``.
 
   * Emit ``consider-using-tuple`` even if list contains a ``starred`` expression.
+  
+* Ignore decorators lines by similarities checker when ignore signatures flag enabled
+
+  Closes #4839
 
 
 What's New in Pylint 2.9.6?

--- a/ChangeLog
+++ b/ChangeLog
@@ -125,7 +125,7 @@ Release date: TBA
   * Limit ``consider-using-tuple`` to be emitted only for in-place defined ``lists``.
 
   * Emit ``consider-using-tuple`` even if list contains a ``starred`` expression.
-  
+
 * Ignore decorators lines by similarities checker when ignore signatures flag enabled
 
   Closes #4839

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -595,7 +595,7 @@ def stripped_lines(
             chain(
                 *(
                     range(
-                        func.fromlineno,
+                        func.lineno,
                         func.body[0].lineno if func.body else func.tolineno + 1,
                     )
                     for func in functions

--- a/tests/checkers/unittest_similar.py
+++ b/tests/checkers/unittest_similar.py
@@ -171,7 +171,7 @@ def test_ignore_signatures_fail():
         == (
             '''
 9 similar lines in 2 files
-==%s:[1:11]
+==%s:[7:17]
 ==%s:[8:18]
        arg1: int = 3,
        arg2: Class1 = val1,
@@ -183,9 +183,19 @@ def test_ignore_signatures_fail():
 
    def example():
        """Valid function definition with docstring only."""
-TOTAL lines=29 duplicates=9 percent=31.03
+
+6 similar lines in 2 files
+==%s:[0:6]
+==%s:[1:7]
+   @deco1(dval1)
+   @deco2(dval2)
+   @deco3(
+       dval3,
+       dval4
+   )
+TOTAL lines=35 duplicates=15 percent=42.86
 '''
-            % (SIMILAR5, SIMILAR6)
+            % (SIMILAR5, SIMILAR6, SIMILAR5, SIMILAR6)
         ).strip()
     )
 
@@ -198,7 +208,7 @@ def test_ignore_signatures_pass():
     assert (
         output.getvalue().strip()
         == """
-TOTAL lines=29 duplicates=0 percent=0.00
+TOTAL lines=35 duplicates=0 percent=0.00
 """.strip()
     )
 

--- a/tests/input/similar5
+++ b/tests/input/similar5
@@ -1,3 +1,9 @@
+@deco1(dval1)
+@deco2(dval2)
+@deco3(
+    dval3,
+    dval4
+)
 def func1(
     arg1: int = 3,
     arg2: Class1 = val1,


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Ignore function decorators during similarities check if ignore signatures flag enabled.

Closes #4839
