### PR TITLE
Remove ``pytest`` marks in test_regr

### DIFF
--- a/tests/test_regr.py
+++ b/tests/test_regr.py
@@ -155,8 +155,6 @@ def timeout(timeout_s: float):
     signal.signal(signal.SIGALRM, signal.SIG_DFL)
 
 
-@pytest.mark.slow
-@pytest.mark.serial
 @pytest.mark.skipif(not hasattr(signal, "setitimer"), reason="Assumes POSIX signals")
 @pytest.mark.parametrize(
     "fname,timeout_s",


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Description

Tests introduced in #5062 actually raise `pytest` warnings. They had two marks which were not specified.
I did not know about this, but looking at [documentation](https://docs.pytest.org/en/stable/mark.html), marks can be used to group or drop certain types of tests.
We don't really use those and have not specified the `slow` or `serial` mark. Furthermore, the `slow` mark is incorrect as this test is not inherently slow but only should fail if it is slow. Thus, if we want to keep the mark I think we should change this.
I suggest removing them as they don't seem to serve a particular goal.

/CC @nelfin, @Pierre-Sassoulas 

Errors:
```bash
tests/test_regr.py:158
  /Users/daniel/DocumentenLaptop/Programming/Github/pylint/tests/test_regr.py:158: PytestUnknownMarkWarning: Unknown pytest.mark.slow - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
    @pytest.mark.slow

tests/test_regr.py:159
  /Users/daniel/DocumentenLaptop/Programming/Github/pylint/tests/test_regr.py:159: PytestUnknownMarkWarning: Unknown pytest.mark.serial - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
    @pytest.mark.serial
```