### PR TITLE
Improve node info for invalid-name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -62,6 +62,8 @@ Release date: TBA
 
   Closes #5111
 
+* Improve node information for ``invalid-name`` on function argument.
+
 
 What's New in Pylint 2.11.1?
 ============================

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1957,7 +1957,7 @@ class NameChecker(_BasicChecker):
         # Check argument names
         args = node.args.args
         if args is not None:
-            self._recursive_check_names(args, node)
+            self._recursive_check_names(args)
 
     visit_asyncfunctiondef = visit_functiondef
 
@@ -2008,13 +2008,13 @@ class NameChecker(_BasicChecker):
                 else:
                     self._check_name("class_attribute", node.name, node)
 
-    def _recursive_check_names(self, args, node):
+    def _recursive_check_names(self, args):
         """check names in a possibly recursive list <arg>"""
         for arg in args:
             if isinstance(arg, nodes.AssignName):
-                self._check_name("argument", arg.name, node)
+                self._check_name("argument", arg.name, arg)
             else:
-                self._recursive_check_names(arg.elts, node)
+                self._recursive_check_names(arg.elts)
 
     def _find_name_group(self, node_type):
         return self._name_group.get(node_type, node_type)

--- a/tests/functional/i/invalid/invalid_name.py
+++ b/tests/functional/i/invalid/invalid_name.py
@@ -74,6 +74,7 @@ a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad()
 class FooBar:
     def __init__(self, fooBar) -> None:  # [invalid-name]
         self.foo_bar = fooBar
+        self.foo_bar2 = None
 
     def func1(
         self,
@@ -93,3 +94,12 @@ class FooBar:
 
     def test_disable3(self, fooBar):  # pylint: disable=invalid-name
         self.foo_bar = fooBar
+
+    def test_disable_mixed(
+        self,
+        fooBar,  # pylint: disable=invalid-name
+        fooBar2,  # [invalid-name]
+    ):
+        """Invalid-name will still be raised for other arguments."""
+        self.foo_bar = fooBar
+        self.foo_bar2 = fooBar2

--- a/tests/functional/i/invalid/invalid_name.py
+++ b/tests/functional/i/invalid/invalid_name.py
@@ -1,5 +1,5 @@
 """ Tests for invalid-name checker. """
-# pylint: disable=unused-import, wrong-import-position, import-outside-toplevel, missing-class-docstring
+# pylint: disable=unused-import, wrong-import-position, import-outside-toplevel, missing-class-docstring,missing-function-docstring
 # pylint: disable=too-few-public-methods
 
 
@@ -72,5 +72,24 @@ a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad()
 
 
 class FooBar:
-    def __init__(self, fooBar) -> None: # [invalid-name]
+    def __init__(self, fooBar) -> None:  # [invalid-name]
+        self.foo_bar = fooBar
+
+    def func1(
+        self,
+        fooBar,  # [invalid-name]
+    ):
+        self.foo_bar = fooBar
+
+    # Test disable invalid-name
+    def test_disable1(self, fooBar):  # pylint: disable=invalid-name
+        self.foo_bar = fooBar
+
+    def test_disable2(
+        self,
+        fooBar,  # pylint: disable=invalid-name
+    ):
+        self.foo_bar = fooBar
+
+    def test_disable3(self, fooBar):  # pylint: disable=invalid-name
         self.foo_bar = fooBar

--- a/tests/functional/i/invalid/invalid_name.txt
+++ b/tests/functional/i/invalid/invalid_name.txt
@@ -4,4 +4,5 @@ invalid-name:32:0:a:"Function name ""a"" doesn't conform to snake_case naming st
 invalid-name:46:4::"Constant name ""Foocapfor"" doesn't conform to UPPER_CASE naming style":HIGH
 invalid-name:63:0:a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad:"Function name ""a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad"" doesn't conform to snake_case naming style":HIGH
 invalid-name:75:23:FooBar.__init__:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
-invalid-name:80:8:FooBar.func1:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
+invalid-name:81:8:FooBar.func1:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
+invalid-name:101:8:FooBar.test_disable_mixed:"Argument name ""fooBar2"" doesn't conform to snake_case naming style":HIGH

--- a/tests/functional/i/invalid/invalid_name.txt
+++ b/tests/functional/i/invalid/invalid_name.txt
@@ -3,4 +3,5 @@ invalid-name:16:4::"Constant name ""time"" doesn't conform to UPPER_CASE naming 
 invalid-name:32:0:a:"Function name ""a"" doesn't conform to snake_case naming style":HIGH
 invalid-name:46:4::"Constant name ""Foocapfor"" doesn't conform to UPPER_CASE naming style":HIGH
 invalid-name:63:0:a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad:"Function name ""a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad"" doesn't conform to snake_case naming style":HIGH
-invalid-name:75:4:FooBar.__init__:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
+invalid-name:75:23:FooBar.__init__:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
+invalid-name:80:8:FooBar.func1:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH

--- a/tests/functional/n/name/name_styles.txt
+++ b/tests/functional/n/name/name_styles.txt
@@ -1,7 +1,7 @@
 invalid-name:11:0::"Constant name ""bad_const_name"" doesn't conform to UPPER_CASE naming style"
 invalid-name:14:0:BADFUNCTION_name:"Function name ""BADFUNCTION_name"" doesn't conform to snake_case naming style"
 invalid-name:16:4:BADFUNCTION_name:"Variable name ""BAD_LOCAL_VAR"" doesn't conform to snake_case naming style"
-invalid-name:20:0:func_bad_argname:"Argument name ""NOT_GOOD"" doesn't conform to snake_case naming style"
+invalid-name:20:21:func_bad_argname:"Argument name ""NOT_GOOD"" doesn't conform to snake_case naming style"
 invalid-name:30:0:bad_class_name:"Class name ""bad_class_name"" doesn't conform to PascalCase naming style"
 invalid-name:41:8:CorrectClassName.__init__:"Attribute name ""_Bad_AtTR_name"" doesn't conform to snake_case naming style"
 invalid-name:42:8:CorrectClassName.__init__:"Attribute name ""Bad_PUBLIC_name"" doesn't conform to snake_case naming style"


### PR DESCRIPTION
## Description

At the moment `invalid-name` for a function argument is emitted on the `function` node. That does work, however it limits where `pylint: disable` can be set. Consider the following example:
```py
class SomeClass:
    def func(
        self,
        var,
        invalidName,
    ):
        pass
```

Only `invalidName` is wrong. With this change it's now possible to add `pylint: disable` directly behind it instead of after `def func`.

This appears to be fully backwards compatible. I.e. both with disable `invalid-name`:
```py
# old
class SomeClass:
    def func(  # pylint: disable=invalid-name
        self,
        var,
        invalidName,
    ):
        pass

# new
class SomeClass:
    def func(
        self,
        var,
        invalidName,  # pylint: disable=invalid-name
    ):
        pass
```