### PR TITLE
Require Python 3.6 for consider f-string check

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,14 +17,18 @@ What's New in Pylint 2.11.2?
 ============================
 Release date: TBA
 
+..
+  Put bug fixes that should not wait for a new minor version here
+
+* Don't emit ``consider-using-f-string`` if ``py-version`` is set to Python < ``3.5``.
+  ``f-strings`` where added in Python ``3.6``
+
+  Closes #5019
 
 
 What's New in Pylint 2.11.1?
 ============================
 Release date: 2021-09-16
-
-..
-  Put bug fixes that should not wait for a new minor version here
 
 * ``unspecified-encoding`` now checks the encoding of ``pathlib.Path()`` correctly
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,8 +20,8 @@ Release date: TBA
 ..
   Put bug fixes that should not wait for a new minor version here
 
-* Don't emit ``consider-using-f-string`` if ``py-version`` is set to Python < ``3.5``.
-  ``f-strings`` where added in Python ``3.6``
+* Don't emit ``consider-using-f-string`` if ``py-version`` is set to Python < ``3.6``.
+  ``f-strings`` were added in Python ``3.6``
 
   Closes #5019
 

--- a/tests/functional/p/py_version/py_version_35.py
+++ b/tests/functional/p/py_version/py_version_35.py
@@ -1,0 +1,14 @@
+"""Test warnings aren't emitted for features that require Python > 3.5"""
+# pylint: disable=invalid-name
+
+# consider-using-f-string -> requires Python 3.6
+"Hello {}".format("World")
+
+
+# ------
+# CodeStyle extension
+
+# consider-using-assignment-expr -> requires Python 3.8
+a1 = 2
+if a1:
+    ...

--- a/tests/functional/p/py_version/py_version_35.rc
+++ b/tests/functional/p/py_version/py_version_35.rc
@@ -1,0 +1,3 @@
+[MASTER]
+load-plugins=pylint.extensions.code_style
+py-version=3.5


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Don't emit `consider-using-f-string` if `py-version` is set to `< 3.6`.

Closes #5019

/CC: @DanielNoord