### PR TITLE
Updated mypy checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,8 +72,8 @@ jobs:
           . venv/bin/activate
           pre-commit install --install-hooks
 
-  formatting:
-    name: Run pre-commit checks
+  pylint:
+    name: Run pylint check
     runs-on: ubuntu-latest
     needs: prepare-base
     steps:
@@ -113,6 +113,48 @@ jobs:
           . venv/bin/activate
           pip install -e .
           pre-commit run pylint --all-files
+
+  mypy:
+    name: Run mypy check
+    runs-on: ubuntu-latest
+    needs: prepare-base
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.3.4
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Restore Python virtual environment
+        id: cache-venv
+        uses: actions/cache@v2.1.6
+        with:
+          path: venv
+          key:
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            needs.prepare-base.outputs.python-key }}
+      - name: Fail job if Python cache restore failed
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore Python venv from cache"
+          exit 1
+      - name: Restore pre-commit environment
+        id: cache-precommit
+        uses: actions/cache@v2.1.6
+        with:
+          path: ${{ env.PRE_COMMIT_CACHE }}
+          key: ${{ runner.os }}-${{ needs.prepare-base.outputs.pre-commit-key }}
+      - name: Fail job if pre-commit cache restore failed
+        if: steps.cache-precommit.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore pre-commit environment from cache"
+          exit 1
+      - name: Run formatting check
+        run: |
+          . venv/bin/activate
+          pip install -e .
+          pre-commit run mypy --all-files
 
   spelling:
     name: Run spelling checks

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,8 +72,8 @@ jobs:
           . venv/bin/activate
           pre-commit install --install-hooks
 
-  pylint:
-    name: Run pylint check
+  formatting:
+    name: Run pre-commit checks
     runs-on: ubuntu-latest
     needs: prepare-base
     steps:
@@ -113,48 +113,6 @@ jobs:
           . venv/bin/activate
           pip install -e .
           pre-commit run pylint --all-files
-
-  mypy:
-    name: Run mypy check
-    runs-on: ubuntu-latest
-    needs: prepare-base
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v2.3.4
-      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-        id: python
-        uses: actions/setup-python@v2.2.2
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: Restore Python virtual environment
-        id: cache-venv
-        uses: actions/cache@v2.1.6
-        with:
-          path: venv
-          key:
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            needs.prepare-base.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
-      - name: Restore pre-commit environment
-        id: cache-precommit
-        uses: actions/cache@v2.1.6
-        with:
-          path: ${{ env.PRE_COMMIT_CACHE }}
-          key: ${{ runner.os }}-${{ needs.prepare-base.outputs.pre-commit-key }}
-      - name: Fail job if pre-commit cache restore failed
-        if: steps.cache-precommit.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore pre-commit environment from cache"
-          exit 1
-      - name: Run formatting check
-        run: |
-          . venv/bin/activate
-          pip install -e .
-          pre-commit run mypy --all-files
 
   spelling:
     name: Run spelling checks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,14 +61,6 @@ repos:
           ]
         # disabled plugins: pylint.extensions.mccabe
         exclude: tests/functional/|tests/input|tests/extensions/data|tests/regrtest_data/|tests/data/|doc/
-      - id: mypy
-        name: mypy
-        entry: mypy
-        language: system
-        types: [python]
-        args: []
-        require_serial: true
-        exclude: tests/functional/|tests/input|tests(/.*)*/data|tests/regrtest_data/|tests/data/|tests(/.*)+/conftest.py|doc/|bin/
       - id: fix-documentation
         name: Fix documentation
         entry: python3 -m script.fix_documentation
@@ -82,6 +74,18 @@ repos:
         args: ["--ignore-roles=func,class,mod", "--report=warning"]
         types: [text] # necessary to include ChangeLog file
         files: ^(ChangeLog|doc/(.*/)*.*\.rst)
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: mypy
+        language: python
+        types: [python]
+        args: []
+        require_serial: true
+        additional_dependencies: ["types-pkg_resources==0.1.3", "types-toml==0.1.3"]
+        exclude: tests/functional/|tests/input|tests(/.*)*/data|tests/regrtest_data/|tests/data/|tests(/.*)+/conftest.py|doc/|bin/
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.3.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,14 @@ repos:
           ]
         # disabled plugins: pylint.extensions.mccabe
         exclude: tests/functional/|tests/input|tests/extensions/data|tests/regrtest_data/|tests/data/|doc/
+      - id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        types: [python]
+        args: []
+        require_serial: true
+        exclude: tests/functional/|tests/input|tests(/.*)*/data|tests/regrtest_data/|tests/data/|tests(/.*)+/conftest.py|doc/|bin/
       - id: fix-documentation
         name: Fix documentation
         entry: python3 -m script.fix_documentation
@@ -74,18 +82,6 @@ repos:
         args: ["--ignore-roles=func,class,mod", "--report=warning"]
         types: [text] # necessary to include ChangeLog file
         files: ^(ChangeLog|doc/(.*/)*.*\.rst)
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
-    hooks:
-      - id: mypy
-        name: mypy
-        entry: mypy
-        language: python
-        types: [python]
-        args: []
-        require_serial: true
-        additional_dependencies: ["types-pkg_resources==0.1.3", "types-toml==0.1.3"]
-        exclude: tests/functional/|tests/input|tests(/.*)*/data|tests/regrtest_data/|tests/data/|tests(/.*)+/conftest.py|doc/|bin/
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.3.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,7 +84,8 @@ repos:
         types: [python]
         args: []
         require_serial: true
-        additional_dependencies: ["types-pkg_resources==0.1.3", "types-toml==0.1.3"]
+        additional_dependencies:
+          ["platformdirs==2.2.0", "types-pkg_resources==0.1.3", "types-toml==0.1.3"]
         exclude: tests/functional/|tests/input|tests(/.*)*/data|tests/regrtest_data/|tests/data/|tests(/.*)+/conftest.py|doc/|bin/
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,9 +83,6 @@ src_paths = pylint
 [mypy]
 scripts_are_modules = True
 
-[mypy-platformdirs]
-ignore_missing_imports = True
-
 [mypy-astroid.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
https://github.com/PyCQA/pylint/pull/4887#discussion_r693329085 mentioned that `platformdirs` is now fully typed.

To be able to remove the import ignore from `setup.cfg`, we would need to add `platformdirs` as an additional dependency in `.pre-commit-config.yaml`. Long term it might be better to just run mypy in the local environment instead.

If the PR is accepted, I'll update `astroid` as well.