### PR TITLE
Fix crash with AssignAttr in TYPE_CHECKING blocks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -58,6 +58,10 @@ Release date: TBA
 
   Closes #3614
 
+* Fix crash with ``AssignAttr`` in ``if TYPE_CHECKING`` blocks.
+
+  Closes #5111
+
 
 What's New in Pylint 2.11.1?
 ============================

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1536,7 +1536,9 @@ class VariablesChecker(BaseChecker):
                     for definition in defstmt_parent.orelse:
                         if isinstance(definition, nodes.Assign):
                             defined_in_or_else = any(
-                                target.name == name for target in definition.targets
+                                target.name == name
+                                for target in definition.targets
+                                if isinstance(target, nodes.AssignName)
                             )
                             if defined_in_or_else:
                                 break

--- a/tests/functional/u/undefined/undefined_variable.py
+++ b/tests/functional/u/undefined/undefined_variable.py
@@ -328,3 +328,13 @@ def decorated3(x):
 @decorator(x * x * y for x in range(3))  # [undefined-variable]
 def decorated4(x):
     print(x)
+
+
+# https://github.com/PyCQA/pylint/issues/5111
+# AssignAttr in orelse block of 'TYPE_CHECKING' shouldn't crash
+# Name being assigned must be imported in orelse block
+if TYPE_CHECKING:
+    pass
+else:
+    from types import GenericAlias
+    object().__class_getitem__ = classmethod(GenericAlias)


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

```py
# AssignAttr in orelse block of 'TYPE_CHECKING' shouldn't crash
# Name being assigned must be imported in orelse block
if TYPE_CHECKING:
    pass
else:
    from types import GenericAlias
    object().__class_getitem__ = classmethod(GenericAlias)
```

Closes #5111
