### PR TITLE
Fix empty ``no_docstring_rgx`` not working correctly

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -57,6 +57,10 @@ Release date: TBA
 
 * Fixed regex options not correctly converting to regex patterns
 
+* Fixed empty ``no_docstring_rgx`` option not being checked correctly
+
+   Closes #4136
+
 
 What's New in Pylint 2.11.1?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -55,6 +55,8 @@ Release date: TBA
 
   Closes #3614
 
+* Fixed regex options not correctly converting to regex patterns
+
 
 What's New in Pylint 2.11.1?
 ============================

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -218,7 +218,7 @@ class DocstringParameterChecker(BaseChecker):
 
         # skip functions that match the 'no-docstring-rgx' config option
         no_docstring_rgx = get_global_option(self, "no-docstring-rgx")
-        if no_docstring_rgx and re.match(no_docstring_rgx, node.name):
+        if no_docstring_rgx.pattern and re.match(no_docstring_rgx, node.name):
             return
 
         # skip functions smaller than 'docstring-min-length'

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -2342,6 +2342,51 @@ class TestParamDocChecker(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
+    @set_config(no_docstring_rgx="")
+    def test_skip_empty_docstring_rgx(self) -> None:
+        """Example of a function that matches an empty 'no-docstring-rgx' config option
+
+        No error message is emitted.
+        """
+        node = astroid.extract_node(
+            """
+        #pylint disable=missing-module-docstring, too-few-public-methods,
+
+        class MyClass:
+            def __init__(self, my_param: int) -> None:
+                '''
+                My init docstring
+                :param my_param: My first param
+                '''
+        """
+        )
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node.body[0])
+
+    @set_config(no_docstring_rgx="")
+    def test_fail_empty_docstring_rgx(self) -> None:
+        """Example of a function that matches an empty 'no-docstring-rgx' config option
+
+        An error message is emitted.
+        """
+        node = astroid.extract_node(
+            """
+        #pylint disable=missing-module-docstring, too-few-public-methods,
+
+        class MyClass:
+            def __init__(self, my_param: int) -> None:
+                '''
+                My init docstring
+                '''
+        """
+        )
+        with self.assertAddsMessages(
+            MessageTest(
+                msg_id="missing-param-doc", node=node.body[0], args=("my_param",)
+            ),
+        ):
+            self.checker.visit_functiondef(node.body[0])
+
     @set_config(docstring_min_length=3)
     def test_skip_docstring_min_length(self) -> None:
         """Example of a function that is less than 'docstring-min-length' config option


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Description

Turns out we did not handle empty regex options correctly. The referenced issue was broken because whenever the `no_docstring_rgx` option was empty it would try to match `re.compile("")` which always matched and would thus never check a parameter.

The change to `get_global_option()` is necessary for it to actually return a `Pattern[str]` for those options. A problem I couldn't solve was that it is impossible (I think) to tell `mypy` that the option belongs to `GLOBAL_OPTION_PATTERN` and should therefore return a `Pattern[str]`. This is because you can't use `isinstance` on `Literal` and there is no good solution to do this any other way (using `cast` also doesn't work).

/CC @cdce8p Because you helped with #4978 and might have a solution for the `mypy` issue that I don't know about 😄 

Closes #4136