### PR TITLE
Add Python 3.11-dev to Github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11-dev"]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
@@ -224,6 +224,40 @@ jobs:
         with:
           name: coverage-${{ matrix.python-version }}
           path: .coverage
+
+  pytest-linux-dev:
+    name: Run tests Python ${{ matrix.python-version }} (Linux)
+    runs-on: ubuntu-latest
+    needs: prepare-tests-linux
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11-dev"]
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.3.4
+      - name: Set up Python ${{ matrix.python-version }}
+        id: python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Restore Python virtual environment
+        id: cache-venv
+        uses: actions/cache@v2.1.6
+        with:
+          path: venv
+          key:
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            needs.prepare-tests-linux.outputs.python-key }}
+      - name: Fail job if Python cache restore failed
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore Python venv from cache"
+          exit 1
+      - name: Run pytest
+        run: |
+          . venv/bin/activate
+          pytest --benchmark-disable --cov --cov-report= tests/
 
   coverage:
     name: Process test coverage


### PR DESCRIPTION
## Description
The first alpha for Python 3.11 was released today: https://discuss.python.org/t/python-3-11-0a1-is-now-available/11014
This adds `3.11-dev` to the  `prepare-tests-linux` job and adds a new one `pytest-linx-dev`. The coverage upload shouldn't be blocked if the `3.11` job fails.

This is blocked util `3.11.0a1` is added here: https://github.com/actions/python-versions/releases