### PR TITLE
Move ``merge_stats`` to ``checkerstats.py``

### DIFF
--- a/pylint/utils/__init__.py
+++ b/pylint/utils/__init__.py
@@ -44,6 +44,7 @@ main pylint class
 """
 
 from pylint.utils.ast_walker import ASTWalker
+from pylint.utils.checkerstats import merge_stats
 from pylint.utils.file_state import FileState
 from pylint.utils.utils import (
     HAS_ISORT_5,
@@ -83,4 +84,5 @@ __all__ = [
     "normalize_text",
     "register_plugins",
     "tokenize_module",
+    "merge_stats",
 ]

--- a/pylint/utils/checkerstats.py
+++ b/pylint/utils/checkerstats.py
@@ -1,0 +1,30 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+
+import collections
+from typing import TYPE_CHECKING, Dict, List, Union
+
+from pylint.typing import CheckerStats
+
+if TYPE_CHECKING:
+    from typing import Counter  # typing.Counter added in Python 3.6.1
+
+
+def merge_stats(stats: List[CheckerStats]):
+    """Used to merge two stats objects into a new one when pylint is run in parallel mode"""
+    merged: CheckerStats = {}
+    by_msg: "Counter[str]" = collections.Counter()
+    for stat in stats:
+        message_stats: Union["Counter[str]", Dict] = stat.pop("by_msg", {})  # type: ignore
+        by_msg.update(message_stats)
+
+        for key, item in stat.items():
+            if key not in merged:
+                merged[key] = item
+            elif isinstance(item, dict):
+                merged[key].update(item)  # type: ignore
+            else:
+                merged[key] = merged[key] + item  # type: ignore
+
+    merged["by_msg"] = by_msg
+    return merged


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

In anticipation of #5074 this moves the `merge_stats` function into the `checkerstats` namespace.