### PR TITLE
Fix the ``raising-bad-type`` warning for string

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,8 @@ Release date: TBA
 * The python3 porting mode checker and it's ``py3k`` option were removed. You can still find it in older pylint
   versions.
 
+* ``raising-bad-type`` is now properly emitted when  raising a string
+
 * Added new extension ``SetMembershipChecker`` with ``use-set-for-membership`` check:
   Emitted when using an in-place defined ``list`` or ``tuple`` to do a membership test. ``sets`` are better optimized for that.
 

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -229,11 +229,9 @@ class ExceptionRaiseLeafVisitor(BaseVisitor):
     """Visitor for handling leaf kinds of a raise value."""
 
     def visit_const(self, const):
-        if not isinstance(const.value, str):
-            # raising-string will be emitted from python3 porting checker.
-            self._checker.add_message(
-                "raising-bad-type", node=self._node, args=const.value.__class__.__name__
-            )
+        self._checker.add_message(
+            "raising-bad-type", node=self._node, args=const.value.__class__.__name__
+        )
 
     def visit_instance(self, instance):
         # pylint: disable=protected-access

--- a/tests/functional/i/invalid/e/invalid_exceptions_raised.py
+++ b/tests/functional/i/invalid/e/invalid_exceptions_raised.py
@@ -103,3 +103,8 @@ def reusing_same_name_picks_the_latest_raised_value():
         exc = Error(exc)
         if exc:
             raise exc
+
+
+def bad_case10():
+    """raise string"""
+    raise "string"  # [raising-bad-type]

--- a/tests/functional/i/invalid/e/invalid_exceptions_raised.txt
+++ b/tests/functional/i/invalid/e/invalid_exceptions_raised.txt
@@ -8,3 +8,4 @@ raising-bad-type:64:4:bad_case6:Raising NoneType while only classes or instances
 raising-non-exception:68:4:bad_case7:Raising a new style class which doesn't inherit from BaseException
 raising-non-exception:72:4:bad_case8:Raising a new style class which doesn't inherit from BaseException
 raising-non-exception:76:4:bad_case9:Raising a new style class which doesn't inherit from BaseException
+raising-bad-type:110:4:bad_case10:Raising str while only classes or instances are allowed


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Apparently this use case was supposed to be handled by the py3K checker but as it was disabled all the time the issue has'nt been handled at all for a long time.
