### PR TITLE
Fix bug with cache's parent directory not existing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -73,6 +73,10 @@ Release date: TBA
 
   Closes #4901
 
+* Fix a bug where pylint complained if the cache's parent directory does not exist
+
+  Closes #4900
+
 
 What's New in Pylint 2.10.3?
 ============================

--- a/doc/whatsnew/2.11.rst
+++ b/doc/whatsnew/2.11.rst
@@ -75,3 +75,7 @@ Other Changes
 * Setting ``min-similarity-lines`` to 0 now makes the similarty checker stop checking for duplicate code
 
   Closes #4901
+
+* Fix a bug where pylint complained if the cache's parent directory does not exist
+
+  Closes #4900

--- a/pylint/config/__init__.py
+++ b/pylint/config/__init__.py
@@ -125,7 +125,7 @@ def load_results(base):
 def save_results(results, base):
     if not os.path.exists(PYLINT_HOME):
         try:
-            os.mkdir(PYLINT_HOME)
+            os.makedirs(PYLINT_HOME)
         except OSError:
             print(f"Unable to create directory {PYLINT_HOME}", file=sys.stderr)
     data_file = _get_pdata_path(base, 1)


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

By changing the function used to create the cache from ``os.mkdir`` to ``os.makedirs`` we now handle non-existing parent directories correctly.
This closes #4900

This was one of the final open issues on the `2.11.0` milestone! 😄 