### PR TITLE
Remove calls to ``os.linesep`` and add misc. typing

### DIFF
--- a/pylint/reporters/ureports/base_writer.py
+++ b/pylint/reporters/ureports/base_writer.py
@@ -16,7 +16,6 @@
 A way to create simple reports using python objects, primarily designed to be
 formatted as text and html.
 """
-import os
 import sys
 from io import StringIO
 from typing import TYPE_CHECKING, Iterator, List, TextIO, Union
@@ -59,7 +58,7 @@ class BaseWriter:
 
     def writeln(self, string: str = "") -> None:
         """write a line in the output buffer"""
-        self.write(string + os.linesep)
+        self.write(string + "\n")
 
     def write(self, string: str) -> None:
         """write a string in the output buffer"""

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -302,10 +302,11 @@ def _check_csv(value):
     return _splitstrip(value)
 
 
-def _comment(string):
+def _comment(string: str) -> str:
     """return string as a comment"""
     lines = [line.strip() for line in string.splitlines()]
-    return "# " + f"{os.linesep}# ".join(lines)
+    sep = "\n"
+    return "# " + f"{sep}# ".join(lines)
 
 
 def _format_option_value(optdict, value):


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This removes all calls to `os.linesep`. As discussed in the `python` docs, it is not good practice to use this in text based output and the use of `\n` is preferred. See: [docs](https://docs.python.org/3/library/os.html#os.linesep)