### PR TITLE
Add typing to references of ``stream`` and ``stream()``

### DIFF
--- a/examples/custom_raw.py
+++ b/examples/custom_raw.py
@@ -1,3 +1,5 @@
+from astroid import nodes
+
 from pylint.checkers import BaseChecker
 from pylint.interfaces import IRawChecker
 
@@ -22,7 +24,7 @@ class MyRawChecker(BaseChecker):
     }
     options = ()
 
-    def process_module(self, node):
+    def process_module(self, node: nodes.Module) -> None:
         """process a module
 
         the module's content is accessible via node.stream() function

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -351,7 +351,7 @@ class FormatChecker(BaseTokenChecker):
             self._lines[line_num] = line.split("\n")[0]
         self.check_lines(line, line_num)
 
-    def process_module(self, _module):
+    def process_module(self, _node: nodes.Module) -> None:
         pass
 
     def _check_keyword_parentheses(

--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -29,6 +29,8 @@
 import re
 import tokenize
 
+from astroid import nodes
+
 from pylint.checkers import BaseChecker
 from pylint.interfaces import IRawChecker, ITokenChecker
 from pylint.message import MessagesHandlerMixIn
@@ -50,11 +52,11 @@ class ByIdManagedMessagesChecker(BaseChecker):
     }
     options = ()
 
-    def process_module(self, module):
+    def process_module(self, node: nodes.Module) -> None:
         """Inspect the source file to find messages activated or deactivated by id."""
         managed_msgs = MessagesHandlerMixIn.get_by_id_managed_msgs()
         for (mod_name, msgid, symbol, lineno, is_disabled) in managed_msgs:
-            if mod_name == module.name:
+            if mod_name == node.name:
                 verb = "disable" if is_disabled else "enable"
                 txt = f"'{msgid}' is cryptic: use '# pylint: {verb}={symbol}' instead"
                 self.add_message("use-symbolic-message-instead", line=lineno, args=txt)
@@ -125,11 +127,11 @@ class EncodingChecker(BaseChecker):
                 self.add_message("syntax-error", line=lineno, args=msg)
         return None
 
-    def process_module(self, module):
+    def process_module(self, node: nodes.Module) -> None:
         """inspect the source file to find encoding problem"""
-        encoding = module.file_encoding if module.file_encoding else "ascii"
+        encoding = node.file_encoding if node.file_encoding else "ascii"
 
-        with module.stream() as stream:
+        with node.stream() as stream:
             for lineno, line in enumerate(stream):
                 self._check_encoding(lineno + 1, line, encoding)
 

--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -28,6 +28,7 @@
 
 import re
 import tokenize
+from typing import Optional
 
 from astroid import nodes
 
@@ -116,13 +117,19 @@ class EncodingChecker(BaseChecker):
 
         self._fixme_pattern = re.compile(regex_string, re.I)
 
-    def _check_encoding(self, lineno, line, file_encoding):
+    def _check_encoding(
+        self, lineno: int, line: bytes, file_encoding: str
+    ) -> Optional[str]:
         try:
             return line.decode(file_encoding)
         except UnicodeDecodeError:
             pass
         except LookupError:
-            if line.startswith("#") and "coding" in line and file_encoding in line:
+            if (
+                line.startswith(b"#")
+                and "coding" in str(line)
+                and file_encoding in str(line)
+            ):
                 msg = f"Cannot decode using encoding '{file_encoding}', bad encoding"
                 self.add_message("syntax-error", line=lineno, args=msg)
         return None

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -820,7 +820,7 @@ class SimilarChecker(BaseChecker, Similar, MapReduceMixin):
             nb_duplicated_lines=0, percent_duplicated_lines=0
         )
 
-    def process_module(self, node):
+    def process_module(self, node: nodes.Module) -> None:
         """process a module
 
         the module's content is accessible via the stream object

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -49,6 +49,7 @@ import re
 import sys
 from collections import defaultdict
 from getopt import getopt
+from io import BufferedIOBase, BufferedReader, BytesIO
 from itertools import chain, groupby
 from typing import (
     Any,
@@ -59,9 +60,11 @@ from typing import (
     List,
     NamedTuple,
     NewType,
+    Optional,
     Set,
     TextIO,
     Tuple,
+    Union,
 )
 
 import astroid
@@ -95,6 +98,9 @@ HashToIndex_T = Dict["LinesChunk", List[Index]]
 
 # Links index in the lineset's stripped lines to the real lines in the file
 IndexToLines_T = Dict[Index, "SuccessiveLinesLimits"]
+
+# The types the streams read by pylint can take. Originating from astroid.nodes.Module.stream() and open()
+STREAM_TYPES = Union[TextIO, BufferedReader, BytesIO]
 
 
 class CplSuccessiveLinesLimits:
@@ -368,12 +374,16 @@ class Similar:
         self.ignore_signatures = ignore_signatures
         self.linesets: List["LineSet"] = []
 
-    def append_stream(self, streamid: str, stream: TextIO, encoding=None) -> None:
+    def append_stream(
+        self, streamid: str, stream: STREAM_TYPES, encoding: Optional[str] = None
+    ) -> None:
         """append a file to search for similarities"""
-        if encoding is None:
-            readlines = stream.readlines
-        else:
+        if isinstance(stream, BufferedIOBase):
+            if encoding is None:
+                raise ValueError
             readlines = decoding_stream(stream, encoding).readlines
+        else:
+            readlines = stream.readlines  # type: ignore # hint parameter is incorrectly typed as non-optional
         try:
             self.linesets.append(
                 LineSet(
@@ -658,12 +668,12 @@ class LineSet:
 
     def __init__(
         self,
-        name,
-        lines,
-        ignore_comments=False,
-        ignore_docstrings=False,
-        ignore_imports=False,
-        ignore_signatures=False,
+        name: str,
+        lines: List[str],
+        ignore_comments: bool = False,
+        ignore_docstrings: bool = False,
+        ignore_imports: bool = False,
+        ignore_signatures: bool = False,
     ) -> None:
         self.name = name
         self._real_lines = lines

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -710,8 +710,8 @@ class StringConstantChecker(BaseTokenChecker):
         super().__init__(*args, **kwargs)
         self.string_tokens = {}  # token position -> (token value, next token)
 
-    def process_module(self, module):
-        self._unicode_literals = "unicode_literals" in module.future_imports
+    def process_module(self, node: nodes.Module) -> None:
+        self._unicode_literals = "unicode_literals" in node.future_imports
 
     def process_tokens(self, tokens):
         encoding = "ascii"

--- a/pylint/config/man_help_formatter.py
+++ b/pylint/config/man_help_formatter.py
@@ -14,6 +14,7 @@ class _ManHelpFormatter(optparse.HelpFormatter):
         optparse.HelpFormatter.__init__(
             self, indent_increment, max_help_position, width, short_first
         )
+        self.output_level: int
 
     def format_heading(self, heading):
         return f".SH {heading.upper()}\n"

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -10,6 +10,8 @@ import functools
 import optparse  # pylint: disable=deprecated-module
 import os
 import sys
+from types import ModuleType
+from typing import Dict, List, Optional, TextIO, Tuple
 
 import toml
 
@@ -186,11 +188,13 @@ class OptionsManagerMixIn:
         """set option on the correct option provider"""
         self._all_options[opt].set_option(opt, value)
 
-    def generate_config(self, stream=None, skipsections=()):
+    def generate_config(
+        self, stream: Optional[TextIO] = None, skipsections: Tuple[str, ...] = ()
+    ) -> None:
         """write a configuration file according to the current configuration
         into the given stream or stdout
         """
-        options_by_section = {}
+        options_by_section: Dict[str, List[Tuple]] = {}
         sections = []
         for provider in self.options_providers:
             for section, options in provider.options_by_section():
@@ -219,7 +223,9 @@ class OptionsManagerMixIn:
             )
             printed = True
 
-    def generate_manpage(self, pkginfo, section=1, stream=sys.stdout):
+    def generate_manpage(
+        self, pkginfo: ModuleType, section: int = 1, stream: TextIO = sys.stdout
+    ) -> None:
         with _patch_optparse():
             formatter = _ManHelpFormatter()
             formatter.output_level = self._maxlevel

--- a/pylint/extensions/empty_comment.py
+++ b/pylint/extensions/empty_comment.py
@@ -1,3 +1,5 @@
+from astroid import nodes
+
 from pylint.checkers import BaseChecker
 from pylint.interfaces import IRawChecker
 
@@ -43,7 +45,7 @@ class CommentChecker(BaseChecker):
     options = ()
     priority = -1  # low priority
 
-    def process_module(self, node):
+    def process_module(self, node: nodes.Module) -> None:
         with node.stream() as stream:
             for (line_num, line) in enumerate(stream):
                 line = line.rstrip()

--- a/pylint/interfaces.py
+++ b/pylint/interfaces.py
@@ -18,6 +18,8 @@
 """Interfaces for Pylint objects"""
 from collections import namedtuple
 
+from astroid import nodes
+
 Confidence = namedtuple("Confidence", ["name", "description"])
 # Warning Certainties
 HIGH = Confidence("HIGH", "No false positive possible.")
@@ -66,7 +68,7 @@ class IChecker(Interface):
 class IRawChecker(IChecker):
     """interface for checker which need to parse the raw file"""
 
-    def process_module(self, astroid):
+    def process_module(self, node: nodes.Module) -> None:
         """process a module
 
         the module's content is accessible via astroid.stream

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -13,7 +13,7 @@ import warnings
 from io import TextIOWrapper
 
 import astroid
-from astroid import AstroidError
+from astroid import AstroidError, nodes
 
 from pylint import checkers, config, exceptions, interfaces, reporters
 from pylint.constants import MAIN_CHECKER_NAME, MSG_TYPES
@@ -1180,10 +1180,12 @@ class PyLinter(
 
         return retval
 
-    def _check_astroid_module(self, ast_node, walker, rawcheckers, tokencheckers):
+    def _check_astroid_module(
+        self, node: nodes.Module, walker, rawcheckers, tokencheckers
+    ):
         """Check given AST node with given walker and checkers
 
-        :param astroid.nodes.Module ast_node: AST node of the module to check
+        :param astroid.nodes.Module node: AST node of the module to check
         :param pylint.utils.ast_walker.ASTWalker walker: AST walker
         :param list rawcheckers: List of token checkers to use
         :param list tokencheckers: List of raw checkers to use
@@ -1193,13 +1195,13 @@ class PyLinter(
         :rtype: bool
         """
         try:
-            tokens = utils.tokenize_module(ast_node)
+            tokens = utils.tokenize_module(node)
         except tokenize.TokenError as ex:
             self.add_message("syntax-error", line=ex.args[1][0], args=ex.args[0])
             return None
 
-        if not ast_node.pure_python:
-            self.add_message("raw-checker-failed", args=ast_node.name)
+        if not node.pure_python:
+            self.add_message("raw-checker-failed", args=node.name)
         else:
             # assert astroid.file.endswith('.py')
             # invoke ITokenChecker interface on self to fetch module/block
@@ -1208,14 +1210,14 @@ class PyLinter(
             if self._ignore_file:
                 return False
             # walk ast to collect line numbers
-            self.file_state.collect_block_lines(self.msgs_store, ast_node)
+            self.file_state.collect_block_lines(self.msgs_store, node)
             # run raw and tokens checkers
             for checker in rawcheckers:
-                checker.process_module(ast_node)
+                checker.process_module(node)
             for checker in tokencheckers:
                 checker.process_tokens(tokens)
         # generate events to astroid checkers
-        walker.walk(ast_node)
+        walker.walk(node)
         return True
 
     # IAstroidChecker interface #################################################

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -2,7 +2,8 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import sys
-from typing import List, Tuple, Union
+from io import TextIOWrapper
+from typing import List, TextIO, Tuple, Union
 
 from pylint.constants import (
     _SCOPE_EXEMPT,
@@ -390,20 +391,13 @@ Below is a list of all checkers and their features.
             result += checker.get_full_documentation(**information)
         return result
 
-    def print_full_documentation(self, stream=None):
+    def print_full_documentation(self, stream: TextIO = sys.stdout) -> None:
         """output a full documentation in ReST format"""
-        if not stream:
-            stream = sys.stdout
         print(self.get_checkers_documentation()[:-1], file=stream)
 
     @staticmethod
-    def _print_checker_doc(information, stream=None):
-        """Helper method for print_full_documentation.
-
-        Also used by doc/exts/pylint_extensions.py.
-        """
-        if not stream:
-            stream = sys.stdout
+    def _print_checker_doc(information, stream: TextIOWrapper) -> None:
+        """Helper method used by doc/exts/pylint_extensions.py."""
         checker = information["checker"]
         del information["checker"]
         print(checker.get_full_documentation(**information)[:-1], file=stream)

--- a/pylint/reporters/ureports/__init__.py
+++ b/pylint/reporters/ureports/__init__.py
@@ -18,20 +18,19 @@ formatted as text and html.
 import os
 import sys
 from io import StringIO
+from typing import Iterator, TextIO
 
 
 class BaseWriter:
     """base class for ureport writers"""
 
-    def format(self, layout, stream=None, encoding=None):
+    def format(self, layout, stream: TextIO = sys.stdout, encoding=None) -> None:
         """format and write the given layout into the stream object
 
         unicode policy: unicode strings may be found in the layout;
         try to call stream.write with it, but give it back encoded using
         the given encoding if it fails
         """
-        if stream is None:
-            stream = sys.stdout
         if not encoding:
             encoding = getattr(stream, "encoding", "UTF-8")
         self.encoding = encoding or "UTF-8"
@@ -79,7 +78,7 @@ class BaseWriter:
         result[-1] += [""] * (cols - len(result[-1]))
         return result
 
-    def compute_content(self, layout):
+    def compute_content(self, layout) -> Iterator[str]:
         """trick to compute the formatting of children layout before actually
         writing it
 

--- a/tests/benchmark/test_baseline_benchmarks.py
+++ b/tests/benchmark/test_baseline_benchmarks.py
@@ -16,6 +16,7 @@ import time
 from unittest.mock import patch
 
 import pytest
+from astroid import nodes
 
 import pylint.interfaces
 from pylint.checkers.base_checker import BaseChecker
@@ -50,7 +51,7 @@ class SleepingChecker(BaseChecker):
     }
     sleep_duration = 0.5  # the time to pretend we're doing work for
 
-    def process_module(self, _astroid):
+    def process_module(self, _node: nodes.Module) -> None:
         """Sleeps for `sleep_duration` on each call
 
         This effectively means each file costs ~`sleep_duration`+framework overhead"""
@@ -75,7 +76,7 @@ class SleepingCheckerLong(BaseChecker):
     }
     sleep_duration = 0.5  # the time to pretend we're doing work for
 
-    def process_module(self, _astroid):
+    def process_module(self, _node: nodes.Module) -> None:
         """Sleeps for `sleep_duration` on each call
 
         This effectively means each file costs ~`sleep_duration`+framework overhead"""
@@ -96,7 +97,7 @@ class NoWorkChecker(BaseChecker):
         )
     }
 
-    def process_module(self, _astroid):
+    def process_module(self, _node: nodes.Module) -> None:
         pass
 
 

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -14,7 +14,7 @@ import os
 from typing import List, Tuple
 
 import pytest
-from astroid.nodes.scoped_nodes import Module
+from astroid import nodes
 
 import pylint.interfaces
 import pylint.lint.parallel
@@ -63,7 +63,7 @@ class SequentialTestChecker(BaseChecker):
         self.data: List[str] = []
         self.linter = linter
 
-    def process_module(self, _astroid: Module) -> None:
+    def process_module(self, _node: nodes.Module) -> None:
         """Called once per stream/file/astroid object"""
         # record the number of invocations with the data object
         record = self.test_data + str(len(self.data))
@@ -125,7 +125,7 @@ class ParallelTestChecker(BaseChecker):
             self.add_message("R9999", args=("From reduce_map_data",))
         recombined.close()
 
-    def process_module(self, _astroid: Module) -> None:
+    def process_module(self, _node: nodes.Module) -> None:
         """Called once per stream/file/astroid object"""
         # record the number of invocations with the data object
         record = self.test_data + str(len(self.data))


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

The next instalment of breaking up #4954 into more manageable PR's. 
This PR is based on two related commits which I felt should be part of the same PR as they deal with a similar topic.

The first is annotation of all implementations of `process_module`. This is fairly straightforward and covers adding `nodes.Module` to the typing of the parameter and changing `module`, `astroid` and other parameter names to the new standard of `node`. As `process_module` calls `node.stream()` often this seemed like a good first step to this PR.

The second commit covers annotation of (most) functions with a reference to `stream`, `filestream` or a similar parameter. There are two important comments about this commit.

The first is for `pylint/checkers/similar.py` where I choose to use `STREAM_TYPES = Union[TextIO, BufferedReader, BytesIO]`. I did this because there seems to be a certain particularity with `TextIO` and `IOBase`. See the (small) discussion here: https://github.com/python/typeshed/issues/3225 In practice this means that return types of `open("b")` and `open("t")` are incompatible. This became problematic and is why I opted to introduce `STREAM_TYPES`. This also means that typing is a little more restrictive than using `IOBase` although in practice this probably won't make a real difference.

The second is that in `pylint/utils/utils.py` I don't fully type the `options` parameter and use `Tuple`. This is because trying to determine the type of the second argument of this `tuple` became difficult and I didn't want to overstretch this PR. If we turn on some of the more stricter flags of mypy in the future this will probably show up again and should be solved then.
