### PR TITLE
Add basic typing to ``pylint/message``

### DIFF
--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -2,17 +2,20 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import sys
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from pylint.constants import MSG_TYPES
 from pylint.exceptions import InvalidMessageError
 from pylint.utils import normalize_text
 
+if TYPE_CHECKING:
+    from pylint.checkers import BaseChecker
+
 
 class MessageDefinition:
     def __init__(
         self,
-        checker,  # BaseChecker
+        checker: "BaseChecker",
         msgid: str,
         msg: str,
         description: str,
@@ -21,7 +24,7 @@ class MessageDefinition:
         minversion: Optional[Tuple[int, int]] = None,
         maxversion: Optional[Tuple[int, int]] = None,
         old_names: Optional[List[Tuple[str, str]]] = None,
-    ):
+    ) -> None:
         self.checker_name = checker.name
         self.check_msgid(msgid)
         self.msgid = msgid
@@ -46,10 +49,10 @@ class MessageDefinition:
         if msgid[0] not in MSG_TYPES:
             raise InvalidMessageError(f"Bad message type {msgid[0]} in {msgid!r}")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"MessageDefinition:{self.symbol} ({self.msgid})"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{repr(self)}:\n{self.msg} {self.description}"
 
     def may_be_emitted(self) -> bool:

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -2,11 +2,14 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import collections
-from typing import Dict, List, Tuple, ValuesView
+from typing import TYPE_CHECKING, Dict, List, Tuple, ValuesView
 
 from pylint.exceptions import UnknownMessageError
 from pylint.message.message_definition import MessageDefinition
 from pylint.message.message_id_store import MessageIdStore
+
+if TYPE_CHECKING:
+    from pylint.checkers import BaseChecker
 
 
 class MessageDefinitionStore:
@@ -15,7 +18,7 @@ class MessageDefinitionStore:
     no particular state during analysis.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.message_id_store: MessageIdStore = MessageIdStore()
         # Primary registry for all active messages definitions.
         # It contains the 1:1 mapping from msgid to MessageDefinition.
@@ -29,7 +32,7 @@ class MessageDefinitionStore:
         """The list of all active messages."""
         return self._messages_definitions.values()
 
-    def register_messages_from_checker(self, checker) -> None:
+    def register_messages_from_checker(self, checker: "BaseChecker") -> None:
         """Register all messages definitions from a checker."""
         checker.check_consistency()
         for message in checker.messages:

--- a/pylint/message/message_id_store.py
+++ b/pylint/message/message_id_store.py
@@ -1,23 +1,29 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+import sys
 from typing import Dict, List, Optional, Tuple
 
 from pylint.exceptions import InvalidMessageError, UnknownMessageError
+
+if sys.version_info >= (3, 6, 2):
+    from typing import NoReturn
+else:
+    from typing_extensions import NoReturn
 
 
 class MessageIdStore:
 
     """The MessageIdStore store MessageId and make sure that there is a 1-1 relation between msgid and symbol."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.__msgid_to_symbol: Dict[str, str] = {}
         self.__symbol_to_msgid: Dict[str, str] = {}
         self.__old_names: Dict[str, List[str]] = {}
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.__msgid_to_symbol)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         result = "MessageIdStore: [\n"
         for msgid, symbol in self.__msgid_to_symbol.items():
             result += f"  - {msgid} ({symbol})\n"
@@ -40,7 +46,7 @@ class MessageIdStore:
 
     def register_message_definition(
         self, msgid: str, symbol: str, old_names: List[Tuple[str, str]]
-    ):
+    ) -> None:
         self.check_msgid_and_symbol(msgid, symbol)
         self.add_msgid_and_symbol(msgid, symbol)
         for old_msgid, old_symbol in old_names:
@@ -81,7 +87,7 @@ class MessageIdStore:
             self._raise_duplicate_symbol(msgid, symbol, existing_symbol)
 
     @staticmethod
-    def _raise_duplicate_symbol(msgid: str, symbol: str, other_symbol: str):
+    def _raise_duplicate_symbol(msgid: str, symbol: str, other_symbol: str) -> NoReturn:
         """Raise an error when a symbol is duplicated."""
         symbols = [symbol, other_symbol]
         symbols.sort()
@@ -90,7 +96,7 @@ class MessageIdStore:
         raise InvalidMessageError(error_message)
 
     @staticmethod
-    def _raise_duplicate_msgid(symbol: str, msgid: str, other_msgid: str) -> None:
+    def _raise_duplicate_msgid(symbol: str, msgid: str, other_msgid: str) -> NoReturn:
         """Raise an error when a msgid is duplicated."""
         msgids = [msgid, other_msgid]
         msgids.sort()


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Ref https://github.com/PyCQA/pylint/issues/2079#issuecomment-928907726
This allows ticking of `pylint/message/message_definition.py`, `pylint/message/message_definition_store.py` and `pylint/message/message_id_store.py` from the list.