### PR TITLE
Use py-version for alternative union syntax check

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -40,6 +40,9 @@ Release date: TBA
   * Added ``using-f-string-in-unsupported-version`` checker. Issued when ``py-version``
     is set to a version that does not support f-strings (< 3.6)
 
+* Use ``py-version`` setting for alternative union syntax check (PEP 604),
+  instead of the Python interpreter version.
+
 
 What's New in Pylint 2.11.2?
 ============================

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -95,7 +95,6 @@ from pylint.checkers.utils import (
     supports_membership_test,
     supports_setitem,
 )
-from pylint.constants import PY310_PLUS
 from pylint.interfaces import INFERENCE, IAstroidChecker
 from pylint.utils import get_global_option
 
@@ -896,6 +895,10 @@ accessed. Python regular expressions are accepted.",
         ),
     )
 
+    def open(self) -> None:
+        py_version = get_global_option(self, "py-version")
+        self._py310_plus = py_version >= (3, 10)
+
     @astroid.decorators.cachedproperty
     def _suggestion_mode(self):
         return get_global_option(self, "suggestion-mode", default=True)
@@ -1694,7 +1697,7 @@ accessed. Python regular expressions are accepted.",
 
     def _detect_unsupported_alternative_union_syntax(self, node: nodes.BinOp) -> None:
         """Detect if unsupported alternative Union syntax (PEP 604) was used."""
-        if PY310_PLUS:  # 310+ supports the new syntax
+        if self._py310_plus:  # 310+ supports the new syntax
             return
 
         if isinstance(

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -9,7 +9,6 @@ from pylint.__pkginfo__ import __version__
 
 PY38_PLUS = sys.version_info[:2] >= (3, 8)
 PY39_PLUS = sys.version_info[:2] >= (3, 9)
-PY310_PLUS = sys.version_info[:2] >= (3, 10)
 
 IS_PYPY = platform.python_implementation() == "PyPy"
 

--- a/tests/functional/a/alternative/alternative_union_syntax.rc
+++ b/tests/functional/a/alternative/alternative_union_syntax.rc
@@ -1,2 +1,5 @@
+[master]
+py-version=3.10
+
 [testoptions]
 min_pyver=3.10

--- a/tests/functional/a/alternative/alternative_union_syntax_error.rc
+++ b/tests/functional/a/alternative/alternative_union_syntax_error.rc
@@ -1,3 +1,5 @@
+[master]
+py-version=3.8
+
 [testoptions]
 min_pyver=3.8
-max_pyver=3.10

--- a/tests/functional/a/alternative/alternative_union_syntax_py37.rc
+++ b/tests/functional/a/alternative/alternative_union_syntax_py37.rc
@@ -1,3 +1,5 @@
+[master]
+py-version=3.8
+
 [testoptions]
 min_pyver=3.8
-max_pyver=3.10


### PR DESCRIPTION
## Description
With this change the `unsupported-binary-operation` warning will be emitted for invalid uses of the alternative union syntax even if checked with Python 3.10+
