### PR TITLE
Refactor and typing of OutputLine

### DIFF
--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import collections
-from typing import Any, Iterable, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Iterable, NamedTuple, Optional, Tuple, Union
 
 from astroid import nodes
 
@@ -95,7 +95,7 @@ class OutputLine(NamedTuple):
 
     @classmethod
     def get_column(cls, column: str) -> int:
-        if not PY38_PLUS:  
+        if not PY38_PLUS:
             # We check the column only for the new better ast parser introduced in python 3.8
             return 0  # pragma: no cover
         return int(column)

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -97,7 +97,7 @@ class OutputLine(NamedTuple):
     def get_column(cls, column: str) -> int:
         if (
             not PY38_PLUS
-        ):  # This mimicks behaviour of MessagesHandlerMixIn.add_one_message()
+        ):  # We check the column only for the new better ast parser introduced in python 3.8
             return 0  # pragma: no cover
         return int(column)
 

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import collections
-from typing import Any, Iterable, NamedTuple, Optional, Tuple, Union
+from typing import Any, NamedTuple, Optional, Sequence, Tuple, Union
 
 from astroid import nodes
 
@@ -83,7 +83,7 @@ class OutputLine(NamedTuple):
 
     @classmethod
     def from_msg(cls, msg: Message) -> "OutputLine":
-        column = cls.get_column(msg.column)
+        column = cls._get_column(msg.column)
         return cls(
             msg.symbol,
             msg.line,
@@ -93,8 +93,8 @@ class OutputLine(NamedTuple):
             msg.confidence.name if msg.confidence != UNDEFINED else HIGH.name,
         )
 
-    @classmethod
-    def get_column(cls, column: str) -> int:
+    @staticmethod
+    def _get_column(column: str) -> int:
         if not PY38_PLUS:
             # We check the column only for the new better ast parser introduced in python 3.8
             return 0  # pragma: no cover
@@ -103,11 +103,12 @@ class OutputLine(NamedTuple):
     @classmethod
     def from_csv(cls, row: Union[Sequence[str], str]) -> "OutputLine":
         try:
-            column = cls.get_column(row[2])
-            if isinstance(row, Iterable) and len(row) == 6:
-                return cls(row[0], int(row[1]), column, row[3], row[4], row[5])
-            if isinstance(row, Iterable) and len(row) == 5:
-                return cls(row[0], int(row[1]), column, row[3], row[4], HIGH.name)
+            column = cls._get_column(row[2])
+            if isinstance(row, Sequence):
+                if len(row) == 6:
+                    return cls(row[0], int(row[1]), column, row[3], row[4], row[5])
+                if len(row) == 5:
+                    return cls(row[0], int(row[1]), column, row[3], row[4], HIGH.name)
             raise IndexError
         except Exception as e:
             raise MalformedOutputLineException(row, e) from e

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -40,7 +40,7 @@ class MessageTest(
 class MalformedOutputLineException(Exception):
     def __init__(
         self,
-        row: Union[Tuple[str, ...], List[str], str],
+        row: Union[Sequence[str], str],
         exception: Exception,
     ) -> None:
         example = "msg-symbolic-name:42:27:MyClass.my_function:The message"
@@ -95,14 +95,13 @@ class OutputLine(NamedTuple):
 
     @classmethod
     def get_column(cls, column: str) -> int:
-        if (
-            not PY38_PLUS
-        ):  # We check the column only for the new better ast parser introduced in python 3.8
+        if not PY38_PLUS:  
+            # We check the column only for the new better ast parser introduced in python 3.8
             return 0  # pragma: no cover
         return int(column)
 
     @classmethod
-    def from_csv(cls, row: Union[Tuple[str, ...], List[str], str]) -> "OutputLine":
+    def from_csv(cls, row: Union[Sequence[str], str]) -> "OutputLine":
         try:
             column = cls.get_column(row[2])
             if isinstance(row, Iterable) and len(row) == 6:

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -105,10 +105,10 @@ class OutputLine(NamedTuple):
         try:
             if isinstance(row, Sequence):
                 column = cls._get_column(row[2])
-                if len(row) == 6:
-                    return cls(row[0], int(row[1]), column, row[3], row[4], row[5])
                 if len(row) == 5:
                     return cls(row[0], int(row[1]), column, row[3], row[4], HIGH.name)
+                if len(row) == 6:
+                    return cls(row[0], int(row[1]), column, row[3], row[4], row[5])
             raise IndexError
         except Exception as e:
             raise MalformedOutputLineException(row, e) from e

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -103,8 +103,8 @@ class OutputLine(NamedTuple):
     @classmethod
     def from_csv(cls, row: Union[Sequence[str], str]) -> "OutputLine":
         try:
-            column = cls._get_column(row[2])
             if isinstance(row, Sequence):
+                column = cls._get_column(row[2])
                 if len(row) == 6:
                     return cls(row[0], int(row[1]), column, row[3], row[4], row[5])
                 if len(row) == 5:

--- a/tests/testutils/test_output_line.py
+++ b/tests/testutils/test_output_line.py
@@ -3,7 +3,7 @@
 
 # pylint: disable=redefined-outer-name
 
-from typing import Callable, List, Optional
+from typing import Callable, Optional
 
 import pytest
 
@@ -11,6 +11,7 @@ from pylint.constants import PY38_PLUS
 from pylint.interfaces import HIGH, INFERENCE, Confidence
 from pylint.message import Message
 from pylint.testutils.output_line import MalformedOutputLineException, OutputLine
+from pylint.typing import MessageLocationTuple
 
 
 @pytest.fixture()
@@ -19,14 +20,14 @@ def message() -> Callable:
         return Message(
             symbol="missing-docstring",
             msg_id="C0123",
-            location=[  # type: ignore
+            location=MessageLocationTuple(
                 "abspath",
                 "path",
                 "module",
                 "obj",
-                "line",
-                "column",
-            ],
+                1,
+                2,
+            ),
             msg="msg",
             confidence=confidence,
         )
@@ -37,11 +38,11 @@ def message() -> Callable:
 def test_output_line() -> None:
     output_line = OutputLine(
         symbol="missing-docstring",
-        lineno=0,
-        column="0",
+        lineno=1,
+        column=2,
         object="",
         msg="Missing docstring's bad.",
-        confidence=HIGH,
+        confidence=HIGH.name,
     )
     assert output_line.symbol == "missing-docstring"
 
@@ -56,10 +57,10 @@ def test_output_line_from_message(message: Callable) -> None:
 def test_output_line_to_csv(confidence: Confidence, message: Callable) -> None:
     output_line = OutputLine.from_msg(message(confidence))
     csv = output_line.to_csv()
-    expected_column = "column" if PY38_PLUS else ""
+    expected_column = "2" if PY38_PLUS else "0"
     assert csv == (
         "missing-docstring",
-        "line",
+        "1",
         expected_column,
         "obj",
         "msg",
@@ -84,10 +85,10 @@ def test_output_line_from_csv_error() -> None:
     "confidence,expected_confidence", [[None, "HIGH"], ["INFERENCE", "INFERENCE"]]
 )
 def test_output_line_from_csv(
-    confidence: Optional[str], expected_confidence: Confidence
+    confidence: Optional[str], expected_confidence: str
 ) -> None:
     if confidence:
-        proper_csv: List[str] = [
+        proper_csv = [
             "missing-docstring",
             "1",
             "2",
@@ -98,7 +99,7 @@ def test_output_line_from_csv(
     else:
         proper_csv = ["missing-docstring", "1", "2", "obj", "msg"]
     output_line = OutputLine.from_csv(proper_csv)
-    expected_column = "2" if PY38_PLUS else ""
+    expected_column = 2 if PY38_PLUS else 0
     assert output_line == OutputLine(
         symbol="missing-docstring",
         lineno=1,


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This brings `OutputLine` in line with the classes dealing with `Message` by making the `line` and `column` attributes `int`. This has increased the size of the diff but I felt that making `line` and `column` `int` throughout the codebase would eventually be worthwhile. `OutputLine` in `csv` form still only consists of `str` (in fact we now make sure this is the case) but whenever we deal with it "internally" we can now assume `line` and `column` are `int`.
The tests have also been changed to accommodate for this. 