### PR TITLE
Fix ``invalid-name`` for overwritten base ``object`` methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -47,6 +47,10 @@ Release date: TBA
 
   Closes #5066
 
+* Fixed ``invalid-name`` not checking parameters of overwritten base ``object`` methods
+
+  Closes #3614
+
 
 What's New in Pylint 2.11.1?
 ============================

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -456,8 +456,11 @@ def assign_parent(node: nodes.NodeNG) -> nodes.NodeNG:
 
 
 def overrides_a_method(class_node: nodes.ClassDef, name: str) -> bool:
-    """return True if <name> is a method overridden from an ancestor"""
+    """return True if <name> is a method overridden from an ancestor
+    which is not the base object class"""
     for ancestor in class_node.ancestors():
+        if ancestor.name == "object":
+            continue
         if name in ancestor and isinstance(ancestor[name], nodes.FunctionDef):
             return True
     return False

--- a/tests/functional/i/invalid/invalid_name.py
+++ b/tests/functional/i/invalid/invalid_name.py
@@ -1,5 +1,7 @@
 """ Tests for invalid-name checker. """
-# pylint: disable=unused-import,  wrong-import-position,import-outside-toplevel
+# pylint: disable=unused-import, wrong-import-position, import-outside-toplevel, missing-class-docstring
+# pylint: disable=too-few-public-methods
+
 
 AAA = 24
 try:
@@ -67,3 +69,8 @@ def a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad():  # Shoul
     print('LOL')
 
 a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad()
+
+
+class FooBar:
+    def __init__(self, fooBar) -> None: # [invalid-name]
+        self.foo_bar = fooBar

--- a/tests/functional/i/invalid/invalid_name.txt
+++ b/tests/functional/i/invalid/invalid_name.txt
@@ -1,5 +1,6 @@
-invalid-name:10:0::"Constant name ""aaa"" doesn't conform to UPPER_CASE naming style"
-invalid-name:14:4::"Constant name ""time"" doesn't conform to UPPER_CASE naming style"
-invalid-name:30:0:a:"Function name ""a"" doesn't conform to snake_case naming style"
-invalid-name:44:4::"Constant name ""Foocapfor"" doesn't conform to UPPER_CASE naming style"
-invalid-name:61:0:a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad:"Function name ""a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad"" doesn't conform to snake_case naming style"
+invalid-name:12:0::"Constant name ""aaa"" doesn't conform to UPPER_CASE naming style":HIGH
+invalid-name:16:4::"Constant name ""time"" doesn't conform to UPPER_CASE naming style":HIGH
+invalid-name:32:0:a:"Function name ""a"" doesn't conform to snake_case naming style":HIGH
+invalid-name:46:4::"Constant name ""Foocapfor"" doesn't conform to UPPER_CASE naming style":HIGH
+invalid-name:63:0:a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad:"Function name ""a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad"" doesn't conform to snake_case naming style":HIGH
+invalid-name:75:4:FooBar.__init__:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`overrides_a_method()` was a little too strict for the `invalid-name` checker as it filtered out overwritten methods of the base `object` class. Therefore, `__init__` would never be checked.

This `utils` function is only used twice, the other instance being here:
https://github.com/PyCQA/pylint/blob/5e24aaa4dde2e3f06027cd0e18fabd96e408f519/pylint/checkers/classes.py#L1409-L1434

Based on the fact that the tests pass and the message that is being checked there I think it is safe to say that excluding overwriting `object` methods is also fine there.

Closes #3614