### PR TITLE
Rename `pylint.testutil.Message` to `pylint.testutil.TestMessage`

### DIFF
--- a/pylint/testutils/__init__.py
+++ b/pylint/testutils/__init__.py
@@ -36,7 +36,7 @@ __all__ = [
     "FunctionalTestFile",
     "linter",
     "LintModuleTest",
-    "Message",
+    "OutputMessage",
     "MinimalTestReporter",
     "set_config",
     "GenericTestReporter",
@@ -52,7 +52,7 @@ from pylint.testutils.functional_test_file import FunctionalTestFile
 from pylint.testutils.get_test_info import _get_tests_info
 from pylint.testutils.global_test_linter import linter
 from pylint.testutils.lint_module_test import LintModuleTest
-from pylint.testutils.output_line import Message
+from pylint.testutils.output_line import OutputMessage
 from pylint.testutils.reporter_for_tests import GenericTestReporter, MinimalTestReporter
 from pylint.testutils.tokenize_str import _tokenize_str
 from pylint.testutils.unittest_linter import UnittestLinter

--- a/pylint/testutils/__init__.py
+++ b/pylint/testutils/__init__.py
@@ -36,7 +36,7 @@ __all__ = [
     "FunctionalTestFile",
     "linter",
     "LintModuleTest",
-    "OutputMessage",
+    "TestMessage",
     "MinimalTestReporter",
     "set_config",
     "GenericTestReporter",
@@ -52,7 +52,7 @@ from pylint.testutils.functional_test_file import FunctionalTestFile
 from pylint.testutils.get_test_info import _get_tests_info
 from pylint.testutils.global_test_linter import linter
 from pylint.testutils.lint_module_test import LintModuleTest
-from pylint.testutils.output_line import OutputMessage
+from pylint.testutils.output_line import TestMessage
 from pylint.testutils.reporter_for_tests import GenericTestReporter, MinimalTestReporter
 from pylint.testutils.tokenize_str import _tokenize_str
 from pylint.testutils.unittest_linter import UnittestLinter

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -9,16 +9,16 @@ from pylint.constants import PY38_PLUS
 from pylint.testutils.constants import UPDATE_OPTION
 
 
-class OutputMessage(
+class TestMessage(
     collections.namedtuple(
-        "OutputMessage", ["msg_id", "line", "node", "args", "confidence"]
+        "TestMessage", ["msg_id", "line", "node", "args", "confidence"]
     )
 ):
     def __new__(cls, msg_id, line=None, node=None, args=None, confidence=None):
         return tuple.__new__(cls, (msg_id, line, node, args, confidence))
 
     def __eq__(self, other):
-        if isinstance(other, OutputMessage):
+        if isinstance(other, TestMessage):
             if self.confidence and other.confidence:
                 return super().__eq__(other)
             return self[:-1] == other[:-1]

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -9,14 +9,16 @@ from pylint.constants import PY38_PLUS
 from pylint.testutils.constants import UPDATE_OPTION
 
 
-class Message(
-    collections.namedtuple("Message", ["msg_id", "line", "node", "args", "confidence"])
+class OutputMessage(
+    collections.namedtuple(
+        "OutputMessage", ["msg_id", "line", "node", "args", "confidence"]
+    )
 ):
     def __new__(cls, msg_id, line=None, node=None, args=None, confidence=None):
         return tuple.__new__(cls, (msg_id, line, node, args, confidence))
 
     def __eq__(self, other):
-        if isinstance(other, Message):
+        if isinstance(other, OutputMessage):
             if self.confidence and other.confidence:
                 return super().__eq__(other)
             return self[:-1] == other[:-1]

--- a/pylint/testutils/unittest_linter.py
+++ b/pylint/testutils/unittest_linter.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 from pylint.testutils.global_test_linter import linter
-from pylint.testutils.output_line import OutputMessage
+from pylint.testutils.output_line import TestMessage
 from pylint.typing import CheckerStats
 
 
@@ -25,7 +25,7 @@ class UnittestLinter:
         self, msg_id, line=None, node=None, args=None, confidence=None, col_offset=None
     ):
         # Do not test col_offset for now since changing Message breaks everything
-        self._messages.append(OutputMessage(msg_id, line, node, args, confidence))
+        self._messages.append(TestMessage(msg_id, line, node, args, confidence))
 
     @staticmethod
     def is_message_enabled(*unused_args, **unused_kwargs):

--- a/pylint/testutils/unittest_linter.py
+++ b/pylint/testutils/unittest_linter.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 from pylint.testutils.global_test_linter import linter
-from pylint.testutils.output_line import Message
+from pylint.testutils.output_line import OutputMessage
 from pylint.typing import CheckerStats
 
 
@@ -25,7 +25,7 @@ class UnittestLinter:
         self, msg_id, line=None, node=None, args=None, confidence=None, col_offset=None
     ):
         # Do not test col_offset for now since changing Message breaks everything
-        self._messages.append(Message(msg_id, line, node, args, confidence))
+        self._messages.append(OutputMessage(msg_id, line, node, args, confidence))
 
     @staticmethod
     def is_message_enabled(*unused_args, **unused_kwargs):

--- a/tests/checkers/unittest_base.py
+++ b/tests/checkers/unittest_base.py
@@ -35,7 +35,7 @@ from typing import Dict, Type
 import astroid
 
 from pylint.checkers import BaseChecker, base
-from pylint.testutils import CheckerTestCase, OutputMessage, set_config
+from pylint.testutils import CheckerTestCase, TestMessage, set_config
 
 
 class TestDocstring(CheckerTestCase):
@@ -43,7 +43,7 @@ class TestDocstring(CheckerTestCase):
 
     def test_missing_docstring_module(self) -> None:
         module = astroid.parse("something")
-        message = OutputMessage("missing-module-docstring", node=module)
+        message = TestMessage("missing-module-docstring", node=module)
         with self.assertAddsMessages(message):
             self.checker.visit_module(module)
 
@@ -54,7 +54,7 @@ class TestDocstring(CheckerTestCase):
 
     def test_empty_docstring_module(self) -> None:
         module = astroid.parse("''''''")
-        message = OutputMessage("empty-docstring", node=module, args=("module",))
+        message = TestMessage("empty-docstring", node=module, args=("module",))
         with self.assertAddsMessages(message):
             self.checker.visit_module(module)
 
@@ -64,7 +64,7 @@ class TestDocstring(CheckerTestCase):
         def func(tion):
            pass"""
         )
-        message = OutputMessage("missing-function-docstring", node=func)
+        message = TestMessage("missing-function-docstring", node=func)
         with self.assertAddsMessages(message):
             self.checker.visit_functiondef(func)
 
@@ -87,7 +87,7 @@ class TestDocstring(CheckerTestCase):
             pass
            """
         )
-        message = OutputMessage("missing-function-docstring", node=func)
+        message = TestMessage("missing-function-docstring", node=func)
         with self.assertAddsMessages(message):
             self.checker.visit_functiondef(func)
 
@@ -102,7 +102,7 @@ class TestDocstring(CheckerTestCase):
                 pass
            """
         )
-        message = OutputMessage("missing-function-docstring", node=func)
+        message = TestMessage("missing-function-docstring", node=func)
         with self.assertAddsMessages(message):
             self.checker.visit_functiondef(func)
 
@@ -122,7 +122,7 @@ class TestDocstring(CheckerTestCase):
         class Klass(object):
            pass"""
         )
-        message = OutputMessage("missing-class-docstring", node=klass)
+        message = TestMessage("missing-class-docstring", node=klass)
         with self.assertAddsMessages(message):
             self.checker.visit_classdef(klass)
 
@@ -182,7 +182,7 @@ class TestNameChecker(CheckerTestCase):
             self.checker.visit_functiondef(methods[2])
             self.checker.visit_functiondef(methods[3])
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "invalid-name",
                 node=methods[1],
                 args=("Attribute", "bar", "'[A-Z]+' pattern"),
@@ -260,7 +260,7 @@ class TestNameChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="assign-to-new-keyword",
                 node=ast[0].targets[0],
                 args=("async", "3.7"),
@@ -268,7 +268,7 @@ class TestNameChecker(CheckerTestCase):
         ):
             self.checker.visit_assignname(ast[0].targets[0])
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="assign-to-new-keyword",
                 node=ast[1].targets[0],
                 args=("await", "3.7"),
@@ -276,13 +276,13 @@ class TestNameChecker(CheckerTestCase):
         ):
             self.checker.visit_assignname(ast[1].targets[0])
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="assign-to-new-keyword", node=ast[2], args=("async", "3.7")
             )
         ):
             self.checker.visit_functiondef(ast[2])
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="assign-to-new-keyword", node=ast[3], args=("async", "3.7")
             )
         ):
@@ -306,7 +306,7 @@ class TestMultiNamingStyle(CheckerTestCase):
             pass
         """
         )
-        message = OutputMessage(
+        message = TestMessage(
             "invalid-name",
             node=classes[0],
             args=(
@@ -335,7 +335,7 @@ class TestMultiNamingStyle(CheckerTestCase):
         """
         )
         messages = [
-            OutputMessage(
+            TestMessage(
                 "invalid-name",
                 node=classes[0],
                 args=(
@@ -344,7 +344,7 @@ class TestMultiNamingStyle(CheckerTestCase):
                     "'(?:(?P<UP>[A-Z]+)|(?P<down>[a-z]+))$' pattern",
                 ),
             ),
-            OutputMessage(
+            TestMessage(
                 "invalid-name",
                 node=classes[2],
                 args=(
@@ -378,7 +378,7 @@ class TestMultiNamingStyle(CheckerTestCase):
         """,
             module_name="test",
         )
-        message = OutputMessage(
+        message = TestMessage(
             "invalid-name",
             node=function_defs[1],
             args=(
@@ -410,7 +410,7 @@ class TestMultiNamingStyle(CheckerTestCase):
             pass
         """
         )
-        message = OutputMessage(
+        message = TestMessage(
             "invalid-name",
             node=function_defs[3],
             args=(
@@ -432,7 +432,7 @@ class TestComparison(CheckerTestCase):
 
     def test_comparison(self) -> None:
         node = astroid.extract_node("foo == True")
-        message = OutputMessage(
+        message = TestMessage(
             "singleton-comparison",
             node=node,
             args=(
@@ -444,7 +444,7 @@ class TestComparison(CheckerTestCase):
             self.checker.visit_compare(node)
 
         node = astroid.extract_node("foo == False")
-        message = OutputMessage(
+        message = TestMessage(
             "singleton-comparison",
             node=node,
             args=(
@@ -456,14 +456,14 @@ class TestComparison(CheckerTestCase):
             self.checker.visit_compare(node)
 
         node = astroid.extract_node("foo == None")
-        message = OutputMessage(
+        message = TestMessage(
             "singleton-comparison", node=node, args=("'foo == None'", "'foo is None'")
         )
         with self.assertAddsMessages(message):
             self.checker.visit_compare(node)
 
         node = astroid.extract_node("foo is float('nan')")
-        message = OutputMessage(
+        message = TestMessage(
             "nan-comparison",
             node=node,
             args=("'foo is float('nan')'", "'math.isnan(foo)'"),
@@ -477,7 +477,7 @@ class TestComparison(CheckerTestCase):
                                 foo != numpy.NaN
                                 """
         )
-        message = OutputMessage(
+        message = TestMessage(
             "nan-comparison",
             node=node,
             args=("'foo != numpy.NaN'", "'not math.isnan(foo)'"),
@@ -491,7 +491,7 @@ class TestComparison(CheckerTestCase):
                                 foo is not nmp.NaN
                                 """
         )
-        message = OutputMessage(
+        message = TestMessage(
             "nan-comparison",
             node=node,
             args=("'foo is not nmp.NaN'", "'not math.isnan(foo)'"),
@@ -501,10 +501,10 @@ class TestComparison(CheckerTestCase):
 
         node = astroid.extract_node("True == foo")
         messages = (
-            OutputMessage(
+            TestMessage(
                 "misplaced-comparison-constant", node=node, args=("foo == True",)
             ),
-            OutputMessage(
+            TestMessage(
                 "singleton-comparison",
                 node=node,
                 args=(
@@ -518,10 +518,10 @@ class TestComparison(CheckerTestCase):
 
         node = astroid.extract_node("False == foo")
         messages = (
-            OutputMessage(
+            TestMessage(
                 "misplaced-comparison-constant", node=node, args=("foo == False",)
             ),
-            OutputMessage(
+            TestMessage(
                 "singleton-comparison",
                 node=node,
                 args=(
@@ -535,10 +535,10 @@ class TestComparison(CheckerTestCase):
 
         node = astroid.extract_node("None == foo")
         messages = (
-            OutputMessage(
+            TestMessage(
                 "misplaced-comparison-constant", node=node, args=("foo == None",)
             ),
-            OutputMessage(
+            TestMessage(
                 "singleton-comparison",
                 node=node,
                 args=("'None == foo'", "'None is foo'"),

--- a/tests/checkers/unittest_base.py
+++ b/tests/checkers/unittest_base.py
@@ -35,7 +35,7 @@ from typing import Dict, Type
 import astroid
 
 from pylint.checkers import BaseChecker, base
-from pylint.testutils import CheckerTestCase, Message, set_config
+from pylint.testutils import CheckerTestCase, OutputMessage, set_config
 
 
 class TestDocstring(CheckerTestCase):
@@ -43,7 +43,7 @@ class TestDocstring(CheckerTestCase):
 
     def test_missing_docstring_module(self) -> None:
         module = astroid.parse("something")
-        message = Message("missing-module-docstring", node=module)
+        message = OutputMessage("missing-module-docstring", node=module)
         with self.assertAddsMessages(message):
             self.checker.visit_module(module)
 
@@ -54,7 +54,7 @@ class TestDocstring(CheckerTestCase):
 
     def test_empty_docstring_module(self) -> None:
         module = astroid.parse("''''''")
-        message = Message("empty-docstring", node=module, args=("module",))
+        message = OutputMessage("empty-docstring", node=module, args=("module",))
         with self.assertAddsMessages(message):
             self.checker.visit_module(module)
 
@@ -64,7 +64,7 @@ class TestDocstring(CheckerTestCase):
         def func(tion):
            pass"""
         )
-        message = Message("missing-function-docstring", node=func)
+        message = OutputMessage("missing-function-docstring", node=func)
         with self.assertAddsMessages(message):
             self.checker.visit_functiondef(func)
 
@@ -87,7 +87,7 @@ class TestDocstring(CheckerTestCase):
             pass
            """
         )
-        message = Message("missing-function-docstring", node=func)
+        message = OutputMessage("missing-function-docstring", node=func)
         with self.assertAddsMessages(message):
             self.checker.visit_functiondef(func)
 
@@ -102,7 +102,7 @@ class TestDocstring(CheckerTestCase):
                 pass
            """
         )
-        message = Message("missing-function-docstring", node=func)
+        message = OutputMessage("missing-function-docstring", node=func)
         with self.assertAddsMessages(message):
             self.checker.visit_functiondef(func)
 
@@ -122,7 +122,7 @@ class TestDocstring(CheckerTestCase):
         class Klass(object):
            pass"""
         )
-        message = Message("missing-class-docstring", node=klass)
+        message = OutputMessage("missing-class-docstring", node=klass)
         with self.assertAddsMessages(message):
             self.checker.visit_classdef(klass)
 
@@ -182,7 +182,7 @@ class TestNameChecker(CheckerTestCase):
             self.checker.visit_functiondef(methods[2])
             self.checker.visit_functiondef(methods[3])
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "invalid-name",
                 node=methods[1],
                 args=("Attribute", "bar", "'[A-Z]+' pattern"),
@@ -260,7 +260,7 @@ class TestNameChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="assign-to-new-keyword",
                 node=ast[0].targets[0],
                 args=("async", "3.7"),
@@ -268,7 +268,7 @@ class TestNameChecker(CheckerTestCase):
         ):
             self.checker.visit_assignname(ast[0].targets[0])
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="assign-to-new-keyword",
                 node=ast[1].targets[0],
                 args=("await", "3.7"),
@@ -276,11 +276,15 @@ class TestNameChecker(CheckerTestCase):
         ):
             self.checker.visit_assignname(ast[1].targets[0])
         with self.assertAddsMessages(
-            Message(msg_id="assign-to-new-keyword", node=ast[2], args=("async", "3.7"))
+            OutputMessage(
+                msg_id="assign-to-new-keyword", node=ast[2], args=("async", "3.7")
+            )
         ):
             self.checker.visit_functiondef(ast[2])
         with self.assertAddsMessages(
-            Message(msg_id="assign-to-new-keyword", node=ast[3], args=("async", "3.7"))
+            OutputMessage(
+                msg_id="assign-to-new-keyword", node=ast[3], args=("async", "3.7")
+            )
         ):
             self.checker.visit_classdef(ast[3])
 
@@ -302,7 +306,7 @@ class TestMultiNamingStyle(CheckerTestCase):
             pass
         """
         )
-        message = Message(
+        message = OutputMessage(
             "invalid-name",
             node=classes[0],
             args=(
@@ -331,7 +335,7 @@ class TestMultiNamingStyle(CheckerTestCase):
         """
         )
         messages = [
-            Message(
+            OutputMessage(
                 "invalid-name",
                 node=classes[0],
                 args=(
@@ -340,7 +344,7 @@ class TestMultiNamingStyle(CheckerTestCase):
                     "'(?:(?P<UP>[A-Z]+)|(?P<down>[a-z]+))$' pattern",
                 ),
             ),
-            Message(
+            OutputMessage(
                 "invalid-name",
                 node=classes[2],
                 args=(
@@ -374,7 +378,7 @@ class TestMultiNamingStyle(CheckerTestCase):
         """,
             module_name="test",
         )
-        message = Message(
+        message = OutputMessage(
             "invalid-name",
             node=function_defs[1],
             args=(
@@ -406,7 +410,7 @@ class TestMultiNamingStyle(CheckerTestCase):
             pass
         """
         )
-        message = Message(
+        message = OutputMessage(
             "invalid-name",
             node=function_defs[3],
             args=(
@@ -428,7 +432,7 @@ class TestComparison(CheckerTestCase):
 
     def test_comparison(self) -> None:
         node = astroid.extract_node("foo == True")
-        message = Message(
+        message = OutputMessage(
             "singleton-comparison",
             node=node,
             args=(
@@ -440,7 +444,7 @@ class TestComparison(CheckerTestCase):
             self.checker.visit_compare(node)
 
         node = astroid.extract_node("foo == False")
-        message = Message(
+        message = OutputMessage(
             "singleton-comparison",
             node=node,
             args=(
@@ -452,14 +456,14 @@ class TestComparison(CheckerTestCase):
             self.checker.visit_compare(node)
 
         node = astroid.extract_node("foo == None")
-        message = Message(
+        message = OutputMessage(
             "singleton-comparison", node=node, args=("'foo == None'", "'foo is None'")
         )
         with self.assertAddsMessages(message):
             self.checker.visit_compare(node)
 
         node = astroid.extract_node("foo is float('nan')")
-        message = Message(
+        message = OutputMessage(
             "nan-comparison",
             node=node,
             args=("'foo is float('nan')'", "'math.isnan(foo)'"),
@@ -473,7 +477,7 @@ class TestComparison(CheckerTestCase):
                                 foo != numpy.NaN
                                 """
         )
-        message = Message(
+        message = OutputMessage(
             "nan-comparison",
             node=node,
             args=("'foo != numpy.NaN'", "'not math.isnan(foo)'"),
@@ -487,7 +491,7 @@ class TestComparison(CheckerTestCase):
                                 foo is not nmp.NaN
                                 """
         )
-        message = Message(
+        message = OutputMessage(
             "nan-comparison",
             node=node,
             args=("'foo is not nmp.NaN'", "'not math.isnan(foo)'"),
@@ -497,8 +501,10 @@ class TestComparison(CheckerTestCase):
 
         node = astroid.extract_node("True == foo")
         messages = (
-            Message("misplaced-comparison-constant", node=node, args=("foo == True",)),
-            Message(
+            OutputMessage(
+                "misplaced-comparison-constant", node=node, args=("foo == True",)
+            ),
+            OutputMessage(
                 "singleton-comparison",
                 node=node,
                 args=(
@@ -512,8 +518,10 @@ class TestComparison(CheckerTestCase):
 
         node = astroid.extract_node("False == foo")
         messages = (
-            Message("misplaced-comparison-constant", node=node, args=("foo == False",)),
-            Message(
+            OutputMessage(
+                "misplaced-comparison-constant", node=node, args=("foo == False",)
+            ),
+            OutputMessage(
                 "singleton-comparison",
                 node=node,
                 args=(
@@ -527,8 +535,10 @@ class TestComparison(CheckerTestCase):
 
         node = astroid.extract_node("None == foo")
         messages = (
-            Message("misplaced-comparison-constant", node=node, args=("foo == None",)),
-            Message(
+            OutputMessage(
+                "misplaced-comparison-constant", node=node, args=("foo == None",)
+            ),
+            OutputMessage(
                 "singleton-comparison",
                 node=node,
                 args=("'None == foo'", "'None is foo'"),

--- a/tests/checkers/unittest_classes.py
+++ b/tests/checkers/unittest_classes.py
@@ -20,7 +20,7 @@
 import astroid
 
 from pylint.checkers import classes
-from pylint.testutils import CheckerTestCase, Message, set_config
+from pylint.testutils import CheckerTestCase, OutputMessage, set_config
 
 
 class TestVariablesChecker(CheckerTestCase):
@@ -37,7 +37,7 @@ class TestVariablesChecker(CheckerTestCase):
             self.first = 0  #@
         """
         )
-        message = Message(
+        message = OutputMessage(
             "access-member-before-definition", node=n1.target, args=("first", n2.lineno)
         )
         with self.assertAddsMessages(message):
@@ -64,7 +64,7 @@ class TestVariablesChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message("protected-access", node=node.body[-1].value, args="_teta")
+            OutputMessage("protected-access", node=node.body[-1].value, args="_teta")
         ):
             self.walk(node.root())
 
@@ -117,7 +117,7 @@ class TestVariablesChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message("protected-access", node=node.value, args="_nargs")
+            OutputMessage("protected-access", node=node.value, args="_nargs")
         ):
             self.checker.visit_attribute(node.value)
 
@@ -154,15 +154,19 @@ class TestVariablesChecker(CheckerTestCase):
         unused_private_attr_1 = classdef.instance_attr("__private")[0]
         unused_private_attr_2 = classdef.instance_attr("__private")[1]
         with self.assertAddsMessages(
-            Message("protected-access", node=attribute_in_eq, args="_protected"),
-            Message("protected-access", node=attribute_in_fake_1, args="_protected"),
-            Message("protected-access", node=attribute_in_fake_2, args="__private"),
-            Message(
+            OutputMessage("protected-access", node=attribute_in_eq, args="_protected"),
+            OutputMessage(
+                "protected-access", node=attribute_in_fake_1, args="_protected"
+            ),
+            OutputMessage(
+                "protected-access", node=attribute_in_fake_2, args="__private"
+            ),
+            OutputMessage(
                 "unused-private-member",
                 node=unused_private_attr_1,
                 args=("Protected", "__private"),
             ),
-            Message(
+            OutputMessage(
                 "unused-private-member",
                 node=unused_private_attr_2,
                 args=("Protected", "__private"),
@@ -201,14 +205,18 @@ class TestVariablesChecker(CheckerTestCase):
         unused_private_attr_1 = classdef.instance_attr("__private")[0]
         unused_private_attr_2 = classdef.instance_attr("__private")[1]
         with self.assertAddsMessages(
-            Message("protected-access", node=attribute_in_fake_1, args="_protected"),
-            Message("protected-access", node=attribute_in_fake_2, args="__private"),
-            Message(
+            OutputMessage(
+                "protected-access", node=attribute_in_fake_1, args="_protected"
+            ),
+            OutputMessage(
+                "protected-access", node=attribute_in_fake_2, args="__private"
+            ),
+            OutputMessage(
                 "unused-private-member",
                 node=unused_private_attr_1,
                 args=("Protected", "__private"),
             ),
-            Message(
+            OutputMessage(
                 "unused-private-member",
                 node=unused_private_attr_2,
                 args=("Protected", "__private"),
@@ -243,5 +251,7 @@ class TestVariablesChecker(CheckerTestCase):
                     pass
             """
         )
-        with self.assertAddsMessages(Message("method-hidden", node=node, args=("", 4))):
+        with self.assertAddsMessages(
+            OutputMessage("method-hidden", node=node, args=("", 4))
+        ):
             self.checker.visit_functiondef(node)

--- a/tests/checkers/unittest_classes.py
+++ b/tests/checkers/unittest_classes.py
@@ -20,7 +20,7 @@
 import astroid
 
 from pylint.checkers import classes
-from pylint.testutils import CheckerTestCase, OutputMessage, set_config
+from pylint.testutils import CheckerTestCase, TestMessage, set_config
 
 
 class TestVariablesChecker(CheckerTestCase):
@@ -37,7 +37,7 @@ class TestVariablesChecker(CheckerTestCase):
             self.first = 0  #@
         """
         )
-        message = OutputMessage(
+        message = TestMessage(
             "access-member-before-definition", node=n1.target, args=("first", n2.lineno)
         )
         with self.assertAddsMessages(message):
@@ -64,7 +64,7 @@ class TestVariablesChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage("protected-access", node=node.body[-1].value, args="_teta")
+            TestMessage("protected-access", node=node.body[-1].value, args="_teta")
         ):
             self.walk(node.root())
 
@@ -117,7 +117,7 @@ class TestVariablesChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage("protected-access", node=node.value, args="_nargs")
+            TestMessage("protected-access", node=node.value, args="_nargs")
         ):
             self.checker.visit_attribute(node.value)
 
@@ -154,19 +154,17 @@ class TestVariablesChecker(CheckerTestCase):
         unused_private_attr_1 = classdef.instance_attr("__private")[0]
         unused_private_attr_2 = classdef.instance_attr("__private")[1]
         with self.assertAddsMessages(
-            OutputMessage("protected-access", node=attribute_in_eq, args="_protected"),
-            OutputMessage(
+            TestMessage("protected-access", node=attribute_in_eq, args="_protected"),
+            TestMessage(
                 "protected-access", node=attribute_in_fake_1, args="_protected"
             ),
-            OutputMessage(
-                "protected-access", node=attribute_in_fake_2, args="__private"
-            ),
-            OutputMessage(
+            TestMessage("protected-access", node=attribute_in_fake_2, args="__private"),
+            TestMessage(
                 "unused-private-member",
                 node=unused_private_attr_1,
                 args=("Protected", "__private"),
             ),
-            OutputMessage(
+            TestMessage(
                 "unused-private-member",
                 node=unused_private_attr_2,
                 args=("Protected", "__private"),
@@ -205,18 +203,16 @@ class TestVariablesChecker(CheckerTestCase):
         unused_private_attr_1 = classdef.instance_attr("__private")[0]
         unused_private_attr_2 = classdef.instance_attr("__private")[1]
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "protected-access", node=attribute_in_fake_1, args="_protected"
             ),
-            OutputMessage(
-                "protected-access", node=attribute_in_fake_2, args="__private"
-            ),
-            OutputMessage(
+            TestMessage("protected-access", node=attribute_in_fake_2, args="__private"),
+            TestMessage(
                 "unused-private-member",
                 node=unused_private_attr_1,
                 args=("Protected", "__private"),
             ),
-            OutputMessage(
+            TestMessage(
                 "unused-private-member",
                 node=unused_private_attr_2,
                 args=("Protected", "__private"),
@@ -252,6 +248,6 @@ class TestVariablesChecker(CheckerTestCase):
             """
         )
         with self.assertAddsMessages(
-            OutputMessage("method-hidden", node=node, args=("", 4))
+            TestMessage("method-hidden", node=node, args=("", 4))
         ):
             self.checker.visit_functiondef(node)

--- a/tests/checkers/unittest_deprecated.py
+++ b/tests/checkers/unittest_deprecated.py
@@ -4,7 +4,7 @@ import astroid
 
 from pylint.checkers import BaseChecker, DeprecatedMixin
 from pylint.interfaces import UNDEFINED, IAstroidChecker
-from pylint.testutils import CheckerTestCase, OutputMessage
+from pylint.testutils import CheckerTestCase, TestMessage
 
 
 class _DeprecatedChecker(DeprecatedMixin, BaseChecker):
@@ -66,7 +66,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-method",
                 args=("deprecated_func",),
                 node=node,
@@ -88,7 +88,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-method",
                 args=("deprecated_method",),
                 node=node,
@@ -113,7 +113,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-method",
                 args=("deprecated_method",),
                 node=node,
@@ -152,7 +152,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction1"),
                 node=node,
@@ -172,7 +172,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction1"),
                 node=node,
@@ -205,7 +205,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction3"),
                 node=node,
@@ -226,7 +226,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod1"),
                 node=node,
@@ -247,7 +247,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod1"),
                 node=node,
@@ -282,7 +282,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod3"),
                 node=node,
@@ -303,13 +303,13 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction2"),
                 node=node,
                 confidence=UNDEFINED,
             ),
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg2", "myfunction2"),
                 node=node,
@@ -329,13 +329,13 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction2"),
                 node=node,
                 confidence=UNDEFINED,
             ),
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg2", "myfunction2"),
                 node=node,
@@ -357,13 +357,13 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod2"),
                 node=node,
                 confidence=UNDEFINED,
             ),
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg2", "mymethod2"),
                 node=node,
@@ -384,13 +384,13 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod2"),
                 node=node,
                 confidence=UNDEFINED,
             ),
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg2", "mymethod2"),
                 node=node,
@@ -411,7 +411,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg", "MyClass"),
                 node=node,
@@ -428,7 +428,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-module",
                 args="deprecated_module",
                 node=node,
@@ -445,7 +445,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-module",
                 args="deprecated_module",
                 node=node,
@@ -462,7 +462,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-class",
                 args=("DeprecatedClass", "deprecated"),
                 node=node,
@@ -479,7 +479,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-class",
                 args=("DeprecatedClass", "deprecated"),
                 node=node,
@@ -497,7 +497,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-class",
                 args=("DeprecatedClass", "deprecated"),
                 node=node,
@@ -521,7 +521,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-decorator",
                 args=".deprecated_decorator",
                 node=node,
@@ -547,7 +547,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="deprecated-decorator",
                 args=".deprecated_decorator",
                 node=node,

--- a/tests/checkers/unittest_deprecated.py
+++ b/tests/checkers/unittest_deprecated.py
@@ -4,7 +4,7 @@ import astroid
 
 from pylint.checkers import BaseChecker, DeprecatedMixin
 from pylint.interfaces import UNDEFINED, IAstroidChecker
-from pylint.testutils import CheckerTestCase, Message
+from pylint.testutils import CheckerTestCase, OutputMessage
 
 
 class _DeprecatedChecker(DeprecatedMixin, BaseChecker):
@@ -66,7 +66,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-method",
                 args=("deprecated_func",),
                 node=node,
@@ -88,7 +88,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-method",
                 args=("deprecated_method",),
                 node=node,
@@ -113,7 +113,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-method",
                 args=("deprecated_method",),
                 node=node,
@@ -152,7 +152,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction1"),
                 node=node,
@@ -172,7 +172,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction1"),
                 node=node,
@@ -205,7 +205,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction3"),
                 node=node,
@@ -226,7 +226,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod1"),
                 node=node,
@@ -247,7 +247,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod1"),
                 node=node,
@@ -282,7 +282,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod3"),
                 node=node,
@@ -303,13 +303,13 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction2"),
                 node=node,
                 confidence=UNDEFINED,
             ),
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg2", "myfunction2"),
                 node=node,
@@ -329,13 +329,13 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction2"),
                 node=node,
                 confidence=UNDEFINED,
             ),
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg2", "myfunction2"),
                 node=node,
@@ -357,13 +357,13 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod2"),
                 node=node,
                 confidence=UNDEFINED,
             ),
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg2", "mymethod2"),
                 node=node,
@@ -384,13 +384,13 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod2"),
                 node=node,
                 confidence=UNDEFINED,
             ),
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg2", "mymethod2"),
                 node=node,
@@ -411,7 +411,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg", "MyClass"),
                 node=node,
@@ -428,7 +428,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-module",
                 args="deprecated_module",
                 node=node,
@@ -445,7 +445,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-module",
                 args="deprecated_module",
                 node=node,
@@ -462,7 +462,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-class",
                 args=("DeprecatedClass", "deprecated"),
                 node=node,
@@ -479,7 +479,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-class",
                 args=("DeprecatedClass", "deprecated"),
                 node=node,
@@ -497,7 +497,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-class",
                 args=("DeprecatedClass", "deprecated"),
                 node=node,
@@ -521,7 +521,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-decorator",
                 args=".deprecated_decorator",
                 node=node,
@@ -547,7 +547,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="deprecated-decorator",
                 args=".deprecated_decorator",
                 node=node,

--- a/tests/checkers/unittest_exceptions.py
+++ b/tests/checkers/unittest_exceptions.py
@@ -18,7 +18,7 @@
 import astroid
 
 from pylint.checkers import exceptions
-from pylint.testutils import CheckerTestCase, OutputMessage
+from pylint.testutils import CheckerTestCase, TestMessage
 
 
 class TestExceptionsChecker(CheckerTestCase):
@@ -33,7 +33,7 @@ class TestExceptionsChecker(CheckerTestCase):
 
     def test_raising_bad_type_python3(self) -> None:
         node = astroid.extract_node("raise (ZeroDivisionError, None)  #@")
-        message = OutputMessage("raising-bad-type", node=node, args="tuple")
+        message = TestMessage("raising-bad-type", node=node, args="tuple")
         with self.assertAddsMessages(message):
             self.checker.visit_raise(node)
 
@@ -49,6 +49,6 @@ class TestExceptionsChecker(CheckerTestCase):
             raise Exception from exc  #@
         """
         )
-        message = OutputMessage("bad-exception-context", node=node)
+        message = TestMessage("bad-exception-context", node=node)
         with self.assertAddsMessages(message):
             self.checker.visit_raise(node)

--- a/tests/checkers/unittest_exceptions.py
+++ b/tests/checkers/unittest_exceptions.py
@@ -18,7 +18,7 @@
 import astroid
 
 from pylint.checkers import exceptions
-from pylint.testutils import CheckerTestCase, Message
+from pylint.testutils import CheckerTestCase, OutputMessage
 
 
 class TestExceptionsChecker(CheckerTestCase):
@@ -33,7 +33,7 @@ class TestExceptionsChecker(CheckerTestCase):
 
     def test_raising_bad_type_python3(self) -> None:
         node = astroid.extract_node("raise (ZeroDivisionError, None)  #@")
-        message = Message("raising-bad-type", node=node, args="tuple")
+        message = OutputMessage("raising-bad-type", node=node, args="tuple")
         with self.assertAddsMessages(message):
             self.checker.visit_raise(node)
 
@@ -49,6 +49,6 @@ class TestExceptionsChecker(CheckerTestCase):
             raise Exception from exc  #@
         """
         )
-        message = Message("bad-exception-context", node=node)
+        message = OutputMessage("bad-exception-context", node=node)
         with self.assertAddsMessages(message):
             self.checker.visit_raise(node)

--- a/tests/checkers/unittest_format.py
+++ b/tests/checkers/unittest_format.py
@@ -37,7 +37,7 @@ import astroid
 
 from pylint import lint, reporters
 from pylint.checkers.format import FormatChecker
-from pylint.testutils import CheckerTestCase, Message, _tokenize_str
+from pylint.testutils import CheckerTestCase, OutputMessage, _tokenize_str
 
 
 class TestMultiStatementLine(CheckerTestCase):
@@ -50,7 +50,9 @@ class TestMultiStatementLine(CheckerTestCase):
         """
         )
         self.checker.config.single_line_if_stmt = False
-        with self.assertAddsMessages(Message("multiple-statements", node=stmt.body[0])):
+        with self.assertAddsMessages(
+            OutputMessage("multiple-statements", node=stmt.body[0])
+        ):
             self.visitFirst(stmt)
         self.checker.config.single_line_if_stmt = True
         with self.assertNoMessages():
@@ -62,7 +64,9 @@ class TestMultiStatementLine(CheckerTestCase):
             pass
         """
         )
-        with self.assertAddsMessages(Message("multiple-statements", node=stmt.body[0])):
+        with self.assertAddsMessages(
+            OutputMessage("multiple-statements", node=stmt.body[0])
+        ):
             self.visitFirst(stmt)
 
     def testSingleLineClassStmts(self) -> None:
@@ -72,7 +76,9 @@ class TestMultiStatementLine(CheckerTestCase):
         """
         )
         self.checker.config.single_line_class_stmt = False
-        with self.assertAddsMessages(Message("multiple-statements", node=stmt.body[0])):
+        with self.assertAddsMessages(
+            OutputMessage("multiple-statements", node=stmt.body[0])
+        ):
             self.visitFirst(stmt)
         self.checker.config.single_line_class_stmt = True
         with self.assertNoMessages():
@@ -84,7 +90,9 @@ class TestMultiStatementLine(CheckerTestCase):
         """
         )
         self.checker.config.single_line_class_stmt = False
-        with self.assertAddsMessages(Message("multiple-statements", node=stmt.body[0])):
+        with self.assertAddsMessages(
+            OutputMessage("multiple-statements", node=stmt.body[0])
+        ):
             self.visitFirst(stmt)
         self.checker.config.single_line_class_stmt = True
         with self.assertNoMessages():
@@ -96,10 +104,14 @@ class TestMultiStatementLine(CheckerTestCase):
         """
         )
         self.checker.config.single_line_class_stmt = False
-        with self.assertAddsMessages(Message("multiple-statements", node=stmt.body[0])):
+        with self.assertAddsMessages(
+            OutputMessage("multiple-statements", node=stmt.body[0])
+        ):
             self.visitFirst(stmt)
         self.checker.config.single_line_class_stmt = True
-        with self.assertAddsMessages(Message("multiple-statements", node=stmt.body[0])):
+        with self.assertAddsMessages(
+            OutputMessage("multiple-statements", node=stmt.body[0])
+        ):
             self.visitFirst(stmt)
 
     def testTryExceptFinallyNoMultipleStatement(self) -> None:
@@ -133,7 +145,9 @@ class TestMultiStatementLine(CheckerTestCase):
         def concat2(arg1: str) -> str: ...
         """
         stmt = astroid.extract_node(code)
-        with self.assertAddsMessages(Message("multiple-statements", node=stmt.body[0])):
+        with self.assertAddsMessages(
+            OutputMessage("multiple-statements", node=stmt.body[0])
+        ):
             self.visitFirst(stmt)
 
 
@@ -163,20 +177,40 @@ class TestSuperfluousParentheses(CheckerTestCase):
 
     def testCheckKeywordParensHandlesUnnecessaryParens(self) -> None:
         cases = [
-            (Message("superfluous-parens", line=1, args="if"), "if (foo):", 0),
-            (Message("superfluous-parens", line=1, args="if"), "if ((foo, bar)):", 0),
-            (Message("superfluous-parens", line=1, args="if"), "if (foo(bar)):", 0),
-            (Message("superfluous-parens", line=1, args="not"), "not (foo)", 0),
-            (Message("superfluous-parens", line=1, args="not"), "if not (foo):", 1),
-            (Message("superfluous-parens", line=1, args="if"), "if (not (foo)):", 0),
-            (Message("superfluous-parens", line=1, args="not"), "if (not (foo)):", 2),
+            (OutputMessage("superfluous-parens", line=1, args="if"), "if (foo):", 0),
             (
-                Message("superfluous-parens", line=1, args="for"),
+                OutputMessage("superfluous-parens", line=1, args="if"),
+                "if ((foo, bar)):",
+                0,
+            ),
+            (
+                OutputMessage("superfluous-parens", line=1, args="if"),
+                "if (foo(bar)):",
+                0,
+            ),
+            (OutputMessage("superfluous-parens", line=1, args="not"), "not (foo)", 0),
+            (
+                OutputMessage("superfluous-parens", line=1, args="not"),
+                "if not (foo):",
+                1,
+            ),
+            (
+                OutputMessage("superfluous-parens", line=1, args="if"),
+                "if (not (foo)):",
+                0,
+            ),
+            (
+                OutputMessage("superfluous-parens", line=1, args="not"),
+                "if (not (foo)):",
+                2,
+            ),
+            (
+                OutputMessage("superfluous-parens", line=1, args="for"),
                 "for (x) in (1, 2, 3):",
                 0,
             ),
             (
-                Message("superfluous-parens", line=1, args="if"),
+                OutputMessage("superfluous-parens", line=1, args="if"),
                 "if (1) in (1, 2, 3):",
                 0,
             ),
@@ -199,8 +233,14 @@ class TestSuperfluousParentheses(CheckerTestCase):
     def testPositiveSuperfluousParensWalrusOperatorIf(self) -> None:
         """Test positive superfluous parens cases with the walrus operator"""
         cases = [
-            (Message("superfluous-parens", line=1, args="if"), "if ((x := y)):\n"),
-            (Message("superfluous-parens", line=1, args="not"), "if not ((x := y)):\n"),
+            (
+                OutputMessage("superfluous-parens", line=1, args="if"),
+                "if ((x := y)):\n",
+            ),
+            (
+                OutputMessage("superfluous-parens", line=1, args="not"),
+                "if not ((x := y)):\n",
+            ),
         ]
         for msg, code in cases:
             with self.assertAddsMessages(msg):

--- a/tests/checkers/unittest_format.py
+++ b/tests/checkers/unittest_format.py
@@ -37,7 +37,7 @@ import astroid
 
 from pylint import lint, reporters
 from pylint.checkers.format import FormatChecker
-from pylint.testutils import CheckerTestCase, OutputMessage, _tokenize_str
+from pylint.testutils import CheckerTestCase, TestMessage, _tokenize_str
 
 
 class TestMultiStatementLine(CheckerTestCase):
@@ -51,7 +51,7 @@ class TestMultiStatementLine(CheckerTestCase):
         )
         self.checker.config.single_line_if_stmt = False
         with self.assertAddsMessages(
-            OutputMessage("multiple-statements", node=stmt.body[0])
+            TestMessage("multiple-statements", node=stmt.body[0])
         ):
             self.visitFirst(stmt)
         self.checker.config.single_line_if_stmt = True
@@ -65,7 +65,7 @@ class TestMultiStatementLine(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage("multiple-statements", node=stmt.body[0])
+            TestMessage("multiple-statements", node=stmt.body[0])
         ):
             self.visitFirst(stmt)
 
@@ -77,7 +77,7 @@ class TestMultiStatementLine(CheckerTestCase):
         )
         self.checker.config.single_line_class_stmt = False
         with self.assertAddsMessages(
-            OutputMessage("multiple-statements", node=stmt.body[0])
+            TestMessage("multiple-statements", node=stmt.body[0])
         ):
             self.visitFirst(stmt)
         self.checker.config.single_line_class_stmt = True
@@ -91,7 +91,7 @@ class TestMultiStatementLine(CheckerTestCase):
         )
         self.checker.config.single_line_class_stmt = False
         with self.assertAddsMessages(
-            OutputMessage("multiple-statements", node=stmt.body[0])
+            TestMessage("multiple-statements", node=stmt.body[0])
         ):
             self.visitFirst(stmt)
         self.checker.config.single_line_class_stmt = True
@@ -105,12 +105,12 @@ class TestMultiStatementLine(CheckerTestCase):
         )
         self.checker.config.single_line_class_stmt = False
         with self.assertAddsMessages(
-            OutputMessage("multiple-statements", node=stmt.body[0])
+            TestMessage("multiple-statements", node=stmt.body[0])
         ):
             self.visitFirst(stmt)
         self.checker.config.single_line_class_stmt = True
         with self.assertAddsMessages(
-            OutputMessage("multiple-statements", node=stmt.body[0])
+            TestMessage("multiple-statements", node=stmt.body[0])
         ):
             self.visitFirst(stmt)
 
@@ -146,7 +146,7 @@ class TestMultiStatementLine(CheckerTestCase):
         """
         stmt = astroid.extract_node(code)
         with self.assertAddsMessages(
-            OutputMessage("multiple-statements", node=stmt.body[0])
+            TestMessage("multiple-statements", node=stmt.body[0])
         ):
             self.visitFirst(stmt)
 
@@ -177,40 +177,40 @@ class TestSuperfluousParentheses(CheckerTestCase):
 
     def testCheckKeywordParensHandlesUnnecessaryParens(self) -> None:
         cases = [
-            (OutputMessage("superfluous-parens", line=1, args="if"), "if (foo):", 0),
+            (TestMessage("superfluous-parens", line=1, args="if"), "if (foo):", 0),
             (
-                OutputMessage("superfluous-parens", line=1, args="if"),
+                TestMessage("superfluous-parens", line=1, args="if"),
                 "if ((foo, bar)):",
                 0,
             ),
             (
-                OutputMessage("superfluous-parens", line=1, args="if"),
+                TestMessage("superfluous-parens", line=1, args="if"),
                 "if (foo(bar)):",
                 0,
             ),
-            (OutputMessage("superfluous-parens", line=1, args="not"), "not (foo)", 0),
+            (TestMessage("superfluous-parens", line=1, args="not"), "not (foo)", 0),
             (
-                OutputMessage("superfluous-parens", line=1, args="not"),
+                TestMessage("superfluous-parens", line=1, args="not"),
                 "if not (foo):",
                 1,
             ),
             (
-                OutputMessage("superfluous-parens", line=1, args="if"),
+                TestMessage("superfluous-parens", line=1, args="if"),
                 "if (not (foo)):",
                 0,
             ),
             (
-                OutputMessage("superfluous-parens", line=1, args="not"),
+                TestMessage("superfluous-parens", line=1, args="not"),
                 "if (not (foo)):",
                 2,
             ),
             (
-                OutputMessage("superfluous-parens", line=1, args="for"),
+                TestMessage("superfluous-parens", line=1, args="for"),
                 "for (x) in (1, 2, 3):",
                 0,
             ),
             (
-                OutputMessage("superfluous-parens", line=1, args="if"),
+                TestMessage("superfluous-parens", line=1, args="if"),
                 "if (1) in (1, 2, 3):",
                 0,
             ),
@@ -234,11 +234,11 @@ class TestSuperfluousParentheses(CheckerTestCase):
         """Test positive superfluous parens cases with the walrus operator"""
         cases = [
             (
-                OutputMessage("superfluous-parens", line=1, args="if"),
+                TestMessage("superfluous-parens", line=1, args="if"),
                 "if ((x := y)):\n",
             ),
             (
-                OutputMessage("superfluous-parens", line=1, args="not"),
+                TestMessage("superfluous-parens", line=1, args="not"),
                 "if not ((x := y)):\n",
             ),
         ]

--- a/tests/checkers/unittest_imports.py
+++ b/tests/checkers/unittest_imports.py
@@ -25,7 +25,7 @@ import astroid
 
 from pylint.checkers import imports
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, OutputMessage, set_config
+from pylint.testutils import CheckerTestCase, TestMessage, set_config
 
 REGR_DATA = os.path.join(os.path.dirname(__file__), "..", "regrtest_data", "")
 
@@ -54,7 +54,7 @@ class TestImportsChecker(CheckerTestCase):
         ).body[0]
 
         with self.assertAddsMessages(
-            OutputMessage("import-outside-toplevel", node=node, args="pylint")
+            TestMessage("import-outside-toplevel", node=node, args="pylint")
         ):
             self.checker.visit_import(node)
 
@@ -110,7 +110,7 @@ class TestImportsChecker(CheckerTestCase):
         import foo, bar
         """
         )
-        msg = OutputMessage("multiple-imports", node=node, args="foo, bar")
+        msg = TestMessage("multiple-imports", node=node, args="foo, bar")
         with self.assertAddsMessages(msg):
             self.checker.visit_import(node)
 
@@ -128,7 +128,7 @@ class TestImportsChecker(CheckerTestCase):
         Test that duplicate imports on single line raise 'reimported'.
         """
         node = astroid.extract_node("from time import sleep, sleep, time")
-        msg = OutputMessage(msg_id="reimported", node=node, args=("sleep", 1))
+        msg = TestMessage(msg_id="reimported", node=node, args=("sleep", 1))
         with self.assertAddsMessages(msg):
             self.checker.visit_importfrom(node)
 
@@ -136,7 +136,7 @@ class TestImportsChecker(CheckerTestCase):
         module = astroid.MANAGER.ast_from_module_name("beyond_top", REGR_DATA)
         import_from = module.body[0]
 
-        msg = OutputMessage(msg_id="relative-beyond-top-level", node=import_from)
+        msg = TestMessage(msg_id="relative-beyond-top-level", node=import_from)
         with self.assertAddsMessages(msg):
             self.checker.visit_importfrom(import_from)
         with self.assertNoMessages():
@@ -155,7 +155,7 @@ class TestImportsChecker(CheckerTestCase):
         module = astroid.MANAGER.ast_from_module_name("wildcard", REGR_DATA)
         import_from = module.body[0]
 
-        msg = OutputMessage(
+        msg = TestMessage(
             msg_id="wildcard-import",
             node=import_from,
             args="empty",

--- a/tests/checkers/unittest_imports.py
+++ b/tests/checkers/unittest_imports.py
@@ -25,7 +25,7 @@ import astroid
 
 from pylint.checkers import imports
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, Message, set_config
+from pylint.testutils import CheckerTestCase, OutputMessage, set_config
 
 REGR_DATA = os.path.join(os.path.dirname(__file__), "..", "regrtest_data", "")
 
@@ -54,7 +54,7 @@ class TestImportsChecker(CheckerTestCase):
         ).body[0]
 
         with self.assertAddsMessages(
-            Message("import-outside-toplevel", node=node, args="pylint")
+            OutputMessage("import-outside-toplevel", node=node, args="pylint")
         ):
             self.checker.visit_import(node)
 
@@ -110,7 +110,7 @@ class TestImportsChecker(CheckerTestCase):
         import foo, bar
         """
         )
-        msg = Message("multiple-imports", node=node, args="foo, bar")
+        msg = OutputMessage("multiple-imports", node=node, args="foo, bar")
         with self.assertAddsMessages(msg):
             self.checker.visit_import(node)
 
@@ -128,7 +128,7 @@ class TestImportsChecker(CheckerTestCase):
         Test that duplicate imports on single line raise 'reimported'.
         """
         node = astroid.extract_node("from time import sleep, sleep, time")
-        msg = Message(msg_id="reimported", node=node, args=("sleep", 1))
+        msg = OutputMessage(msg_id="reimported", node=node, args=("sleep", 1))
         with self.assertAddsMessages(msg):
             self.checker.visit_importfrom(node)
 
@@ -136,7 +136,7 @@ class TestImportsChecker(CheckerTestCase):
         module = astroid.MANAGER.ast_from_module_name("beyond_top", REGR_DATA)
         import_from = module.body[0]
 
-        msg = Message(msg_id="relative-beyond-top-level", node=import_from)
+        msg = OutputMessage(msg_id="relative-beyond-top-level", node=import_from)
         with self.assertAddsMessages(msg):
             self.checker.visit_importfrom(import_from)
         with self.assertNoMessages():
@@ -155,7 +155,7 @@ class TestImportsChecker(CheckerTestCase):
         module = astroid.MANAGER.ast_from_module_name("wildcard", REGR_DATA)
         import_from = module.body[0]
 
-        msg = Message(
+        msg = OutputMessage(
             msg_id="wildcard-import",
             node=import_from,
             args="empty",

--- a/tests/checkers/unittest_logging.py
+++ b/tests/checkers/unittest_logging.py
@@ -23,7 +23,7 @@ import pytest
 
 from pylint.checkers import logging
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, OutputMessage, set_config
+from pylint.testutils import CheckerTestCase, TestMessage, set_config
 
 
 class TestLoggingModuleDetection(CheckerTestCase):
@@ -39,7 +39,7 @@ class TestLoggingModuleDetection(CheckerTestCase):
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
         with self.assertAddsMessages(
-            OutputMessage("logging-not-lazy", node=stmts[1], args=("lazy %",))
+            TestMessage("logging-not-lazy", node=stmts[1], args=("lazy %",))
         ):
             self.checker.visit_call(stmts[1])
 
@@ -62,7 +62,7 @@ class TestLoggingModuleDetection(CheckerTestCase):
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
         with self.assertAddsMessages(
-            OutputMessage("logging-not-lazy", node=stmts[1], args=("lazy %",))
+            TestMessage("logging-not-lazy", node=stmts[1], args=("lazy %",))
         ):
             self.checker.visit_call(stmts[1])
 
@@ -77,7 +77,7 @@ class TestLoggingModuleDetection(CheckerTestCase):
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
         with self.assertAddsMessages(
-            OutputMessage("logging-not-lazy", node=stmts[1], args=("lazy %",))
+            TestMessage("logging-not-lazy", node=stmts[1], args=("lazy %",))
         ):
             self.checker.visit_call(stmts[1])
 
@@ -112,10 +112,10 @@ class TestLoggingModuleDetection(CheckerTestCase):
         )
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
-        messages = [OutputMessage(msg, node=stmts[1], args=args, confidence=UNDEFINED)]
+        messages = [TestMessage(msg, node=stmts[1], args=args, confidence=UNDEFINED)]
         if with_too_many:
             messages.append(
-                OutputMessage(
+                TestMessage(
                     "logging-too-many-args", node=stmts[1], confidence=UNDEFINED
                 )
             )

--- a/tests/checkers/unittest_logging.py
+++ b/tests/checkers/unittest_logging.py
@@ -23,7 +23,7 @@ import pytest
 
 from pylint.checkers import logging
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, Message, set_config
+from pylint.testutils import CheckerTestCase, OutputMessage, set_config
 
 
 class TestLoggingModuleDetection(CheckerTestCase):
@@ -39,7 +39,7 @@ class TestLoggingModuleDetection(CheckerTestCase):
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
         with self.assertAddsMessages(
-            Message("logging-not-lazy", node=stmts[1], args=("lazy %",))
+            OutputMessage("logging-not-lazy", node=stmts[1], args=("lazy %",))
         ):
             self.checker.visit_call(stmts[1])
 
@@ -62,7 +62,7 @@ class TestLoggingModuleDetection(CheckerTestCase):
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
         with self.assertAddsMessages(
-            Message("logging-not-lazy", node=stmts[1], args=("lazy %",))
+            OutputMessage("logging-not-lazy", node=stmts[1], args=("lazy %",))
         ):
             self.checker.visit_call(stmts[1])
 
@@ -77,7 +77,7 @@ class TestLoggingModuleDetection(CheckerTestCase):
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
         with self.assertAddsMessages(
-            Message("logging-not-lazy", node=stmts[1], args=("lazy %",))
+            OutputMessage("logging-not-lazy", node=stmts[1], args=("lazy %",))
         ):
             self.checker.visit_call(stmts[1])
 
@@ -112,10 +112,12 @@ class TestLoggingModuleDetection(CheckerTestCase):
         )
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
-        messages = [Message(msg, node=stmts[1], args=args, confidence=UNDEFINED)]
+        messages = [OutputMessage(msg, node=stmts[1], args=args, confidence=UNDEFINED)]
         if with_too_many:
             messages.append(
-                Message("logging-too-many-args", node=stmts[1], confidence=UNDEFINED)
+                OutputMessage(
+                    "logging-too-many-args", node=stmts[1], confidence=UNDEFINED
+                )
             )
         with self.assertAddsMessages(*messages):
             self.checker.visit_call(stmts[1])

--- a/tests/checkers/unittest_misc.py
+++ b/tests/checkers/unittest_misc.py
@@ -19,7 +19,7 @@
 """Tests for the misc checker."""
 
 from pylint.checkers import misc
-from pylint.testutils import CheckerTestCase, OutputMessage, _tokenize_str, set_config
+from pylint.testutils import CheckerTestCase, TestMessage, _tokenize_str, set_config
 
 
 class TestFixme(CheckerTestCase):
@@ -30,7 +30,7 @@ class TestFixme(CheckerTestCase):
                 # FIXME message
                 """
         with self.assertAddsMessages(
-            OutputMessage(msg_id="fixme", line=2, args="FIXME message")
+            TestMessage(msg_id="fixme", line=2, args="FIXME message")
         ):
             self.checker.process_tokens(_tokenize_str(code))
 
@@ -38,16 +38,14 @@ class TestFixme(CheckerTestCase):
         code = """a = 1
                 # TODO
                 """
-        with self.assertAddsMessages(
-            OutputMessage(msg_id="fixme", line=2, args="TODO")
-        ):
+        with self.assertAddsMessages(TestMessage(msg_id="fixme", line=2, args="TODO")):
             self.checker.process_tokens(_tokenize_str(code))
 
     def test_xxx_without_space(self) -> None:
         code = """a = 1
                 #XXX
                 """
-        with self.assertAddsMessages(OutputMessage(msg_id="fixme", line=2, args="XXX")):
+        with self.assertAddsMessages(TestMessage(msg_id="fixme", line=2, args="XXX")):
             self.checker.process_tokens(_tokenize_str(code))
 
     def test_xxx_middle(self) -> None:
@@ -61,9 +59,7 @@ class TestFixme(CheckerTestCase):
         code = """a = 1
                 #FIXME
                 """
-        with self.assertAddsMessages(
-            OutputMessage(msg_id="fixme", line=2, args="FIXME")
-        ):
+        with self.assertAddsMessages(TestMessage(msg_id="fixme", line=2, args="FIXME")):
             self.checker.process_tokens(_tokenize_str(code))
 
     @set_config(notes=[])
@@ -83,7 +79,7 @@ class TestFixme(CheckerTestCase):
                 # FIXME
                 """
         with self.assertAddsMessages(
-            OutputMessage(msg_id="fixme", line=2, args="CODETAG")
+            TestMessage(msg_id="fixme", line=2, args="CODETAG")
         ):
             self.checker.process_tokens(_tokenize_str(code))
 
@@ -95,7 +91,7 @@ class TestFixme(CheckerTestCase):
     def test_issue_2321_should_trigger(self) -> None:
         code = "# TODO this should not trigger a fixme"
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="fixme", line=1, args="TODO this should not trigger a fixme"
             )
         ):

--- a/tests/checkers/unittest_misc.py
+++ b/tests/checkers/unittest_misc.py
@@ -19,7 +19,7 @@
 """Tests for the misc checker."""
 
 from pylint.checkers import misc
-from pylint.testutils import CheckerTestCase, Message, _tokenize_str, set_config
+from pylint.testutils import CheckerTestCase, OutputMessage, _tokenize_str, set_config
 
 
 class TestFixme(CheckerTestCase):
@@ -30,7 +30,7 @@ class TestFixme(CheckerTestCase):
                 # FIXME message
                 """
         with self.assertAddsMessages(
-            Message(msg_id="fixme", line=2, args="FIXME message")
+            OutputMessage(msg_id="fixme", line=2, args="FIXME message")
         ):
             self.checker.process_tokens(_tokenize_str(code))
 
@@ -38,14 +38,16 @@ class TestFixme(CheckerTestCase):
         code = """a = 1
                 # TODO
                 """
-        with self.assertAddsMessages(Message(msg_id="fixme", line=2, args="TODO")):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="fixme", line=2, args="TODO")
+        ):
             self.checker.process_tokens(_tokenize_str(code))
 
     def test_xxx_without_space(self) -> None:
         code = """a = 1
                 #XXX
                 """
-        with self.assertAddsMessages(Message(msg_id="fixme", line=2, args="XXX")):
+        with self.assertAddsMessages(OutputMessage(msg_id="fixme", line=2, args="XXX")):
             self.checker.process_tokens(_tokenize_str(code))
 
     def test_xxx_middle(self) -> None:
@@ -59,7 +61,9 @@ class TestFixme(CheckerTestCase):
         code = """a = 1
                 #FIXME
                 """
-        with self.assertAddsMessages(Message(msg_id="fixme", line=2, args="FIXME")):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="fixme", line=2, args="FIXME")
+        ):
             self.checker.process_tokens(_tokenize_str(code))
 
     @set_config(notes=[])
@@ -78,7 +82,9 @@ class TestFixme(CheckerTestCase):
                 # CODETAG
                 # FIXME
                 """
-        with self.assertAddsMessages(Message(msg_id="fixme", line=2, args="CODETAG")):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="fixme", line=2, args="CODETAG")
+        ):
             self.checker.process_tokens(_tokenize_str(code))
 
     def test_issue_2321_should_not_trigger(self) -> None:
@@ -89,7 +95,9 @@ class TestFixme(CheckerTestCase):
     def test_issue_2321_should_trigger(self) -> None:
         code = "# TODO this should not trigger a fixme"
         with self.assertAddsMessages(
-            Message(msg_id="fixme", line=1, args="TODO this should not trigger a fixme")
+            OutputMessage(
+                msg_id="fixme", line=1, args="TODO this should not trigger a fixme"
+            )
         ):
             self.checker.process_tokens(_tokenize_str(code))
 

--- a/tests/checkers/unittest_spelling.py
+++ b/tests/checkers/unittest_spelling.py
@@ -22,7 +22,7 @@ import astroid
 import pytest
 
 from pylint.checkers import spelling
-from pylint.testutils import CheckerTestCase, OutputMessage, _tokenize_str, set_config
+from pylint.testutils import CheckerTestCase, TestMessage, _tokenize_str, set_config
 
 # try to create enchant dictionary
 try:
@@ -57,7 +57,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     @set_config(spelling_dict=spell_dict)
     def test_check_bad_coment(self):
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -75,7 +75,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     @set_config(max_spelling_suggestions=2)
     def test_check_bad_coment_custom_suggestion_count(self):
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -93,7 +93,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_check_bad_docstring(self):
         stmt = astroid.extract_node('def fff():\n   """bad coment"""\n   pass')
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -108,7 +108,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
 
         stmt = astroid.extract_node('class Abc(object):\n   """bad coment"""\n   pass')
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -127,7 +127,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_invalid_docstring_characters(self):
         stmt = astroid.extract_node('def fff():\n   """test\\x00"""\n   pass')
         with self.assertAddsMessages(
-            OutputMessage("invalid-characters-in-docstring", line=2, args=("test\x00",))
+            TestMessage("invalid-characters-in-docstring", line=2, args=("test\x00",))
         ):
             self.checker.visit_functiondef(stmt)
 
@@ -181,7 +181,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """ComentAbc with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -201,7 +201,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """comentAbc with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -219,7 +219,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """argumentN with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -274,7 +274,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """This is :class:`ComentAbc` with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -294,7 +294,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """This is :py:attr:`ComentAbc` with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -338,7 +338,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     ):
         full_comment = f"# {misspelled_portion_of_directive}{second_portion_of_directive} {misspelled_portion_of_directive}"
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -356,7 +356,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_skip_code_flanked_in_double_backticks(self):
         full_comment = "# The function ``.qsize()`` .qsize()"
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -374,7 +374,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_skip_code_flanked_in_single_backticks(self):
         full_comment = "# The function `.qsize()` .qsize()"
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -395,7 +395,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_skip_directives_specified_in_pylintrc(self):
         full_comment = "# newdirective: do this newdirective"
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -419,7 +419,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(
@@ -439,7 +439,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """Check teh dummy comment teh"""\n   pass'
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -449,7 +449,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
                     self._get_msg_suggestions("teh"),
                 ),
             ),
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -466,7 +466,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     @set_config(spelling_dict=spell_dict)
     def test_more_than_one_error_in_same_line_for_same_word_on_comment(self):
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -476,7 +476,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
                     self._get_msg_suggestions("coment"),
                 ),
             ),
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -499,7 +499,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """'''
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(
@@ -520,7 +520,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """# msitake"""'''
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -543,7 +543,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """'''
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(
@@ -578,7 +578,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """'''
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(
@@ -601,7 +601,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """'''
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(

--- a/tests/checkers/unittest_spelling.py
+++ b/tests/checkers/unittest_spelling.py
@@ -22,7 +22,7 @@ import astroid
 import pytest
 
 from pylint.checkers import spelling
-from pylint.testutils import CheckerTestCase, Message, _tokenize_str, set_config
+from pylint.testutils import CheckerTestCase, OutputMessage, _tokenize_str, set_config
 
 # try to create enchant dictionary
 try:
@@ -57,7 +57,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     @set_config(spelling_dict=spell_dict)
     def test_check_bad_coment(self):
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -75,7 +75,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     @set_config(max_spelling_suggestions=2)
     def test_check_bad_coment_custom_suggestion_count(self):
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -93,7 +93,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_check_bad_docstring(self):
         stmt = astroid.extract_node('def fff():\n   """bad coment"""\n   pass')
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -108,7 +108,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
 
         stmt = astroid.extract_node('class Abc(object):\n   """bad coment"""\n   pass')
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -127,7 +127,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_invalid_docstring_characters(self):
         stmt = astroid.extract_node('def fff():\n   """test\\x00"""\n   pass')
         with self.assertAddsMessages(
-            Message("invalid-characters-in-docstring", line=2, args=("test\x00",))
+            OutputMessage("invalid-characters-in-docstring", line=2, args=("test\x00",))
         ):
             self.checker.visit_functiondef(stmt)
 
@@ -181,7 +181,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """ComentAbc with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -201,7 +201,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """comentAbc with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -219,7 +219,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """argumentN with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -274,7 +274,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """This is :class:`ComentAbc` with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -294,7 +294,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """This is :py:attr:`ComentAbc` with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -338,7 +338,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     ):
         full_comment = f"# {misspelled_portion_of_directive}{second_portion_of_directive} {misspelled_portion_of_directive}"
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -356,7 +356,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_skip_code_flanked_in_double_backticks(self):
         full_comment = "# The function ``.qsize()`` .qsize()"
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -374,7 +374,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_skip_code_flanked_in_single_backticks(self):
         full_comment = "# The function `.qsize()` .qsize()"
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -395,7 +395,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_skip_directives_specified_in_pylintrc(self):
         full_comment = "# newdirective: do this newdirective"
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -419,7 +419,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
         '''
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(
@@ -439,7 +439,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """Check teh dummy comment teh"""\n   pass'
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -449,7 +449,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
                     self._get_msg_suggestions("teh"),
                 ),
             ),
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -466,7 +466,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     @set_config(spelling_dict=spell_dict)
     def test_more_than_one_error_in_same_line_for_same_word_on_comment(self):
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -476,7 +476,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
                     self._get_msg_suggestions("coment"),
                 ),
             ),
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -499,7 +499,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """'''
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(
@@ -520,7 +520,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """# msitake"""'''
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -543,7 +543,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """'''
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(
@@ -578,7 +578,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """'''
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(
@@ -601,7 +601,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """'''
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(

--- a/tests/checkers/unittest_stdlib.py
+++ b/tests/checkers/unittest_stdlib.py
@@ -21,7 +21,7 @@ from astroid.nodes.node_classes import AssignAttr, Name
 
 from pylint.checkers import stdlib
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, Message
+from pylint.testutils import CheckerTestCase, OutputMessage
 
 
 @contextlib.contextmanager
@@ -76,7 +76,9 @@ class TestStdlibChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="shallow-copy-environ", node=node, confidence=UNDEFINED)
+            OutputMessage(
+                msg_id="shallow-copy-environ", node=node, confidence=UNDEFINED
+            )
         ):
             self.checker.visit_call(node)
 
@@ -91,7 +93,9 @@ class TestStdlibChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="shallow-copy-environ", node=node, confidence=UNDEFINED)
+            OutputMessage(
+                msg_id="shallow-copy-environ", node=node, confidence=UNDEFINED
+            )
         ):
             self.checker.visit_call(node)
 

--- a/tests/checkers/unittest_stdlib.py
+++ b/tests/checkers/unittest_stdlib.py
@@ -21,7 +21,7 @@ from astroid.nodes.node_classes import AssignAttr, Name
 
 from pylint.checkers import stdlib
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, OutputMessage
+from pylint.testutils import CheckerTestCase, TestMessage
 
 
 @contextlib.contextmanager
@@ -76,9 +76,7 @@ class TestStdlibChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="shallow-copy-environ", node=node, confidence=UNDEFINED
-            )
+            TestMessage(msg_id="shallow-copy-environ", node=node, confidence=UNDEFINED)
         ):
             self.checker.visit_call(node)
 
@@ -93,9 +91,7 @@ class TestStdlibChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="shallow-copy-environ", node=node, confidence=UNDEFINED
-            )
+            TestMessage(msg_id="shallow-copy-environ", node=node, confidence=UNDEFINED)
         ):
             self.checker.visit_call(node)
 

--- a/tests/checkers/unittest_strings.py
+++ b/tests/checkers/unittest_strings.py
@@ -14,7 +14,7 @@
 import astroid
 
 from pylint.checkers import strings
-from pylint.testutils import CheckerTestCase, Message
+from pylint.testutils import CheckerTestCase, OutputMessage
 
 TEST_TOKENS = (
     '"X"',
@@ -81,7 +81,7 @@ class TestStringChecker(CheckerTestCase):
         ):
             node = astroid.extract_node(code)
             with self.assertAddsMessages(
-                Message(
+                OutputMessage(
                     "bad-string-format-type", node=node, args=(arg_type, format_type)
                 )
             ):

--- a/tests/checkers/unittest_strings.py
+++ b/tests/checkers/unittest_strings.py
@@ -14,7 +14,7 @@
 import astroid
 
 from pylint.checkers import strings
-from pylint.testutils import CheckerTestCase, OutputMessage
+from pylint.testutils import CheckerTestCase, TestMessage
 
 TEST_TOKENS = (
     '"X"',
@@ -81,7 +81,7 @@ class TestStringChecker(CheckerTestCase):
         ):
             node = astroid.extract_node(code)
             with self.assertAddsMessages(
-                OutputMessage(
+                TestMessage(
                     "bad-string-format-type", node=node, args=(arg_type, format_type)
                 )
             ):

--- a/tests/checkers/unittest_typecheck.py
+++ b/tests/checkers/unittest_typecheck.py
@@ -30,7 +30,7 @@ import pytest
 
 from pylint.checkers import typecheck
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, Message, set_config
+from pylint.testutils import CheckerTestCase, OutputMessage, set_config
 
 try:
     from coverage import tracer as _  # pylint: disable=unused-import
@@ -59,7 +59,7 @@ class TestTypeChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "no-member",
                 node=node,
                 args=("Module", "optparse", "THIS_does_not_EXIST", ""),
@@ -90,7 +90,7 @@ class TestTypeChecker(CheckerTestCase):
         xml.etree.Lala
         """
         )
-        message = Message(
+        message = OutputMessage(
             "no-member", node=node, args=("Module", "xml.etree", "Lala", "")
         )
         with self.assertAddsMessages(message):
@@ -127,7 +127,7 @@ class TestTypeChecker(CheckerTestCase):
         xml.etree.ElementTree.Test
         """
         )
-        message = Message(
+        message = OutputMessage(
             "no-member", node=node, args=("Module", "xml.etree.ElementTree", "Test", "")
         )
         with self.assertAddsMessages(message):
@@ -166,7 +166,7 @@ class TestTypeChecker(CheckerTestCase):
         tracer.CTracer  #@
         """
         )
-        message = Message(
+        message = OutputMessage(
             "no-member", node=node, args=("Module", "coverage.tracer", "CTracer", "")
         )
         with self.assertAddsMessages(message):
@@ -181,7 +181,7 @@ class TestTypeChecker(CheckerTestCase):
         tracer.CTracer  #@
         """
         )
-        message = Message(
+        message = OutputMessage(
             "c-extension-no-member",
             node=node,
             args=("Module", "coverage.tracer", "CTracer", ""),
@@ -238,7 +238,7 @@ class TestTypeChecker(CheckerTestCase):
             ("FirstInvalid", "int"),
         ):
             classdef = module[class_obj]
-            message = Message(
+            message = OutputMessage(
                 "invalid-metaclass", node=classdef, args=(metaclass_name,)
             )
             with self.assertAddsMessages(message):
@@ -259,7 +259,7 @@ class TestTypeChecker(CheckerTestCase):
         )
         for class_obj, metaclass_name in (("Invalid", "int"), ("InvalidSecond", "1")):
             classdef = module[class_obj]
-            message = Message(
+            message = OutputMessage(
                 "invalid-metaclass", node=classdef, args=(metaclass_name,)
             )
             with self.assertAddsMessages(message):
@@ -358,7 +358,7 @@ class TestTypeChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message("not-callable", node=call, args="get_num(10)")
+            OutputMessage("not-callable", node=call, args="get_num(10)")
         ):
             self.checker.visit_call(call)
 
@@ -400,7 +400,7 @@ class TestTypeCheckerOnDecorators(CheckerTestCase):
         )
         subscript = module.body[-1].value
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "unsubscriptable-object",
                 node=subscript.value,
                 args="collections",
@@ -451,7 +451,7 @@ class TestTypeCheckerOnDecorators(CheckerTestCase):
         )
         subscript = module.body[-1].value
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "unsubscriptable-object",
                 node=subscript.value,
                 args="decorated",
@@ -491,7 +491,7 @@ class TestTypeCheckerOnDecorators(CheckerTestCase):
         )
         subscript = module.body[-1].value
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 "unsubscriptable-object",
                 node=subscript.value,
                 args="decorated",

--- a/tests/checkers/unittest_typecheck.py
+++ b/tests/checkers/unittest_typecheck.py
@@ -30,7 +30,7 @@ import pytest
 
 from pylint.checkers import typecheck
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, OutputMessage, set_config
+from pylint.testutils import CheckerTestCase, TestMessage, set_config
 
 try:
     from coverage import tracer as _  # pylint: disable=unused-import
@@ -59,7 +59,7 @@ class TestTypeChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "no-member",
                 node=node,
                 args=("Module", "optparse", "THIS_does_not_EXIST", ""),
@@ -90,7 +90,7 @@ class TestTypeChecker(CheckerTestCase):
         xml.etree.Lala
         """
         )
-        message = OutputMessage(
+        message = TestMessage(
             "no-member", node=node, args=("Module", "xml.etree", "Lala", "")
         )
         with self.assertAddsMessages(message):
@@ -127,7 +127,7 @@ class TestTypeChecker(CheckerTestCase):
         xml.etree.ElementTree.Test
         """
         )
-        message = OutputMessage(
+        message = TestMessage(
             "no-member", node=node, args=("Module", "xml.etree.ElementTree", "Test", "")
         )
         with self.assertAddsMessages(message):
@@ -166,7 +166,7 @@ class TestTypeChecker(CheckerTestCase):
         tracer.CTracer  #@
         """
         )
-        message = OutputMessage(
+        message = TestMessage(
             "no-member", node=node, args=("Module", "coverage.tracer", "CTracer", "")
         )
         with self.assertAddsMessages(message):
@@ -181,7 +181,7 @@ class TestTypeChecker(CheckerTestCase):
         tracer.CTracer  #@
         """
         )
-        message = OutputMessage(
+        message = TestMessage(
             "c-extension-no-member",
             node=node,
             args=("Module", "coverage.tracer", "CTracer", ""),
@@ -238,7 +238,7 @@ class TestTypeChecker(CheckerTestCase):
             ("FirstInvalid", "int"),
         ):
             classdef = module[class_obj]
-            message = OutputMessage(
+            message = TestMessage(
                 "invalid-metaclass", node=classdef, args=(metaclass_name,)
             )
             with self.assertAddsMessages(message):
@@ -259,7 +259,7 @@ class TestTypeChecker(CheckerTestCase):
         )
         for class_obj, metaclass_name in (("Invalid", "int"), ("InvalidSecond", "1")):
             classdef = module[class_obj]
-            message = OutputMessage(
+            message = TestMessage(
                 "invalid-metaclass", node=classdef, args=(metaclass_name,)
             )
             with self.assertAddsMessages(message):
@@ -358,7 +358,7 @@ class TestTypeChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage("not-callable", node=call, args="get_num(10)")
+            TestMessage("not-callable", node=call, args="get_num(10)")
         ):
             self.checker.visit_call(call)
 
@@ -400,7 +400,7 @@ class TestTypeCheckerOnDecorators(CheckerTestCase):
         )
         subscript = module.body[-1].value
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "unsubscriptable-object",
                 node=subscript.value,
                 args="collections",
@@ -451,7 +451,7 @@ class TestTypeCheckerOnDecorators(CheckerTestCase):
         )
         subscript = module.body[-1].value
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "unsubscriptable-object",
                 node=subscript.value,
                 args="decorated",
@@ -491,7 +491,7 @@ class TestTypeCheckerOnDecorators(CheckerTestCase):
         )
         subscript = module.body[-1].value
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 "unsubscriptable-object",
                 node=subscript.value,
                 args="decorated",

--- a/tests/checkers/unittest_variables.py
+++ b/tests/checkers/unittest_variables.py
@@ -31,7 +31,7 @@ import astroid
 from pylint.checkers import variables
 from pylint.constants import IS_PYPY
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, Message, linter, set_config
+from pylint.testutils import CheckerTestCase, OutputMessage, linter, set_config
 
 REGR_DATA_DIR = str(Path(__file__).parent / ".." / "regrtest_data")
 
@@ -104,7 +104,7 @@ class TestVariablesChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message("redefined-builtin", node=node.body[0], args="open")
+            OutputMessage("redefined-builtin", node=node.body[0], args="open")
         ):
             self.checker.visit_module(node)
 
@@ -128,7 +128,7 @@ class TestVariablesChecker(CheckerTestCase):
                 import sys, lala
         """
         )
-        msg = Message("global-statement", node=node, confidence=UNDEFINED)
+        msg = OutputMessage("global-statement", node=node, confidence=UNDEFINED)
         with self.assertAddsMessages(msg):
             self.checker.visit_global(node)
 
@@ -256,7 +256,7 @@ class TestVariablesCheckerWithTearDown(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message("unused-argument", node=node["abc"], args="abc")
+            OutputMessage("unused-argument", node=node["abc"], args="abc")
         ):
             self.checker.visit_functiondef(node)
             self.checker.leave_functiondef(node)
@@ -268,7 +268,7 @@ class TestVariablesCheckerWithTearDown(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message("unused-argument", node=node["abc"], args="abc")
+            OutputMessage("unused-argument", node=node["abc"], args="abc")
         ):
             self.checker.visit_functiondef(node)
             self.checker.leave_functiondef(node)
@@ -281,7 +281,7 @@ class TestVariablesCheckerWithTearDown(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message("redefined-builtin", node=node.body[0], args="open")
+            OutputMessage("redefined-builtin", node=node.body[0], args="open")
         ):
             self.checker.visit_module(node)
 

--- a/tests/checkers/unittest_variables.py
+++ b/tests/checkers/unittest_variables.py
@@ -31,7 +31,7 @@ import astroid
 from pylint.checkers import variables
 from pylint.constants import IS_PYPY
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, OutputMessage, linter, set_config
+from pylint.testutils import CheckerTestCase, TestMessage, linter, set_config
 
 REGR_DATA_DIR = str(Path(__file__).parent / ".." / "regrtest_data")
 
@@ -104,7 +104,7 @@ class TestVariablesChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage("redefined-builtin", node=node.body[0], args="open")
+            TestMessage("redefined-builtin", node=node.body[0], args="open")
         ):
             self.checker.visit_module(node)
 
@@ -128,7 +128,7 @@ class TestVariablesChecker(CheckerTestCase):
                 import sys, lala
         """
         )
-        msg = OutputMessage("global-statement", node=node, confidence=UNDEFINED)
+        msg = TestMessage("global-statement", node=node, confidence=UNDEFINED)
         with self.assertAddsMessages(msg):
             self.checker.visit_global(node)
 
@@ -256,7 +256,7 @@ class TestVariablesCheckerWithTearDown(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage("unused-argument", node=node["abc"], args="abc")
+            TestMessage("unused-argument", node=node["abc"], args="abc")
         ):
             self.checker.visit_functiondef(node)
             self.checker.leave_functiondef(node)
@@ -268,7 +268,7 @@ class TestVariablesCheckerWithTearDown(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage("unused-argument", node=node["abc"], args="abc")
+            TestMessage("unused-argument", node=node["abc"], args="abc")
         ):
             self.checker.visit_functiondef(node)
             self.checker.leave_functiondef(node)
@@ -281,7 +281,7 @@ class TestVariablesCheckerWithTearDown(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage("redefined-builtin", node=node.body[0], args="open")
+            TestMessage("redefined-builtin", node=node.body[0], args="open")
         ):
             self.checker.visit_module(node)
 

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -30,7 +30,7 @@ import pytest
 from astroid import nodes
 
 from pylint.extensions.docparams import DocstringParameterChecker
-from pylint.testutils import CheckerTestCase, OutputMessage, set_config
+from pylint.testutils import CheckerTestCase, TestMessage, set_config
 
 
 class TestParamDocChecker(CheckerTestCase):
@@ -60,8 +60,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("y",)),
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            TestMessage(msg_id="missing-param-doc", node=node, args=("y",)),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -84,8 +84,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("y",)),
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            TestMessage(msg_id="missing-param-doc", node=node, args=("y",)),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -173,7 +173,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("x",))
+            TestMessage(msg_id="missing-type-doc", node=node, args=("x",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -255,10 +255,10 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("that",)),
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("that",)),
-            OutputMessage(msg_id="differing-param-doc", node=node, args=("these",)),
-            OutputMessage(msg_id="differing-type-doc", node=node, args=("these",)),
+            TestMessage(msg_id="missing-param-doc", node=node, args=("that",)),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("that",)),
+            TestMessage(msg_id="differing-param-doc", node=node, args=("these",)),
+            TestMessage(msg_id="differing-type-doc", node=node, args=("these",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -284,8 +284,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("y",)),
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            TestMessage(msg_id="missing-param-doc", node=node, args=("y",)),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -322,8 +322,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("x, y",)),
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            TestMessage(msg_id="missing-param-doc", node=node, args=("x, y",)),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -373,8 +373,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         method_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=method_node, args=("y",)),
-            OutputMessage(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
+            TestMessage(msg_id="missing-param-doc", node=method_node, args=("y",)),
+            TestMessage(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -398,8 +398,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         method_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=method_node, args=("y",)),
-            OutputMessage(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
+            TestMessage(msg_id="missing-param-doc", node=method_node, args=("y",)),
+            TestMessage(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -425,8 +425,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         method_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=method_node, args=("y",)),
-            OutputMessage(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
+            TestMessage(msg_id="missing-param-doc", node=method_node, args=("y",)),
+            TestMessage(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -537,14 +537,12 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("yarg, zarg",)),
-            OutputMessage(
+            TestMessage(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("yarg, zarg",)),
+            TestMessage(
                 msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)
             ),
-            OutputMessage(
-                msg_id="differing-type-doc", node=node, args=("yarg1, zarg1",)
-            ),
+            TestMessage(msg_id="differing-type-doc", node=node, args=("yarg1, zarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -562,8 +560,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="differing-param-doc", node=node, args=("yarg1",)),
-            OutputMessage(msg_id="differing-type-doc", node=node, args=("yarg1",)),
+            TestMessage(msg_id="differing-param-doc", node=node, args=("yarg1",)),
+            TestMessage(msg_id="differing-type-doc", node=node, args=("yarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -586,14 +584,12 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
-            OutputMessage(
+            TestMessage(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
+            TestMessage(
                 msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)
             ),
-            OutputMessage(
-                msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)
-            ),
+            TestMessage(msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -611,8 +607,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="differing-param-doc", node=node, args=("yarg1",)),
-            OutputMessage(msg_id="differing-type-doc", node=node, args=("yarg1",)),
+            TestMessage(msg_id="differing-param-doc", node=node, args=("yarg1",)),
+            TestMessage(msg_id="differing-type-doc", node=node, args=("yarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -639,14 +635,12 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
-            OutputMessage(
+            TestMessage(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
+            TestMessage(
                 msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)
             ),
-            OutputMessage(
-                msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)
-            ),
+            TestMessage(msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -666,8 +660,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="differing-param-doc", node=node, args=("yarg1",)),
-            OutputMessage(msg_id="differing-type-doc", node=node, args=("yarg1",)),
+            TestMessage(msg_id="differing-param-doc", node=node, args=("yarg1",)),
+            TestMessage(msg_id="differing-type-doc", node=node, args=("yarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -758,8 +752,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("x",)),
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            TestMessage(msg_id="missing-param-doc", node=node, args=("x",)),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -786,8 +780,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("x",)),
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            TestMessage(msg_id="missing-param-doc", node=node, args=("x",)),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -816,8 +810,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("x",)),
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            TestMessage(msg_id="missing-param-doc", node=node, args=("x",)),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -869,10 +863,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="missing-param-doc", node=constructor_node, args=("x",)
-            ),
-            OutputMessage(
+            TestMessage(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            TestMessage(
                 msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
             ),
         ):
@@ -901,10 +893,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="missing-param-doc", node=constructor_node, args=("x",)
-            ),
-            OutputMessage(
+            TestMessage(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            TestMessage(
                 msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
             ),
         ):
@@ -935,10 +925,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="missing-param-doc", node=constructor_node, args=("x",)
-            ),
-            OutputMessage(
+            TestMessage(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            TestMessage(
                 msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
             ),
         ):
@@ -1012,15 +1000,13 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="multiple-constructor-doc", node=node, args=(node.name,)
             ),
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("x",)),
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
-            OutputMessage(
-                msg_id="missing-param-doc", node=constructor_node, args=("x",)
-            ),
-            OutputMessage(
+            TestMessage(msg_id="missing-param-doc", node=node, args=("x",)),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            TestMessage(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            TestMessage(
                 msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
             ),
         ):
@@ -1058,15 +1044,13 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="multiple-constructor-doc", node=node, args=(node.name,)
             ),
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("x",)),
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
-            OutputMessage(
-                msg_id="missing-param-doc", node=constructor_node, args=("x",)
-            ),
-            OutputMessage(
+            TestMessage(msg_id="missing-param-doc", node=node, args=("x",)),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            TestMessage(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            TestMessage(
                 msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
             ),
         ):
@@ -1108,15 +1092,13 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="multiple-constructor-doc", node=node, args=(node.name,)
             ),
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("x",)),
-            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
-            OutputMessage(
-                msg_id="missing-param-doc", node=constructor_node, args=("x",)
-            ),
-            OutputMessage(
+            TestMessage(msg_id="missing-param-doc", node=node, args=("x",)),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            TestMessage(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            TestMessage(
                 msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
             ),
         ):
@@ -1134,12 +1116,10 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="missing-param-doc", node=node, args=("missing_kwonly",)
             ),
-            OutputMessage(
-                msg_id="missing-type-doc", node=node, args=("missing_kwonly",)
-            ),
+            TestMessage(msg_id="missing-type-doc", node=node, args=("missing_kwonly",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -1159,7 +1139,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("args",))
+            TestMessage(msg_id="missing-param-doc", node=node, args=("args",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1179,7 +1159,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("kwargs",))
+            TestMessage(msg_id="missing-param-doc", node=node, args=("kwargs",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1200,7 +1180,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("args",))
+            TestMessage(msg_id="missing-param-doc", node=node, args=("args",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1221,7 +1201,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("kwargs",))
+            TestMessage(msg_id="missing-param-doc", node=node, args=("kwargs",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1246,7 +1226,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("args",))
+            TestMessage(msg_id="missing-param-doc", node=node, args=("args",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1271,7 +1251,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-param-doc", node=node, args=("kwargs",))
+            TestMessage(msg_id="missing-param-doc", node=node, args=("kwargs",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1628,7 +1608,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="missing-raises-doc",
                 node=property_node,
                 args=("AttributeError",),
@@ -1662,7 +1642,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="missing-raises-doc",
                 node=property_node,
                 args=("AttributeError",),
@@ -1698,7 +1678,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="missing-raises-doc",
                 node=property_node,
                 args=("AttributeError",),
@@ -1733,7 +1713,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="missing-raises-doc", node=setter_node, args=("AttributeError",)
             )
         ):
@@ -1769,7 +1749,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="missing-raises-doc", node=setter_node, args=("AttributeError",)
             )
         ):
@@ -1809,7 +1789,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="missing-raises-doc", node=setter_node, args=("AttributeError",)
             )
         ):
@@ -1916,7 +1896,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-type-doc", node=property_node)
+            TestMessage(msg_id="missing-return-type-doc", node=property_node)
         ):
             self.checker.visit_return(node)
 
@@ -1960,7 +1940,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-type-doc", node=property_node)
+            TestMessage(msg_id="missing-return-type-doc", node=property_node)
         ):
             self.checker.visit_return(node)
 
@@ -1985,7 +1965,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-type-doc", node=property_node)
+            TestMessage(msg_id="missing-return-type-doc", node=property_node)
         ):
             self.checker.visit_return(node)
 
@@ -2005,8 +1985,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-doc", node=func_node),
-            OutputMessage(msg_id="missing-return-type-doc", node=func_node),
+            TestMessage(msg_id="missing-return-doc", node=func_node),
+            TestMessage(msg_id="missing-return-type-doc", node=func_node),
         ):
             self.checker.visit_return(node)
 
@@ -2028,8 +2008,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-doc", node=func_node),
-            OutputMessage(msg_id="missing-return-type-doc", node=func_node),
+            TestMessage(msg_id="missing-return-doc", node=func_node),
+            TestMessage(msg_id="missing-return-type-doc", node=func_node),
         ):
             self.checker.visit_return(node)
 
@@ -2053,8 +2033,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-doc", node=func_node),
-            OutputMessage(msg_id="missing-return-type-doc", node=func_node),
+            TestMessage(msg_id="missing-return-doc", node=func_node),
+            TestMessage(msg_id="missing-return-type-doc", node=func_node),
         ):
             self.checker.visit_return(node)
 
@@ -2078,7 +2058,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-doc", node=func_node)
+            TestMessage(msg_id="missing-return-doc", node=func_node)
         ):
             self.checker.visit_return(node)
 
@@ -2285,8 +2265,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="useless-type-doc", node=node, args=("_",)),
-            OutputMessage(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
+            TestMessage(msg_id="useless-type-doc", node=node, args=("_",)),
+            TestMessage(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -2309,8 +2289,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="useless-type-doc", node=node, args=("_",)),
-            OutputMessage(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
+            TestMessage(msg_id="useless-type-doc", node=node, args=("_",)),
+            TestMessage(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -2339,8 +2319,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="useless-type-doc", node=node, args=("_",)),
-            OutputMessage(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
+            TestMessage(msg_id="useless-type-doc", node=node, args=("_",)),
+            TestMessage(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
         ):
             self.checker.visit_functiondef(node)
 

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -30,7 +30,7 @@ import pytest
 from astroid import nodes
 
 from pylint.extensions.docparams import DocstringParameterChecker
-from pylint.testutils import CheckerTestCase, Message, set_config
+from pylint.testutils import CheckerTestCase, OutputMessage, set_config
 
 
 class TestParamDocChecker(CheckerTestCase):
@@ -60,8 +60,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("y",)),
-            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("y",)),
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -84,8 +84,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("y",)),
-            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("y",)),
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -173,7 +173,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-type-doc", node=node, args=("x",))
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("x",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -255,10 +255,10 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("that",)),
-            Message(msg_id="missing-type-doc", node=node, args=("that",)),
-            Message(msg_id="differing-param-doc", node=node, args=("these",)),
-            Message(msg_id="differing-type-doc", node=node, args=("these",)),
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("that",)),
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("that",)),
+            OutputMessage(msg_id="differing-param-doc", node=node, args=("these",)),
+            OutputMessage(msg_id="differing-type-doc", node=node, args=("these",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -284,8 +284,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("y",)),
-            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("y",)),
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -322,8 +322,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("x, y",)),
-            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("x, y",)),
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -373,8 +373,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         method_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=method_node, args=("y",)),
-            Message(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
+            OutputMessage(msg_id="missing-param-doc", node=method_node, args=("y",)),
+            OutputMessage(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -398,8 +398,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         method_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=method_node, args=("y",)),
-            Message(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
+            OutputMessage(msg_id="missing-param-doc", node=method_node, args=("y",)),
+            OutputMessage(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -425,8 +425,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         method_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=method_node, args=("y",)),
-            Message(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
+            OutputMessage(msg_id="missing-param-doc", node=method_node, args=("y",)),
+            OutputMessage(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -537,10 +537,14 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
-            Message(msg_id="missing-type-doc", node=node, args=("yarg, zarg",)),
-            Message(msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)),
-            Message(msg_id="differing-type-doc", node=node, args=("yarg1, zarg1",)),
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("yarg, zarg",)),
+            OutputMessage(
+                msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)
+            ),
+            OutputMessage(
+                msg_id="differing-type-doc", node=node, args=("yarg1, zarg1",)
+            ),
         ):
             self.checker.visit_functiondef(node)
 
@@ -558,8 +562,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="differing-param-doc", node=node, args=("yarg1",)),
-            Message(msg_id="differing-type-doc", node=node, args=("yarg1",)),
+            OutputMessage(msg_id="differing-param-doc", node=node, args=("yarg1",)),
+            OutputMessage(msg_id="differing-type-doc", node=node, args=("yarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -582,10 +586,14 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
-            Message(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
-            Message(msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)),
-            Message(msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)),
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
+            OutputMessage(
+                msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)
+            ),
+            OutputMessage(
+                msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)
+            ),
         ):
             self.checker.visit_functiondef(node)
 
@@ -603,8 +611,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="differing-param-doc", node=node, args=("yarg1",)),
-            Message(msg_id="differing-type-doc", node=node, args=("yarg1",)),
+            OutputMessage(msg_id="differing-param-doc", node=node, args=("yarg1",)),
+            OutputMessage(msg_id="differing-type-doc", node=node, args=("yarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -631,10 +639,14 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
-            Message(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
-            Message(msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)),
-            Message(msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)),
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
+            OutputMessage(
+                msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)
+            ),
+            OutputMessage(
+                msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)
+            ),
         ):
             self.checker.visit_functiondef(node)
 
@@ -654,8 +666,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="differing-param-doc", node=node, args=("yarg1",)),
-            Message(msg_id="differing-type-doc", node=node, args=("yarg1",)),
+            OutputMessage(msg_id="differing-param-doc", node=node, args=("yarg1",)),
+            OutputMessage(msg_id="differing-type-doc", node=node, args=("yarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -746,8 +758,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("x",)),
-            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("x",)),
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -774,8 +786,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("x",)),
-            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("x",)),
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -804,8 +816,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("x",)),
-            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("x",)),
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -857,8 +869,12 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
-            Message(msg_id="missing-type-doc", node=constructor_node, args=("x, y",)),
+            OutputMessage(
+                msg_id="missing-param-doc", node=constructor_node, args=("x",)
+            ),
+            OutputMessage(
+                msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
+            ),
         ):
             self._visit_methods_of_class(node)
 
@@ -885,8 +901,12 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
-            Message(msg_id="missing-type-doc", node=constructor_node, args=("x, y",)),
+            OutputMessage(
+                msg_id="missing-param-doc", node=constructor_node, args=("x",)
+            ),
+            OutputMessage(
+                msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
+            ),
         ):
             self._visit_methods_of_class(node)
 
@@ -915,8 +935,12 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
-            Message(msg_id="missing-type-doc", node=constructor_node, args=("x, y",)),
+            OutputMessage(
+                msg_id="missing-param-doc", node=constructor_node, args=("x",)
+            ),
+            OutputMessage(
+                msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
+            ),
         ):
             self._visit_methods_of_class(node)
 
@@ -988,11 +1012,17 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="multiple-constructor-doc", node=node, args=(node.name,)),
-            Message(msg_id="missing-param-doc", node=node, args=("x",)),
-            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
-            Message(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
-            Message(msg_id="missing-type-doc", node=constructor_node, args=("x, y",)),
+            OutputMessage(
+                msg_id="multiple-constructor-doc", node=node, args=(node.name,)
+            ),
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("x",)),
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            OutputMessage(
+                msg_id="missing-param-doc", node=constructor_node, args=("x",)
+            ),
+            OutputMessage(
+                msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
+            ),
         ):
             self._visit_methods_of_class(node)
 
@@ -1028,11 +1058,17 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="multiple-constructor-doc", node=node, args=(node.name,)),
-            Message(msg_id="missing-param-doc", node=node, args=("x",)),
-            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
-            Message(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
-            Message(msg_id="missing-type-doc", node=constructor_node, args=("x, y",)),
+            OutputMessage(
+                msg_id="multiple-constructor-doc", node=node, args=(node.name,)
+            ),
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("x",)),
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            OutputMessage(
+                msg_id="missing-param-doc", node=constructor_node, args=("x",)
+            ),
+            OutputMessage(
+                msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
+            ),
         ):
             self._visit_methods_of_class(node)
 
@@ -1072,11 +1108,17 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="multiple-constructor-doc", node=node, args=(node.name,)),
-            Message(msg_id="missing-param-doc", node=node, args=("x",)),
-            Message(msg_id="missing-type-doc", node=node, args=("x, y",)),
-            Message(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
-            Message(msg_id="missing-type-doc", node=constructor_node, args=("x, y",)),
+            OutputMessage(
+                msg_id="multiple-constructor-doc", node=node, args=(node.name,)
+            ),
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("x",)),
+            OutputMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            OutputMessage(
+                msg_id="missing-param-doc", node=constructor_node, args=("x",)
+            ),
+            OutputMessage(
+                msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
+            ),
         ):
             self._visit_methods_of_class(node)
 
@@ -1092,8 +1134,12 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("missing_kwonly",)),
-            Message(msg_id="missing-type-doc", node=node, args=("missing_kwonly",)),
+            OutputMessage(
+                msg_id="missing-param-doc", node=node, args=("missing_kwonly",)
+            ),
+            OutputMessage(
+                msg_id="missing-type-doc", node=node, args=("missing_kwonly",)
+            ),
         ):
             self.checker.visit_functiondef(node)
 
@@ -1113,7 +1159,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("args",))
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("args",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1133,7 +1179,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("kwargs",))
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("kwargs",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1154,7 +1200,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("args",))
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("args",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1175,7 +1221,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("kwargs",))
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("kwargs",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1200,7 +1246,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("args",))
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("args",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1225,7 +1271,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-param-doc", node=node, args=("kwargs",))
+            OutputMessage(msg_id="missing-param-doc", node=node, args=("kwargs",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1582,7 +1628,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="missing-raises-doc",
                 node=property_node,
                 args=("AttributeError",),
@@ -1616,7 +1662,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="missing-raises-doc",
                 node=property_node,
                 args=("AttributeError",),
@@ -1652,7 +1698,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="missing-raises-doc",
                 node=property_node,
                 args=("AttributeError",),
@@ -1687,7 +1733,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="missing-raises-doc", node=setter_node, args=("AttributeError",)
             )
         ):
@@ -1723,7 +1769,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="missing-raises-doc", node=setter_node, args=("AttributeError",)
             )
         ):
@@ -1763,7 +1809,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="missing-raises-doc", node=setter_node, args=("AttributeError",)
             )
         ):
@@ -1870,7 +1916,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-return-type-doc", node=property_node)
+            OutputMessage(msg_id="missing-return-type-doc", node=property_node)
         ):
             self.checker.visit_return(node)
 
@@ -1914,7 +1960,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-return-type-doc", node=property_node)
+            OutputMessage(msg_id="missing-return-type-doc", node=property_node)
         ):
             self.checker.visit_return(node)
 
@@ -1939,7 +1985,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-return-type-doc", node=property_node)
+            OutputMessage(msg_id="missing-return-type-doc", node=property_node)
         ):
             self.checker.visit_return(node)
 
@@ -1959,8 +2005,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-return-doc", node=func_node),
-            Message(msg_id="missing-return-type-doc", node=func_node),
+            OutputMessage(msg_id="missing-return-doc", node=func_node),
+            OutputMessage(msg_id="missing-return-type-doc", node=func_node),
         ):
             self.checker.visit_return(node)
 
@@ -1982,8 +2028,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-return-doc", node=func_node),
-            Message(msg_id="missing-return-type-doc", node=func_node),
+            OutputMessage(msg_id="missing-return-doc", node=func_node),
+            OutputMessage(msg_id="missing-return-type-doc", node=func_node),
         ):
             self.checker.visit_return(node)
 
@@ -2007,8 +2053,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-return-doc", node=func_node),
-            Message(msg_id="missing-return-type-doc", node=func_node),
+            OutputMessage(msg_id="missing-return-doc", node=func_node),
+            OutputMessage(msg_id="missing-return-type-doc", node=func_node),
         ):
             self.checker.visit_return(node)
 
@@ -2032,7 +2078,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="missing-return-doc", node=func_node)
+            OutputMessage(msg_id="missing-return-doc", node=func_node)
         ):
             self.checker.visit_return(node)
 
@@ -2239,8 +2285,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="useless-type-doc", node=node, args=("_",)),
-            Message(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
+            OutputMessage(msg_id="useless-type-doc", node=node, args=("_",)),
+            OutputMessage(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -2263,8 +2309,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="useless-type-doc", node=node, args=("_",)),
-            Message(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
+            OutputMessage(msg_id="useless-type-doc", node=node, args=("_",)),
+            OutputMessage(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -2293,8 +2339,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            Message(msg_id="useless-type-doc", node=node, args=("_",)),
-            Message(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
+            OutputMessage(msg_id="useless-type-doc", node=node, args=("_",)),
+            OutputMessage(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
         ):
             self.checker.visit_functiondef(node)
 

--- a/tests/extensions/test_check_raise_docs.py
+++ b/tests/extensions/test_check_raise_docs.py
@@ -23,7 +23,7 @@
 import astroid
 
 from pylint.extensions.docparams import DocstringParameterChecker
-from pylint.testutils import CheckerTestCase, OutputMessage, set_config
+from pylint.testutils import CheckerTestCase, TestMessage, set_config
 
 
 class TestDocstringCheckerRaise(CheckerTestCase):
@@ -64,9 +64,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
-            )
+            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -84,9 +82,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
-            )
+            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -105,9 +101,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
-            )
+            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -158,7 +152,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[1]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-raises-doc", node=node, args=("error",))
+            TestMessage(msg_id="missing-raises-doc", node=node, args=("error",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -232,9 +226,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
-            )
+            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -367,9 +359,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
-            )
+            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -392,9 +382,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
-            )
+            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -419,9 +407,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
-            )
+            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -443,7 +429,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="missing-raises-doc",
                 node=node,
                 args=("RuntimeError, ValueError",),
@@ -470,7 +456,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="missing-raises-doc",
                 node=node,
                 args=("RuntimeError, ValueError",),
@@ -499,7 +485,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            OutputMessage(
+            TestMessage(
                 msg_id="missing-raises-doc",
                 node=node,
                 args=("RuntimeError, ValueError",),
@@ -621,7 +607,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[1]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-raises-doc", node=node, args=("error",))
+            TestMessage(msg_id="missing-raises-doc", node=node, args=("error",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -679,9 +665,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
-            )
+            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -701,9 +685,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
-            )
+            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -751,7 +733,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[1]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-raises-doc", node=node, args=("error",))
+            TestMessage(msg_id="missing-raises-doc", node=node, args=("error",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -826,9 +808,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            OutputMessage(
-                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
-            )
+            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             # we do NOT expect a warning about the OSError in inner_func!
             self.checker.visit_raise(raise_node)

--- a/tests/extensions/test_check_raise_docs.py
+++ b/tests/extensions/test_check_raise_docs.py
@@ -23,7 +23,7 @@
 import astroid
 
 from pylint.extensions.docparams import DocstringParameterChecker
-from pylint.testutils import CheckerTestCase, Message, set_config
+from pylint.testutils import CheckerTestCase, OutputMessage, set_config
 
 
 class TestDocstringCheckerRaise(CheckerTestCase):
@@ -64,7 +64,9 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            OutputMessage(
+                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
+            )
         ):
             self.checker.visit_raise(raise_node)
 
@@ -82,7 +84,9 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            OutputMessage(
+                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
+            )
         ):
             self.checker.visit_raise(raise_node)
 
@@ -101,7 +105,9 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            OutputMessage(
+                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
+            )
         ):
             self.checker.visit_raise(raise_node)
 
@@ -152,7 +158,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[1]
         with self.assertAddsMessages(
-            Message(msg_id="missing-raises-doc", node=node, args=("error",))
+            OutputMessage(msg_id="missing-raises-doc", node=node, args=("error",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -226,7 +232,9 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            OutputMessage(
+                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
+            )
         ):
             self.checker.visit_raise(raise_node)
 
@@ -359,7 +367,9 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            OutputMessage(
+                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
+            )
         ):
             self.checker.visit_raise(raise_node)
 
@@ -382,7 +392,9 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            OutputMessage(
+                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
+            )
         ):
             self.checker.visit_raise(raise_node)
 
@@ -407,7 +419,9 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            OutputMessage(
+                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
+            )
         ):
             self.checker.visit_raise(raise_node)
 
@@ -429,7 +443,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="missing-raises-doc",
                 node=node,
                 args=("RuntimeError, ValueError",),
@@ -456,7 +470,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="missing-raises-doc",
                 node=node,
                 args=("RuntimeError, ValueError",),
@@ -485,7 +499,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(
+            OutputMessage(
                 msg_id="missing-raises-doc",
                 node=node,
                 args=("RuntimeError, ValueError",),
@@ -607,7 +621,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[1]
         with self.assertAddsMessages(
-            Message(msg_id="missing-raises-doc", node=node, args=("error",))
+            OutputMessage(msg_id="missing-raises-doc", node=node, args=("error",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -665,7 +679,9 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            OutputMessage(
+                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
+            )
         ):
             self.checker.visit_raise(raise_node)
 
@@ -685,7 +701,9 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            OutputMessage(
+                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
+            )
         ):
             self.checker.visit_raise(raise_node)
 
@@ -733,7 +751,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[1]
         with self.assertAddsMessages(
-            Message(msg_id="missing-raises-doc", node=node, args=("error",))
+            OutputMessage(msg_id="missing-raises-doc", node=node, args=("error",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -808,7 +826,9 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            Message(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            OutputMessage(
+                msg_id="missing-raises-doc", node=node, args=("RuntimeError",)
+            )
         ):
             # we do NOT expect a warning about the OSError in inner_func!
             self.checker.visit_raise(raise_node)

--- a/tests/extensions/test_check_return_docs.py
+++ b/tests/extensions/test_check_return_docs.py
@@ -24,7 +24,7 @@
 import astroid
 
 from pylint.extensions.docparams import DocstringParameterChecker
-from pylint.testutils import CheckerTestCase, Message, set_config
+from pylint.testutils import CheckerTestCase, OutputMessage, set_config
 
 
 class TestDocstringCheckerReturn(CheckerTestCase):
@@ -52,8 +52,8 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-return-doc", node=node),
-            Message(msg_id="missing-return-type-doc", node=node),
+            OutputMessage(msg_id="missing-return-doc", node=node),
+            OutputMessage(msg_id="missing-return-type-doc", node=node),
         ):
             self.checker.visit_return(return_node)
 
@@ -81,7 +81,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-return-type-doc", node=node)
+            OutputMessage(msg_id="missing-return-type-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -112,7 +112,9 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         return_node = node.body[0]
-        with self.assertAddsMessages(Message(msg_id="missing-return-doc", node=node)):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="missing-return-doc", node=node)
+        ):
             self.checker.visit_return(return_node)
 
     def test_warn_missing_sphinx_returns(self) -> None:
@@ -129,8 +131,8 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-return-doc", node=node),
-            Message(msg_id="missing-return-type-doc", node=node),
+            OutputMessage(msg_id="missing-return-doc", node=node),
+            OutputMessage(msg_id="missing-return-type-doc", node=node),
         ):
             self.checker.visit_return(return_node)
 
@@ -148,7 +150,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-return-type-doc", node=node)
+            OutputMessage(msg_id="missing-return-type-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -165,7 +167,9 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         return_node = node.body[0]
-        with self.assertAddsMessages(Message(msg_id="missing-return-doc", node=node)):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="missing-return-doc", node=node)
+        ):
             self.checker.visit_return(return_node)
 
     def test_warn_missing_google_returns(self) -> None:
@@ -182,8 +186,8 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-return-doc", node=node),
-            Message(msg_id="missing-return-type-doc", node=node),
+            OutputMessage(msg_id="missing-return-doc", node=node),
+            OutputMessage(msg_id="missing-return-type-doc", node=node),
         ):
             self.checker.visit_return(return_node)
 
@@ -206,7 +210,9 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         return_node = node.body[0]
-        with self.assertAddsMessages(Message(msg_id="missing-return-doc", node=node)):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="missing-return-doc", node=node)
+        ):
             self.checker.visit_return(return_node)
 
     def test_warn_missing_numpy_returns(self) -> None:
@@ -225,8 +231,8 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-return-doc", node=node),
-            Message(msg_id="missing-return-type-doc", node=node),
+            OutputMessage(msg_id="missing-return-doc", node=node),
+            OutputMessage(msg_id="missing-return-type-doc", node=node),
         ):
             self.checker.visit_return(return_node)
 
@@ -447,7 +453,9 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         return_node = node.body[0]
-        with self.assertAddsMessages(Message(msg_id="missing-return-doc", node=node)):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="missing-return-doc", node=node)
+        ):
             self.checker.visit_return(return_node)
 
     def test_warns_google_return_list_of_custom_class_without_description(self) -> None:
@@ -463,7 +471,9 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         return_node = node.body[0]
-        with self.assertAddsMessages(Message(msg_id="missing-return-doc", node=node)):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="missing-return-doc", node=node)
+        ):
             self.checker.visit_return(return_node)
 
     def test_warns_numpy_return_list_of_custom_class_without_description(self) -> None:
@@ -480,7 +490,9 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         return_node = node.body[0]
-        with self.assertAddsMessages(Message(msg_id="missing-return-doc", node=node)):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="missing-return-doc", node=node)
+        ):
             self.checker.visit_return(return_node)
 
     def test_warns_sphinx_redundant_return_doc(self) -> None:
@@ -495,7 +507,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="redundant-returns-doc", node=node)
+            OutputMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -511,7 +523,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="redundant-returns-doc", node=node)
+            OutputMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -528,7 +540,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="redundant-returns-doc", node=node)
+            OutputMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -545,7 +557,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="redundant-returns-doc", node=node)
+            OutputMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -564,7 +576,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="redundant-returns-doc", node=node)
+            OutputMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -582,7 +594,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="redundant-returns-doc", node=node)
+            OutputMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -673,7 +685,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="redundant-returns-doc", node=node)
+            OutputMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -692,6 +704,6 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            Message(msg_id="redundant-returns-doc", node=node)
+            OutputMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)

--- a/tests/extensions/test_check_return_docs.py
+++ b/tests/extensions/test_check_return_docs.py
@@ -24,7 +24,7 @@
 import astroid
 
 from pylint.extensions.docparams import DocstringParameterChecker
-from pylint.testutils import CheckerTestCase, OutputMessage, set_config
+from pylint.testutils import CheckerTestCase, TestMessage, set_config
 
 
 class TestDocstringCheckerReturn(CheckerTestCase):
@@ -52,8 +52,8 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-doc", node=node),
-            OutputMessage(msg_id="missing-return-type-doc", node=node),
+            TestMessage(msg_id="missing-return-doc", node=node),
+            TestMessage(msg_id="missing-return-type-doc", node=node),
         ):
             self.checker.visit_return(return_node)
 
@@ -81,7 +81,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-type-doc", node=node)
+            TestMessage(msg_id="missing-return-type-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -113,7 +113,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-doc", node=node)
+            TestMessage(msg_id="missing-return-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -131,8 +131,8 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-doc", node=node),
-            OutputMessage(msg_id="missing-return-type-doc", node=node),
+            TestMessage(msg_id="missing-return-doc", node=node),
+            TestMessage(msg_id="missing-return-type-doc", node=node),
         ):
             self.checker.visit_return(return_node)
 
@@ -150,7 +150,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-type-doc", node=node)
+            TestMessage(msg_id="missing-return-type-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -168,7 +168,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-doc", node=node)
+            TestMessage(msg_id="missing-return-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -186,8 +186,8 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-doc", node=node),
-            OutputMessage(msg_id="missing-return-type-doc", node=node),
+            TestMessage(msg_id="missing-return-doc", node=node),
+            TestMessage(msg_id="missing-return-type-doc", node=node),
         ):
             self.checker.visit_return(return_node)
 
@@ -211,7 +211,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-doc", node=node)
+            TestMessage(msg_id="missing-return-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -231,8 +231,8 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-doc", node=node),
-            OutputMessage(msg_id="missing-return-type-doc", node=node),
+            TestMessage(msg_id="missing-return-doc", node=node),
+            TestMessage(msg_id="missing-return-type-doc", node=node),
         ):
             self.checker.visit_return(return_node)
 
@@ -454,7 +454,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-doc", node=node)
+            TestMessage(msg_id="missing-return-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -472,7 +472,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-doc", node=node)
+            TestMessage(msg_id="missing-return-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -491,7 +491,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-return-doc", node=node)
+            TestMessage(msg_id="missing-return-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -507,7 +507,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="redundant-returns-doc", node=node)
+            TestMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -523,7 +523,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="redundant-returns-doc", node=node)
+            TestMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -540,7 +540,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="redundant-returns-doc", node=node)
+            TestMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -557,7 +557,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="redundant-returns-doc", node=node)
+            TestMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -576,7 +576,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="redundant-returns-doc", node=node)
+            TestMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -594,7 +594,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="redundant-returns-doc", node=node)
+            TestMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -685,7 +685,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="redundant-returns-doc", node=node)
+            TestMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -704,6 +704,6 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="redundant-returns-doc", node=node)
+            TestMessage(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)

--- a/tests/extensions/test_check_yields_docs.py
+++ b/tests/extensions/test_check_yields_docs.py
@@ -20,7 +20,7 @@
 import astroid
 
 from pylint.extensions.docparams import DocstringParameterChecker
-from pylint.testutils import CheckerTestCase, OutputMessage, set_config
+from pylint.testutils import CheckerTestCase, TestMessage, set_config
 
 
 class TestDocstringCheckerYield(CheckerTestCase):
@@ -48,8 +48,8 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-yield-doc", node=node),
-            OutputMessage(msg_id="missing-yield-type-doc", node=node),
+            TestMessage(msg_id="missing-yield-doc", node=node),
+            TestMessage(msg_id="missing-yield-type-doc", node=node),
         ):
             self.checker.visit_yield(yield_node)
 
@@ -77,7 +77,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-yield-type-doc", node=node)
+            TestMessage(msg_id="missing-yield-type-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -94,7 +94,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-yield-doc", node=node)
+            TestMessage(msg_id="missing-yield-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -112,8 +112,8 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-yield-doc", node=node),
-            OutputMessage(msg_id="missing-yield-type-doc", node=node),
+            TestMessage(msg_id="missing-yield-doc", node=node),
+            TestMessage(msg_id="missing-yield-type-doc", node=node),
         ):
             self.checker.visit_yield(yield_node)
 
@@ -131,7 +131,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-yield-type-doc", node=node)
+            TestMessage(msg_id="missing-yield-type-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -149,7 +149,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-yield-doc", node=node)
+            TestMessage(msg_id="missing-yield-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -167,8 +167,8 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-yield-doc", node=node),
-            OutputMessage(msg_id="missing-yield-type-doc", node=node),
+            TestMessage(msg_id="missing-yield-doc", node=node),
+            TestMessage(msg_id="missing-yield-type-doc", node=node),
         ):
             self.checker.visit_yield(yield_node)
 
@@ -188,8 +188,8 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-yield-doc", node=node),
-            OutputMessage(msg_id="missing-yield-type-doc", node=node),
+            TestMessage(msg_id="missing-yield-doc", node=node),
+            TestMessage(msg_id="missing-yield-type-doc", node=node),
         ):
             self.checker.visit_yield(yield_node)
 
@@ -347,7 +347,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-yield-doc", node=node)
+            TestMessage(msg_id="missing-yield-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -365,7 +365,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-yield-doc", node=node)
+            TestMessage(msg_id="missing-yield-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -384,7 +384,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            OutputMessage(msg_id="missing-yield-doc", node=node)
+            TestMessage(msg_id="missing-yield-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -445,7 +445,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="redundant-yields-doc", node=node)
+            TestMessage(msg_id="redundant-yields-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -464,7 +464,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            OutputMessage(msg_id="redundant-yields-doc", node=node)
+            TestMessage(msg_id="redundant-yields-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 

--- a/tests/extensions/test_check_yields_docs.py
+++ b/tests/extensions/test_check_yields_docs.py
@@ -20,7 +20,7 @@
 import astroid
 
 from pylint.extensions.docparams import DocstringParameterChecker
-from pylint.testutils import CheckerTestCase, Message, set_config
+from pylint.testutils import CheckerTestCase, OutputMessage, set_config
 
 
 class TestDocstringCheckerYield(CheckerTestCase):
@@ -48,8 +48,8 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-yield-doc", node=node),
-            Message(msg_id="missing-yield-type-doc", node=node),
+            OutputMessage(msg_id="missing-yield-doc", node=node),
+            OutputMessage(msg_id="missing-yield-type-doc", node=node),
         ):
             self.checker.visit_yield(yield_node)
 
@@ -77,7 +77,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-yield-type-doc", node=node)
+            OutputMessage(msg_id="missing-yield-type-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -93,7 +93,9 @@ class TestDocstringCheckerYield(CheckerTestCase):
         '''
         )
         yield_node = node.body[0]
-        with self.assertAddsMessages(Message(msg_id="missing-yield-doc", node=node)):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="missing-yield-doc", node=node)
+        ):
             self.checker.visit_yield(yield_node)
 
     def test_warn_missing_sphinx_yields(self) -> None:
@@ -110,8 +112,8 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-yield-doc", node=node),
-            Message(msg_id="missing-yield-type-doc", node=node),
+            OutputMessage(msg_id="missing-yield-doc", node=node),
+            OutputMessage(msg_id="missing-yield-type-doc", node=node),
         ):
             self.checker.visit_yield(yield_node)
 
@@ -129,7 +131,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-yield-type-doc", node=node)
+            OutputMessage(msg_id="missing-yield-type-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -146,7 +148,9 @@ class TestDocstringCheckerYield(CheckerTestCase):
         '''
         )
         yield_node = node.body[0]
-        with self.assertAddsMessages(Message(msg_id="missing-yield-doc", node=node)):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="missing-yield-doc", node=node)
+        ):
             self.checker.visit_yield(yield_node)
 
     def test_warn_missing_google_yields(self) -> None:
@@ -163,8 +167,8 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-yield-doc", node=node),
-            Message(msg_id="missing-yield-type-doc", node=node),
+            OutputMessage(msg_id="missing-yield-doc", node=node),
+            OutputMessage(msg_id="missing-yield-type-doc", node=node),
         ):
             self.checker.visit_yield(yield_node)
 
@@ -184,8 +188,8 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            Message(msg_id="missing-yield-doc", node=node),
-            Message(msg_id="missing-yield-type-doc", node=node),
+            OutputMessage(msg_id="missing-yield-doc", node=node),
+            OutputMessage(msg_id="missing-yield-type-doc", node=node),
         ):
             self.checker.visit_yield(yield_node)
 
@@ -342,7 +346,9 @@ class TestDocstringCheckerYield(CheckerTestCase):
         '''
         )
         yield_node = node.body[0]
-        with self.assertAddsMessages(Message(msg_id="missing-yield-doc", node=node)):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="missing-yield-doc", node=node)
+        ):
             self.checker.visit_yield(yield_node)
 
     def test_warns_google_yield_list_of_custom_class_without_description(self) -> None:
@@ -358,7 +364,9 @@ class TestDocstringCheckerYield(CheckerTestCase):
         '''
         )
         yield_node = node.body[0]
-        with self.assertAddsMessages(Message(msg_id="missing-yield-doc", node=node)):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="missing-yield-doc", node=node)
+        ):
             self.checker.visit_yield(yield_node)
 
     def test_warns_numpy_yield_list_of_custom_class_without_description(self) -> None:
@@ -375,7 +383,9 @@ class TestDocstringCheckerYield(CheckerTestCase):
         '''
         )
         yield_node = node.body[0]
-        with self.assertAddsMessages(Message(msg_id="missing-yield-doc", node=node)):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="missing-yield-doc", node=node)
+        ):
             self.checker.visit_yield(yield_node)
 
     # No such thing as redundant yield documentation for sphinx because it
@@ -434,7 +444,9 @@ class TestDocstringCheckerYield(CheckerTestCase):
             return 1
         '''
         )
-        with self.assertAddsMessages(Message(msg_id="redundant-yields-doc", node=node)):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="redundant-yields-doc", node=node)
+        ):
             self.checker.visit_functiondef(node)
 
     def test_warns_numpy_redundant_yield_doc_return(self) -> None:
@@ -451,7 +463,9 @@ class TestDocstringCheckerYield(CheckerTestCase):
             return 1
         '''
         )
-        with self.assertAddsMessages(Message(msg_id="redundant-yields-doc", node=node)):
+        with self.assertAddsMessages(
+            OutputMessage(msg_id="redundant-yields-doc", node=node)
+        ):
             self.checker.visit_functiondef(node)
 
     def test_sphinx_missing_yield_type_with_annotations(self) -> None:

--- a/tests/extensions/test_confusing_elif.py
+++ b/tests/extensions/test_confusing_elif.py
@@ -12,7 +12,7 @@
 import astroid
 
 from pylint.extensions.confusing_elif import ConfusingConsecutiveElifChecker
-from pylint.testutils import CheckerTestCase, Message
+from pylint.testutils import CheckerTestCase, OutputMessage
 
 MSG_ID_CONFUSING_CONSECUTIVE_ELIF = "confusing-consecutive-elif"
 
@@ -40,7 +40,7 @@ class TestConfusingConsecutiveElifChecker(CheckerTestCase):
         """
         if_node_to_test, elif_node = astroid.extract_node(example_code)
         with self.assertAddsMessages(
-            Message(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
+            OutputMessage(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
         ):
             self.checker.visit_if(if_node_to_test)
 
@@ -64,7 +64,7 @@ class TestConfusingConsecutiveElifChecker(CheckerTestCase):
         """
         if_node_to_test, elif_node = astroid.extract_node(example_code)
         with self.assertAddsMessages(
-            Message(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
+            OutputMessage(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
         ):
             self.checker.visit_if(if_node_to_test)
 
@@ -84,7 +84,7 @@ class TestConfusingConsecutiveElifChecker(CheckerTestCase):
         """
         if_node_to_test, elif_node = astroid.extract_node(example_code)
         with self.assertAddsMessages(
-            Message(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
+            OutputMessage(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
         ):
             self.checker.visit_if(if_node_to_test)
 

--- a/tests/extensions/test_confusing_elif.py
+++ b/tests/extensions/test_confusing_elif.py
@@ -12,7 +12,7 @@
 import astroid
 
 from pylint.extensions.confusing_elif import ConfusingConsecutiveElifChecker
-from pylint.testutils import CheckerTestCase, OutputMessage
+from pylint.testutils import CheckerTestCase, TestMessage
 
 MSG_ID_CONFUSING_CONSECUTIVE_ELIF = "confusing-consecutive-elif"
 
@@ -40,7 +40,7 @@ class TestConfusingConsecutiveElifChecker(CheckerTestCase):
         """
         if_node_to_test, elif_node = astroid.extract_node(example_code)
         with self.assertAddsMessages(
-            OutputMessage(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
+            TestMessage(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
         ):
             self.checker.visit_if(if_node_to_test)
 
@@ -64,7 +64,7 @@ class TestConfusingConsecutiveElifChecker(CheckerTestCase):
         """
         if_node_to_test, elif_node = astroid.extract_node(example_code)
         with self.assertAddsMessages(
-            OutputMessage(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
+            TestMessage(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
         ):
             self.checker.visit_if(if_node_to_test)
 
@@ -84,7 +84,7 @@ class TestConfusingConsecutiveElifChecker(CheckerTestCase):
         """
         if_node_to_test, elif_node = astroid.extract_node(example_code)
         with self.assertAddsMessages(
-            OutputMessage(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
+            TestMessage(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
         ):
             self.checker.visit_if(if_node_to_test)
 

--- a/tests/extensions/test_while_used.py
+++ b/tests/extensions/test_while_used.py
@@ -4,7 +4,7 @@
 import astroid
 
 from pylint.extensions.while_used import WhileChecker
-from pylint.testutils import CheckerTestCase, OutputMessage
+from pylint.testutils import CheckerTestCase, TestMessage
 
 
 class TestWhileUsed(CheckerTestCase):
@@ -21,5 +21,5 @@ class TestWhileUsed(CheckerTestCase):
         """
         ).body[1]
 
-        with self.assertAddsMessages(OutputMessage("while-used", node=node)):
+        with self.assertAddsMessages(TestMessage("while-used", node=node)):
             self.checker.visit_while(node)

--- a/tests/extensions/test_while_used.py
+++ b/tests/extensions/test_while_used.py
@@ -4,7 +4,7 @@
 import astroid
 
 from pylint.extensions.while_used import WhileChecker
-from pylint.testutils import CheckerTestCase, Message
+from pylint.testutils import CheckerTestCase, OutputMessage
 
 
 class TestWhileUsed(CheckerTestCase):
@@ -21,5 +21,5 @@ class TestWhileUsed(CheckerTestCase):
         """
         ).body[1]
 
-        with self.assertAddsMessages(Message("while-used", node=node)):
+        with self.assertAddsMessages(OutputMessage("while-used", node=node)):
             self.checker.visit_while(node)


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

We had two different `Message` classes. This renames one of them to become `OutputMessage` as I was running into conflicts with typing and imports. 