### PR TITLE
Rename `TestMessage` to `MessageTest`

### DIFF
--- a/pylint/testutils/__init__.py
+++ b/pylint/testutils/__init__.py
@@ -36,7 +36,7 @@ __all__ = [
     "FunctionalTestFile",
     "linter",
     "LintModuleTest",
-    "TestMessage",
+    "MessageTest",
     "MinimalTestReporter",
     "set_config",
     "GenericTestReporter",
@@ -52,7 +52,7 @@ from pylint.testutils.functional_test_file import FunctionalTestFile
 from pylint.testutils.get_test_info import _get_tests_info
 from pylint.testutils.global_test_linter import linter
 from pylint.testutils.lint_module_test import LintModuleTest
-from pylint.testutils.output_line import TestMessage
+from pylint.testutils.output_line import MessageTest
 from pylint.testutils.reporter_for_tests import GenericTestReporter, MinimalTestReporter
 from pylint.testutils.tokenize_str import _tokenize_str
 from pylint.testutils.unittest_linter import UnittestLinter

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -10,6 +10,9 @@ from pylint.testutils.constants import UPDATE_OPTION
 
 
 class MessageTest(
+    """Used to test messages produced by pylint. Class name cannot start with Test as pytest doesn't allow constructors in test classes.
+    """
+
     collections.namedtuple(
         "MessageTest", ["msg_id", "line", "node", "args", "confidence"]
     )

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -10,13 +10,12 @@ from pylint.testutils.constants import UPDATE_OPTION
 
 
 class MessageTest(
-    """Used to test messages produced by pylint. Class name cannot start with Test as pytest doesn't allow constructors in test classes.
-    """
-
     collections.namedtuple(
         "MessageTest", ["msg_id", "line", "node", "args", "confidence"]
     )
 ):
+    """Used to test messages produced by pylint. Class name cannot start with Test as pytest doesn't allow constructors in test classes."""
+
     def __new__(cls, msg_id, line=None, node=None, args=None, confidence=None):
         return tuple.__new__(cls, (msg_id, line, node, args, confidence))
 

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -9,16 +9,16 @@ from pylint.constants import PY38_PLUS
 from pylint.testutils.constants import UPDATE_OPTION
 
 
-class TestMessage(
+class MessageTest(
     collections.namedtuple(
-        "TestMessage", ["msg_id", "line", "node", "args", "confidence"]
+        "MessageTest", ["msg_id", "line", "node", "args", "confidence"]
     )
 ):
     def __new__(cls, msg_id, line=None, node=None, args=None, confidence=None):
         return tuple.__new__(cls, (msg_id, line, node, args, confidence))
 
     def __eq__(self, other):
-        if isinstance(other, TestMessage):
+        if isinstance(other, MessageTest):
             if self.confidence and other.confidence:
                 return super().__eq__(other)
             return self[:-1] == other[:-1]

--- a/pylint/testutils/unittest_linter.py
+++ b/pylint/testutils/unittest_linter.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 from pylint.testutils.global_test_linter import linter
-from pylint.testutils.output_line import TestMessage
+from pylint.testutils.output_line import MessageTest
 from pylint.typing import CheckerStats
 
 
@@ -25,7 +25,7 @@ class UnittestLinter:
         self, msg_id, line=None, node=None, args=None, confidence=None, col_offset=None
     ):
         # Do not test col_offset for now since changing Message breaks everything
-        self._messages.append(TestMessage(msg_id, line, node, args, confidence))
+        self._messages.append(MessageTest(msg_id, line, node, args, confidence))
 
     @staticmethod
     def is_message_enabled(*unused_args, **unused_kwargs):

--- a/tests/checkers/unittest_base.py
+++ b/tests/checkers/unittest_base.py
@@ -35,7 +35,7 @@ from typing import Dict, Type
 import astroid
 
 from pylint.checkers import BaseChecker, base
-from pylint.testutils import CheckerTestCase, TestMessage, set_config
+from pylint.testutils import CheckerTestCase, MessageTest, set_config
 
 
 class TestDocstring(CheckerTestCase):
@@ -43,7 +43,7 @@ class TestDocstring(CheckerTestCase):
 
     def test_missing_docstring_module(self) -> None:
         module = astroid.parse("something")
-        message = TestMessage("missing-module-docstring", node=module)
+        message = MessageTest("missing-module-docstring", node=module)
         with self.assertAddsMessages(message):
             self.checker.visit_module(module)
 
@@ -54,7 +54,7 @@ class TestDocstring(CheckerTestCase):
 
     def test_empty_docstring_module(self) -> None:
         module = astroid.parse("''''''")
-        message = TestMessage("empty-docstring", node=module, args=("module",))
+        message = MessageTest("empty-docstring", node=module, args=("module",))
         with self.assertAddsMessages(message):
             self.checker.visit_module(module)
 
@@ -64,7 +64,7 @@ class TestDocstring(CheckerTestCase):
         def func(tion):
            pass"""
         )
-        message = TestMessage("missing-function-docstring", node=func)
+        message = MessageTest("missing-function-docstring", node=func)
         with self.assertAddsMessages(message):
             self.checker.visit_functiondef(func)
 
@@ -87,7 +87,7 @@ class TestDocstring(CheckerTestCase):
             pass
            """
         )
-        message = TestMessage("missing-function-docstring", node=func)
+        message = MessageTest("missing-function-docstring", node=func)
         with self.assertAddsMessages(message):
             self.checker.visit_functiondef(func)
 
@@ -102,7 +102,7 @@ class TestDocstring(CheckerTestCase):
                 pass
            """
         )
-        message = TestMessage("missing-function-docstring", node=func)
+        message = MessageTest("missing-function-docstring", node=func)
         with self.assertAddsMessages(message):
             self.checker.visit_functiondef(func)
 
@@ -122,7 +122,7 @@ class TestDocstring(CheckerTestCase):
         class Klass(object):
            pass"""
         )
-        message = TestMessage("missing-class-docstring", node=klass)
+        message = MessageTest("missing-class-docstring", node=klass)
         with self.assertAddsMessages(message):
             self.checker.visit_classdef(klass)
 
@@ -182,7 +182,7 @@ class TestNameChecker(CheckerTestCase):
             self.checker.visit_functiondef(methods[2])
             self.checker.visit_functiondef(methods[3])
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "invalid-name",
                 node=methods[1],
                 args=("Attribute", "bar", "'[A-Z]+' pattern"),
@@ -260,7 +260,7 @@ class TestNameChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="assign-to-new-keyword",
                 node=ast[0].targets[0],
                 args=("async", "3.7"),
@@ -268,7 +268,7 @@ class TestNameChecker(CheckerTestCase):
         ):
             self.checker.visit_assignname(ast[0].targets[0])
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="assign-to-new-keyword",
                 node=ast[1].targets[0],
                 args=("await", "3.7"),
@@ -276,13 +276,13 @@ class TestNameChecker(CheckerTestCase):
         ):
             self.checker.visit_assignname(ast[1].targets[0])
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="assign-to-new-keyword", node=ast[2], args=("async", "3.7")
             )
         ):
             self.checker.visit_functiondef(ast[2])
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="assign-to-new-keyword", node=ast[3], args=("async", "3.7")
             )
         ):
@@ -306,7 +306,7 @@ class TestMultiNamingStyle(CheckerTestCase):
             pass
         """
         )
-        message = TestMessage(
+        message = MessageTest(
             "invalid-name",
             node=classes[0],
             args=(
@@ -335,7 +335,7 @@ class TestMultiNamingStyle(CheckerTestCase):
         """
         )
         messages = [
-            TestMessage(
+            MessageTest(
                 "invalid-name",
                 node=classes[0],
                 args=(
@@ -344,7 +344,7 @@ class TestMultiNamingStyle(CheckerTestCase):
                     "'(?:(?P<UP>[A-Z]+)|(?P<down>[a-z]+))$' pattern",
                 ),
             ),
-            TestMessage(
+            MessageTest(
                 "invalid-name",
                 node=classes[2],
                 args=(
@@ -378,7 +378,7 @@ class TestMultiNamingStyle(CheckerTestCase):
         """,
             module_name="test",
         )
-        message = TestMessage(
+        message = MessageTest(
             "invalid-name",
             node=function_defs[1],
             args=(
@@ -410,7 +410,7 @@ class TestMultiNamingStyle(CheckerTestCase):
             pass
         """
         )
-        message = TestMessage(
+        message = MessageTest(
             "invalid-name",
             node=function_defs[3],
             args=(
@@ -432,7 +432,7 @@ class TestComparison(CheckerTestCase):
 
     def test_comparison(self) -> None:
         node = astroid.extract_node("foo == True")
-        message = TestMessage(
+        message = MessageTest(
             "singleton-comparison",
             node=node,
             args=(
@@ -444,7 +444,7 @@ class TestComparison(CheckerTestCase):
             self.checker.visit_compare(node)
 
         node = astroid.extract_node("foo == False")
-        message = TestMessage(
+        message = MessageTest(
             "singleton-comparison",
             node=node,
             args=(
@@ -456,14 +456,14 @@ class TestComparison(CheckerTestCase):
             self.checker.visit_compare(node)
 
         node = astroid.extract_node("foo == None")
-        message = TestMessage(
+        message = MessageTest(
             "singleton-comparison", node=node, args=("'foo == None'", "'foo is None'")
         )
         with self.assertAddsMessages(message):
             self.checker.visit_compare(node)
 
         node = astroid.extract_node("foo is float('nan')")
-        message = TestMessage(
+        message = MessageTest(
             "nan-comparison",
             node=node,
             args=("'foo is float('nan')'", "'math.isnan(foo)'"),
@@ -477,7 +477,7 @@ class TestComparison(CheckerTestCase):
                                 foo != numpy.NaN
                                 """
         )
-        message = TestMessage(
+        message = MessageTest(
             "nan-comparison",
             node=node,
             args=("'foo != numpy.NaN'", "'not math.isnan(foo)'"),
@@ -491,7 +491,7 @@ class TestComparison(CheckerTestCase):
                                 foo is not nmp.NaN
                                 """
         )
-        message = TestMessage(
+        message = MessageTest(
             "nan-comparison",
             node=node,
             args=("'foo is not nmp.NaN'", "'not math.isnan(foo)'"),
@@ -501,10 +501,10 @@ class TestComparison(CheckerTestCase):
 
         node = astroid.extract_node("True == foo")
         messages = (
-            TestMessage(
+            MessageTest(
                 "misplaced-comparison-constant", node=node, args=("foo == True",)
             ),
-            TestMessage(
+            MessageTest(
                 "singleton-comparison",
                 node=node,
                 args=(
@@ -518,10 +518,10 @@ class TestComparison(CheckerTestCase):
 
         node = astroid.extract_node("False == foo")
         messages = (
-            TestMessage(
+            MessageTest(
                 "misplaced-comparison-constant", node=node, args=("foo == False",)
             ),
-            TestMessage(
+            MessageTest(
                 "singleton-comparison",
                 node=node,
                 args=(
@@ -535,10 +535,10 @@ class TestComparison(CheckerTestCase):
 
         node = astroid.extract_node("None == foo")
         messages = (
-            TestMessage(
+            MessageTest(
                 "misplaced-comparison-constant", node=node, args=("foo == None",)
             ),
-            TestMessage(
+            MessageTest(
                 "singleton-comparison",
                 node=node,
                 args=("'None == foo'", "'None is foo'"),

--- a/tests/checkers/unittest_classes.py
+++ b/tests/checkers/unittest_classes.py
@@ -20,7 +20,7 @@
 import astroid
 
 from pylint.checkers import classes
-from pylint.testutils import CheckerTestCase, TestMessage, set_config
+from pylint.testutils import CheckerTestCase, MessageTest, set_config
 
 
 class TestVariablesChecker(CheckerTestCase):
@@ -37,7 +37,7 @@ class TestVariablesChecker(CheckerTestCase):
             self.first = 0  #@
         """
         )
-        message = TestMessage(
+        message = MessageTest(
             "access-member-before-definition", node=n1.target, args=("first", n2.lineno)
         )
         with self.assertAddsMessages(message):
@@ -64,7 +64,7 @@ class TestVariablesChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage("protected-access", node=node.body[-1].value, args="_teta")
+            MessageTest("protected-access", node=node.body[-1].value, args="_teta")
         ):
             self.walk(node.root())
 
@@ -117,7 +117,7 @@ class TestVariablesChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage("protected-access", node=node.value, args="_nargs")
+            MessageTest("protected-access", node=node.value, args="_nargs")
         ):
             self.checker.visit_attribute(node.value)
 
@@ -154,17 +154,17 @@ class TestVariablesChecker(CheckerTestCase):
         unused_private_attr_1 = classdef.instance_attr("__private")[0]
         unused_private_attr_2 = classdef.instance_attr("__private")[1]
         with self.assertAddsMessages(
-            TestMessage("protected-access", node=attribute_in_eq, args="_protected"),
-            TestMessage(
+            MessageTest("protected-access", node=attribute_in_eq, args="_protected"),
+            MessageTest(
                 "protected-access", node=attribute_in_fake_1, args="_protected"
             ),
-            TestMessage("protected-access", node=attribute_in_fake_2, args="__private"),
-            TestMessage(
+            MessageTest("protected-access", node=attribute_in_fake_2, args="__private"),
+            MessageTest(
                 "unused-private-member",
                 node=unused_private_attr_1,
                 args=("Protected", "__private"),
             ),
-            TestMessage(
+            MessageTest(
                 "unused-private-member",
                 node=unused_private_attr_2,
                 args=("Protected", "__private"),
@@ -203,16 +203,16 @@ class TestVariablesChecker(CheckerTestCase):
         unused_private_attr_1 = classdef.instance_attr("__private")[0]
         unused_private_attr_2 = classdef.instance_attr("__private")[1]
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "protected-access", node=attribute_in_fake_1, args="_protected"
             ),
-            TestMessage("protected-access", node=attribute_in_fake_2, args="__private"),
-            TestMessage(
+            MessageTest("protected-access", node=attribute_in_fake_2, args="__private"),
+            MessageTest(
                 "unused-private-member",
                 node=unused_private_attr_1,
                 args=("Protected", "__private"),
             ),
-            TestMessage(
+            MessageTest(
                 "unused-private-member",
                 node=unused_private_attr_2,
                 args=("Protected", "__private"),
@@ -248,6 +248,6 @@ class TestVariablesChecker(CheckerTestCase):
             """
         )
         with self.assertAddsMessages(
-            TestMessage("method-hidden", node=node, args=("", 4))
+            MessageTest("method-hidden", node=node, args=("", 4))
         ):
             self.checker.visit_functiondef(node)

--- a/tests/checkers/unittest_deprecated.py
+++ b/tests/checkers/unittest_deprecated.py
@@ -4,7 +4,7 @@ import astroid
 
 from pylint.checkers import BaseChecker, DeprecatedMixin
 from pylint.interfaces import UNDEFINED, IAstroidChecker
-from pylint.testutils import CheckerTestCase, TestMessage
+from pylint.testutils import CheckerTestCase, MessageTest
 
 
 class _DeprecatedChecker(DeprecatedMixin, BaseChecker):
@@ -66,7 +66,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-method",
                 args=("deprecated_func",),
                 node=node,
@@ -88,7 +88,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-method",
                 args=("deprecated_method",),
                 node=node,
@@ -113,7 +113,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-method",
                 args=("deprecated_method",),
                 node=node,
@@ -152,7 +152,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction1"),
                 node=node,
@@ -172,7 +172,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction1"),
                 node=node,
@@ -205,7 +205,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction3"),
                 node=node,
@@ -226,7 +226,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod1"),
                 node=node,
@@ -247,7 +247,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod1"),
                 node=node,
@@ -282,7 +282,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod3"),
                 node=node,
@@ -303,13 +303,13 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction2"),
                 node=node,
                 confidence=UNDEFINED,
             ),
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg2", "myfunction2"),
                 node=node,
@@ -329,13 +329,13 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "myfunction2"),
                 node=node,
                 confidence=UNDEFINED,
             ),
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg2", "myfunction2"),
                 node=node,
@@ -357,13 +357,13 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod2"),
                 node=node,
                 confidence=UNDEFINED,
             ),
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg2", "mymethod2"),
                 node=node,
@@ -384,13 +384,13 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg1", "mymethod2"),
                 node=node,
                 confidence=UNDEFINED,
             ),
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg2", "mymethod2"),
                 node=node,
@@ -411,7 +411,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-argument",
                 args=("deprecated_arg", "MyClass"),
                 node=node,
@@ -428,7 +428,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-module",
                 args="deprecated_module",
                 node=node,
@@ -445,7 +445,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-module",
                 args="deprecated_module",
                 node=node,
@@ -462,7 +462,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-class",
                 args=("DeprecatedClass", "deprecated"),
                 node=node,
@@ -479,7 +479,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-class",
                 args=("DeprecatedClass", "deprecated"),
                 node=node,
@@ -497,7 +497,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-class",
                 args=("DeprecatedClass", "deprecated"),
                 node=node,
@@ -521,7 +521,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-decorator",
                 args=".deprecated_decorator",
                 node=node,
@@ -547,7 +547,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="deprecated-decorator",
                 args=".deprecated_decorator",
                 node=node,

--- a/tests/checkers/unittest_exceptions.py
+++ b/tests/checkers/unittest_exceptions.py
@@ -18,7 +18,7 @@
 import astroid
 
 from pylint.checkers import exceptions
-from pylint.testutils import CheckerTestCase, TestMessage
+from pylint.testutils import CheckerTestCase, MessageTest
 
 
 class TestExceptionsChecker(CheckerTestCase):
@@ -33,7 +33,7 @@ class TestExceptionsChecker(CheckerTestCase):
 
     def test_raising_bad_type_python3(self) -> None:
         node = astroid.extract_node("raise (ZeroDivisionError, None)  #@")
-        message = TestMessage("raising-bad-type", node=node, args="tuple")
+        message = MessageTest("raising-bad-type", node=node, args="tuple")
         with self.assertAddsMessages(message):
             self.checker.visit_raise(node)
 
@@ -49,6 +49,6 @@ class TestExceptionsChecker(CheckerTestCase):
             raise Exception from exc  #@
         """
         )
-        message = TestMessage("bad-exception-context", node=node)
+        message = MessageTest("bad-exception-context", node=node)
         with self.assertAddsMessages(message):
             self.checker.visit_raise(node)

--- a/tests/checkers/unittest_format.py
+++ b/tests/checkers/unittest_format.py
@@ -37,7 +37,7 @@ import astroid
 
 from pylint import lint, reporters
 from pylint.checkers.format import FormatChecker
-from pylint.testutils import CheckerTestCase, TestMessage, _tokenize_str
+from pylint.testutils import CheckerTestCase, MessageTest, _tokenize_str
 
 
 class TestMultiStatementLine(CheckerTestCase):
@@ -51,7 +51,7 @@ class TestMultiStatementLine(CheckerTestCase):
         )
         self.checker.config.single_line_if_stmt = False
         with self.assertAddsMessages(
-            TestMessage("multiple-statements", node=stmt.body[0])
+            MessageTest("multiple-statements", node=stmt.body[0])
         ):
             self.visitFirst(stmt)
         self.checker.config.single_line_if_stmt = True
@@ -65,7 +65,7 @@ class TestMultiStatementLine(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage("multiple-statements", node=stmt.body[0])
+            MessageTest("multiple-statements", node=stmt.body[0])
         ):
             self.visitFirst(stmt)
 
@@ -77,7 +77,7 @@ class TestMultiStatementLine(CheckerTestCase):
         )
         self.checker.config.single_line_class_stmt = False
         with self.assertAddsMessages(
-            TestMessage("multiple-statements", node=stmt.body[0])
+            MessageTest("multiple-statements", node=stmt.body[0])
         ):
             self.visitFirst(stmt)
         self.checker.config.single_line_class_stmt = True
@@ -91,7 +91,7 @@ class TestMultiStatementLine(CheckerTestCase):
         )
         self.checker.config.single_line_class_stmt = False
         with self.assertAddsMessages(
-            TestMessage("multiple-statements", node=stmt.body[0])
+            MessageTest("multiple-statements", node=stmt.body[0])
         ):
             self.visitFirst(stmt)
         self.checker.config.single_line_class_stmt = True
@@ -105,12 +105,12 @@ class TestMultiStatementLine(CheckerTestCase):
         )
         self.checker.config.single_line_class_stmt = False
         with self.assertAddsMessages(
-            TestMessage("multiple-statements", node=stmt.body[0])
+            MessageTest("multiple-statements", node=stmt.body[0])
         ):
             self.visitFirst(stmt)
         self.checker.config.single_line_class_stmt = True
         with self.assertAddsMessages(
-            TestMessage("multiple-statements", node=stmt.body[0])
+            MessageTest("multiple-statements", node=stmt.body[0])
         ):
             self.visitFirst(stmt)
 
@@ -146,7 +146,7 @@ class TestMultiStatementLine(CheckerTestCase):
         """
         stmt = astroid.extract_node(code)
         with self.assertAddsMessages(
-            TestMessage("multiple-statements", node=stmt.body[0])
+            MessageTest("multiple-statements", node=stmt.body[0])
         ):
             self.visitFirst(stmt)
 
@@ -177,40 +177,40 @@ class TestSuperfluousParentheses(CheckerTestCase):
 
     def testCheckKeywordParensHandlesUnnecessaryParens(self) -> None:
         cases = [
-            (TestMessage("superfluous-parens", line=1, args="if"), "if (foo):", 0),
+            (MessageTest("superfluous-parens", line=1, args="if"), "if (foo):", 0),
             (
-                TestMessage("superfluous-parens", line=1, args="if"),
+                MessageTest("superfluous-parens", line=1, args="if"),
                 "if ((foo, bar)):",
                 0,
             ),
             (
-                TestMessage("superfluous-parens", line=1, args="if"),
+                MessageTest("superfluous-parens", line=1, args="if"),
                 "if (foo(bar)):",
                 0,
             ),
-            (TestMessage("superfluous-parens", line=1, args="not"), "not (foo)", 0),
+            (MessageTest("superfluous-parens", line=1, args="not"), "not (foo)", 0),
             (
-                TestMessage("superfluous-parens", line=1, args="not"),
+                MessageTest("superfluous-parens", line=1, args="not"),
                 "if not (foo):",
                 1,
             ),
             (
-                TestMessage("superfluous-parens", line=1, args="if"),
+                MessageTest("superfluous-parens", line=1, args="if"),
                 "if (not (foo)):",
                 0,
             ),
             (
-                TestMessage("superfluous-parens", line=1, args="not"),
+                MessageTest("superfluous-parens", line=1, args="not"),
                 "if (not (foo)):",
                 2,
             ),
             (
-                TestMessage("superfluous-parens", line=1, args="for"),
+                MessageTest("superfluous-parens", line=1, args="for"),
                 "for (x) in (1, 2, 3):",
                 0,
             ),
             (
-                TestMessage("superfluous-parens", line=1, args="if"),
+                MessageTest("superfluous-parens", line=1, args="if"),
                 "if (1) in (1, 2, 3):",
                 0,
             ),
@@ -234,11 +234,11 @@ class TestSuperfluousParentheses(CheckerTestCase):
         """Test positive superfluous parens cases with the walrus operator"""
         cases = [
             (
-                TestMessage("superfluous-parens", line=1, args="if"),
+                MessageTest("superfluous-parens", line=1, args="if"),
                 "if ((x := y)):\n",
             ),
             (
-                TestMessage("superfluous-parens", line=1, args="not"),
+                MessageTest("superfluous-parens", line=1, args="not"),
                 "if not ((x := y)):\n",
             ),
         ]
@@ -293,9 +293,9 @@ def test_disable_global_option_end_of_line() -> None:
     Test for issue with disabling tokenizer messages
     that extend beyond the scope of the ast tokens
     """
-    file_ = tempfile.NamedTemporaryFile(  # pylint: disable=consider-using-with
+    file_ = tempfile.NamedTemporaryFile(
         "w", delete=False
-    )
+    )  # pylint: disable=consider-using-with
     with file_:
         file_.write(
             """

--- a/tests/checkers/unittest_imports.py
+++ b/tests/checkers/unittest_imports.py
@@ -25,7 +25,7 @@ import astroid
 
 from pylint.checkers import imports
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, TestMessage, set_config
+from pylint.testutils import CheckerTestCase, MessageTest, set_config
 
 REGR_DATA = os.path.join(os.path.dirname(__file__), "..", "regrtest_data", "")
 
@@ -54,7 +54,7 @@ class TestImportsChecker(CheckerTestCase):
         ).body[0]
 
         with self.assertAddsMessages(
-            TestMessage("import-outside-toplevel", node=node, args="pylint")
+            MessageTest("import-outside-toplevel", node=node, args="pylint")
         ):
             self.checker.visit_import(node)
 
@@ -110,7 +110,7 @@ class TestImportsChecker(CheckerTestCase):
         import foo, bar
         """
         )
-        msg = TestMessage("multiple-imports", node=node, args="foo, bar")
+        msg = MessageTest("multiple-imports", node=node, args="foo, bar")
         with self.assertAddsMessages(msg):
             self.checker.visit_import(node)
 
@@ -128,7 +128,7 @@ class TestImportsChecker(CheckerTestCase):
         Test that duplicate imports on single line raise 'reimported'.
         """
         node = astroid.extract_node("from time import sleep, sleep, time")
-        msg = TestMessage(msg_id="reimported", node=node, args=("sleep", 1))
+        msg = MessageTest(msg_id="reimported", node=node, args=("sleep", 1))
         with self.assertAddsMessages(msg):
             self.checker.visit_importfrom(node)
 
@@ -136,7 +136,7 @@ class TestImportsChecker(CheckerTestCase):
         module = astroid.MANAGER.ast_from_module_name("beyond_top", REGR_DATA)
         import_from = module.body[0]
 
-        msg = TestMessage(msg_id="relative-beyond-top-level", node=import_from)
+        msg = MessageTest(msg_id="relative-beyond-top-level", node=import_from)
         with self.assertAddsMessages(msg):
             self.checker.visit_importfrom(import_from)
         with self.assertNoMessages():
@@ -155,7 +155,7 @@ class TestImportsChecker(CheckerTestCase):
         module = astroid.MANAGER.ast_from_module_name("wildcard", REGR_DATA)
         import_from = module.body[0]
 
-        msg = TestMessage(
+        msg = MessageTest(
             msg_id="wildcard-import",
             node=import_from,
             args="empty",

--- a/tests/checkers/unittest_logging.py
+++ b/tests/checkers/unittest_logging.py
@@ -23,7 +23,7 @@ import pytest
 
 from pylint.checkers import logging
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, TestMessage, set_config
+from pylint.testutils import CheckerTestCase, MessageTest, set_config
 
 
 class TestLoggingModuleDetection(CheckerTestCase):
@@ -39,7 +39,7 @@ class TestLoggingModuleDetection(CheckerTestCase):
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
         with self.assertAddsMessages(
-            TestMessage("logging-not-lazy", node=stmts[1], args=("lazy %",))
+            MessageTest("logging-not-lazy", node=stmts[1], args=("lazy %",))
         ):
             self.checker.visit_call(stmts[1])
 
@@ -62,7 +62,7 @@ class TestLoggingModuleDetection(CheckerTestCase):
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
         with self.assertAddsMessages(
-            TestMessage("logging-not-lazy", node=stmts[1], args=("lazy %",))
+            MessageTest("logging-not-lazy", node=stmts[1], args=("lazy %",))
         ):
             self.checker.visit_call(stmts[1])
 
@@ -77,7 +77,7 @@ class TestLoggingModuleDetection(CheckerTestCase):
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
         with self.assertAddsMessages(
-            TestMessage("logging-not-lazy", node=stmts[1], args=("lazy %",))
+            MessageTest("logging-not-lazy", node=stmts[1], args=("lazy %",))
         ):
             self.checker.visit_call(stmts[1])
 
@@ -112,10 +112,10 @@ class TestLoggingModuleDetection(CheckerTestCase):
         )
         self.checker.visit_module(None)
         self.checker.visit_import(stmts[0])
-        messages = [TestMessage(msg, node=stmts[1], args=args, confidence=UNDEFINED)]
+        messages = [MessageTest(msg, node=stmts[1], args=args, confidence=UNDEFINED)]
         if with_too_many:
             messages.append(
-                TestMessage(
+                MessageTest(
                     "logging-too-many-args", node=stmts[1], confidence=UNDEFINED
                 )
             )

--- a/tests/checkers/unittest_misc.py
+++ b/tests/checkers/unittest_misc.py
@@ -19,7 +19,7 @@
 """Tests for the misc checker."""
 
 from pylint.checkers import misc
-from pylint.testutils import CheckerTestCase, TestMessage, _tokenize_str, set_config
+from pylint.testutils import CheckerTestCase, MessageTest, _tokenize_str, set_config
 
 
 class TestFixme(CheckerTestCase):
@@ -30,7 +30,7 @@ class TestFixme(CheckerTestCase):
                 # FIXME message
                 """
         with self.assertAddsMessages(
-            TestMessage(msg_id="fixme", line=2, args="FIXME message")
+            MessageTest(msg_id="fixme", line=2, args="FIXME message")
         ):
             self.checker.process_tokens(_tokenize_str(code))
 
@@ -38,14 +38,14 @@ class TestFixme(CheckerTestCase):
         code = """a = 1
                 # TODO
                 """
-        with self.assertAddsMessages(TestMessage(msg_id="fixme", line=2, args="TODO")):
+        with self.assertAddsMessages(MessageTest(msg_id="fixme", line=2, args="TODO")):
             self.checker.process_tokens(_tokenize_str(code))
 
     def test_xxx_without_space(self) -> None:
         code = """a = 1
                 #XXX
                 """
-        with self.assertAddsMessages(TestMessage(msg_id="fixme", line=2, args="XXX")):
+        with self.assertAddsMessages(MessageTest(msg_id="fixme", line=2, args="XXX")):
             self.checker.process_tokens(_tokenize_str(code))
 
     def test_xxx_middle(self) -> None:
@@ -59,7 +59,7 @@ class TestFixme(CheckerTestCase):
         code = """a = 1
                 #FIXME
                 """
-        with self.assertAddsMessages(TestMessage(msg_id="fixme", line=2, args="FIXME")):
+        with self.assertAddsMessages(MessageTest(msg_id="fixme", line=2, args="FIXME")):
             self.checker.process_tokens(_tokenize_str(code))
 
     @set_config(notes=[])
@@ -79,7 +79,7 @@ class TestFixme(CheckerTestCase):
                 # FIXME
                 """
         with self.assertAddsMessages(
-            TestMessage(msg_id="fixme", line=2, args="CODETAG")
+            MessageTest(msg_id="fixme", line=2, args="CODETAG")
         ):
             self.checker.process_tokens(_tokenize_str(code))
 
@@ -91,7 +91,7 @@ class TestFixme(CheckerTestCase):
     def test_issue_2321_should_trigger(self) -> None:
         code = "# TODO this should not trigger a fixme"
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="fixme", line=1, args="TODO this should not trigger a fixme"
             )
         ):

--- a/tests/checkers/unittest_spelling.py
+++ b/tests/checkers/unittest_spelling.py
@@ -22,7 +22,7 @@ import astroid
 import pytest
 
 from pylint.checkers import spelling
-from pylint.testutils import CheckerTestCase, TestMessage, _tokenize_str, set_config
+from pylint.testutils import CheckerTestCase, MessageTest, _tokenize_str, set_config
 
 # try to create enchant dictionary
 try:
@@ -57,7 +57,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     @set_config(spelling_dict=spell_dict)
     def test_check_bad_coment(self):
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -75,7 +75,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     @set_config(max_spelling_suggestions=2)
     def test_check_bad_coment_custom_suggestion_count(self):
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -93,7 +93,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_check_bad_docstring(self):
         stmt = astroid.extract_node('def fff():\n   """bad coment"""\n   pass')
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -108,7 +108,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
 
         stmt = astroid.extract_node('class Abc(object):\n   """bad coment"""\n   pass')
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -127,7 +127,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_invalid_docstring_characters(self):
         stmt = astroid.extract_node('def fff():\n   """test\\x00"""\n   pass')
         with self.assertAddsMessages(
-            TestMessage("invalid-characters-in-docstring", line=2, args=("test\x00",))
+            MessageTest("invalid-characters-in-docstring", line=2, args=("test\x00",))
         ):
             self.checker.visit_functiondef(stmt)
 
@@ -181,7 +181,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """ComentAbc with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -201,7 +201,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """comentAbc with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -219,7 +219,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """argumentN with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -274,7 +274,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """This is :class:`ComentAbc` with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -294,7 +294,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """This is :py:attr:`ComentAbc` with a bad coment"""\n   pass'
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -338,7 +338,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     ):
         full_comment = f"# {misspelled_portion_of_directive}{second_portion_of_directive} {misspelled_portion_of_directive}"
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -356,7 +356,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_skip_code_flanked_in_double_backticks(self):
         full_comment = "# The function ``.qsize()`` .qsize()"
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -374,7 +374,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_skip_code_flanked_in_single_backticks(self):
         full_comment = "# The function `.qsize()` .qsize()"
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -395,7 +395,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     def test_skip_directives_specified_in_pylintrc(self):
         full_comment = "# newdirective: do this newdirective"
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -419,7 +419,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(
@@ -439,7 +439,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
             'class ComentAbc(object):\n   """Check teh dummy comment teh"""\n   pass'
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -449,7 +449,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
                     self._get_msg_suggestions("teh"),
                 ),
             ),
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -466,7 +466,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     @set_config(spelling_dict=spell_dict)
     def test_more_than_one_error_in_same_line_for_same_word_on_comment(self):
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -476,7 +476,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
                     self._get_msg_suggestions("coment"),
                 ),
             ),
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-comment",
                 line=1,
                 args=(
@@ -499,7 +499,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """'''
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(
@@ -520,7 +520,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """# msitake"""'''
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=2,
                 args=(
@@ -543,7 +543,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """'''
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(
@@ -578,7 +578,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """'''
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(
@@ -601,7 +601,7 @@ class TestSpellingChecker(CheckerTestCase):  # pylint:disable=too-many-public-me
     """'''
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "wrong-spelling-in-docstring",
                 line=3,
                 args=(

--- a/tests/checkers/unittest_stdlib.py
+++ b/tests/checkers/unittest_stdlib.py
@@ -21,7 +21,7 @@ from astroid.nodes.node_classes import AssignAttr, Name
 
 from pylint.checkers import stdlib
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, TestMessage
+from pylint.testutils import CheckerTestCase, MessageTest
 
 
 @contextlib.contextmanager
@@ -76,7 +76,7 @@ class TestStdlibChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="shallow-copy-environ", node=node, confidence=UNDEFINED)
+            MessageTest(msg_id="shallow-copy-environ", node=node, confidence=UNDEFINED)
         ):
             self.checker.visit_call(node)
 
@@ -91,7 +91,7 @@ class TestStdlibChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="shallow-copy-environ", node=node, confidence=UNDEFINED)
+            MessageTest(msg_id="shallow-copy-environ", node=node, confidence=UNDEFINED)
         ):
             self.checker.visit_call(node)
 

--- a/tests/checkers/unittest_strings.py
+++ b/tests/checkers/unittest_strings.py
@@ -14,7 +14,7 @@
 import astroid
 
 from pylint.checkers import strings
-from pylint.testutils import CheckerTestCase, TestMessage
+from pylint.testutils import CheckerTestCase, MessageTest
 
 TEST_TOKENS = (
     '"X"',
@@ -81,7 +81,7 @@ class TestStringChecker(CheckerTestCase):
         ):
             node = astroid.extract_node(code)
             with self.assertAddsMessages(
-                TestMessage(
+                MessageTest(
                     "bad-string-format-type", node=node, args=(arg_type, format_type)
                 )
             ):

--- a/tests/checkers/unittest_typecheck.py
+++ b/tests/checkers/unittest_typecheck.py
@@ -30,7 +30,7 @@ import pytest
 
 from pylint.checkers import typecheck
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, TestMessage, set_config
+from pylint.testutils import CheckerTestCase, MessageTest, set_config
 
 try:
     from coverage import tracer as _  # pylint: disable=unused-import
@@ -59,7 +59,7 @@ class TestTypeChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "no-member",
                 node=node,
                 args=("Module", "optparse", "THIS_does_not_EXIST", ""),
@@ -90,7 +90,7 @@ class TestTypeChecker(CheckerTestCase):
         xml.etree.Lala
         """
         )
-        message = TestMessage(
+        message = MessageTest(
             "no-member", node=node, args=("Module", "xml.etree", "Lala", "")
         )
         with self.assertAddsMessages(message):
@@ -127,7 +127,7 @@ class TestTypeChecker(CheckerTestCase):
         xml.etree.ElementTree.Test
         """
         )
-        message = TestMessage(
+        message = MessageTest(
             "no-member", node=node, args=("Module", "xml.etree.ElementTree", "Test", "")
         )
         with self.assertAddsMessages(message):
@@ -166,7 +166,7 @@ class TestTypeChecker(CheckerTestCase):
         tracer.CTracer  #@
         """
         )
-        message = TestMessage(
+        message = MessageTest(
             "no-member", node=node, args=("Module", "coverage.tracer", "CTracer", "")
         )
         with self.assertAddsMessages(message):
@@ -181,7 +181,7 @@ class TestTypeChecker(CheckerTestCase):
         tracer.CTracer  #@
         """
         )
-        message = TestMessage(
+        message = MessageTest(
             "c-extension-no-member",
             node=node,
             args=("Module", "coverage.tracer", "CTracer", ""),
@@ -238,7 +238,7 @@ class TestTypeChecker(CheckerTestCase):
             ("FirstInvalid", "int"),
         ):
             classdef = module[class_obj]
-            message = TestMessage(
+            message = MessageTest(
                 "invalid-metaclass", node=classdef, args=(metaclass_name,)
             )
             with self.assertAddsMessages(message):
@@ -259,7 +259,7 @@ class TestTypeChecker(CheckerTestCase):
         )
         for class_obj, metaclass_name in (("Invalid", "int"), ("InvalidSecond", "1")):
             classdef = module[class_obj]
-            message = TestMessage(
+            message = MessageTest(
                 "invalid-metaclass", node=classdef, args=(metaclass_name,)
             )
             with self.assertAddsMessages(message):
@@ -358,7 +358,7 @@ class TestTypeChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage("not-callable", node=call, args="get_num(10)")
+            MessageTest("not-callable", node=call, args="get_num(10)")
         ):
             self.checker.visit_call(call)
 
@@ -400,7 +400,7 @@ class TestTypeCheckerOnDecorators(CheckerTestCase):
         )
         subscript = module.body[-1].value
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "unsubscriptable-object",
                 node=subscript.value,
                 args="collections",
@@ -451,7 +451,7 @@ class TestTypeCheckerOnDecorators(CheckerTestCase):
         )
         subscript = module.body[-1].value
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "unsubscriptable-object",
                 node=subscript.value,
                 args="decorated",
@@ -491,7 +491,7 @@ class TestTypeCheckerOnDecorators(CheckerTestCase):
         )
         subscript = module.body[-1].value
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 "unsubscriptable-object",
                 node=subscript.value,
                 args="decorated",

--- a/tests/checkers/unittest_variables.py
+++ b/tests/checkers/unittest_variables.py
@@ -31,7 +31,7 @@ import astroid
 from pylint.checkers import variables
 from pylint.constants import IS_PYPY
 from pylint.interfaces import UNDEFINED
-from pylint.testutils import CheckerTestCase, TestMessage, linter, set_config
+from pylint.testutils import CheckerTestCase, MessageTest, linter, set_config
 
 REGR_DATA_DIR = str(Path(__file__).parent / ".." / "regrtest_data")
 
@@ -104,7 +104,7 @@ class TestVariablesChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage("redefined-builtin", node=node.body[0], args="open")
+            MessageTest("redefined-builtin", node=node.body[0], args="open")
         ):
             self.checker.visit_module(node)
 
@@ -128,7 +128,7 @@ class TestVariablesChecker(CheckerTestCase):
                 import sys, lala
         """
         )
-        msg = TestMessage("global-statement", node=node, confidence=UNDEFINED)
+        msg = MessageTest("global-statement", node=node, confidence=UNDEFINED)
         with self.assertAddsMessages(msg):
             self.checker.visit_global(node)
 
@@ -256,7 +256,7 @@ class TestVariablesCheckerWithTearDown(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage("unused-argument", node=node["abc"], args="abc")
+            MessageTest("unused-argument", node=node["abc"], args="abc")
         ):
             self.checker.visit_functiondef(node)
             self.checker.leave_functiondef(node)
@@ -268,7 +268,7 @@ class TestVariablesCheckerWithTearDown(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage("unused-argument", node=node["abc"], args="abc")
+            MessageTest("unused-argument", node=node["abc"], args="abc")
         ):
             self.checker.visit_functiondef(node)
             self.checker.leave_functiondef(node)
@@ -281,7 +281,7 @@ class TestVariablesCheckerWithTearDown(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage("redefined-builtin", node=node.body[0], args="open")
+            MessageTest("redefined-builtin", node=node.body[0], args="open")
         ):
             self.checker.visit_module(node)
 

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -30,7 +30,7 @@ import pytest
 from astroid import nodes
 
 from pylint.extensions.docparams import DocstringParameterChecker
-from pylint.testutils import CheckerTestCase, TestMessage, set_config
+from pylint.testutils import CheckerTestCase, MessageTest, set_config
 
 
 class TestParamDocChecker(CheckerTestCase):
@@ -60,8 +60,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("y",)),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            MessageTest(msg_id="missing-param-doc", node=node, args=("y",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -84,8 +84,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("y",)),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            MessageTest(msg_id="missing-param-doc", node=node, args=("y",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -173,7 +173,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-type-doc", node=node, args=("x",))
+            MessageTest(msg_id="missing-type-doc", node=node, args=("x",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -255,10 +255,10 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("that",)),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("that",)),
-            TestMessage(msg_id="differing-param-doc", node=node, args=("these",)),
-            TestMessage(msg_id="differing-type-doc", node=node, args=("these",)),
+            MessageTest(msg_id="missing-param-doc", node=node, args=("that",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("that",)),
+            MessageTest(msg_id="differing-param-doc", node=node, args=("these",)),
+            MessageTest(msg_id="differing-type-doc", node=node, args=("these",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -284,8 +284,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("y",)),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            MessageTest(msg_id="missing-param-doc", node=node, args=("y",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -322,8 +322,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("x, y",)),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            MessageTest(msg_id="missing-param-doc", node=node, args=("x, y",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -373,8 +373,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         method_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=method_node, args=("y",)),
-            TestMessage(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
+            MessageTest(msg_id="missing-param-doc", node=method_node, args=("y",)),
+            MessageTest(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -398,8 +398,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         method_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=method_node, args=("y",)),
-            TestMessage(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
+            MessageTest(msg_id="missing-param-doc", node=method_node, args=("y",)),
+            MessageTest(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -425,8 +425,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         method_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=method_node, args=("y",)),
-            TestMessage(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
+            MessageTest(msg_id="missing-param-doc", node=method_node, args=("y",)),
+            MessageTest(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -537,12 +537,12 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("yarg, zarg",)),
-            TestMessage(
+            MessageTest(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("yarg, zarg",)),
+            MessageTest(
                 msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)
             ),
-            TestMessage(msg_id="differing-type-doc", node=node, args=("yarg1, zarg1",)),
+            MessageTest(msg_id="differing-type-doc", node=node, args=("yarg1, zarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -560,8 +560,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="differing-param-doc", node=node, args=("yarg1",)),
-            TestMessage(msg_id="differing-type-doc", node=node, args=("yarg1",)),
+            MessageTest(msg_id="differing-param-doc", node=node, args=("yarg1",)),
+            MessageTest(msg_id="differing-type-doc", node=node, args=("yarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -584,12 +584,12 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
-            TestMessage(
+            MessageTest(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
+            MessageTest(
                 msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)
             ),
-            TestMessage(msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)),
+            MessageTest(msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -607,8 +607,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="differing-param-doc", node=node, args=("yarg1",)),
-            TestMessage(msg_id="differing-type-doc", node=node, args=("yarg1",)),
+            MessageTest(msg_id="differing-param-doc", node=node, args=("yarg1",)),
+            MessageTest(msg_id="differing-type-doc", node=node, args=("yarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -635,12 +635,12 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
-            TestMessage(
+            MessageTest(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
+            MessageTest(
                 msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)
             ),
-            TestMessage(msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)),
+            MessageTest(msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -660,8 +660,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="differing-param-doc", node=node, args=("yarg1",)),
-            TestMessage(msg_id="differing-type-doc", node=node, args=("yarg1",)),
+            MessageTest(msg_id="differing-param-doc", node=node, args=("yarg1",)),
+            MessageTest(msg_id="differing-type-doc", node=node, args=("yarg1",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -752,8 +752,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("x",)),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            MessageTest(msg_id="missing-param-doc", node=node, args=("x",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -780,8 +780,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("x",)),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            MessageTest(msg_id="missing-param-doc", node=node, args=("x",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -810,8 +810,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("x",)),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            MessageTest(msg_id="missing-param-doc", node=node, args=("x",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("x, y",)),
         ):
             self._visit_methods_of_class(node)
 
@@ -863,8 +863,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
-            TestMessage(
+            MessageTest(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            MessageTest(
                 msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
             ),
         ):
@@ -893,8 +893,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
-            TestMessage(
+            MessageTest(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            MessageTest(
                 msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
             ),
         ):
@@ -925,8 +925,8 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
-            TestMessage(
+            MessageTest(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            MessageTest(
                 msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
             ),
         ):
@@ -1000,13 +1000,13 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="multiple-constructor-doc", node=node, args=(node.name,)
             ),
-            TestMessage(msg_id="missing-param-doc", node=node, args=("x",)),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
-            TestMessage(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
-            TestMessage(
+            MessageTest(msg_id="missing-param-doc", node=node, args=("x",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            MessageTest(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            MessageTest(
                 msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
             ),
         ):
@@ -1044,13 +1044,13 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="multiple-constructor-doc", node=node, args=(node.name,)
             ),
-            TestMessage(msg_id="missing-param-doc", node=node, args=("x",)),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
-            TestMessage(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
-            TestMessage(
+            MessageTest(msg_id="missing-param-doc", node=node, args=("x",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            MessageTest(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            MessageTest(
                 msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
             ),
         ):
@@ -1092,13 +1092,13 @@ class TestParamDocChecker(CheckerTestCase):
         )
         constructor_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="multiple-constructor-doc", node=node, args=(node.name,)
             ),
-            TestMessage(msg_id="missing-param-doc", node=node, args=("x",)),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("x, y",)),
-            TestMessage(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
-            TestMessage(
+            MessageTest(msg_id="missing-param-doc", node=node, args=("x",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("x, y",)),
+            MessageTest(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
+            MessageTest(
                 msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
             ),
         ):
@@ -1116,10 +1116,10 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="missing-param-doc", node=node, args=("missing_kwonly",)
             ),
-            TestMessage(msg_id="missing-type-doc", node=node, args=("missing_kwonly",)),
+            MessageTest(msg_id="missing-type-doc", node=node, args=("missing_kwonly",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -1139,7 +1139,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("args",))
+            MessageTest(msg_id="missing-param-doc", node=node, args=("args",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1159,7 +1159,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("kwargs",))
+            MessageTest(msg_id="missing-param-doc", node=node, args=("kwargs",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1180,7 +1180,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("args",))
+            MessageTest(msg_id="missing-param-doc", node=node, args=("args",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1201,7 +1201,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("kwargs",))
+            MessageTest(msg_id="missing-param-doc", node=node, args=("kwargs",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1226,7 +1226,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("args",))
+            MessageTest(msg_id="missing-param-doc", node=node, args=("args",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1251,7 +1251,7 @@ class TestParamDocChecker(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-param-doc", node=node, args=("kwargs",))
+            MessageTest(msg_id="missing-param-doc", node=node, args=("kwargs",))
         ):
             self.checker.visit_functiondef(node)
 
@@ -1608,7 +1608,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="missing-raises-doc",
                 node=property_node,
                 args=("AttributeError",),
@@ -1642,7 +1642,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="missing-raises-doc",
                 node=property_node,
                 args=("AttributeError",),
@@ -1678,7 +1678,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="missing-raises-doc",
                 node=property_node,
                 args=("AttributeError",),
@@ -1713,7 +1713,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="missing-raises-doc", node=setter_node, args=("AttributeError",)
             )
         ):
@@ -1749,7 +1749,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="missing-raises-doc", node=setter_node, args=("AttributeError",)
             )
         ):
@@ -1789,7 +1789,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="missing-raises-doc", node=setter_node, args=("AttributeError",)
             )
         ):
@@ -1896,7 +1896,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-type-doc", node=property_node)
+            MessageTest(msg_id="missing-return-type-doc", node=property_node)
         ):
             self.checker.visit_return(node)
 
@@ -1940,7 +1940,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-type-doc", node=property_node)
+            MessageTest(msg_id="missing-return-type-doc", node=property_node)
         ):
             self.checker.visit_return(node)
 
@@ -1965,7 +1965,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-type-doc", node=property_node)
+            MessageTest(msg_id="missing-return-type-doc", node=property_node)
         ):
             self.checker.visit_return(node)
 
@@ -1985,8 +1985,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-doc", node=func_node),
-            TestMessage(msg_id="missing-return-type-doc", node=func_node),
+            MessageTest(msg_id="missing-return-doc", node=func_node),
+            MessageTest(msg_id="missing-return-type-doc", node=func_node),
         ):
             self.checker.visit_return(node)
 
@@ -2008,8 +2008,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-doc", node=func_node),
-            TestMessage(msg_id="missing-return-type-doc", node=func_node),
+            MessageTest(msg_id="missing-return-doc", node=func_node),
+            MessageTest(msg_id="missing-return-type-doc", node=func_node),
         ):
             self.checker.visit_return(node)
 
@@ -2033,8 +2033,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-doc", node=func_node),
-            TestMessage(msg_id="missing-return-type-doc", node=func_node),
+            MessageTest(msg_id="missing-return-doc", node=func_node),
+            MessageTest(msg_id="missing-return-type-doc", node=func_node),
         ):
             self.checker.visit_return(node)
 
@@ -2058,7 +2058,7 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-doc", node=func_node)
+            MessageTest(msg_id="missing-return-doc", node=func_node)
         ):
             self.checker.visit_return(node)
 
@@ -2265,8 +2265,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="useless-type-doc", node=node, args=("_",)),
-            TestMessage(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
+            MessageTest(msg_id="useless-type-doc", node=node, args=("_",)),
+            MessageTest(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -2289,8 +2289,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="useless-type-doc", node=node, args=("_",)),
-            TestMessage(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
+            MessageTest(msg_id="useless-type-doc", node=node, args=("_",)),
+            MessageTest(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
         ):
             self.checker.visit_functiondef(node)
 
@@ -2319,8 +2319,8 @@ class TestParamDocChecker(CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="useless-type-doc", node=node, args=("_",)),
-            TestMessage(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
+            MessageTest(msg_id="useless-type-doc", node=node, args=("_",)),
+            MessageTest(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
         ):
             self.checker.visit_functiondef(node)
 

--- a/tests/extensions/test_check_raise_docs.py
+++ b/tests/extensions/test_check_raise_docs.py
@@ -23,7 +23,7 @@
 import astroid
 
 from pylint.extensions.docparams import DocstringParameterChecker
-from pylint.testutils import CheckerTestCase, TestMessage, set_config
+from pylint.testutils import CheckerTestCase, MessageTest, set_config
 
 
 class TestDocstringCheckerRaise(CheckerTestCase):
@@ -64,7 +64,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            MessageTest(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -82,7 +82,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            MessageTest(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -101,7 +101,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            MessageTest(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -152,7 +152,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[1]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-raises-doc", node=node, args=("error",))
+            MessageTest(msg_id="missing-raises-doc", node=node, args=("error",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -226,7 +226,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            MessageTest(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -359,7 +359,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            MessageTest(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -382,7 +382,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            MessageTest(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -407,7 +407,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            MessageTest(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -429,7 +429,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="missing-raises-doc",
                 node=node,
                 args=("RuntimeError, ValueError",),
@@ -456,7 +456,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="missing-raises-doc",
                 node=node,
                 args=("RuntimeError, ValueError",),
@@ -485,7 +485,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            TestMessage(
+            MessageTest(
                 msg_id="missing-raises-doc",
                 node=node,
                 args=("RuntimeError, ValueError",),
@@ -607,7 +607,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[1]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-raises-doc", node=node, args=("error",))
+            MessageTest(msg_id="missing-raises-doc", node=node, args=("error",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -665,7 +665,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            MessageTest(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -685,7 +685,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            MessageTest(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -733,7 +733,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         raise_node = node.body[1]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-raises-doc", node=node, args=("error",))
+            MessageTest(msg_id="missing-raises-doc", node=node, args=("error",))
         ):
             self.checker.visit_raise(raise_node)
 
@@ -808,7 +808,7 @@ class TestDocstringCheckerRaise(CheckerTestCase):
         )
         node = raise_node.frame()
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
+            MessageTest(msg_id="missing-raises-doc", node=node, args=("RuntimeError",))
         ):
             # we do NOT expect a warning about the OSError in inner_func!
             self.checker.visit_raise(raise_node)

--- a/tests/extensions/test_check_return_docs.py
+++ b/tests/extensions/test_check_return_docs.py
@@ -24,7 +24,7 @@
 import astroid
 
 from pylint.extensions.docparams import DocstringParameterChecker
-from pylint.testutils import CheckerTestCase, TestMessage, set_config
+from pylint.testutils import CheckerTestCase, MessageTest, set_config
 
 
 class TestDocstringCheckerReturn(CheckerTestCase):
@@ -52,8 +52,8 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-doc", node=node),
-            TestMessage(msg_id="missing-return-type-doc", node=node),
+            MessageTest(msg_id="missing-return-doc", node=node),
+            MessageTest(msg_id="missing-return-type-doc", node=node),
         ):
             self.checker.visit_return(return_node)
 
@@ -81,7 +81,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-type-doc", node=node)
+            MessageTest(msg_id="missing-return-type-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -113,7 +113,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-doc", node=node)
+            MessageTest(msg_id="missing-return-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -131,8 +131,8 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-doc", node=node),
-            TestMessage(msg_id="missing-return-type-doc", node=node),
+            MessageTest(msg_id="missing-return-doc", node=node),
+            MessageTest(msg_id="missing-return-type-doc", node=node),
         ):
             self.checker.visit_return(return_node)
 
@@ -150,7 +150,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-type-doc", node=node)
+            MessageTest(msg_id="missing-return-type-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -168,7 +168,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-doc", node=node)
+            MessageTest(msg_id="missing-return-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -186,8 +186,8 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-doc", node=node),
-            TestMessage(msg_id="missing-return-type-doc", node=node),
+            MessageTest(msg_id="missing-return-doc", node=node),
+            MessageTest(msg_id="missing-return-type-doc", node=node),
         ):
             self.checker.visit_return(return_node)
 
@@ -211,7 +211,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-doc", node=node)
+            MessageTest(msg_id="missing-return-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -231,8 +231,8 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-doc", node=node),
-            TestMessage(msg_id="missing-return-type-doc", node=node),
+            MessageTest(msg_id="missing-return-doc", node=node),
+            MessageTest(msg_id="missing-return-type-doc", node=node),
         ):
             self.checker.visit_return(return_node)
 
@@ -454,7 +454,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-doc", node=node)
+            MessageTest(msg_id="missing-return-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -472,7 +472,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-doc", node=node)
+            MessageTest(msg_id="missing-return-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -491,7 +491,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         )
         return_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-return-doc", node=node)
+            MessageTest(msg_id="missing-return-doc", node=node)
         ):
             self.checker.visit_return(return_node)
 
@@ -507,7 +507,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="redundant-returns-doc", node=node)
+            MessageTest(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -523,7 +523,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="redundant-returns-doc", node=node)
+            MessageTest(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -540,7 +540,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="redundant-returns-doc", node=node)
+            MessageTest(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -557,7 +557,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="redundant-returns-doc", node=node)
+            MessageTest(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -576,7 +576,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="redundant-returns-doc", node=node)
+            MessageTest(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -594,7 +594,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="redundant-returns-doc", node=node)
+            MessageTest(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -685,7 +685,7 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="redundant-returns-doc", node=node)
+            MessageTest(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -704,6 +704,6 @@ class TestDocstringCheckerReturn(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="redundant-returns-doc", node=node)
+            MessageTest(msg_id="redundant-returns-doc", node=node)
         ):
             self.checker.visit_functiondef(node)

--- a/tests/extensions/test_check_yields_docs.py
+++ b/tests/extensions/test_check_yields_docs.py
@@ -20,7 +20,7 @@
 import astroid
 
 from pylint.extensions.docparams import DocstringParameterChecker
-from pylint.testutils import CheckerTestCase, TestMessage, set_config
+from pylint.testutils import CheckerTestCase, MessageTest, set_config
 
 
 class TestDocstringCheckerYield(CheckerTestCase):
@@ -48,8 +48,8 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-yield-doc", node=node),
-            TestMessage(msg_id="missing-yield-type-doc", node=node),
+            MessageTest(msg_id="missing-yield-doc", node=node),
+            MessageTest(msg_id="missing-yield-type-doc", node=node),
         ):
             self.checker.visit_yield(yield_node)
 
@@ -77,7 +77,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-yield-type-doc", node=node)
+            MessageTest(msg_id="missing-yield-type-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -94,7 +94,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-yield-doc", node=node)
+            MessageTest(msg_id="missing-yield-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -112,8 +112,8 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-yield-doc", node=node),
-            TestMessage(msg_id="missing-yield-type-doc", node=node),
+            MessageTest(msg_id="missing-yield-doc", node=node),
+            MessageTest(msg_id="missing-yield-type-doc", node=node),
         ):
             self.checker.visit_yield(yield_node)
 
@@ -131,7 +131,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-yield-type-doc", node=node)
+            MessageTest(msg_id="missing-yield-type-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -149,7 +149,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-yield-doc", node=node)
+            MessageTest(msg_id="missing-yield-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -167,8 +167,8 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-yield-doc", node=node),
-            TestMessage(msg_id="missing-yield-type-doc", node=node),
+            MessageTest(msg_id="missing-yield-doc", node=node),
+            MessageTest(msg_id="missing-yield-type-doc", node=node),
         ):
             self.checker.visit_yield(yield_node)
 
@@ -188,8 +188,8 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-yield-doc", node=node),
-            TestMessage(msg_id="missing-yield-type-doc", node=node),
+            MessageTest(msg_id="missing-yield-doc", node=node),
+            MessageTest(msg_id="missing-yield-type-doc", node=node),
         ):
             self.checker.visit_yield(yield_node)
 
@@ -347,7 +347,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-yield-doc", node=node)
+            MessageTest(msg_id="missing-yield-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -365,7 +365,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-yield-doc", node=node)
+            MessageTest(msg_id="missing-yield-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -384,7 +384,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         )
         yield_node = node.body[0]
         with self.assertAddsMessages(
-            TestMessage(msg_id="missing-yield-doc", node=node)
+            MessageTest(msg_id="missing-yield-doc", node=node)
         ):
             self.checker.visit_yield(yield_node)
 
@@ -445,7 +445,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="redundant-yields-doc", node=node)
+            MessageTest(msg_id="redundant-yields-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 
@@ -464,7 +464,7 @@ class TestDocstringCheckerYield(CheckerTestCase):
         '''
         )
         with self.assertAddsMessages(
-            TestMessage(msg_id="redundant-yields-doc", node=node)
+            MessageTest(msg_id="redundant-yields-doc", node=node)
         ):
             self.checker.visit_functiondef(node)
 

--- a/tests/extensions/test_confusing_elif.py
+++ b/tests/extensions/test_confusing_elif.py
@@ -12,7 +12,7 @@
 import astroid
 
 from pylint.extensions.confusing_elif import ConfusingConsecutiveElifChecker
-from pylint.testutils import CheckerTestCase, TestMessage
+from pylint.testutils import CheckerTestCase, MessageTest
 
 MSG_ID_CONFUSING_CONSECUTIVE_ELIF = "confusing-consecutive-elif"
 
@@ -40,7 +40,7 @@ class TestConfusingConsecutiveElifChecker(CheckerTestCase):
         """
         if_node_to_test, elif_node = astroid.extract_node(example_code)
         with self.assertAddsMessages(
-            TestMessage(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
+            MessageTest(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
         ):
             self.checker.visit_if(if_node_to_test)
 
@@ -64,7 +64,7 @@ class TestConfusingConsecutiveElifChecker(CheckerTestCase):
         """
         if_node_to_test, elif_node = astroid.extract_node(example_code)
         with self.assertAddsMessages(
-            TestMessage(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
+            MessageTest(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
         ):
             self.checker.visit_if(if_node_to_test)
 
@@ -84,7 +84,7 @@ class TestConfusingConsecutiveElifChecker(CheckerTestCase):
         """
         if_node_to_test, elif_node = astroid.extract_node(example_code)
         with self.assertAddsMessages(
-            TestMessage(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
+            MessageTest(msg_id=MSG_ID_CONFUSING_CONSECUTIVE_ELIF, node=elif_node)
         ):
             self.checker.visit_if(if_node_to_test)
 

--- a/tests/extensions/test_while_used.py
+++ b/tests/extensions/test_while_used.py
@@ -4,7 +4,7 @@
 import astroid
 
 from pylint.extensions.while_used import WhileChecker
-from pylint.testutils import CheckerTestCase, TestMessage
+from pylint.testutils import CheckerTestCase, MessageTest
 
 
 class TestWhileUsed(CheckerTestCase):
@@ -21,5 +21,5 @@ class TestWhileUsed(CheckerTestCase):
         """
         ).body[1]
 
-        with self.assertAddsMessages(TestMessage("while-used", node=node)):
+        with self.assertAddsMessages(MessageTest("while-used", node=node)):
             self.checker.visit_while(node)


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

The change introduced in #5043 creates numerous `pytest` warnings because the class name begins with `Test`. This causes it to throw this error:
```bash
PytestCollectionWarning: cannot collect test class 'TestingMessage' because it has a __new__ constructor (from: tests/checkers/unittest_deprecated.py)
    class TestingMessage(
```

I don't really like the name `MessageTest` but couldn't come up with anything that doesn't start with `Test`.