### PR TITLE
pyreverse - Add project modules to sys.path

### DIFF
--- a/pylint/pyreverse/main.py
+++ b/pylint/pyreverse/main.py
@@ -21,11 +21,11 @@
 
   create UML diagrams for classes and modules in <packages>
 """
-import os
 import sys
 from typing import Iterable
 
 from pylint.config import ConfigurationMixIn
+from pylint.lint.utils import fix_import_path
 from pylint.pyreverse import writer
 from pylint.pyreverse.diadefslib import DiadefsHandler
 from pylint.pyreverse.inspector import Linker, project_from_files
@@ -212,10 +212,7 @@ class Run(ConfigurationMixIn):
         if not args:
             print(self.help())
             return 1
-        # insert current working directory to the python path to recognize
-        # dependencies to local modules even if cwd is not in the PYTHONPATH
-        sys.path.insert(0, os.getcwd())
-        try:
+        with fix_import_path(args):
             project = project_from_files(
                 args,
                 project_name=self.config.project,
@@ -224,9 +221,7 @@ class Run(ConfigurationMixIn):
             linker = Linker(project, tag=True)
             handler = DiadefsHandler(self.config)
             diadefs = handler.get_diadefs(project, linker)
-        finally:
-            sys.path.pop(0)
-        writer.DiagramWriter(self.config).write(diadefs)
+            writer.DiagramWriter(self.config).write(diadefs)
         return 0
 
 


### PR DESCRIPTION
Closes #2479

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
The pyreverse 'import from' logic is affected by the sys.path contents on this line: https://github.com/PyCQA/astroid/blob/main/astroid/interpreter/_import/spec.py#L353

Can get to this point by placing a breakpoint() on the following line and following the import logic for one of the import statements: https://github.com/PyCQA/astroid/blob/main/astroid/inference.py#L271

Currently the current directory is placed in sys.path. 
With the change, all modules can be found as they are all placed in sys.path similarly to how pylint itself does.

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #2479
