### PR TITLE
Suppress ``consider-using-with`` on return statements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,10 @@ Release date: TBA
 
   Closes #4498
 
+* ``consider-using-with`` is no longer triggered if a context manager is returned from a function.
+
+  Closes #4748
+
 * pylint does not crash with a traceback anymore when a file is problematic. It
   creates a template text file for opening an issue on the bug tracker instead.
   The linting can go on for other non problematic files instead of being impossible.

--- a/doc/whatsnew/2.10.rst
+++ b/doc/whatsnew/2.10.rst
@@ -46,6 +46,8 @@ Other Changes
 
 * Pyreverse - add output in PlantUML format
 
+* ``consider-using-with`` is no longer triggered if a context manager is returned from a function.
+
 * pylint does not crash with a traceback anymore when a file is problematic. It
   creates a template text file for opening an issue on the bug tracker instead.
   The linting can go on for other non problematic files instead of being impossible.

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -113,6 +113,16 @@ def _is_inside_context_manager(node: astroid.Call) -> bool:
     )
 
 
+def _is_a_return_statement(node: astroid.Call) -> bool:
+    frame = node.frame()
+    parent = node.parent
+    while parent is not frame:
+        if isinstance(parent, astroid.Return):
+            return True
+        parent = parent.parent
+    return False
+
+
 def _is_part_of_with_items(node: astroid.Call) -> bool:
     """
     Checks if one of the node's parents is an ``astroid.With`` node and that the node itself is located
@@ -1443,8 +1453,10 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             stack[varname] = value
 
     def _check_consider_using_with(self, node: astroid.Call):
-        if _is_inside_context_manager(node):
-            # if we are inside a context manager itself, we assume that it will handle the resource management itself.
+        if _is_inside_context_manager(node) or _is_a_return_statement(node):
+            # If we are inside a context manager itself, we assume that it will handle the resource management itself.
+            # If the node is a child of a return, we assume that the caller knows he is getting a context manager
+            # he should use properly (i.e. in a ``with``).
             return
         if (
             node

--- a/tests/functional/c/consider/consider_using_with_open.py
+++ b/tests/functional/c/consider/consider_using_with_open.py
@@ -64,3 +64,7 @@ def test_single_line_with(file1):
 def test_multiline_with_items(file1, file2, which):
     with (open(file1, encoding="utf-8") if which
         else open(file2, encoding="utf-8")) as input_file: return input_file.read()
+
+
+def test_suppress_on_return():
+    return open("foo", encoding="utf8")  # must not trigger


### PR DESCRIPTION

- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
As discussed in #4748 the ``consider-using-with`` check should be suppressed on ``return`` statements.

The new proposal for ``consider-using-context-manager`` is not included in this MR. I think we should discuss the use cases where this message should - and especially should not - trigger before starting the implementation. 

Closes #4748 
