### PR TITLE
Add additional test case - consider-using-assignment-expr

### DIFF
--- a/tests/functional/ext/code_style/code_style_consider_using_assignment_expr.py
+++ b/tests/functional/ext/code_style/code_style_consider_using_assignment_expr.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring,invalid-name,undefined-variable
+# pylint: disable=missing-docstring,invalid-name,undefined-variable,too-few-public-methods
 
 a1 = 2
 if a1:  # [consider-using-assignment-expr]
@@ -146,3 +146,14 @@ def func_p():
         ...
     elif p6_other:
         ...
+
+
+# -----
+# Assignment expression does NOT work for attribute access
+# Make sure not to emit message!
+class A:
+    var = 1
+
+A.var = 2
+if A.var:
+    ...


### PR DESCRIPTION
## Description
Small test case to make sure pylint doesn't emit `consider-using-assignment-expr` for attribute access. Assignment expressions only work for `Name`.