### PR TITLE
Add pylintrc config for typing extension

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -381,6 +381,15 @@ int-import-graph=
 overgeneral-exceptions=Exception
 
 
+[TYPING]
+
+# Minimum supported python version (used for typing only!)
+py-version = 3.6
+
+# Annotations are used exclusively for type checking
+runtime-typing = no
+
+
 [pylint.DEPRECATED_BUILTINS]
 
 # List of builtins function names that should not be used, separated by a comma


### PR DESCRIPTION
## Description

#4842 enabled the `Typing` plugin for pylint. At least for the moment it isn't of any help for us. This will change once support for Python 3.6 is removed.

This PR adds the necessary config for the extension.

--
Updating the `py-version` can probably be added as task in #4683.
