### PR TITLE
Fix PyreverseConfig imports in pyreverse's tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,6 +89,9 @@ warn_unused_ignores = True
 [mypy-astroid.*]
 ignore_missing_imports = True
 
+[mypy-tests.*]
+ignore_missing_imports = True
+
 [mypy-coverage]
 ignore_missing_imports = True
 

--- a/tests/pyreverse/test_diadefs.py
+++ b/tests/pyreverse/test_diadefs.py
@@ -26,7 +26,7 @@ from typing import Callable, Dict, List, Tuple
 
 import pytest
 from astroid import nodes
-from conftest import PyreverseConfig  # type: ignore #pylint: disable=no-name-in-module
+from tests.pyreverse.conftest import PyreverseConfig
 
 from pylint.pyreverse.diadefslib import (
     ClassDiadefGenerator,

--- a/tests/pyreverse/test_writer.py
+++ b/tests/pyreverse/test_writer.py
@@ -28,7 +28,7 @@ from typing import Callable, Iterator, List
 from unittest.mock import Mock
 
 import pytest
-from conftest import PyreverseConfig  # type: ignore #pylint: disable=no-name-in-module
+from tests.pyreverse.conftest import PyreverseConfig
 
 from pylint.pyreverse.diadefslib import DefaultDiadefGenerator, DiadefsHandler
 from pylint.pyreverse.inspector import Linker, Project


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fix an import error due to pytest adding all file to the pythonpath before launching tests.
