### PR TITLE
Remove `safe_decode()` and `deprecated_option()` from utils

### DIFF
--- a/pylint/utils/__init__.py
+++ b/pylint/utils/__init__.py
@@ -53,7 +53,6 @@ from pylint.utils.utils import (
     _splitstrip,
     _unquote,
     decoding_stream,
-    deprecated_option,
     diff_string,
     format_section,
     get_global_option,
@@ -62,7 +61,6 @@ from pylint.utils.utils import (
     get_rst_title,
     normalize_text,
     register_plugins,
-    safe_decode,
     tokenize_module,
 )
 
@@ -75,7 +73,6 @@ __all__ = [
     "_splitstrip",
     "_unquote",
     "decoding_stream",
-    "deprecated_option",
     "diff_string",
     "FileState",
     "format_section",
@@ -85,6 +82,5 @@ __all__ = [
     "get_rst_title",
     "normalize_text",
     "register_plugins",
-    "safe_decode",
     "tokenize_module",
 ]

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -137,14 +137,6 @@ def get_rst_section(section, options, doc=None):
     return result
 
 
-def safe_decode(line, encoding, *args, **kwargs):
-    """return decoded line from encoding or decode with default encoding"""
-    try:
-        return line.decode(encoding or sys.getdefaultencoding(), *args, **kwargs)
-    except LookupError:
-        return line.decode(sys.getdefaultencoding(), *args, **kwargs)
-
-
 def decoding_stream(
     stream: Union[BufferedReader, BytesIO],
     encoding: str,
@@ -261,26 +253,6 @@ def get_global_option(
             if options[0] == option:
                 return getattr(provider.config, option.replace("-", "_"))
     return default
-
-
-def deprecated_option(
-    shortname=None, opt_type=None, help_msg=None, deprecation_msg=None
-):
-    def _warn_deprecated(option, optname, *args):  # pylint: disable=unused-argument
-        if deprecation_msg:
-            sys.stderr.write(deprecation_msg % (optname,))
-
-    option = {
-        "help": help_msg,
-        "hide": True,
-        "type": opt_type,
-        "action": "callback",
-        "callback": _warn_deprecated,
-        "deprecated": True,
-    }
-    if shortname:
-        option["shortname"] = shortname
-    return option
 
 
 def _splitstrip(string, sep=","):


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

While working on the typing of `pylint/utils/utils.py` I noticed these two functions never get called. Therefore they seem like candidates for removal from the codebase.