### PR TITLE
Fix false positive ``protected-access`` in typing 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,8 @@ Release date: TBA
 
   Closes #3802
 
+* Fix false positive for ``protected-access`` if a protected member is used in type hints of function definitions
+
 
 What's New in Pylint 2.10.3?
 ============================

--- a/doc/whatsnew/2.10.rst
+++ b/doc/whatsnew/2.10.rst
@@ -82,9 +82,6 @@ Other Changes
 
 * ``consider-using-with`` is no longer triggered if a context manager is returned from a function.
 
-* Fix false positive for ``consider-using-with`` if a context manager is assigned to a
-  variable in different paths of control flow (e. g. if-else clause).
-
 * pylint does not crash with a traceback anymore when a file is problematic. It
   creates a template text file for opening an issue on the bug tracker instead.
   The linting can go on for other non problematic files instead of being impossible.

--- a/doc/whatsnew/2.11.rst
+++ b/doc/whatsnew/2.11.rst
@@ -41,3 +41,6 @@ Other Changes
 * Added ``py-version`` config key (if ``[MASTER]`` section). Used for version dependant checks.
   Will default to whatever Python version pylint is executed with.
 * The ``invalid-name`` message is now more detailed when using multiple naming style regexes.
+
+
+* Fix false positive for ``protected-access`` if a protected member is used in type hints of function definitions

--- a/doc/whatsnew/2.11.rst
+++ b/doc/whatsnew/2.11.rst
@@ -49,5 +49,5 @@ Other Changes
 * Fix false positive for ``function-redefined`` for simple type annotations
 
   Closes #4936
-  
+
 * Fix false positive for ``protected-access`` if a protected member is used in type hints of function definitions

--- a/doc/whatsnew/2.11.rst
+++ b/doc/whatsnew/2.11.rst
@@ -20,12 +20,10 @@ New checkers
 Extensions
 ==========
 
-
 * Added new extension ``SetMembershipChecker`` with ``use-set-for-membership`` check:
   Emitted when using an in-place defined ``list`` or ``tuple`` to do a membership test. ``sets`` are better optimized for that.
 
   Closes #4776
-
 
 * ``CodeStyleChecker``
 
@@ -40,7 +38,12 @@ Other Changes
 
 * Added ``py-version`` config key (if ``[MASTER]`` section). Used for version dependant checks.
   Will default to whatever Python version pylint is executed with.
+
 * The ``invalid-name`` message is now more detailed when using multiple naming style regexes.
 
+* Fix false positive for ``consider-using-with`` if a context manager is assigned to a
+  variable in different paths of control flow (e. g. if-else clause).
+
+  Closes #4751
 
 * Fix false positive for ``protected-access`` if a protected member is used in type hints of function definitions

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -52,7 +52,7 @@ from typing import List, Pattern, cast
 import astroid
 from astroid import nodes
 
-from pylint.checkers import BaseChecker
+from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import (
     PYMETHODS,
     SPECIAL_METHODS_PARAMS,
@@ -1563,7 +1563,7 @@ a metaclass class method.",
         if any(method_name == member.name for member in parent_class.mymethods()):
             self.add_message(msg, node=node.targets[0])
 
-    def _check_protected_attribute_access(self, node):
+    def _check_protected_attribute_access(self, node: nodes.Attribute):
         """Given an attribute access node (set or get), check if attribute
         access is legitimate. Call _check_first_attr with node before calling
         this method. Valid cases are:
@@ -1585,6 +1585,10 @@ a metaclass class method.",
             # In classes, check we are not getting a parent method
             # through the class object or through super
             callee = node.expr.as_string()
+
+            # Typing annotations in funciton definitions can include protected members
+            if utils.is_node_in_type_annotation_context(node):
+                return
 
             # We are not in a class, no remaining valid case
             if klass is None:

--- a/tests/functional/a/access/access_to_protected_members_typing.py
+++ b/tests/functional/a/access/access_to_protected_members_typing.py
@@ -1,0 +1,32 @@
+# pylint: disable=too-few-public-methods, invalid-name
+"""Test typing with a protected member"""
+from __future__ import annotations
+
+
+class MyClass:
+    """Class with protected members."""
+
+    class _Inner_Class:
+        """Inner class with protected members."""
+
+        def __init__(self) -> None:
+            self.data = 1
+
+        def return_data(self) -> int:
+            """Return data"""
+            return self.data
+
+    def return_private_class(self) -> MyClass._Inner_Class:
+        """Doing nothing."""
+        return self._Inner_Class()
+
+
+def access_protected_class(data: MyClass._Inner_Class) -> int:
+    """Function that always receives a protected class."""
+    return data.return_data() + 1
+
+
+def pass_protected_class() -> None:
+    """Function that passes a protected class to another function."""
+    data_value = access_protected_class(MyClass().return_private_class())
+    print(data_value)

--- a/tests/functional/a/access/access_to_protected_members_typing.rc
+++ b/tests/functional/a/access/access_to_protected_members_typing.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.7


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description

Fix false positive protected-access in typing
Class functions can return protected members which can then be passed as arguments to other functions.
When using type hints in function definitions these raised a message which they shouldn't do.

I did not create an issue for this so no issue is assigned, if needed I can still do this

I also saw some discrepancies between the `Changelog` and the `2.10` & `2.11` files. I fixed these and added the customary styling of the `whatsnew` documents to the `2.11`. I thought this might be helpful, but let me know if I should remove or change that commit!