### PR TITLE
Fix false-positive undefined-variable with Lambda, IfExp, and :=

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,9 @@ Release date: TBA
 
   Closes #5012
 
+* Fix false-positive ``undefined-variable`` with ``Lambda``, ``IfExp``, and
+  assignment expression.
+
 
 What's New in Pylint 2.11.1?
 ============================

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1459,7 +1459,7 @@ class VariablesChecker(BaseChecker):
                     # same line as the function definition
                     maybee0601 = False
                 elif (
-                    isinstance(
+                    isinstance(  # pylint: disable=too-many-boolean-expressions
                         defstmt,
                         (
                             nodes.Assign,
@@ -1469,7 +1469,11 @@ class VariablesChecker(BaseChecker):
                             nodes.Return,
                         ),
                     )
-                    and isinstance(defstmt.value, nodes.IfExp)
+                    and (
+                        isinstance(defstmt.value, nodes.IfExp)
+                        or isinstance(defstmt.value, nodes.Lambda)
+                        and isinstance(defstmt.value.body, nodes.IfExp)
+                    )
                     and frame is defframe
                     and defframe.parent_of(node)
                     and stmt is defstmt

--- a/tests/functional/a/assign/assignment_expression.py
+++ b/tests/functional/a/assign/assignment_expression.py
@@ -1,6 +1,6 @@
 """Test assignment expressions"""
 # pylint: disable=missing-docstring,unused-argument,unused-import,invalid-name
-# pylint: disable=blacklisted-name,unused-variable,pointless-statement
+# pylint: disable=blacklisted-name,unused-variable,pointless-statement,unused-variable
 import re
 
 if (a := True):
@@ -89,3 +89,8 @@ def func2():
 # https://github.com/PyCQA/pylint/issues/4828
 def func3():
     return bar if (bar := "") else ""
+
+
+# Lambda and IfExp
+def func4():
+    l = lambda x: y if (y := x) else None


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fix false-positive `undefined-variable` for `y`.

```py
l = lambda x: y if (y := x) else None
```