### PR TITLE
Require platformdirs 2.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    platformdirs>=2.0.0
+    platformdirs>=2.2.0
     astroid>=2.7.2,<2.8 # (You should also upgrade requirements_test_min.txt)
     isort>=4.2.5,<6
     mccabe>=0.6,<0.7


### PR DESCRIPTION
## Description
Update `platformdirs` requirement to `>=2.2.0`.

Version `2.1.0` added typing support: https://github.com/platformdirs/platformdirs/releases/tag/2.1.0
Version `2.2.0` added a fallback if the `XDG` environment variable is empty: https://github.com/platformdirs/platformdirs/releases/tag/2.2.0

No changelog entry require as no pylint version with `platformdirs` has been released yet.