### PR TITLE
``astroid.const.BUILTINS`` use removed for clarity and so astroid can also removes it later

### DIFF
--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -70,7 +70,6 @@ from typing import Pattern
 
 import astroid
 from astroid import nodes
-from astroid.const import BUILTINS
 
 from pylint import checkers, exceptions, interfaces
 from pylint import utils as lint_utils
@@ -179,7 +178,7 @@ REVERSED_METHODS = (SEQUENCE_PROTOCOL_METHODS, (REVERSED_PROTOCOL_METHOD,))
 TYPECHECK_COMPARISON_OPERATORS = frozenset(("is", "is not", "==", "!="))
 LITERAL_NODE_TYPES = (nodes.Const, nodes.Dict, nodes.List, nodes.Set)
 UNITTEST_CASE = "unittest.case"
-TYPE_QNAME = "%s.type" % BUILTINS
+TYPE_QNAME = "builtins.type"
 ABC_METACLASSES = {"_py_abc.ABCMeta", "abc.ABCMeta"}  # Python 3.7+,
 
 # Name categories that are always consistent with all naming conventions.
@@ -189,7 +188,7 @@ EXEMPT_NAME_CATEGORIES = {"exempt", "ignore"}
 # about dangerous default values as arguments
 DEFAULT_ARGUMENT_SYMBOLS = dict(
     zip(
-        [".".join([BUILTINS, x]) for x in ("set", "dict", "list")],
+        [".".join(["builtins", x]) for x in ("set", "dict", "list")],
         ["set()", "{}", "[]"],
     ),
     **{

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -70,6 +70,7 @@ from typing import Pattern
 
 import astroid
 from astroid import nodes
+from astroid.const import BUILTINS
 
 from pylint import checkers, exceptions, interfaces
 from pylint import utils as lint_utils
@@ -79,7 +80,6 @@ from pylint.checkers.utils import (
     is_property_deleter,
     is_property_setter,
 )
-from pylint.constants import BUILTINS
 from pylint.reporters.ureports import nodes as reporter_nodes
 
 

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -51,7 +51,6 @@ from typing import List, Pattern, cast
 
 import astroid
 from astroid import nodes
-from astroid.const import BUILTINS
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import (
@@ -439,7 +438,7 @@ def _is_attribute_property(name, klass):
         attributes = klass.getattr(name)
     except astroid.NotFoundError:
         return False
-    property_name = f"{BUILTINS}.property"
+    property_name = "builtins.property"
     for attr in attributes:
         if attr is astroid.Uninferable:
             continue
@@ -881,7 +880,7 @@ a metaclass class method.",
             if not ancestor:
                 continue
             if isinstance(ancestor, astroid.Instance) and ancestor.is_subtype_of(
-                f"{BUILTINS}.type"
+                "builtins.type"
             ):
                 continue
 
@@ -2176,7 +2175,7 @@ class SpecialMethodsChecker(BaseChecker):
             # by no-method-argument.
             return
 
-        if decorated_with(node, [f"{BUILTINS}.staticmethod"]):
+        if decorated_with(node, ["builtins.staticmethod"]):
             # We expect to not take in consideration self.
             all_args = node.args.args
         else:

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -51,6 +51,7 @@ from typing import List, Pattern, cast
 
 import astroid
 from astroid import nodes
+from astroid.const import BUILTINS
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import (
@@ -438,7 +439,7 @@ def _is_attribute_property(name, klass):
         attributes = klass.getattr(name)
     except astroid.NotFoundError:
         return False
-    property_name = f"{astroid.bases.BUILTINS}.property"
+    property_name = f"{BUILTINS}.property"
     for attr in attributes:
         if attr is astroid.Uninferable:
             continue
@@ -880,7 +881,7 @@ a metaclass class method.",
             if not ancestor:
                 continue
             if isinstance(ancestor, astroid.Instance) and ancestor.is_subtype_of(
-                f"{astroid.bases.BUILTINS}.type"
+                f"{BUILTINS}.type"
             ):
                 continue
 
@@ -2175,7 +2176,7 @@ class SpecialMethodsChecker(BaseChecker):
             # by no-method-argument.
             return
 
-        if decorated_with(node, [astroid.bases.BUILTINS + ".staticmethod"]):
+        if decorated_with(node, [f"{BUILTINS}.staticmethod"]):
             # We expect to not take in consideration self.
             all_args = node.args.args
         else:

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -47,7 +47,6 @@ from collections import namedtuple
 
 import astroid
 from astroid import nodes
-from astroid.const import BUILTINS
 
 from pylint import checkers, interfaces
 from pylint.checkers import utils
@@ -980,7 +979,7 @@ class Python3Checker(checkers.BaseChecker):
                 # classmethod 1 argument should cause a failure, if it is a
                 # staticmethod 0 arguments should cause a failure.
                 failing_arg_count = 1
-                if utils.decorated_with(node, [f"{BUILTINS}.staticmethod"]):
+                if utils.decorated_with(node, ["builtins.staticmethod"]):
                     failing_arg_count = 0
                 if len(node.args.args) == failing_arg_count:
                     self.add_message("next-method-defined", node=node)
@@ -1118,7 +1117,7 @@ class Python3Checker(checkers.BaseChecker):
             if not inferred:
                 return
 
-            builtins_list = f"{BUILTINS}.list"
+            builtins_list = "builtins.list"
             if isinstance(inferred, nodes.List) or inferred.qname() == builtins_list:
                 kwargs = node.keywords
 
@@ -1127,7 +1126,7 @@ class Python3Checker(checkers.BaseChecker):
             if not inferred:
                 return
 
-            builtins_sorted = f"{BUILTINS}.sorted"
+            builtins_sorted = "builtins.sorted"
             if inferred.qname() == builtins_sorted:
                 kwargs = node.keywords
 

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -47,6 +47,7 @@ from collections import namedtuple
 
 import astroid
 from astroid import nodes
+from astroid.const import BUILTINS
 
 from pylint import checkers, interfaces
 from pylint.checkers import utils
@@ -979,9 +980,7 @@ class Python3Checker(checkers.BaseChecker):
                 # classmethod 1 argument should cause a failure, if it is a
                 # staticmethod 0 arguments should cause a failure.
                 failing_arg_count = 1
-                if utils.decorated_with(
-                    node, [astroid.bases.BUILTINS + ".staticmethod"]
-                ):
+                if utils.decorated_with(node, [f"{BUILTINS}.staticmethod"]):
                     failing_arg_count = 0
                 if len(node.args.args) == failing_arg_count:
                     self.add_message("next-method-defined", node=node)
@@ -1119,7 +1118,7 @@ class Python3Checker(checkers.BaseChecker):
             if not inferred:
                 return
 
-            builtins_list = f"{astroid.bases.BUILTINS}.list"
+            builtins_list = f"{BUILTINS}.list"
             if isinstance(inferred, nodes.List) or inferred.qname() == builtins_list:
                 kwargs = node.keywords
 
@@ -1128,7 +1127,7 @@ class Python3Checker(checkers.BaseChecker):
             if not inferred:
                 return
 
-            builtins_sorted = f"{astroid.bases.BUILTINS}.sorted"
+            builtins_sorted = f"{BUILTINS}.sorted"
             if inferred.qname() == builtins_sorted:
                 kwargs = node.keywords
 

--- a/pylint/checkers/refactoring/not_checker.py
+++ b/pylint/checkers/refactoring/not_checker.py
@@ -3,10 +3,10 @@
 
 
 import astroid
+from astroid.const import BUILTINS
 
 from pylint import checkers, interfaces
 from pylint.checkers import utils
-from pylint.constants import BUILTINS
 
 
 class NotChecker(checkers.BaseChecker):

--- a/pylint/checkers/refactoring/not_checker.py
+++ b/pylint/checkers/refactoring/not_checker.py
@@ -3,7 +3,6 @@
 
 
 import astroid
-from astroid.const import BUILTINS
 
 from pylint import checkers, interfaces
 from pylint.checkers import utils
@@ -39,7 +38,7 @@ class NotChecker(checkers.BaseChecker):
     # not equivalent to "set(LEFT_VALS) > set(RIGHT_VALS)"
     skipped_nodes = (astroid.Set,)
     # 'builtins' py3, '__builtin__' py2
-    skipped_classnames = [f"{BUILTINS}.{qname}" for qname in ("set", "frozenset")]
+    skipped_classnames = [f"builtins.{qname}" for qname in ("set", "frozenset")]
 
     @utils.check_messages("unneeded-not")
     def visit_unaryop(self, node):

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -42,7 +42,6 @@ from typing import TYPE_CHECKING, Iterable
 
 import astroid
 from astroid import nodes
-from astroid.const import BUILTINS
 
 from pylint.checkers import BaseChecker, BaseTokenChecker, utils
 from pylint.checkers.utils import check_messages
@@ -243,11 +242,11 @@ def arg_matches_format_type(arg_type, format_type):
         return True
     if isinstance(arg_type, astroid.Instance):
         arg_type = arg_type.pytype()
-        if arg_type == f"{BUILTINS}.str":
+        if arg_type == "builtins.str":
             return format_type == "c"
-        if arg_type == f"{BUILTINS}.float":
+        if arg_type == "builtins.float":
             return format_type in "deEfFgGn%"
-        if arg_type == f"{BUILTINS}.int":
+        if arg_type == "builtins.int":
             # Integers allow all types
             return True
         return False

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -42,10 +42,10 @@ from typing import TYPE_CHECKING, Iterable
 
 import astroid
 from astroid import nodes
+from astroid.const import BUILTINS
 
 from pylint.checkers import BaseChecker, BaseTokenChecker, utils
 from pylint.checkers.utils import check_messages
-from pylint.constants import BUILTINS
 from pylint.interfaces import IAstroidChecker, IRawChecker, ITokenChecker
 
 if TYPE_CHECKING:
@@ -223,10 +223,6 @@ OTHER_NODES = (
     nodes.GeneratorExp,
 )
 
-BUILTINS_STR = BUILTINS + ".str"
-BUILTINS_FLOAT = BUILTINS + ".float"
-BUILTINS_INT = BUILTINS + ".int"
-
 
 def get_access_path(key, parts):
     """Given a list of format specifiers, returns
@@ -247,11 +243,11 @@ def arg_matches_format_type(arg_type, format_type):
         return True
     if isinstance(arg_type, astroid.Instance):
         arg_type = arg_type.pytype()
-        if arg_type == BUILTINS_STR:
+        if arg_type == f"{BUILTINS}.str":
             return format_type == "c"
-        if arg_type == BUILTINS_FLOAT:
+        if arg_type == f"{BUILTINS}.float":
             return format_type in "deEfFgGn%"
-        if arg_type == BUILTINS_INT:
+        if arg_type == f"{BUILTINS}.int":
             # Integers allow all types
             return True
         return False

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -70,7 +70,6 @@ from typing import Pattern, Tuple
 
 import astroid
 from astroid import nodes
-from pylint.constants import PY310_PLUS
 
 from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import (
@@ -94,6 +93,7 @@ from pylint.checkers.utils import (
     supports_membership_test,
     supports_setitem,
 )
+from pylint.constants import PY310_PLUS
 from pylint.interfaces import INFERENCE, IAstroidChecker
 from pylint.utils import get_global_option
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -70,6 +70,7 @@ from typing import Pattern, Tuple
 
 import astroid
 from astroid import nodes
+from astroid.const import BUILTINS, PY310_PLUS
 
 from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import (
@@ -93,7 +94,6 @@ from pylint.checkers.utils import (
     supports_membership_test,
     supports_setitem,
 )
-from pylint.constants import BUILTINS, PY310_PLUS
 from pylint.interfaces import INFERENCE, IAstroidChecker
 from pylint.utils import get_global_option
 
@@ -1535,7 +1535,7 @@ accessed. Python regular expressions are accepted.",
                 return None
         # Instance values must be int, slice, or have an __index__ method
         elif isinstance(index_type, astroid.Instance):
-            if index_type.pytype() in (BUILTINS + ".int", BUILTINS + ".slice"):
+            if index_type.pytype() in (f"{BUILTINS}.int", f"{BUILTINS}.slice"):
                 return None
             try:
                 index_type.getattr("__index__")
@@ -1578,7 +1578,7 @@ accessed. Python regular expressions are accepted.",
             # Instance values must be of type int, None or an object
             # with __index__
             elif isinstance(index_type, astroid.Instance):
-                if index_type.pytype() in (BUILTINS + ".int", BUILTINS + ".NoneType"):
+                if index_type.pytype() in (f"{BUILTINS}.int", f"{BUILTINS}.NoneType"):
                     continue
 
                 try:

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -70,7 +70,7 @@ from typing import Pattern, Tuple
 
 import astroid
 from astroid import nodes
-from astroid.const import BUILTINS, PY310_PLUS
+from astroid.const import PY310_PLUS
 
 from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import (
@@ -97,7 +97,7 @@ from pylint.checkers.utils import (
 from pylint.interfaces import INFERENCE, IAstroidChecker
 from pylint.utils import get_global_option
 
-STR_FORMAT = {"%s.str.format" % BUILTINS}
+STR_FORMAT = {"builtins.str.format"}
 ASYNCIO_COROUTINE = "asyncio.coroutines.coroutine"
 BUILTIN_TUPLE = "builtins.tuple"
 TYPE_ANNOTATION_NODES_TYPES = (
@@ -1514,7 +1514,7 @@ accessed. Python regular expressions are accepted.",
             return None
         if (
             not isinstance(itemmethod, nodes.FunctionDef)
-            or itemmethod.root().name != BUILTINS
+            or itemmethod.root().name != "builtins"
             or not itemmethod.parent
             or itemmethod.parent.name not in SEQUENCE_TYPES
         ):
@@ -1535,7 +1535,7 @@ accessed. Python regular expressions are accepted.",
                 return None
         # Instance values must be int, slice, or have an __index__ method
         elif isinstance(index_type, astroid.Instance):
-            if index_type.pytype() in (f"{BUILTINS}.int", f"{BUILTINS}.slice"):
+            if index_type.pytype() in ("builtins.int", "builtins.slice"):
                 return None
             try:
                 index_type.getattr("__index__")
@@ -1578,7 +1578,7 @@ accessed. Python regular expressions are accepted.",
             # Instance values must be of type int, None or an object
             # with __index__
             elif isinstance(index_type, astroid.Instance):
-                if index_type.pytype() in (f"{BUILTINS}.int", f"{BUILTINS}.NoneType"):
+                if index_type.pytype() in ("builtins.int", "builtins.NoneType"):
                     continue
 
                 try:

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -70,7 +70,7 @@ from typing import Pattern, Tuple
 
 import astroid
 from astroid import nodes
-from astroid.const import PY310_PLUS
+from pylint.constants import PY310_PLUS
 
 from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import (

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -74,7 +74,6 @@ import _string
 import astroid
 import astroid.objects
 from astroid import TooManyLevelsError
-from astroid.const import BUILTINS
 
 COMP_NODE_TYPES = (
     astroid.ListComp,
@@ -304,7 +303,7 @@ def get_all_elements(
 
 def is_super(node: astroid.node_classes.NodeNG) -> bool:
     """return True if the node is referencing the "super" builtin function"""
-    if getattr(node, "name", None) == "super" and node.root().name == BUILTINS:
+    if getattr(node, "name", None) == "super" and node.root().name == "builtins":
         return True
     return False
 
@@ -320,7 +319,7 @@ SPECIAL_BUILTINS = ("__builtins__",)  # '__path__', '__file__')
 
 def is_builtin_object(node: astroid.node_classes.NodeNG) -> bool:
     """Returns True if the given node is an object from the __builtin__ module."""
-    return node and node.root().name == BUILTINS
+    return node and node.root().name == "builtins"
 
 
 def is_builtin(name: str) -> bool:
@@ -799,7 +798,7 @@ def _is_property_decorator(decorator: astroid.Name) -> bool:
             if inferred.qname() in ("builtins.property", "functools.cached_property"):
                 return True
             for ancestor in inferred.ancestors():
-                if ancestor.name == "property" and ancestor.root().name == BUILTINS:
+                if ancestor.name == "property" and ancestor.root().name == "builtins":
                     return True
         elif isinstance(inferred, astroid.FunctionDef):
             # If decorator is function, check if it has exactly one return

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -74,8 +74,7 @@ import _string
 import astroid
 import astroid.objects
 from astroid import TooManyLevelsError
-
-from pylint.constants import BUILTINS
+from astroid.const import BUILTINS
 
 COMP_NODE_TYPES = (
     astroid.ListComp,

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -1,6 +1,5 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
-import builtins
 import platform
 import sys
 
@@ -8,7 +7,6 @@ import astroid
 
 from pylint.__pkginfo__ import __version__
 
-BUILTINS = builtins.__name__
 PY38_PLUS = sys.version_info[:2] >= (3, 8)
 PY39_PLUS = sys.version_info[:2] >= (3, 9)
 PY310_PLUS = sys.version_info[:2] >= (3, 10)

--- a/pylint/extensions/redefined_variable_type.py
+++ b/pylint/extensions/redefined_variable_type.py
@@ -11,10 +11,10 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import astroid
+from astroid.const import BUILTINS
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import check_messages, is_none, node_type
-from pylint.constants import BUILTINS
 from pylint.interfaces import IAstroidChecker
 
 
@@ -85,8 +85,8 @@ class MultipleTypesChecker(BaseChecker):
                     ) and redef_parent in orig_parent.nodes_of_class(astroid.If):
                         orig_node, orig_type = redef_node, redef_type
                         continue
-                orig_type = orig_type.replace(BUILTINS + ".", "")
-                redef_type = redef_type.replace(BUILTINS + ".", "")
+                orig_type = orig_type.replace(f"{BUILTINS}.", "")
+                redef_type = redef_type.replace(f"{BUILTINS}.", "")
                 self.add_message(
                     "redefined-variable-type",
                     node=redef_node,

--- a/pylint/extensions/redefined_variable_type.py
+++ b/pylint/extensions/redefined_variable_type.py
@@ -11,7 +11,6 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import astroid
-from astroid.const import BUILTINS
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import check_messages, is_none, node_type
@@ -85,8 +84,8 @@ class MultipleTypesChecker(BaseChecker):
                     ) and redef_parent in orig_parent.nodes_of_class(astroid.If):
                         orig_node, orig_type = redef_node, redef_type
                         continue
-                orig_type = orig_type.replace(f"{BUILTINS}.", "")
-                redef_type = redef_type.replace(f"{BUILTINS}.", "")
+                orig_type = orig_type.replace("builtins.", "")
+                redef_type = redef_type.replace("builtins.", "")
                 self.add_message(
                     "redefined-variable-type",
                     node=redef_node,

--- a/pylint/pyreverse/diadefslib.py
+++ b/pylint/pyreverse/diadefslib.py
@@ -21,8 +21,8 @@
 """
 
 import astroid
+from astroid.const import BUILTINS
 
-from pylint.constants import BUILTINS
 from pylint.pyreverse.diagrams import ClassDiagram, PackageDiagram
 from pylint.pyreverse.utils import LocalsVisitor
 

--- a/pylint/pyreverse/diadefslib.py
+++ b/pylint/pyreverse/diadefslib.py
@@ -21,7 +21,6 @@
 """
 
 import astroid
-from astroid.const import BUILTINS
 
 from pylint.pyreverse.diagrams import ClassDiagram, PackageDiagram
 from pylint.pyreverse.utils import LocalsVisitor
@@ -78,7 +77,7 @@ class DiaDefGenerator:
         """true if builtins and not show_builtins"""
         if self.config.show_builtin:
             return True
-        return node.root().name != BUILTINS
+        return node.root().name != "builtins"
 
     def add_class(self, node):
         """visit one class and add it to diagram"""


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Replace the constant BUILTINS by the string 'builtins'
    
This make for clearer and also slightly faster code (means time
seems to decrease by 0.68% with this change alone (astroid/pylint)
in the pylint tests benchmarks). Done originally because we were using an
import from astroid from astroid.bases for one of those, which is
kinda messy.

