### PR TITLE
Create new ``Argument`` class for options

### DIFF
--- a/pylint/config/__init__.py
+++ b/pylint/config/__init__.py
@@ -42,6 +42,7 @@ from datetime import datetime
 
 import platformdirs
 
+from pylint.config.argument_types import Argument, StoreArgument
 from pylint.config.configuration_mixin import ConfigurationMixIn
 from pylint.config.find_default_config_files import find_default_config_files
 from pylint.config.man_help_formatter import _ManHelpFormatter
@@ -60,6 +61,8 @@ __all__ = [
     "OptionParser",
     "OptionsProviderMixIn",
     "UnsupportedAction",
+    "StoreArgument",
+    "Argument",
 ]
 
 USER_HOME = os.path.expanduser("~")

--- a/pylint/config/argument_types.py
+++ b/pylint/config/argument_types.py
@@ -1,0 +1,66 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+import sys
+from typing import NamedTuple, Optional, Tuple, Union
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+
+class Argument(NamedTuple):
+    """Data about a argument to be parsed by argparse (or optparse until deprecation)
+    Follows structure of the parameters for argparse.ArgumentParser.add_argument
+    See https://docs.python.org/3/library/argparse.html#the-add-argument-method"""
+
+    name: Tuple[str, ...]
+    """Tuple of names or flags (i.e., -f or --foo)"""
+
+    action: str
+    """Action to do after"""
+
+    nargs: Optional[int]
+    """The number of command line arguments to capture"""
+
+    const: Optional[str]
+    """The const to store with certain types of actions"""
+
+    default: Union[str, int, bool, None]
+    """Default value"""
+
+    argument_type: str
+    """Name of validator"""
+
+    help_string: str
+    """Help message"""
+
+    metavar: str
+    """Metavar for help message"""
+
+
+class StoreArgument(Argument):
+    """Used to store a passed argument or default value"""
+
+    def __new__(
+        cls,
+        name: Tuple[str, ...],
+        action: Literal["store"],
+        nargs: Literal[1],
+        const: None,
+        default: Union[str, int, bool, None],
+        argument_type: Literal["yn"],
+        help_string: str,
+        metavar: Literal["<y_or_n>"],
+    ) -> "StoreArgument":
+        return Argument.__new__(
+            cls,
+            name,
+            action,
+            nargs,
+            const,
+            default,
+            argument_type,
+            help_string,
+            metavar,
+        )

--- a/pylint/extensions/typing.py
+++ b/pylint/extensions/typing.py
@@ -9,6 +9,7 @@ from pylint.checkers.utils import (
     is_node_in_type_annotation_context,
     safe_infer,
 )
+from pylint.config import StoreArgument
 from pylint.interfaces import IAstroidChecker
 from pylint.lint import PyLinter
 from pylint.utils.utils import get_global_option
@@ -119,6 +120,24 @@ class TypingChecker(BaseChecker):
                     "Applies to Python versions 3.7 - 3.9"
                 ),
             },
+        ),
+    )
+    arguments = (
+        StoreArgument(
+            ("runtime-typing",),
+            "store",
+            1,
+            None,
+            True,
+            "yn",
+            "Set to ``no`` if the app / library does **NOT** need to "
+            "support runtime introspection of type annotations. "
+            "If you use type annotations **exclusively** for type checking "
+            "of an application, you're probably fine. For libraries, "
+            "evaluate if some users what to access the type hints "
+            "at runtime first, e.g., through ``typing.get_type_hints``. "
+            "Applies to Python versions 3.7 - 3.9",
+            "<y_or_n>",
         ),
     )
 


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

I've looked into [`argparse`](https://docs.python.org/3/library/argparse.html) and the move from `optparse` towards it. This is still a long road ahead. We would need to rewrite (almost) every bit of code dealing with options and config.

I've thought about the best way to do this and think the best way might be to start preparing the codebase by duplicating some functionality/data and slowly preparing a final move. It helps that the terminology of `argparse` relies on `arguments` instead of `options`, which allows duplicating methods and attributes with similar though different names.
Before continuing with this I would like some **response from maintainers** if this is indeed the best way to do this, or if there are other ways to allow for a gradual change to `argparse`.

This PR is a first step towards this gradual transformation. I have created a new `NamedTuple` and one that inherits from it. These are based on the parameters we would eventually need to pass to `ArgumentParser.add_argument()`. For now I would suggest to add duplicate all `options` of all checkers into an `arguments` attributes. If all checkers have an `arguments` attribute we can then start working on methods that utilise this (for example the documentation creation methods).
The `StoreArgument` is probably not the only type of subclassed `NamedTuple` I will need to create to do this, but serves as an example of how subclassing `Argument` would work.

TLDR: 1) Is temporary duplication the best way to facilitate the move towards `argparse`? 2) Is the use of `Argument` `NamedTuples`'s a good way to store `arguments` data?