### PR TITLE
Fix empty regex options not converting to regex

### DIFF
--- a/pylint/config/option.py
+++ b/pylint/config/option.py
@@ -78,7 +78,7 @@ VALIDATORS = {
     "string": utils._unquote,
     "int": int,
     "float": float,
-    "regexp": re.compile,
+    "regexp": lambda pattern: re.compile(pattern or ""),
     "regexp_csv": _regexp_csv_validator,
     "csv": _csv_validator,
     "yn": _yn_validator,

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -65,7 +65,7 @@ GLOBAL_OPTION_NAMES = Union[
     GLOBAL_OPTION_TUPLE_INT,
 ]
 T_GlobalOptionReturnTypes = TypeVar(
-    "T_GlobalOptionReturnTypes", bool, int, List[str], Pattern, Tuple[int, ...]
+    "T_GlobalOptionReturnTypes", bool, int, List[str], Pattern[str], Tuple[int, ...]
 )
 
 
@@ -215,8 +215,8 @@ def get_global_option(
 def get_global_option(
     checker: "BaseChecker",
     option: GLOBAL_OPTION_PATTERN,
-    default: Optional[Pattern] = None,
-) -> Pattern:
+    default: Optional[Pattern[str]] = None,
+) -> Pattern[str]:
     ...
 
 

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -25,6 +25,8 @@ in particular the parameter documentation checker `DocstringChecker`
 
 # pylint: disable=too-many-public-methods
 
+import re
+
 import astroid
 import pytest
 from astroid import nodes
@@ -2325,7 +2327,7 @@ class TestParamDocChecker(CheckerTestCase):
         ):
             self.checker.visit_functiondef(node)
 
-    @set_config_directly(no_docstring_rgx=r"^_(?!_).*$")
+    @set_config_directly(no_docstring_rgx=re.compile(r"^_(?!_).*$"))
     def test_skip_no_docstring_rgx(self) -> None:
         """Example of a function that matches the default 'no-docstring-rgx' config option
 


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Whenever a regex option is `None` we do not correctly convert those to patterns.
This also add additional typing and fixes a related issue with one of the tests.

Let me know if you would rather have this be 3 separate commits. It is a bit of a weird collection of `regex option` related stuff.
