### PR TITLE
Make test decorator use ``checker.set_option()``

### DIFF
--- a/pylint/testutils/decorator.py
+++ b/pylint/testutils/decorator.py
@@ -2,12 +2,50 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import functools
+import optparse  # pylint: disable=deprecated-module
 
+from pylint.lint import PyLinter
 from pylint.testutils.checker_test_case import CheckerTestCase
 
 
 def set_config(**kwargs):
     """Decorator for setting config values on a checker.
+
+    Passing the args and kwargs back to the test function itself
+    allows this decorator to be used on parametrized test cases.
+    """
+
+    def _wrapper(fun):
+        @functools.wraps(fun)
+        def _forward(self, *args, **test_function_kwargs):
+            try:
+                for key, value in kwargs.items():
+                    self.checker.set_option(key.replace("_", "-"), value)
+            except optparse.OptionError:
+                # Check if option is one of the base options of the PyLinter class
+                for key, value in kwargs.items():
+                    self.checker.set_option(
+                        key.replace("_", "-"),
+                        value,
+                        optdict=dict(PyLinter.make_options()),
+                    )
+            if isinstance(self, CheckerTestCase):
+                # reopen checker in case, it may be interested in configuration change
+                self.checker.open()
+            fun(self, *args, **test_function_kwargs)
+
+        return _forward
+
+    return _wrapper
+
+
+def set_config_directly(**kwargs):
+    """Decorator for setting config values on a checker without validation.
+
+    Some options should be declared in two different checkers. This is
+    impossible without duplicating the option key. For example:
+    "no-docstring-rgx" in DocstringParameterChecker & DocStringChecker
+    This decorator allows to directly set such options.
 
     Passing the args and kwargs back to the test function itself
     allows this decorator to be used on parametrized test cases.

--- a/pylintrc
+++ b/pylintrc
@@ -27,6 +27,10 @@ load-plugins=
 # Use multiple processes to speed up Pylint.
 jobs=1
 
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
@@ -272,7 +276,7 @@ ignore-mixin-members=yes
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis
+# and thus existing member attributes cannot be deduced by static analysis)
 ignored-modules=
 
 # List of classes names for which member attributes should not be checked

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -31,6 +31,7 @@ from astroid import nodes
 
 from pylint.extensions.docparams import DocstringParameterChecker
 from pylint.testutils import CheckerTestCase, MessageTest, set_config
+from pylint.testutils.decorator import set_config_directly
 
 
 class TestParamDocChecker(CheckerTestCase):
@@ -2324,7 +2325,7 @@ class TestParamDocChecker(CheckerTestCase):
         ):
             self.checker.visit_functiondef(node)
 
-    @set_config(no_docstring_rgx=r"^_(?!_).*$")
+    @set_config_directly(no_docstring_rgx=r"^_(?!_).*$")
     def test_skip_no_docstring_rgx(self) -> None:
         """Example of a function that matches the default 'no-docstring-rgx' config option
 
@@ -2342,7 +2343,7 @@ class TestParamDocChecker(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
-    @set_config(docstring_min_length=3)
+    @set_config_directly(docstring_min_length=3)
     def test_skip_docstring_min_length(self) -> None:
         """Example of a function that is less than 'docstring-min-length' config option
 


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

While working on #5084 I noticed our current unittests don't actually fully test the `set_option` behaviour and we are therefore not able to correctly test some settings.
We need to call `set_option` to make the settings pass the validators and actually set them like they would have been in normal circumstances.

After adding this I found that we are actually missing a lot of options in the `options` attributes of some of the checkers. `docparams` which is needed for #5084 is missing `no_docstring_rgx` for example. We would need to add those for this to fully work, but I think they shouldn't be missing anyway.

I would like to know if this assertion is correct as I can then start work on adding the missing settings to the checkers.