### PR TITLE
Make ``min-similarity-lines == 0`` stop similarity check

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -63,6 +63,10 @@ Release date: TBA
 
   Closes #4907
 
+* Setting ``min-similarity-lines`` to 0 now makes the similarty checker stop checking for duplicate code
+
+  Closes #4901
+
 
 What's New in Pylint 2.10.3?
 ============================

--- a/doc/whatsnew/2.11.rst
+++ b/doc/whatsnew/2.11.rst
@@ -69,3 +69,7 @@ Other Changes
 * Fix false positive ``superfluous-parens`` for tuples created with inner tuples
 
   Closes #4907
+
+* Setting ``min-similarity-lines`` to 0 now makes the similarty checker stop checking for duplicate code
+
+  Closes #4901

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -390,6 +390,8 @@ class Similar:
 
     def run(self) -> None:
         """start looking for similarities and display results on stdout"""
+        if self.min_lines == 0:
+            sys.exit(0)
         self._display_sims(self._compute_sims())
 
     def _compute_sims(self) -> List[Tuple[int, Set[LinesChunkLimits_T]]]:
@@ -919,8 +921,6 @@ def Run(argv=None):
             ignore_signatures = True
     if not args:
         usage(1)
-    if min_lines == 0:
-        sys.exit(0)
     sim = Similar(
         min_lines, ignore_comments, ignore_docstrings, ignore_imports, ignore_signatures
     )

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -919,6 +919,8 @@ def Run(argv=None):
             ignore_signatures = True
     if not args:
         usage(1)
+    if min_lines == 0:
+        sys.exit(0)
     sim = Similar(
         min_lines, ignore_comments, ignore_docstrings, ignore_imports, ignore_signatures
     )

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -391,7 +391,7 @@ class Similar:
     def run(self) -> None:
         """start looking for similarities and display results on stdout"""
         if self.min_lines == 0:
-            sys.exit(0)
+            return
         self._display_sims(self._compute_sims())
 
     def _compute_sims(self) -> List[Tuple[int, Set[LinesChunkLimits_T]]]:

--- a/tests/checkers/unittest_similar.py
+++ b/tests/checkers/unittest_similar.py
@@ -502,3 +502,11 @@ def test_get_map_data() -> None:
         # There doesn't seem to be a faster way of doing this, yet.
         lines = (linespec.text for linespec in lineset_obj.stripped_lines)
         assert tuple(expected_lines) == tuple(lines)
+
+
+def test_set_duplicate_lines_to_zero() -> None:
+    output = StringIO()
+    with redirect_stdout(output), pytest.raises(SystemExit) as ex:
+        similar.Run(["--duplicates=0", SIMILAR1, SIMILAR2])
+    assert ex.value.code == 0
+    assert output.getvalue() == ""


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |

## Description

This makes it so that setting ``min-similarity-lines`` to zero exits the
similarity code checker with a successful exit.
This closes #4901
