### PR TITLE
Fix ``useless-suppression`` for ``wrong-import-order``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,10 @@ Release date: TBA
 * Fix false-positive ``undefined-variable`` with ``Lambda``, ``IfExp``, and
   assignment expression.
 
+* Fix false-positive ``useless-suppression`` for ``wrong-import-order``
+
+  Closes #2366
+
 
 What's New in Pylint 2.11.1?
 ============================

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -755,8 +755,13 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             elif import_category == "THIRDPARTY":
                 third_party_imports.append(node_and_package_import)
                 external_imports.append(node_and_package_import)
-                if not nested and not ignore_for_import_order:
-                    third_party_not_ignored.append(node_and_package_import)
+                if not nested:
+                    if not ignore_for_import_order:
+                        third_party_not_ignored.append(node_and_package_import)
+                    else:
+                        self.linter.add_ignored_message(
+                            "wrong-import-order", node.fromlineno, node
+                        )
                 wrong_import = first_party_not_ignored or local_not_ignored
                 if wrong_import and not nested:
                     self.add_message(
@@ -770,8 +775,13 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             elif import_category == "FIRSTPARTY":
                 first_party_imports.append(node_and_package_import)
                 external_imports.append(node_and_package_import)
-                if not nested and not ignore_for_import_order:
-                    first_party_not_ignored.append(node_and_package_import)
+                if not nested:
+                    if not ignore_for_import_order:
+                        first_party_not_ignored.append(node_and_package_import)
+                    else:
+                        self.linter.add_ignored_message(
+                            "wrong-import-order", node.fromlineno, node
+                        )
                 wrong_import = local_not_ignored
                 if wrong_import and not nested:
                     self.add_message(
@@ -784,8 +794,13 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
                     )
             elif import_category == "LOCALFOLDER":
                 local_imports.append((node, package))
-                if not nested and not ignore_for_import_order:
-                    local_not_ignored.append((node, package))
+                if not nested:
+                    if not ignore_for_import_order:
+                        local_not_ignored.append((node, package))
+                    else:
+                        self.linter.add_ignored_message(
+                            "wrong-import-order", node.fromlineno, node
+                        )
         return std_imports, external_imports, local_imports
 
     def _get_imported_module(self, importnode, modname):

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -257,6 +257,33 @@ class MessagesHandlerMixIn:
                 message_definition, line, node, args, confidence, col_offset
             )
 
+    def add_ignored_message(  # type: ignore # MessagesHandlerMixIn is always mixed with PyLinter
+        self: "PyLinter",
+        msgid: str,
+        line: int,
+        node: nodes.NodeNG,
+        confidence: Optional[Confidence] = UNDEFINED,
+    ) -> None:
+        """Prepares a message to be added to the ignored message storage
+
+        When earlier checks make it so add_message() is never called
+        useless-suppression will create false-positives.
+        This function avoids this by adding those message to the ignored msgs attribute
+        """
+        message_definitions = self.msgs_store.get_message_definitions(msgid)
+        for message_definition in message_definitions:
+            self.check_message_definition(message_definition, line, node)
+            self.file_state.handle_ignored_message(
+                self.get_message_state_scope(
+                    message_definition.msgid, line, confidence
+                ),
+                message_definition.msgid,
+                line,
+                node,
+                None,
+                confidence,
+            )
+
     @staticmethod
     def check_message_definition(message_definition, line, node):
         if message_definition.msgid[0] not in _SCOPE_EXEMPT:

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -266,8 +266,9 @@ class MessagesHandlerMixIn:
     ) -> None:
         """Prepares a message to be added to the ignored message storage
 
-        When earlier checks make it so add_message() is never called
-        useless-suppression will create false-positives.
+        Some checks return early in special cases and never reach add_message(),
+        even though they would normally issue a message.
+        This creates false positives for useless-suppression.
         This function avoids this by adding those message to the ignored msgs attribute
         """
         message_definitions = self.msgs_store.get_message_definitions(msgid)
@@ -279,9 +280,6 @@ class MessagesHandlerMixIn:
                 ),
                 message_definition.msgid,
                 line,
-                node,
-                None,
-                confidence,
             )
 
     @staticmethod

--- a/tests/functional/u/useless/useless_suppression.py
+++ b/tests/functional/u/useless/useless_suppression.py
@@ -1,0 +1,6 @@
+"""Test for useless suppression false positive for wrong-import-order
+Reported in https://github.com/PyCQA/pylint/issues/2366"""
+# pylint: enable=useless-suppression
+# pylint: disable=unused-import, wrong-import-order
+from pylint import run_pylint
+import astroid


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This also adds a new method to ``MessagesHandlerMixIn`` which adds messages to the list of the ignored messages without doing anything else. 
This will be useful for some other ``useless-suppression`` false positives.
This closes #2366
