### PR TITLE
Better read the doc configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,9 +3,10 @@
 version: 2
 
 sphinx:
+  fail_on_warning: true
   configuration: doc/conf.py
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: doc/requirements.txt

--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,10 @@ Release date: TBA
 
   Closes #4751
 
+* https is now prefered in the documentation and http://pylint.pycqa.org correctly redirect to https://pylint.pycqa.org
+
+  Closes #3802
+
 
 What's New in Pylint 2.10.3?
 ============================

--- a/doc/user_guide/message-control.rst
+++ b/doc/user_guide/message-control.rst
@@ -1,3 +1,5 @@
+.. _message-control:
+
 Messages control
 ================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,9 +36,9 @@ project_urls =
     What's New = https://pylint.pycqa.org/en/latest/whatsnew/
     Bug Tracker = https://github.com/PyCQA/pylint/issues
     Discord Server = https://discord.gg/Egy6P8AMB5
-    Docs: User Guide = http://pylint.pycqa.org/en/latest/
-    Docs: Contributing = http://pylint.pycqa.org/en/latest/development_guide/contribute.html
-    Docs: Technical Reference = http://pylint.pycqa.org/en/latest/technical_reference/index.html
+    Docs: User Guide = https://pylint.pycqa.org/en/latest/
+    Docs: Contributing = https://pylint.pycqa.org/en/latest/development_guide/contribute.html
+    Docs: Technical Reference = https://pylint.pycqa.org/en/latest/technical_reference/index.html
 
 [options]
 packages = find:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

 https is now prefered in the documentation and http://pylint.pycqa.org correctly redirect to https://pylint.pycqa.org

  Closes #3802