### PR TITLE
Improve and flatten ``unused-wildcard-import`` message

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,9 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.12.rst'
 
+* Improve and flatten ``unused-wildcard-import`` message
+
+  Closes #3859
 
 
 What's New in Pylint 2.11.2?

--- a/doc/whatsnew/2.12.rst
+++ b/doc/whatsnew/2.12.rst
@@ -23,3 +23,7 @@ Extensions
 
 Other Changes
 =============
+
+* Improve and flatten ``unused-wildcard-import`` message
+
+  Closes #3859

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -60,6 +60,7 @@ import itertools
 import os
 import re
 from functools import lru_cache
+from typing import DefaultDict, List, Tuple
 
 import astroid
 from astroid import nodes
@@ -449,7 +450,7 @@ MSGS = {
         "Used when a function or method argument is not used.",
     ),
     "W0614": (
-        "Unused import %s from wildcard import",
+        "Unused import(s) %s from wildcard import of %s",
         "unused-wildcard-import",
         "Used when an imported module or variable is not used from a "
         "`'from X import *'` style import.",
@@ -2079,6 +2080,9 @@ class VariablesChecker(BaseChecker):
     def _check_imports(self, not_consumed):
         local_names = _fix_dot_imports(not_consumed)
         checked = set()
+        unused_wildcard_imports: DefaultDict[
+            Tuple[str, nodes.ImportFrom], List[str]
+        ] = collections.defaultdict(list)
         for name, stmt in local_names:
             for imports in stmt.names:
                 real_name = imported_name = imports[0]
@@ -2133,7 +2137,7 @@ class VariablesChecker(BaseChecker):
                         continue
 
                     if imported_name == "*":
-                        self.add_message("unused-wildcard-import", args=name, node=stmt)
+                        unused_wildcard_imports[(stmt.modname, stmt)].append(name)
                     else:
                         if as_name is None:
                             msg = f"{imported_name} imported from {stmt.modname}"
@@ -2141,6 +2145,18 @@ class VariablesChecker(BaseChecker):
                             msg = f"{imported_name} imported from {stmt.modname} as {as_name}"
                         if not _is_type_checking_import(stmt):
                             self.add_message("unused-import", args=msg, node=stmt)
+
+        # Construct string for unused-wildcard-import message
+        for module, unused_list in unused_wildcard_imports.items():
+            if len(unused_list) == 1:
+                arg_string = unused_list[0]
+            else:
+                arg_string = (
+                    f"{', '.join(i for i in unused_list[:-1])} and {unused_list[-1]}"
+                )
+            self.add_message(
+                "unused-wildcard-import", args=(arg_string, module[0]), node=module[1]
+            )
         del self._to_consume
 
     def _check_metaclasses(self, node):

--- a/tests/functional/u/unused/unused_name_from_wilcard_import.py
+++ b/tests/functional/u/unused/unused_name_from_wilcard_import.py
@@ -1,3 +1,5 @@
 """check unused import from a wildcard import"""
 # pylint: disable=line-too-long
 from .unused_argument_py3 import *  # [unused-wildcard-import, wildcard-import]
+from .unused_global_variable1 import * # [unused-wildcard-import, wildcard-import]
+from .unused_import_py30 import * # [unused-wildcard-import, wildcard-import]

--- a/tests/functional/u/unused/unused_name_from_wilcard_import.py
+++ b/tests/functional/u/unused/unused_name_from_wilcard_import.py
@@ -1,3 +1,3 @@
 """check unused import from a wildcard import"""
 # pylint: disable=line-too-long
-from .unused_argument_py3 import *  # [unused-wildcard-import, unused-wildcard-import, wildcard-import]
+from .unused_argument_py3 import *  # [unused-wildcard-import, wildcard-import]

--- a/tests/functional/u/unused/unused_name_from_wilcard_import.txt
+++ b/tests/functional/u/unused/unused_name_from_wilcard_import.txt
@@ -1,2 +1,6 @@
 unused-wildcard-import:3:0::Unused import(s) func and only_raises from wildcard import of unused_argument_py3:HIGH
-wildcard-import:3:0::Wildcard import unused_argument_py3
+wildcard-import:3:0::Wildcard import unused_argument_py3:HIGH
+unused-wildcard-import:4:0::Unused import(s) VAR from wildcard import of unused_global_variable1:HIGH
+wildcard-import:4:0::Wildcard import unused_global_variable1:HIGH
+unused-wildcard-import:5:0::Unused import(s) abc, sys, Meta, Meta2, Meta3, ABCMeta and SomethingElse from wildcard import of unused_import_py30:HIGH
+wildcard-import:5:0::Wildcard import unused_import_py30:HIGH

--- a/tests/functional/u/unused/unused_name_from_wilcard_import.txt
+++ b/tests/functional/u/unused/unused_name_from_wilcard_import.txt
@@ -1,3 +1,2 @@
-unused-wildcard-import:3:0::Unused import func from wildcard import
-unused-wildcard-import:3:0::Unused import only_raises from wildcard import
+unused-wildcard-import:3:0::Unused import(s) func and only_raises from wildcard import of unused_argument_py3:HIGH
 wildcard-import:3:0::Wildcard import unused_argument_py3


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Instead of reporting all unused imports, the checker now emits one single message for all unused imports with a stylized string containing all imports.
This closes #3859