### PR TITLE
pylint does not crash when PYLINT_HOME does not exist

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,9 +15,9 @@ What's New in Pylint 2.10.1?
 ============================
 Release date: TBA
 
-..
-  Put bug fixes that should not wait for a new minor version here
+* pylint does not crash when PYLINT_HOME does not exist.
 
+  Closes #4883
 
 
 What's New in Pylint 2.10.0?

--- a/pylint/config/__init__.py
+++ b/pylint/config/__init__.py
@@ -35,6 +35,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import os
+import pathlib
 import pickle
 import sys
 from datetime import datetime
@@ -86,14 +87,17 @@ else:
             file=sys.stderr,
         )
         # Remove old spam prevention file
-        for filename in os.listdir(PYLINT_HOME):
-            if prefix_spam_prevention in filename:
-                try:
-                    os.remove(os.path.join(PYLINT_HOME, filename))
-                except OSError:
-                    pass
+        if os.path.exists(PYLINT_HOME):
+            for filename in os.listdir(PYLINT_HOME):
+                if prefix_spam_prevention in filename:
+                    try:
+                        os.remove(os.path.join(PYLINT_HOME, filename))
+                    except OSError:
+                        pass
+
         # Create spam prevention file for today
         try:
+            pathlib.Path(PYLINT_HOME).mkdir(parents=True, exist_ok=True)
             with open(spam_prevention_file, "w", encoding="utf8") as f:
                 f.write("")
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #4883