### PR TITLE
Make ``global-variable-not-assigned`` check local scope

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -77,6 +77,11 @@ Release date: TBA
 
   Closes #4900
 
+* The ``global-variable-not-assigned`` checker now catches global variables that are never reassigned in a
+  local scope
+
+  Closes #1375
+
 
 What's New in Pylint 2.10.3?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -78,9 +78,10 @@ Release date: TBA
   Closes #4900
 
 * The ``global-variable-not-assigned`` checker now catches global variables that are never reassigned in a
-  local scope
+  local scope and catches (reassigned) functions
 
   Closes #1375
+  Closes #330
 
 * Fix ``no-self-use`` and ``docparams extension`` for async functions and methods.
 

--- a/doc/whatsnew/2.11.rst
+++ b/doc/whatsnew/2.11.rst
@@ -79,3 +79,8 @@ Other Changes
 * Fix a bug where pylint complained if the cache's parent directory does not exist
 
   Closes #4900
+
+* The ``global-variable-not-assigned`` checker now catches global variables that are never reassigned in a
+  local scope
+
+  Closes #1375

--- a/doc/whatsnew/2.11.rst
+++ b/doc/whatsnew/2.11.rst
@@ -81,6 +81,7 @@ Other Changes
   Closes #4900
 
 * The ``global-variable-not-assigned`` checker now catches global variables that are never reassigned in a
-  local scope
+  local scope and catches (reassigned) functions
 
   Closes #1375
+  Closes #330

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1562,7 +1562,7 @@ def is_node_in_guarded_import_block(node: nodes.NodeNG) -> bool:
 
 def is_reassigned_after_current(node: nodes.NodeNG, varname: str) -> bool:
     """Check if the given variable name is reassigned in the same scope after the current node"""
-    for assign_node in node.scope().nodes_of_class(nodes.AssignName):
-        if assign_node.name == varname and node.lineno < assign_node.lineno:
-            return True
-    return False
+    return any(
+        a.name == varname and  a.lineno > node.lineno
+        for a in node.scope().nodes_of_class(nodes.AssignName)
+    )

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1564,5 +1564,5 @@ def is_reassigned_after_current(node: nodes.NodeNG, varname: str) -> bool:
     """Check if the given variable name is reassigned in the same scope after the current node"""
     return any(
         a.name == varname and a.lineno > node.lineno
-        for a in node.scope().nodes_of_class(nodes.AssignName)
+        for a in node.scope().nodes_of_class((nodes.AssignName, nodes.FunctionDef))
     )

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1558,3 +1558,11 @@ def is_node_in_guarded_import_block(node: nodes.NodeNG) -> bool:
     return isinstance(node.parent, nodes.If) and (
         node.parent.is_sys_guard() or node.parent.is_typing_guard()
     )
+
+
+def is_reassigned_after_current(node: nodes.NodeNG, varname: str) -> bool:
+    """Check if the given variable name is reassigned in the same scope after the current node"""
+    for assign_node in node.scope().nodes_of_class(nodes.AssignName):
+        if assign_node.name == varname and node.lineno < assign_node.lineno:
+            return True
+    return False

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1563,6 +1563,6 @@ def is_node_in_guarded_import_block(node: nodes.NodeNG) -> bool:
 def is_reassigned_after_current(node: nodes.NodeNG, varname: str) -> bool:
     """Check if the given variable name is reassigned in the same scope after the current node"""
     return any(
-        a.name == varname and  a.lineno > node.lineno
+        a.name == varname and a.lineno > node.lineno
         for a in node.scope().nodes_of_class(nodes.AssignName)
     )

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -949,6 +949,9 @@ class VariablesChecker(BaseChecker):
                 if anode.frame() is module:
                     # module level assignment
                     break
+                if isinstance(anode, nodes.FunctionDef) and anode.parent is module:
+                    # module level function assignment
+                    break
             else:
                 if not_defined_locally_by_import:
                     # global undefined at the module scope

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -931,7 +931,10 @@ class VariablesChecker(BaseChecker):
             not_defined_locally_by_import = not any(
                 isinstance(local, nodes.Import) for local in locals_.get(name, ())
             )
-            if not assign_nodes and not_defined_locally_by_import:
+            if (
+                not utils.is_reassigned_after_current(node, name)
+                and not_defined_locally_by_import
+            ):
                 self.add_message("global-variable-not-assigned", args=name, node=node)
                 default_message = False
                 continue

--- a/tests/functional/g/globals.py
+++ b/tests/functional/g/globals.py
@@ -30,3 +30,16 @@ def global_with_import():
     """should only warn for global-statement"""
     global sys  # [global-statement]
     import sys  # pylint: disable=import-outside-toplevel
+
+
+def global_no_assign():
+    """Not assigning anything to the global makes 'global' superfluous"""
+    global CONSTANT  # [global-variable-not-assigned]
+    print(CONSTANT)
+
+
+def global_operator_assign():
+    """Operator assigns should only throw a global statement error"""
+    global CONSTANT  # [global-statement]
+    print(CONSTANT)
+    CONSTANT += 1

--- a/tests/functional/g/globals.py
+++ b/tests/functional/g/globals.py
@@ -1,10 +1,13 @@
 """Warnings about global statements and usage of global variables."""
+# pylint: disable=invalid-name, redefined-outer-name, missing-function-docstring
 from __future__ import print_function
 
 global CSTE  # [global-at-module-level]
 print(CSTE)  # [undefined-variable]
 
 CONSTANT = 1
+def FUNC():
+    pass
 
 def fix_contant(value):
     """all this is ok, but try not using global ;)"""
@@ -25,7 +28,6 @@ def define_constant():
     SOMEVAR = 2
 
 
-# pylint: disable=invalid-name
 def global_with_import():
     """should only warn for global-statement"""
     global sys  # [global-statement]
@@ -43,3 +45,23 @@ def global_operator_assign():
     global CONSTANT  # [global-statement]
     print(CONSTANT)
     CONSTANT += 1
+
+
+def global_function_assign():
+    """Function assigns should only throw a global statement error"""
+    global CONSTANT  # [global-statement]
+
+    def CONSTANT():
+        pass
+
+    CONSTANT()
+
+
+def override_func():
+    """Overriding a function should only throw a global statement error"""
+    global FUNC # [global-statement]
+
+    def FUNC():
+        pass
+
+    FUNC()

--- a/tests/functional/g/globals.txt
+++ b/tests/functional/g/globals.txt
@@ -5,3 +5,5 @@ global-variable-not-assigned:18:4:other:Using global for 'HOP' but no assignment
 undefined-variable:19:10:other:Undefined variable 'HOP'
 global-variable-undefined:24:4:define_constant:Global variable 'SOMEVAR' undefined at the module level
 global-statement:31:4:global_with_import:Using the global statement
+global-variable-not-assigned:37:4:global_no_assign:Using global for 'CONSTANT' but no assignment is done:HIGH
+global-statement:43:4:global_operator_assign:Using the global statement:HIGH

--- a/tests/functional/g/globals.txt
+++ b/tests/functional/g/globals.txt
@@ -1,9 +1,11 @@
-global-at-module-level:4:0::Using the global statement at the module level
-undefined-variable:5:6::Undefined variable 'CSTE'
-global-statement:11:4:fix_contant:Using the global statement
-global-variable-not-assigned:18:4:other:Using global for 'HOP' but no assignment is done
-undefined-variable:19:10:other:Undefined variable 'HOP'
-global-variable-undefined:24:4:define_constant:Global variable 'SOMEVAR' undefined at the module level
-global-statement:31:4:global_with_import:Using the global statement
-global-variable-not-assigned:37:4:global_no_assign:Using global for 'CONSTANT' but no assignment is done:HIGH
-global-statement:43:4:global_operator_assign:Using the global statement:HIGH
+global-at-module-level:5:0::Using the global statement at the module level:HIGH
+undefined-variable:6:6::Undefined variable 'CSTE':HIGH
+global-statement:14:4:fix_contant:Using the global statement:HIGH
+global-variable-not-assigned:21:4:other:Using global for 'HOP' but no assignment is done:HIGH
+undefined-variable:22:10:other:Undefined variable 'HOP':HIGH
+global-variable-undefined:27:4:define_constant:Global variable 'SOMEVAR' undefined at the module level:HIGH
+global-statement:33:4:global_with_import:Using the global statement:HIGH
+global-variable-not-assigned:39:4:global_no_assign:Using global for 'CONSTANT' but no assignment is done:HIGH
+global-statement:45:4:global_operator_assign:Using the global statement:HIGH
+global-statement:52:4:global_function_assign:Using the global statement:HIGH
+global-statement:62:4:override_func:Using the global statement:HIGH

--- a/tests/functional/u/unused/unused_variable.py
+++ b/tests/functional/u/unused/unused_variable.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, invalid-name, too-few-public-methods, no-self-use, useless-object-inheritance,import-outside-toplevel, fixme
+# pylint: disable=missing-docstring, invalid-name, too-few-public-methods, no-self-use, useless-object-inheritance,import-outside-toplevel, fixme, line-too-long
 
 def test_regression_737():
     import xml # [unused-import]
@@ -94,7 +94,7 @@ def test_global():
     """ Test various assignments of global
     variables through imports.
     """
-    global PATH, OS, collections, deque  # [global-statement]
+    global PATH, OS, collections, deque  # [global-variable-not-assigned, global-variable-not-assigned]
     from os import path as PATH
     import os as OS
     import collections

--- a/tests/functional/u/unused/unused_variable.txt
+++ b/tests/functional/u/unused/unused_variable.txt
@@ -13,7 +13,8 @@ unused-import:55:4:unused_import_from:Unused namedtuple imported from collection
 unused-import:59:4:unused_import_in_function:Unused hexdigits imported from string
 unused-variable:64:4:hello:Unused variable 'my_var'
 unused-variable:76:4:function:Unused variable 'aaaa'
-global-statement:97:4:test_global:Using the global statement
+global-variable-not-assigned:97:4:test_global:Using global for 'PATH' but no assignment is done:HIGH
+global-variable-not-assigned:97:4:test_global:Using global for 'deque' but no assignment is done:HIGH
 unused-import:103:4:test_global:Unused platform imported from sys
 unused-import:104:4:test_global:Unused version imported from sys as VERSION
 unused-import:105:4:test_global:Unused import this


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

This checker now checks whether the names after the global keyword are reassigned in the local scope.
I created a small `utils` function that checks whether the name appears in any of the `AssignName` nodes in the scope.

The updated test only throws an error for 2 of the 4 variables. Not quite sure what that is about and we might want to make another issue/PR to fix that. However, since the change did not break any of the tests the file is designed for I guessed it was okay for now. This PR does fix the original issue.

This closes #1375
This closes #330