### PR TITLE
Add guard helper functions from astroid

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -72,6 +72,9 @@ Release date: TBA
 
   Closes #4736
 
+* Add ``is_sys_guard`` and ``is_typing_guard`` helper functions from astroid
+  to ``pylint.checkers.utils``.
+
 
 What's New in Pylint 2.11.1?
 ============================

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -62,6 +62,7 @@ from pylint.checkers.utils import (
     get_import_name,
     is_from_fallback_block,
     is_node_in_guarded_import_block,
+    is_typing_guard,
     node_ignores_exception,
 )
 from pylint.exceptions import EmptyReportError
@@ -843,8 +844,8 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
         except ImportError:
             pass
 
-        in_type_checking_block = (
-            isinstance(node.parent, nodes.If) and node.parent.is_typing_guard()
+        in_type_checking_block = isinstance(node.parent, nodes.If) and is_typing_guard(
+            node.parent
         )
 
         if context_name == importedmodname:


### PR DESCRIPTION
## Description

Followup to the discussion here: https://github.com/PyCQA/pylint/pull/5107#discussion_r721744321

Add `is_typing_guard` and `is_sys_guard` helper functions to `pylint.checkers.utils`.

--
Deprecation astroid: https://github.com/PyCQA/astroid/pull/1202

/CC: @Pierre-Sassoulas @DanielNoord