### PR TITLE
Fix loop in too-many-ancestors when an inheritance cycle is inferred

### DIFF
--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -267,6 +267,12 @@ def _get_parents_iter(
         if parent.qname() in ignored_parents:
             continue
         if parent not in parents:
+            # This guard might appear to be performing the same function as
+            # adding the resolved parents to a set to eliminate duplicates
+            # (legitimate due to diamond inheritance patterns), but its
+            # additional purpose is to prevent cycles (not normally possible,
+            # but potential due to inference) and thus guarantee termination
+            # of the while-loop
             yield parent
             parents.add(parent)
             to_explore.extend(parent.ancestors(recurs=False))

--- a/tests/regrtest_data/hang/pkg4972/flask/__init__.py
+++ b/tests/regrtest_data/hang/pkg4972/flask/__init__.py
@@ -1,7 +1,0 @@
-import flask
-import pkg4972.flask  # self-import necessary
-
-class Fake(flask.Flask):
-    pass
-
-flask.Flask = Fake

--- a/tests/regrtest_data/hang/pkg4972/flask/__init__.py
+++ b/tests/regrtest_data/hang/pkg4972/flask/__init__.py
@@ -1,0 +1,7 @@
+import flask
+import pkg4972.flask  # self-import necessary
+
+class Fake(flask.Flask):
+    pass
+
+flask.Flask = Fake

--- a/tests/regrtest_data/hang/pkg4972/string/__init__.py
+++ b/tests/regrtest_data/hang/pkg4972/string/__init__.py
@@ -1,0 +1,7 @@
+import string
+import pkg4972.string  # self-import necessary
+
+class Fake(string.Formatter):
+    pass
+
+string.Formatter = Fake

--- a/tests/test_regr.py
+++ b/tests/test_regr.py
@@ -161,7 +161,7 @@ def timeout(timeout_s):
 @pytest.mark.parametrize(
     "fname,timeout_s",
     [
-        (join(REGR_DATA, "hang", "pkg4972.flask"), 30.0),
+        (join(REGR_DATA, "hang", "pkg4972.string"), 30.0),
     ],
 )
 def test_hang(finalize_linter, fname, timeout_s):

--- a/tests/test_regr.py
+++ b/tests/test_regr.py
@@ -144,7 +144,7 @@ def test_pylint_config_attr() -> None:
 
 
 @contextmanager
-def timeout(timeout_s):
+def timeout(timeout_s: float):
     def _handle(_signum, _frame):
         pytest.fail("timed out")
 
@@ -164,6 +164,6 @@ def timeout(timeout_s):
         (join(REGR_DATA, "hang", "pkg4972.string"), 30.0),
     ],
 )
-def test_hang(finalize_linter, fname, timeout_s):
+def test_hang(finalize_linter, fname: str, timeout_s: float) -> None:
     with timeout(timeout_s):
         finalize_linter.check(fname)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

If a class could be inferred as an ancestor of itself then
the implementation of _get_parents could get caught in an infinite loop,
forever adding itself to to_explore. This could be possible by
monkeypatching an ancestor after class definition like in the following
simplified example:

```python
    class Fake(module.Cls):
        pass

    module.Cls = Fake
```

Reproducing this is pretty tricky, but this integration test shows the behaviour on current `main`:

```sh
#!/bin/sh

HERE=$(readlink -f .)
VENV=$HERE/venv-repro
PIP=$VENV/bin/pip

python -m venv "$VENV"

PYLINT=$VENV/bin/pylint

# assume running in pylint dir
$PIP install -e .
$PIP install flask

mkdir -p repro/flask/
touch repro/__init__.py
cat > repro/flask/__init__.py <<'EOF'
import flask
import repro.flask  # self-import necessary

class Fake(flask.Flask):
    pass

flask.Flask = Fake
EOF

echo +++ this is fine
$PYLINT --rcfile=/dev/null -- repro/flask/
echo +++ finished

echo +++ this loops forever
cd repro/; $PYLINT --rcfile=/dev/null -- flask/
```
--

Closes #4972 
