### PR TITLE
Allow true / false in pylintrc

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -130,6 +130,8 @@ Release date: TBA
 
   Closes #4839
 
+* Allow ``true`` and ``false`` values in ``pylintrc`` for better compatibility with ``toml`` config.
+
 
 What's New in Pylint 2.9.6?
 ===========================

--- a/pylint/config/option.py
+++ b/pylint/config/option.py
@@ -35,11 +35,11 @@ def _choice_validator(choices, name, value):
 def _yn_validator(opt, _, value):
     if isinstance(value, int):
         return bool(value)
-    if value in ("y", "yes"):
+    if value in ("y", "yes", "true"):
         return True
-    if value in ("n", "no"):
+    if value in ("n", "no", "false"):
         return False
-    msg = "option %s: invalid yn value %r, should be in (y, yes, n, no)"
+    msg = "option %s: invalid yn value %r, should be in (y, yes, true, n, no, false)"
     raise optparse.OptionValueError(msg % (opt, value))
 
 


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Pylint does support rich types in `.toml` config files. However when copying a `true` / `false` option back to a `pylintrc` file, it is an error.

This is how the conversion is done for `.toml` files:
https://github.com/PyCQA/pylint/blob/09ffc07fcb9ac2ac99d56b1d2c818ce93e509426/pylint/config/option_manager_mixin.py#L280-L284


### Example
```toml
# toml
reports = true
```

```ini
# pylintrc

# old
reports = yes


# with PR also allowed
reports = true
```
