### PR TITLE
Small py-version improvements

### DIFF
--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -58,7 +58,7 @@ class RecommendationChecker(checkers.BaseChecker):
             "consider-using-f-string",
             "Used when we detect a string that is being formatted with format() or % "
             "which could potentially be a f-string. The use of f-strings is preferred. "
-            "Requires Python 3.6",
+            "Requires Python 3.6 and ``py-version >= 3.6``.",
         ),
     }
 

--- a/pylint/config/option.py
+++ b/pylint/config/option.py
@@ -68,7 +68,9 @@ def _py_version_validator(_, name, value):
         try:
             value = tuple(int(val) for val in value.split("."))
         except (ValueError, AttributeError):
-            raise optparse.OptionValueError(f"Invalid format for {name}") from None
+            raise optparse.OptionValueError(
+                f"Invalid format for {name}, should be version string. E.g., '3.8'"
+            ) from None
     return value
 
 

--- a/pylint/extensions/code_style.py
+++ b/pylint/extensions/code_style.py
@@ -53,7 +53,7 @@ class CodeStyleChecker(BaseChecker):
             "consider-using-assignment-expr",
             "Emitted when an if assignment is directly followed by an if statement and "
             "both can be combined by using an assignment expression ``:=``. "
-            "Requires Python 3.8",
+            "Requires Python 3.8 and ``py-version >= 3.8``.",
         ),
     }
     options = (

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -311,7 +311,7 @@ def _comment(string):
 def _format_option_value(optdict, value):
     """return the user input's value from a 'compiled' value"""
     if optdict.get("type", None) == "py_version":
-        value = ".".join(str(item) for item in value)
+        value = "current Python interpreter version (e.g., '3.8')"
     elif isinstance(value, (list, tuple)):
         value = ",".join(_format_option_value(optdict, item) for item in value)
     elif isinstance(value, dict):

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -131,7 +131,7 @@ def get_rst_section(section, options, doc=None):
         if help_opt:
             formatted_help = normalize_text(help_opt, indent="  ")
             result += f"{formatted_help}\n"
-        if value:
+        if value and optname != "py-version":
             value = str(_format_option_value(optdict, value))
             result += f"\n  Default: ``{value.replace('`` ', '```` ``')}``\n"
     return result
@@ -311,7 +311,7 @@ def _comment(string):
 def _format_option_value(optdict, value):
     """return the user input's value from a 'compiled' value"""
     if optdict.get("type", None) == "py_version":
-        value = "current Python interpreter version (e.g., '3.8')"
+        value = ".".join(str(item) for item in value)
     elif isinstance(value, (list, tuple)):
         value = ",".join(_format_option_value(optdict, item) for item in value)
     elif isinstance(value, dict):


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Followup to review comments here: https://github.com/PyCQA/pylint/pull/5024#discussion_r710739423
Partially addresses #5038

/CC: @Pierre-Sassoulas @scop

#### Changes
* Add `py-version` requirement to checker documentation
* Improve default value documentation for `py-version` (see image below)
* Improve option parser error message for `py-version`

--
![Screen Shot 2021-09-23 at 15 43 46](https://user-images.githubusercontent.com/30130371/134518164-a26ef7a8-91d5-416f-b333-4b6d8ec7f783.png)
https://pylint--5069.org.readthedocs.build/en/5069/technical_reference/features.html