### PR TITLE
Fix a crash if ``str.format`` is referenced without being called

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -546,3 +546,5 @@ contributors:
 
 * Jeroen Seegers (jeroenseegers): contributor
   - Fixed `toml` dependency issue
+
+* Tim Martin: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -55,6 +55,10 @@ Release date: TBA
 
   Closes #3614
 
+* Fixed crash in ``consider-using-f-string`` if ``format`` is not called
+
+  Closes #5058
+
 
 What's New in Pylint 2.11.1?
 ============================

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -341,8 +341,8 @@ class RecommendationChecker(checkers.BaseChecker):
             isinstance(node.parent, nodes.Attribute)
             and node.parent.attrname == "format"
         ):
-            # Allow assigning .format to a variable
-            if isinstance(node.parent.parent, nodes.Assign):
+            # Don't warn on referencing / assigning .format without calling it
+            if not isinstance(node.parent.parent, nodes.Call):
                 return
 
             if node.parent.parent.args:

--- a/tests/functional/c/consider/consider_using_f_string.py
+++ b/tests/functional/c/consider/consider_using_f_string.py
@@ -116,3 +116,11 @@ def assignment_bad():
     h = "String %s" % (PARAM_1)  # [consider-using-f-string]
     i = "String %s %s" % (PARAM_1, PARAM_2)  # [consider-using-f-string]
     j = "String %s" % (PARAM_LIST_SINGLE)  # [consider-using-f-string]
+
+
+def regression_tests():
+    # Referencing .format in a kwarg should not be warned
+    def wrap_print(value):
+        print(value)
+
+    wrap_print(value="{}".format)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

If the `str.format` function was being referenced (not called) in the keyword argument to a function, the `consider-using-f-string` checker was crashing due to attempting to obtain the `.args` from something that wasn't a call object. Referencing format without calling it in this way might be a mistake, but that should probably be another checker.

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #5058
