### PR TITLE
Fix false positive ``unused-private-member`` for accessing attributes in a class using ``cls``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -63,6 +63,10 @@ Release date: TBA
 
   Closes #4907
 
+* Fix false positive ``unused-private-member`` for accessing attributes in a class using ``cls``
+
+  Closes #4849
+
 
 What's New in Pylint 2.10.3?
 ============================

--- a/doc/whatsnew/2.11.rst
+++ b/doc/whatsnew/2.11.rst
@@ -69,3 +69,7 @@ Other Changes
 * Fix false positive ``superfluous-parens`` for tuples created with inner tuples
 
   Closes #4907
+
+* Fix false positive ``unused-private-member`` for accessing attributes in a class using ``cls``
+
+  Closes #4849

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -1000,11 +1000,11 @@ a metaclass class method.",
                 if attribute.attrname != assign_attr.attrname:
                     continue
 
-                if assign_attr.expr.name == "cls" and attribute.expr.name in [
+                if assign_attr.expr.name in [
                     "cls",
-                    "self",
-                ]:
-                    # If assigned to cls.attrib, can be accessed by cls/self
+                    node.name,
+                ] and attribute.expr.name in ["cls", "self", node.name]:
+                    # If assigned to cls or class name, can be accessed by cls/self/class name
                     break
 
                 if (

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -1000,10 +1000,14 @@ a metaclass class method.",
                 if attribute.attrname != assign_attr.attrname:
                     continue
 
-                if assign_attr.expr.name in [
-                    "cls",
-                    node.name,
-                ] and attribute.expr.name in ["cls", "self", node.name]:
+                if (
+                    assign_attr.expr.name
+                    in [
+                        "cls",
+                        node.name,
+                    ]
+                    and attribute.expr.name in ["cls", "self", node.name]
+                ):
                     # If assigned to cls or class name, can be accessed by cls/self/class name
                     break
 

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -260,7 +260,7 @@ class FalsePositive4681b:
             print("Error")
             FalsePositive4681b.__instance = False  # This should be fine
 
-            
+
 # https://github.com/PyCQA/pylint/issues/4849
 # Accessing private static methods from classmethods via `cls` should not result in a
 # false positive
@@ -279,7 +279,7 @@ class FalsePositive4849:
         """Calls private method."""
         cls.__private_method()  # This should pass
 
-        
+
 class Pony:
     """https://github.com/PyCQA/pylint/issues/4837"""
     __defaults = {}

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -242,6 +242,23 @@ class FalsePositive4681:
             FalsePositive4681.__instance = False  # This should be fine
             FalsePositive4681.__should_cause_error = False  # [unused-private-member]
 
+# Accessing attributes of the class using `cls` should not result in a false positive
+# as long as it is used within the class
+class FalsePositive4681b:
+    __instance = None
+
+    @classmethod  # Use class method here
+    def instance(cls):
+        if cls.__instance is None:
+            cls()
+        return cls.__instance
+
+    def __init__(self):
+        try:
+            FalsePositive4681b.__instance = 42  # This should be fine
+        except Exception:  # pylint: disable=broad-except
+            print("Error")
+            FalsePositive4681b.__instance = False  # This should be fine
 
 class Pony:
     """https://github.com/PyCQA/pylint/issues/4837"""

--- a/tests/functional/u/unused/unused_private_member.txt
+++ b/tests/functional/u/unused/unused_private_member.txt
@@ -14,5 +14,5 @@ unused-private-member:212:8:Crash4755Context.__init__:Unused private member `Cra
 unused-private-member:229:4:FalsePositive4681:Unused private member `FalsePositive4681.__should_cause_error`:HIGH
 unused-private-member:239:12:FalsePositive4681.__init__:Unused private member `FalsePositive4681.__should_cause_error`:HIGH
 unused-private-member:243:12:FalsePositive4681.__init__:Unused private member `FalsePositive4681.__should_cause_error`:HIGH
-unused-private-member:254:4:Pony.__init_defaults:Unused private member `Pony.__init_defaults(self)`:HIGH
-unused-private-member:259:4:Pony.__get_fur_color:Unused private member `Pony.__get_fur_color(self)`:HIGH
+unused-private-member:271:4:Pony.__init_defaults:Unused private member `Pony.__init_defaults(self)`:HIGH
+unused-private-member:276:4:Pony.__get_fur_color:Unused private member `Pony.__get_fur_color(self)`:HIGH

--- a/tests/functional/u/unused/unused_private_member.txt
+++ b/tests/functional/u/unused/unused_private_member.txt
@@ -14,8 +14,6 @@ unused-private-member:212:8:Crash4755Context.__init__:Unused private member `Cra
 unused-private-member:229:4:FalsePositive4681:Unused private member `FalsePositive4681.__should_cause_error`:HIGH
 unused-private-member:239:12:FalsePositive4681.__init__:Unused private member `FalsePositive4681.__should_cause_error`:HIGH
 unused-private-member:243:12:FalsePositive4681.__init__:Unused private member `FalsePositive4681.__should_cause_error`:HIGH
-unused-private-member:271:4:Pony.__init_defaults:Unused private member `Pony.__init_defaults(self)`:HIGH
-unused-private-member:276:4:Pony.__get_fur_color:Unused private member `Pony.__get_fur_color(self)`:HIGH
-unused-private-member:255:4:FalsePositive4849.__unused_private_method:Unused private member `FalsePositive4849.__unused_private_method()`:HIGH
-unused-private-member:272:4:Pony.__init_defaults:Unused private member `Pony.__init_defaults(self)`:HIGH
-unused-private-member:277:4:Pony.__get_fur_color:Unused private member `Pony.__get_fur_color(self)`:HIGH
+unused-private-member:274:4:FalsePositive4849.__unused_private_method:Unused private member `FalsePositive4849.__unused_private_method()`:HIGH
+unused-private-member:291:4:Pony.__init_defaults:Unused private member `Pony.__init_defaults(self)`:HIGH
+unused-private-member:296:4:Pony.__get_fur_color:Unused private member `Pony.__get_fur_color(self)`:HIGH


### PR DESCRIPTION


<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Fix false positive for ``unused-private-member`` when accessing attribs in class using ``cls`` by extending logic

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #4681 
