### PR TITLE
Extend consider-using-in for attribute access

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -63,6 +63,8 @@ Release date: TBA
 
   Closes #4907
 
+* Extended ``consider-using-in`` check to work for attribute access.
+
 
 What's New in Pylint 2.10.3?
 ============================

--- a/doc/whatsnew/2.11.rst
+++ b/doc/whatsnew/2.11.rst
@@ -69,3 +69,5 @@ Other Changes
 * Fix false positive ``superfluous-parens`` for tuples created with inner tuples
 
   Closes #4907
+
+* Extended ``consider-using-in`` check to work for attribute access.

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1185,7 +1185,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         for value in node.values:
             variable_set = set()
             for comparable in value.left, value.ops[0][1]:
-                if isinstance(comparable, nodes.Name):
+                if isinstance(comparable, (nodes.Name, nodes.Attribute)):
                     variable_set.add(comparable.as_string())
                 values.append(comparable.as_string())
             variables.append(variable_set)

--- a/tests/functional/c/consider/consider_using_in.py
+++ b/tests/functional/c/consider/consider_using_in.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, invalid-name, pointless-statement, misplaced-comparison-constant, undefined-variable, literal-comparison, line-too-long, unneeded-not
+# pylint: disable=missing-docstring, invalid-name, pointless-statement, misplaced-comparison-constant, undefined-variable, literal-comparison, line-too-long, unneeded-not, too-few-public-methods
 
 value = value1 = 1
 value2 = 2
@@ -44,3 +44,10 @@ def oops():
 
 
 some_value = value == 4 or value == 5 or value == oops() # We only look for names and constants
+
+
+# With attribute nodes
+class A:
+    value = 2
+
+A.value == 1 or A.value == 2  # [consider-using-in]

--- a/tests/functional/c/consider/consider_using_in.txt
+++ b/tests/functional/c/consider/consider_using_in.txt
@@ -11,3 +11,4 @@ consider-using-in:19:0::"Consider merging these comparisons with ""in"" to 'valu
 consider-using-in:20:0::"Consider merging these comparisons with ""in"" to 'value not in (1, 2)'"
 consider-using-in:21:0::"Consider merging these comparisons with ""in"" to 'value1 in (value2,)'"
 consider-using-in:22:0::"Consider merging these comparisons with ""in"" to 'a_list in ([1, 2, 3], [])'"
+consider-using-in:53:0::"Consider merging these comparisons with ""in"" to 'A.value in (1, 2)'"


### PR DESCRIPTION
## Type of Changes


|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description
`consider-using-in` doesn't need to be limited to `Name` nodes. `Attribute` once work too.

```py
class A:
    def __init__(self):
        self.a = 2

    def func(self):
        var = self.a
        if var == 2 or var == 3:
            print()
        if self.a == 2 or self.a == 3:  # new
            print()