### PR TITLE
Add basic typing to ``pylint/pyreverse``

### DIFF
--- a/pylint/pyreverse/dot_printer.py
+++ b/pylint/pyreverse/dot_printer.py
@@ -28,7 +28,7 @@ SHAPES: Dict[NodeType, str] = {
     NodeType.INTERFACE: "record",
     NodeType.CLASS: "record",
 }
-ARROWS: Dict[EdgeType, Dict] = {
+ARROWS: Dict[EdgeType, Dict[str, str]] = {
     EdgeType.INHERITS: dict(arrowtail="none", arrowhead="empty"),
     EdgeType.IMPLEMENTS: dict(arrowtail="node", arrowhead="empty", style="dashed"),
     EdgeType.ASSOCIATION: dict(

--- a/pylint/pyreverse/printer.py
+++ b/pylint/pyreverse/printer.py
@@ -54,7 +54,7 @@ class Printer(ABC):
         title: str,
         layout: Optional[Layout] = None,
         use_automatic_namespace: Optional[bool] = None,
-    ):
+    ) -> None:
         self.title: str = title
         self.layout = layout
         self.use_automatic_namespace = use_automatic_namespace
@@ -62,11 +62,11 @@ class Printer(ABC):
         self._indent = ""
         self._open_graph()
 
-    def _inc_indent(self):
+    def _inc_indent(self) -> None:
         """increment indentation"""
         self._indent += "  "
 
-    def _dec_indent(self):
+    def _dec_indent(self) -> None:
         """decrement indentation"""
         self._indent = self._indent[:-2]
 

--- a/pylint/pyreverse/printer_factory.py
+++ b/pylint/pyreverse/printer_factory.py
@@ -3,14 +3,14 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
-from typing import Type
+from typing import Dict, Type
 
 from pylint.pyreverse.dot_printer import DotPrinter
 from pylint.pyreverse.plantuml_printer import PlantUmlPrinter
 from pylint.pyreverse.printer import Printer
 from pylint.pyreverse.vcg_printer import VCGPrinter
 
-filetype_to_printer = {
+filetype_to_printer: Dict[str, Type[Printer]] = {
     "vcg": VCGPrinter,
     "plantuml": PlantUmlPrinter,
     "puml": PlantUmlPrinter,


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Ref #2079 (comment)
This allows ticking of `pylint/pyreverse/dot_printer.py`, `pylint/pyreverse/printer.py` and `pylint/pyreverse/printer_factory.py` from the list.