### PR TITLE
Add typing to `BaseReporter.out`

### DIFF
--- a/pylint/reporters/base_reporter.py
+++ b/pylint/reporters/base_reporter.py
@@ -26,7 +26,7 @@ class BaseReporter:
     def __init__(self, output: TextIO = sys.stdout):
         self.linter: "PyLinter"
         self.section = 0
-        self.out: TextIO = output
+        self.out: TextIO = output or sys.stdout
         self.messages: List[Message] = []
         # Build the path prefix to strip to get relative paths
         self.path_strip_prefix = os.getcwd() + os.sep

--- a/pylint/reporters/base_reporter.py
+++ b/pylint/reporters/base_reporter.py
@@ -3,13 +3,14 @@
 
 import os
 import sys
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, TextIO
 
 from pylint.message import Message
 from pylint.reporters.ureports.nodes import Text
 from pylint.typing import CheckerStats
 
 if TYPE_CHECKING:
+    from pylint.lint.pylinter import PyLinter
     from pylint.reporters.ureports.nodes import Section
 
 
@@ -21,11 +22,10 @@ class BaseReporter:
 
     extension = ""
 
-    def __init__(self, output=None):
-        self.linter = None
+    def __init__(self, output: Optional[TextIO] = None):
+        self.linter: "PyLinter"
         self.section = 0
-        self.out = None
-        self.out_encoding = None
+        self.out: TextIO
         self.set_output(output)
         self.messages: List[Message] = []
         # Build the path prefix to strip to get relative paths
@@ -35,7 +35,7 @@ class BaseReporter:
         """Handle a new message triggered on the current file."""
         self.messages.append(msg)
 
-    def set_output(self, output=None):
+    def set_output(self, output: Optional[TextIO] = None) -> None:
         """set output stream"""
         self.out = output or sys.stdout
 

--- a/pylint/reporters/base_reporter.py
+++ b/pylint/reporters/base_reporter.py
@@ -4,6 +4,7 @@
 import os
 import sys
 from typing import TYPE_CHECKING, List, Optional, TextIO
+from warnings import warn
 
 from pylint.message import Message
 from pylint.reporters.ureports.nodes import Text
@@ -26,7 +27,6 @@ class BaseReporter:
         self.linter: "PyLinter"
         self.section = 0
         self.out: TextIO = output
-        self.set_output(output)
         self.messages: List[Message] = []
         # Build the path prefix to strip to get relative paths
         self.path_strip_prefix = os.getcwd() + os.sep
@@ -37,6 +37,12 @@ class BaseReporter:
 
     def set_output(self, output: Optional[TextIO] = None) -> None:
         """set output stream"""
+        # pylint: disable-next=fixme
+        # TODO: Remove this method after depreciation
+        warn(
+            "'set_output' will be removed in 3.0, please use 'reporter.out = stream' instead",
+            DeprecationWarning,
+        )
         self.out = output or sys.stdout
 
     def writeln(self, string=""):

--- a/pylint/reporters/base_reporter.py
+++ b/pylint/reporters/base_reporter.py
@@ -22,10 +22,10 @@ class BaseReporter:
 
     extension = ""
 
-    def __init__(self, output: Optional[TextIO] = None):
+    def __init__(self, output: TextIO = sys.stdout):
         self.linter: "PyLinter"
         self.section = 0
-        self.out: TextIO
+        self.out: TextIO = output
         self.set_output(output)
         self.messages: List[Message] = []
         # Build the path prefix to strip to get relative paths

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -121,11 +121,11 @@ class MultiReporter(BaseReporter):
         pass
 
     @property
-    def out(self) -> TextIO:  # type: ignore # Property is not the same as BaseLinter's attr
+    def out(self) -> TextIO:  # type: ignore[override]
         return self._reporters[0].out
 
-    @property  # type: ignore # Property is not the same as BaseLinter's attr
-    def linter(self) -> PyLinter:  # type: ignore
+    @property  # type: ignore[override]
+    def linter(self) -> PyLinter:  # type: ignore[override]
         return self._linter
 
     @linter.setter

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -51,12 +51,11 @@ from copy import copy
 from io import StringIO
 from os.path import abspath, dirname, join
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generator, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Generator, Iterator, List, Optional, TextIO
 from unittest import mock
 from unittest.mock import patch
 
 import pytest
-from _pytest.capture import EncodedFile
 from py._path.local import LocalPath  # type: ignore
 
 from pylint import modify_sys_path
@@ -79,7 +78,7 @@ UNNECESSARY_LAMBDA = join(
 
 
 @contextlib.contextmanager
-def _patch_streams(out: Union[StringIO, EncodedFile]) -> Iterator:
+def _patch_streams(out: TextIO) -> Iterator:
     sys.stderr = sys.stdout = out
     try:
         yield
@@ -122,11 +121,11 @@ class MultiReporter(BaseReporter):
         pass
 
     @property
-    def out(self) -> StringIO:
+    def out(self) -> TextIO:  # type: ignore # Property is not the same as BaseLinter's attr
         return self._reporters[0].out
 
-    @property
-    def linter(self) -> Optional[Any]:
+    @property  # type: ignore # Property is not the same as BaseLinter's attr
+    def linter(self) -> PyLinter:  # type: ignore
         return self._linter
 
     @linter.setter
@@ -159,9 +158,7 @@ class TestRunTC:
         assert pylint_code == code, msg
 
     @staticmethod
-    def _run_pylint(
-        args: List[str], out: Union[StringIO, EncodedFile], reporter: Any = None
-    ) -> int:
+    def _run_pylint(args: List[str], out: TextIO, reporter: Any = None) -> int:
         args = args + ["--persistent=no"]
         with _patch_streams(out):
             with pytest.raises(SystemExit) as cm:


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | 😨 Refactor         |

## Description

Small changes which are needed for further typing of `pylint/reporters`.
I ran the test suite and printed out all types of `BaseReporter.out`. It was only ever `io.TextIO` which also seems fair given what it is doing. However, perhaps somebody with more knowledge of the code base wants to take a look at this.
