### PR TITLE
Remove unused ``visit_package`` function

### DIFF
--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -123,16 +123,6 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
         for module in node.modules:
             self.visit(module)
 
-    def visit_package(self, node):
-        """visit an astroid.Package node
-
-        * optionally tag the node with a unique id
-        """
-        if self.tag:
-            node.uid = self.generate_id()
-        for subelmt in node.values():
-            self.visit(subelmt)
-
     def visit_module(self, node):
         """visit an astroid.Module node
 


### PR DESCRIPTION
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

See:
>I'm not too familiar with the `pyreverse` code, but even if it isn't called anymore, we shouldn't remove it here. That should be done in a separate PR.

_Originally posted by @cdce8p in https://github.com/PyCQA/pylint/pull/4940#discussion_r700316157_
