### PR TITLE
Use ``overload`` to type ``get_global_option``

### DIFF
--- a/pylint/extensions/code_style.py
+++ b/pylint/extensions/code_style.py
@@ -77,7 +77,7 @@ class CodeStyleChecker(BaseChecker):
         super().__init__(linter=linter)
 
     def open(self) -> None:
-        py_version: Tuple[int, int] = get_global_option(self, "py-version")
+        py_version = get_global_option(self, "py-version")
         self._py38_plus = py_version >= (3, 8)
         self._max_length: int = (
             self.config.max_line_length_suggestions

--- a/pylint/extensions/typing.py
+++ b/pylint/extensions/typing.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, NamedTuple, Set, Tuple, Union
+from typing import Dict, List, NamedTuple, Set, Union
 
 import astroid.bases
 from astroid import nodes
@@ -139,7 +139,7 @@ class TypingChecker(BaseChecker):
         self._consider_using_alias_msgs: List[DeprecatedTypingAliasMsg] = []
 
     def open(self) -> None:
-        py_version: Tuple[int, int] = get_global_option(self, "py-version")
+        py_version = get_global_option(self, "py-version")
         self._py37_plus = py_version >= (3, 7)
         self._py39_plus = py_version >= (3, 9)
         self._py310_plus = py_version >= (3, 10)

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -17,12 +17,39 @@ import re
 import sys
 import textwrap
 import tokenize
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    List,
+    Literal,
+    Optional,
+    Pattern,
+    Tuple,
+    Union,
+    overload,
+)
 
 from astroid import Module, modutils
 
 from pylint.constants import PY_EXTS
 
+if TYPE_CHECKING:
+    from pylint.checkers.base_checker import BaseChecker
+
 DEFAULT_LINE_LENGTH = 79
+GLOBAL_OPTION_BOOL = Union[
+    Literal["ignore-mixin-members"],
+    Literal["suggestion-mode"],
+    Literal["analyse-fallback-blocks"],
+    Literal["allow-global-unused-variables"],
+]
+GLOBAL_OPTION_INT = Union[Literal["max-line-length"], Literal["docstring-min-length"]]
+GLOBAL_OPTION_LIST = Literal["ignored-modules"]
+GLOBAL_OPTION_PATTERN = Union[
+    Literal["no-docstring-rgx"],
+    Literal["dummy-variables-rgx"],
+    Literal["ignored-argument-names"],
+]
 
 
 def normalize_text(text, line_len=DEFAULT_LINE_LENGTH, indent=""):
@@ -148,7 +175,50 @@ def register_plugins(linter, directory):
                     imported[base] = 1
 
 
-def get_global_option(checker, option, default=None):
+@overload
+def get_global_option(
+    checker: "BaseChecker", option: GLOBAL_OPTION_BOOL, default: Optional[bool] = None
+) -> bool:
+    ...
+
+
+@overload
+def get_global_option(
+    checker: "BaseChecker", option: GLOBAL_OPTION_INT, default: Optional[int] = None
+) -> int:
+    ...
+
+
+@overload
+def get_global_option(
+    checker: "BaseChecker",
+    option: GLOBAL_OPTION_LIST,
+    default: Optional[List[str]] = None,
+) -> List[str]:
+    ...
+
+
+@overload
+def get_global_option(
+    checker: "BaseChecker",
+    option: GLOBAL_OPTION_PATTERN,
+    default: Optional[Pattern] = None,
+) -> Pattern:
+    ...
+
+
+@overload
+def get_global_option(
+    checker: "BaseChecker",
+    option: Literal["py-version"],
+    default: Tuple[int, ...] = None,
+) -> Tuple[int, ...]:
+    ...
+
+
+def get_global_option(
+    checker: "BaseChecker", option: str, default: Optional[Any] = None
+) -> Any:
     """Retrieve an option defined by the given *checker* or
     by all known option providers.
 


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

The next step in splitting #4954 in more manageable PR's.

I opted to go for `overload` as it allows us to immediately tell what ``get_global_option`` will return or throw an error if it is unspecified.
The globals added to `pylint/utils/utils.py` could go in `pylint/typing` but since they won't be used outside of this file I thought it would be best to add them here.