### PR TITLE
Add ``no-implicit-optional`` flag to ``mypy``

### DIFF
--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -51,7 +51,7 @@ import copy
 import os
 import sys
 from distutils import sysconfig
-from typing import Any, Dict, List, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import astroid
 from astroid import nodes
@@ -424,7 +424,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
     )
 
     def __init__(
-        self, linter: PyLinter = None
+        self, linter: Optional[PyLinter] = None
     ):  # pylint: disable=super-init-not-called # See https://github.com/PyCQA/pylint/issues/4941
         BaseChecker.__init__(self, linter)
         self.stats: CheckerStats = {}

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -39,7 +39,7 @@
 
 import sys
 from collections.abc import Iterable
-from typing import Any, Dict, Set
+from typing import Any, Dict, Optional, Set
 
 import astroid
 from astroid import nodes
@@ -447,7 +447,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
     }
 
     def __init__(
-        self, linter: PyLinter = None
+        self, linter: Optional[PyLinter] = None
     ):  # pylint: disable=super-init-not-called # See https://github.com/PyCQA/pylint/issues/4941
         BaseChecker.__init__(self, linter)
         self._deprecated_methods: Set[Any] = set()

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -674,7 +674,7 @@ def is_attr_private(attrname: str) -> Optional[Match[str]]:
 
 
 def get_argument_from_call(
-    call_node: nodes.Call, position: int = None, keyword: str = None
+    call_node: nodes.Call, position: Optional[int] = None, keyword: Optional[str] = None
 ) -> nodes.Name:
     """Returns the specified argument from a function call.
 

--- a/pylint/graph.py
+++ b/pylint/graph.py
@@ -26,6 +26,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from typing import Optional
 
 
 def target_info_from_filename(filename):
@@ -82,7 +83,9 @@ class DotBackend:
 
     source = property(get_source)
 
-    def generate(self, outputfile: str = None, mapfile: str = None) -> str:
+    def generate(
+        self, outputfile: Optional[str] = None, mapfile: Optional[str] = None
+    ) -> str:
         """Generates a graph file.
 
         :param str outputfile: filename and path [defaults to graphname.png]

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -20,7 +20,7 @@ class MessageDefinition:
         scope: str,
         minversion: Optional[Tuple[int, int]] = None,
         maxversion: Optional[Tuple[int, int]] = None,
-        old_names: List[Tuple[str, str]] = None,
+        old_names: Optional[List[Tuple[str, str]]] = None,
     ):
         self.checker_name = checker.name
         self.check_msgid(msgid)

--- a/pylint/message/message_handler_mix_in.py
+++ b/pylint/message/message_handler_mix_in.py
@@ -74,7 +74,7 @@ class MessagesHandlerMixIn:
         self,
         msgid: str,
         scope: str = "package",
-        line: Union[bool, int] = None,
+        line: Union[bool, int, None] = None,
         ignore_unknown: bool = False,
     ):
         if not line:

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,6 +83,7 @@ skip_glob = tests/functional/**,tests/input/**,tests/extensions/data/**,tests/re
 src_paths = pylint
 
 [mypy]
+no_implicit_optional = True
 scripts_are_modules = True
 warn_unused_ignores = True
 

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -141,7 +141,7 @@ class TestRunTC:
         args: List[str],
         reporter: Any = None,
         out: Optional[StringIO] = None,
-        code: int = None,
+        code: Optional[int] = None,
     ) -> None:
         if out is None:
             out = StringIO()


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

After the recent typing and refactoring work I think it will be good to add some additional flags to `mypy` to prevent future typing issues.
This is one of those which can be turned on already without much changes to the code.