### PR TITLE
Fix #4370: false-positive no-member in class based on typing.NamedTuple

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -25,7 +25,7 @@ Current team:
   Added Python 3 check for accessing deprecated methods on the 'string' module,
   various patches.
 
-* Dmitry Pribysh: committer
+* Dmitri Prybysh: committer
 
   multiple-imports, not-iterable, not-a-mapping, various patches.
 

--- a/tests/functional/n/no/no_member_nested_namedtuple.py
+++ b/tests/functional/n/no/no_member_nested_namedtuple.py
@@ -1,0 +1,8 @@
+from typing import NamedTuple
+
+class Ax(NamedTuple):
+    class Bx:
+        b = 0
+
+
+print(Ax.Bx.b)

--- a/tests/functional/n/no/no_member_nested_namedtuple.rc
+++ b/tests/functional/n/no/no_member_nested_namedtuple.rc
@@ -1,0 +1,10 @@
+[testoptions]
+min_pyver=3.7
+
+[MESSAGES CONTROL]
+disable=fixme,
+    logging-too-many-args,
+    logging-fstring-interpolation,
+    missing-docstring,
+    no-else-return,
+    too-few-public-methods,


### PR DESCRIPTION
This PR adds a functional test that's demonstrating #4370. The test should become green once PyCQA/astroid#1166 is merged and astroid is released.

(Oh, and i took the liberty to update my last name in contributors list.)

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #4370.