### PR TITLE
Fix typing of `ReportsHandlerMixIn`

### DIFF
--- a/pylint/reporters/reports_handler_mix_in.py
+++ b/pylint/reporters/reports_handler_mix_in.py
@@ -12,6 +12,8 @@ from pylint.typing import CheckerStats
 if TYPE_CHECKING:
     from pylint.lint.pylinter import PyLinter
 
+ReportsDict = DefaultDict[IChecker, List[Tuple[str, str, Callable]]]
+
 
 class ReportsHandlerMixIn:
     """a mix-in class containing all the reports and stats manipulation
@@ -19,15 +21,11 @@ class ReportsHandlerMixIn:
     """
 
     def __init__(self) -> None:
-        self._reports: DefaultDict[
-            IChecker, List[Tuple[str, str, Callable]]
-        ] = collections.defaultdict(list)
+        self._reports: ReportsDict = collections.defaultdict(list)
         self._reports_state: Dict[str, bool] = {}
 
-    def report_order(self):
-        """Return a list of reports, sorted in the order
-        in which they must be called.
-        """
+    def report_order(self) -> List[IChecker]:
+        """Return a list of reporerts"""
         return list(self._reports)
 
     def register_report(

--- a/pylint/reporters/reports_handler_mix_in.py
+++ b/pylint/reporters/reports_handler_mix_in.py
@@ -25,7 +25,7 @@ class ReportsHandlerMixIn:
         self._reports_state: Dict[str, bool] = {}
 
     def report_order(self) -> List[IChecker]:
-        """Return a list of reporerts"""
+        """Return a list of reporters"""
         return list(self._reports)
 
     def register_report(


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

No better way than to start the Friday morning with a small typing PR.
Small changes to break up #4954.

I moved `ReportsDict` as I felt it fitted much better there. The update to the docstring is because it incorrectly describes what is returned. There is no sorting and there is also no list of reports.
