### PR TITLE
Improve invalid-metaclass error message for Instances

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -160,6 +160,8 @@ Release date: TBA
 
 * Improve performance when inferring ``Call`` nodes, by utilizing caching.
 
+* Improve error message for invalid-metaclass when the node is an Instance.
+
 
 What's New in Pylint 2.9.6?
 ===========================

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -69,7 +69,7 @@ from functools import singledispatch
 from typing import Pattern, Tuple
 
 import astroid
-from astroid import nodes
+from astroid import bases, nodes
 
 from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import (
@@ -927,8 +927,13 @@ accessed. Python regular expressions are accepted.",
     @check_messages("invalid-metaclass")
     def visit_classdef(self, node):
         def _metaclass_name(metaclass):
+            # pylint: disable=unidiomatic-typecheck
             if isinstance(metaclass, (nodes.ClassDef, nodes.FunctionDef)):
                 return metaclass.name
+            if type(metaclass) is bases.Instance:
+                # Really do mean type, not isinstance, since subclasses of bases.Instance
+                # like Const or Dict should use metaclass.as_string below.
+                return str(metaclass)
             return metaclass.as_string()
 
         metaclass = node.declared_metaclass()

--- a/tests/checkers/unittest_typecheck.py
+++ b/tests/checkers/unittest_typecheck.py
@@ -224,9 +224,13 @@ class TestTypeChecker(CheckerTestCase):
 
         class ThirdInvalid(object, metaclass=2):
             pass
+
+        class FourthInvalid(object, metaclass=InvalidAsMetaclass()):
+            pass
         """
         )
         for class_obj, metaclass_name in (
+            ("FourthInvalid", "Instance of .InvalidAsMetaclass"),
             ("ThirdInvalid", "2"),
             ("SecondInvalid", "InvalidAsMetaclass"),
             ("FirstInvalid", "int"),


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Ref https://github.com/PyCQA/pylint/pull/4870#discussion_r691830356

Previously, the `invalid-metaclass` message prints out the full class text when given an `Instance` of a `ClassDef`. I added a check so that their repr (`Instance of ...`) would be displayed instead.

As a comment, because `bases.Instance` has some subclasses like `nodes.Const` and `nodes.Dict` where we *do* want to call `as_string`, I used an unidiomatic type check to pull out `Instance` objects directly. Not amazing, but I left a comment explaining why. I feel like astroid should support a separate subclass of `Instance` for "instance of a class with an unknown value" to differentiate it from `Const`/`Dict`/etc.