### PR TITLE
Type `add_message` and add `MessageLocationTuple`

### DIFF
--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -18,7 +18,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 import functools
 from inspect import cleandoc
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Optional
 
 from astroid import nodes
 
@@ -115,7 +115,7 @@ class BaseChecker(OptionsProviderMixIn):
         msgid: str,
         line: Optional[int] = None,
         node: Optional[nodes.NodeNG] = None,
-        args: Union[str, Tuple[Union[str, int], ...], None] = None,
+        args: Optional[Any] = None,
         confidence: Optional[Confidence] = None,
         col_offset: Optional[int] = None,
     ) -> None:

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -18,12 +18,14 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 import functools
 from inspect import cleandoc
-from typing import Any
+from typing import Any, Optional, Tuple, Union
+
+from astroid import nodes
 
 from pylint.config import OptionsProviderMixIn
 from pylint.constants import _MSG_ORDER, WarningScope
 from pylint.exceptions import InvalidMessageError
-from pylint.interfaces import UNDEFINED, IRawChecker, ITokenChecker, implements
+from pylint.interfaces import Confidence, IRawChecker, ITokenChecker, implements
 from pylint.message.message_definition import MessageDefinition
 from pylint.typing import CheckerStats
 from pylint.utils import get_rst_section, get_rst_title
@@ -109,10 +111,14 @@ class BaseChecker(OptionsProviderMixIn):
         return result
 
     def add_message(
-        self, msgid, line=None, node=None, args=None, confidence=None, col_offset=None
-    ):
-        if not confidence:
-            confidence = UNDEFINED
+        self,
+        msgid: str,
+        line: Optional[int] = None,
+        node: Optional[nodes.NodeNG] = None,
+        args: Union[str, Tuple[Union[str, int], ...], None] = None,
+        confidence: Optional[Confidence] = None,
+        col_offset: Optional[int] = None,
+    ) -> None:
         self.linter.add_message(msgid, line, node, args, confidence, col_offset)
 
     def check_consistency(self):

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -115,7 +115,7 @@ class BaseChecker(OptionsProviderMixIn):
         msgid: str,
         line: Optional[int] = None,
         node: Optional[nodes.NodeNG] = None,
-        args: Optional[Any] = None,
+        args: Any = None,
         confidence: Optional[Confidence] = None,
         col_offset: Optional[int] = None,
     ) -> None:

--- a/pylint/message/message.py
+++ b/pylint/message/message.py
@@ -3,8 +3,12 @@
 
 
 import collections
+from typing import Optional, Tuple, Union
+from warnings import warn
 
 from pylint.constants import MSG_TYPES
+from pylint.interfaces import Confidence
+from pylint.typing import MessageLocationTuple
 
 _MsgBase = collections.namedtuple(
     "_MsgBase",
@@ -28,7 +32,19 @@ _MsgBase = collections.namedtuple(
 class Message(_MsgBase):
     """This class represent a message to be issued by the reporters"""
 
-    def __new__(cls, msg_id, symbol, location, msg, confidence):
+    def __new__(
+        cls,
+        msg_id: str,
+        symbol: str,
+        location: Union[Tuple[str, str, str, str, int, int], MessageLocationTuple],
+        msg: str,
+        confidence: Optional[Confidence],
+    ):
+        if isinstance(location, tuple):
+            warn(
+                "In pylint 3.0, Messages will only accept a MessageLocationTuple as location parameter",
+                DeprecationWarning,
+            )
         return _MsgBase.__new__(
             cls,
             msg_id,

--- a/pylint/message/message.py
+++ b/pylint/message/message.py
@@ -3,7 +3,7 @@
 
 
 import collections
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, overload
 from warnings import warn
 
 from pylint.constants import MSG_TYPES
@@ -32,6 +32,28 @@ _MsgBase = collections.namedtuple(
 class Message(_MsgBase):
     """This class represent a message to be issued by the reporters"""
 
+    @overload
+    def __new__(
+        cls,
+        msg_id: str,
+        symbol: str,
+        location: MessageLocationTuple,
+        msg: str,
+        confidence: Optional[Confidence],
+    ) -> "Message":
+        ...
+
+    @overload
+    def __new__(
+        cls,
+        msg_id: str,
+        symbol: str,
+        location: Tuple[str, str, str, str, int, int],
+        msg: str,
+        confidence: Optional[Confidence],
+    ) -> "Message":
+        ...
+
     def __new__(
         cls,
         msg_id: str,
@@ -39,8 +61,8 @@ class Message(_MsgBase):
         location: Union[Tuple[str, str, str, str, int, int], MessageLocationTuple],
         msg: str,
         confidence: Optional[Confidence],
-    ):
-        if isinstance(location, tuple):
+    ) -> "Message":
+        if not isinstance(location, MessageLocationTuple):
             warn(
                 "In pylint 3.0, Messages will only accept a MessageLocationTuple as location parameter",
                 DeprecationWarning,

--- a/pylint/message/message.py
+++ b/pylint/message/message.py
@@ -52,6 +52,7 @@ class Message(_MsgBase):
         msg: str,
         confidence: Optional[Confidence],
     ) -> "Message":
+        # Remove for pylint 3.0
         ...
 
     def __new__(

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -3,7 +3,7 @@
 
 import sys
 from io import TextIOWrapper
-from typing import TYPE_CHECKING, List, Optional, TextIO, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, TextIO, Tuple, Union
 
 from astroid import nodes
 
@@ -237,7 +237,7 @@ class MessagesHandlerMixIn:
         msgid: str,
         line: Optional[int] = None,
         node: Optional[nodes.NodeNG] = None,
-        args: Union[str, Tuple[Union[str, int], ...], None] = None,
+        args: Optional[Any] = None,
         confidence: Optional[Confidence] = None,
         col_offset: Optional[int] = None,
     ) -> None:
@@ -284,7 +284,7 @@ class MessagesHandlerMixIn:
         message_definition: "MessageDefinition",
         line: Optional[int],
         node: Optional[nodes.NodeNG],
-        args: Union[str, Tuple[Union[str, int], ...], None],
+        args: Optional[Any],
         confidence: Optional[Confidence],
         col_offset: Optional[int],
     ) -> None:

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -232,7 +232,7 @@ class MessagesHandlerMixIn:
                 return self._msgs_state.get(msgid, fallback)
             return self._msgs_state.get(msgid, True)
 
-    def add_message(  # type: ignore # MessagesHandlesMixIn is always mixed with PyLinter
+    def add_message(  # type: ignore # MessagesHandlerMixIn is always mixed with PyLinter
         self: "PyLinter",
         msgid: str,
         line: Optional[int] = None,

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -279,7 +279,7 @@ class MessagesHandlerMixIn:
                         f"Message {message_definition.msgid} must provide Node, got None"
                     )
 
-    def add_one_message(  # type: ignore # MessagesHandlesMixIn is always mixed with PyLinter
+    def add_one_message(  # type: ignore # MessagesHandlerMixIn is always mixed with PyLinter
         self: "PyLinter",
         message_definition: "MessageDefinition",
         line: Optional[int],

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -237,7 +237,7 @@ class MessagesHandlerMixIn:
         msgid: str,
         line: Optional[int] = None,
         node: Optional[nodes.NodeNG] = None,
-        args: Optional[Any] = None,
+        args: Any = None,
         confidence: Optional[Confidence] = None,
         col_offset: Optional[int] = None,
     ) -> None:
@@ -284,7 +284,7 @@ class MessagesHandlerMixIn:
         message_definition: "MessageDefinition",
         line: Optional[int],
         node: Optional[nodes.NodeNG],
-        args: Optional[Any],
+        args: Any,
         confidence: Optional[Confidence],
         col_offset: Optional[int],
     ) -> None:

--- a/pylint/testutils/unittest_linter.py
+++ b/pylint/testutils/unittest_linter.py
@@ -1,7 +1,7 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
-from typing import Optional, Tuple, Union
+from typing import Any, Optional
 
 from astroid import nodes
 
@@ -31,7 +31,7 @@ class UnittestLinter:
         msg_id: str,
         line: Optional[int] = None,
         node: Optional[nodes.NodeNG] = None,
-        args: Union[str, Tuple[Union[str, int], ...], None] = None,
+        args: Optional[Any] = None,
         confidence: Optional[Confidence] = None,
         col_offset: Optional[int] = None,
     ) -> None:

--- a/pylint/testutils/unittest_linter.py
+++ b/pylint/testutils/unittest_linter.py
@@ -1,6 +1,11 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
+from typing import Optional, Tuple, Union
+
+from astroid import nodes
+
+from pylint.interfaces import Confidence
 from pylint.testutils.global_test_linter import linter
 from pylint.testutils.output_line import TestMessage
 from pylint.typing import CheckerStats
@@ -22,8 +27,14 @@ class UnittestLinter:
             self._messages = []
 
     def add_message(
-        self, msg_id, line=None, node=None, args=None, confidence=None, col_offset=None
-    ):
+        self,
+        msg_id: str,
+        line: Optional[int] = None,
+        node: Optional[nodes.NodeNG] = None,
+        args: Union[str, Tuple[Union[str, int], ...], None] = None,
+        confidence: Optional[Confidence] = None,
+        col_offset: Optional[int] = None,
+    ) -> None:
         # Do not test col_offset for now since changing Message breaks everything
         self._messages.append(TestMessage(msg_id, line, node, args, confidence))
 

--- a/pylint/testutils/unittest_linter.py
+++ b/pylint/testutils/unittest_linter.py
@@ -31,7 +31,7 @@ class UnittestLinter:
         msg_id: str,
         line: Optional[int] = None,
         node: Optional[nodes.NodeNG] = None,
-        args: Optional[Any] = None,
+        args: Any = None,
         confidence: Optional[Confidence] = None,
         col_offset: Optional[int] = None,
     ) -> None:

--- a/pylint/typing.py
+++ b/pylint/typing.py
@@ -52,8 +52,9 @@ CheckerStats = Dict[
 ]
 
 
-# Tuple with information about the location of a to-be-displayed message
 class MessageLocationTuple(NamedTuple):
+    """Tuple with information about the location of a to-be-displayed message"""
+
     abspath: str
     path: str
     module: str

--- a/pylint/typing.py
+++ b/pylint/typing.py
@@ -50,3 +50,13 @@ class ErrorDescriptionDict(TypedDict):
 CheckerStats = Dict[
     str, Union[int, "Counter[str]", List, Dict[str, Union[int, str, Dict[str, int]]]]
 ]
+
+
+# Tuple with information about the location of a to-be-displayed message
+class MessageLocationTuple(NamedTuple):
+    abspath: str
+    path: str
+    module: str
+    obj: str
+    line: int
+    column: int

--- a/tests/message/unittest_message.py
+++ b/tests/message/unittest_message.py
@@ -1,29 +1,31 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
-from typing import Dict, ValuesView
+from typing import ValuesView
 
+from pylint.interfaces import HIGH
 from pylint.message import Message
 from pylint.message.message_definition import MessageDefinition
+from pylint.typing import MessageLocationTuple
 
 
 def test_new_message(message_definitions: ValuesView[MessageDefinition]) -> None:
     def build_message(
-        message_definition: MessageDefinition, location_value: Dict[str, str]
+        message_definition: MessageDefinition, location_value: MessageLocationTuple
     ) -> Message:
         return Message(
             symbol=message_definition.symbol,
             msg_id=message_definition.msgid,
-            location=[
-                location_value["abspath"],
-                location_value["path"],
-                location_value["module"],
-                location_value["obj"],
-                location_value["line"],
-                location_value["column"],
-            ],
+            location=(
+                location_value.abspath,
+                location_value.path,
+                location_value.module,
+                location_value.obj,
+                location_value.line,
+                location_value.column,
+            ),
             msg=message_definition.msg,
-            confidence="high",
+            confidence=HIGH,
         )
 
     template = "{path}:{line}:{column}: {msg_id}: {msg} ({symbol})"
@@ -32,22 +34,22 @@ def test_new_message(message_definitions: ValuesView[MessageDefinition]) -> None
             e1234_message_definition = message_definition
         if message_definition.msgid == "W1234":
             w1234_message_definition = message_definition
-    e1234_location_values = {
-        "abspath": "1",
-        "path": "2",
-        "module": "3",
-        "obj": "4",
-        "line": "5",
-        "column": "6",
-    }
-    w1234_location_values = {
-        "abspath": "7",
-        "path": "8",
-        "module": "9",
-        "obj": "10",
-        "line": "11",
-        "column": "12",
-    }
+    e1234_location_values = MessageLocationTuple(
+        abspath="1",
+        path="2",
+        module="3",
+        obj="4",
+        line=5,
+        column=6,
+    )
+    w1234_location_values = MessageLocationTuple(
+        abspath="7",
+        path="8",
+        module="9",
+        obj="10",
+        line=11,
+        column=12,
+    )
     expected = (
         "2:5:6: E1234: Duplicate keyword argument %r in %s call (duplicate-keyword-arg)"
     )

--- a/tests/message/unittest_message.py
+++ b/tests/message/unittest_message.py
@@ -16,14 +16,7 @@ def test_new_message(message_definitions: ValuesView[MessageDefinition]) -> None
         return Message(
             symbol=message_definition.symbol,
             msg_id=message_definition.msgid,
-            location=(
-                location_value.abspath,
-                location_value.path,
-                location_value.module,
-                location_value.obj,
-                location_value.line,
-                location_value.column,
-            ),
+            location=location_value,
             msg=message_definition.msg,
             confidence=HIGH,
         )

--- a/tests/testutils/test_output_line.py
+++ b/tests/testutils/test_output_line.py
@@ -19,7 +19,7 @@ def message() -> Callable:
         return Message(
             symbol="missing-docstring",
             msg_id="C0123",
-            location=[
+            location=[  # type: ignore
                 "abspath",
                 "path",
                 "module",


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This adds typing to `add_message` and adds a new `NamedTuple` to `typing.py`. I add a deprecation warning for `Message`, but I'm not sure if it is even necessary. Is `Message` part of the public API? If not I can remove it.

The `type: ignore` in `tests/testutils/test_output_line.py` will be fixed in a follow-up PR. `OutputLine` needs a little refactor to only accept `int` for `column` and `line`. This will bring it in line with all other code that references `column` or `line`, where those are also `int`.