### PR TITLE
Rename typing of `global types`

### DIFF
--- a/pylint/reporters/reports_handler_mix_in.py
+++ b/pylint/reporters/reports_handler_mix_in.py
@@ -12,7 +12,7 @@ from pylint.typing import CheckerStats
 if TYPE_CHECKING:
     from pylint.lint.pylinter import PyLinter
 
-ReportsDict = DefaultDict[IChecker, List[Tuple[str, str, Callable]]]
+REPORTS_DICT = DefaultDict[IChecker, List[Tuple[str, str, Callable]]]
 
 
 class ReportsHandlerMixIn:
@@ -21,7 +21,7 @@ class ReportsHandlerMixIn:
     """
 
     def __init__(self) -> None:
-        self._reports: ReportsDict = collections.defaultdict(list)
+        self._reports: REPORTS_DICT = collections.defaultdict(list)
         self._reports_state: Dict[str, bool] = {}
 
     def report_order(self) -> List[IChecker]:

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -28,7 +28,7 @@ from pylint.utils import utils
 if TYPE_CHECKING:
     from typing import Counter as CounterType  # typing.Counter added in Python 3.6.1
 
-    MessageCounter = CounterType[Tuple[int, str]]
+    MESSAGE_COUNTER = CounterType[Tuple[int, str]]
 
 
 class LintModuleTest:
@@ -96,7 +96,7 @@ class LintModuleTest:
         return f"{self._test_file.base} ({self.__class__.__module__}.{self.__class__.__name__})"
 
     @staticmethod
-    def get_expected_messages(stream: TextIO) -> "MessageCounter":
+    def get_expected_messages(stream: TextIO) -> "MESSAGE_COUNTER":
         """Parses a file and get expected messages.
 
         :param stream: File-like input stream.
@@ -104,7 +104,7 @@ class LintModuleTest:
         :returns: A dict mapping line,msg-symbol tuples to the count on this line.
         :rtype: dict
         """
-        messages: "MessageCounter" = Counter()
+        messages: "MESSAGE_COUNTER" = Counter()
         for i, line in enumerate(stream):
             match = _EXPECTED_RE.search(line)
             if match is None:
@@ -130,9 +130,9 @@ class LintModuleTest:
 
     @staticmethod
     def multiset_difference(
-        expected_entries: "MessageCounter",
-        actual_entries: "MessageCounter",
-    ) -> Tuple["MessageCounter", Dict[Tuple[int, str], int]]:
+        expected_entries: "MESSAGE_COUNTER",
+        actual_entries: "MESSAGE_COUNTER",
+    ) -> Tuple["MESSAGE_COUNTER", Dict[Tuple[int, str], int]]:
         """Takes two multisets and compares them.
 
         A multiset is a dict with the cardinality of the key as the value."""
@@ -161,7 +161,7 @@ class LintModuleTest:
             return open(self._test_file.source, encoding="latin1")
         return open(self._test_file.source, encoding="utf8")
 
-    def _get_expected(self) -> Tuple["MessageCounter", List[OutputLine]]:
+    def _get_expected(self) -> Tuple["MESSAGE_COUNTER", List[OutputLine]]:
         with self._open_source_file() as f:
             expected_msgs = self.get_expected_messages(f)
         if not expected_msgs:
@@ -172,10 +172,10 @@ class LintModuleTest:
             ]
         return expected_msgs, expected_output_lines
 
-    def _get_actual(self) -> Tuple["MessageCounter", List[OutputLine]]:
+    def _get_actual(self) -> Tuple["MESSAGE_COUNTER", List[OutputLine]]:
         messages: List[Message] = self._linter.reporter.messages
         messages.sort(key=lambda m: (m.line, m.symbol, m.msg))
-        received_msgs: "MessageCounter" = Counter()
+        received_msgs: "MESSAGE_COUNTER" = Counter()
         received_output_lines = []
         for msg in messages:
             assert (
@@ -200,8 +200,8 @@ class LintModuleTest:
 
     def error_msg_for_unequal_messages(
         self,
-        actual_messages: "MessageCounter",
-        expected_messages: "MessageCounter",
+        actual_messages: "MESSAGE_COUNTER",
+        expected_messages: "MESSAGE_COUNTER",
         actual_output: List[OutputLine],
     ) -> str:
         msg = [f'Wrong results for file "{self._test_file.base}":']
@@ -246,7 +246,7 @@ class LintModuleTest:
 
     def _check_output_text(
         self,
-        _: "MessageCounter",
+        _: "MESSAGE_COUNTER",
         expected_output: List[OutputLine],
         actual_output: List[OutputLine],
     ) -> None:


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

While working on #5041 I noticed these did not have the right casing. Global module types should be all caps, right?