### PR TITLE
Remove test dependency mypy-extensions

### DIFF
--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -2,4 +2,3 @@
 astroid==2.7.3  # Pinned to a specific version for tests
 pytest~=6.2
 pytest-benchmark~=3.4
-mypy_extensions==0.4.3

--- a/tests/lint/test_pylinter.py
+++ b/tests/lint/test_pylinter.py
@@ -1,13 +1,18 @@
+import sys
 from typing import Any
 from unittest.mock import patch
 
 from _pytest.capture import CaptureFixture
 from astroid import AstroidBuildingError
-from mypy_extensions import NoReturn
 from py._path.local import LocalPath  # type: ignore
 
 from pylint.lint.pylinter import PyLinter
 from pylint.utils import FileState
+
+if sys.version_info >= (3, 6, 2):
+    from typing import NoReturn
+else:
+    from typing_extensions import NoReturn
 
 
 def raise_exception(*args: Any, **kwargs: Any) -> NoReturn:


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
`pylint` already uses `typing-extensions`. There is no need to add `mypy-extensions` as well. Ref #4950
https://docs.python.org/3/library/typing.html#typing.NoReturn

/CC: @DanielNoord