### PR TITLE
Fix false pos. `dict-iter-missing-items` for tuple keys

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -45,6 +45,10 @@ Release date: TBA
 
 * Fix false positive for ``protected-access`` if a protected member is used in type hints of function definitions
 
+* Fix false positive ``dict-iter-missing-items`` for dictionaries only using tuples as keys
+
+  Closes #3282
+
 
 What's New in Pylint 2.10.3?
 ============================

--- a/doc/whatsnew/2.11.rst
+++ b/doc/whatsnew/2.11.rst
@@ -51,3 +51,7 @@ Other Changes
   Closes #4936
 
 * Fix false positive for ``protected-access`` if a protected member is used in type hints of function definitions
+
+* Fix false positive ``dict-iter-missing-items`` for dictionaries only using tuples as keys
+
+  Closes #3282

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1862,6 +1862,10 @@ accessed. Python regular expressions are accepted.",
             # the iterable is not a dict
             return
 
+        if all(isinstance(i[0], nodes.Tuple) for i in inferred.items):
+            # if all keys are tuples
+            return
+
         self.add_message("dict-iter-missing-items", node=node)
 
 

--- a/tests/functional/d/dict_iter_missing_items.py
+++ b/tests/functional/d/dict_iter_missing_items.py
@@ -2,6 +2,7 @@
 from unknown import Uninferable
 
 d = {1: 1, 2: 2}
+d_tuple = {(1, 2): 3, (4, 5): 6}
 l = [1, 2]
 s1 = {1, 2}
 s2 = {1, 2, 3}
@@ -20,4 +21,6 @@ for i, v in enumerate(l):
 for i, v in s1.intersection(s2):
     pass
 for k, v in Uninferable:
+    pass
+for a, b in d_tuple:
     pass

--- a/tests/functional/d/dict_iter_missing_items.txt
+++ b/tests/functional/d/dict_iter_missing_items.txt
@@ -1,1 +1,1 @@
-dict-iter-missing-items:10:0::Unpacking a dictionary in iteration without calling .items()
+dict-iter-missing-items:11:0::Unpacking a dictionary in iteration without calling .items()


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This fixes a false positive emitted for dictionaries that contain only
tuples as keys. This makes unpacking the dictionary without calling `.items()` valid.
This closes #3283