### PR TITLE
Fix py-version usage in typing extension tests

### DIFF
--- a/tests/functional/ext/typing/typing_consider_using_alias.rc
+++ b/tests/functional/ext/typing/typing_consider_using_alias.rc
@@ -1,9 +1,9 @@
 [master]
+py-version=3.8
 load-plugins=pylint.extensions.typing
 
 [testoptions]
 min_pyver=3.8
 
 [typing]
-py-version=3.7
 runtime-typing=no

--- a/tests/functional/ext/typing/typing_consider_using_alias_without_future.rc
+++ b/tests/functional/ext/typing/typing_consider_using_alias_without_future.rc
@@ -1,9 +1,9 @@
 [master]
+py-version=3.8
 load-plugins=pylint.extensions.typing
 
 [testoptions]
 min_pyver=3.8
 
 [typing]
-py-version=3.7
 runtime-typing=no

--- a/tests/functional/ext/typing/typing_consider_using_union.rc
+++ b/tests/functional/ext/typing/typing_consider_using_union.rc
@@ -1,9 +1,9 @@
 [master]
+py-version=3.8
 load-plugins=pylint.extensions.typing
 
 [testoptions]
 min_pyver=3.8
 
 [typing]
-py-version=3.7
 runtime-typing=no

--- a/tests/functional/ext/typing/typing_consider_using_union_py310.rc
+++ b/tests/functional/ext/typing/typing_consider_using_union_py310.rc
@@ -1,8 +1,8 @@
 [master]
+py-version=3.10
 load-plugins=pylint.extensions.typing
 
 [testoptions]
-min_pyver=3.8
+min_pyver=3.10
 
 [typing]
-py-version=3.10

--- a/tests/functional/ext/typing/typing_consider_using_union_without_future.rc
+++ b/tests/functional/ext/typing/typing_consider_using_union_without_future.rc
@@ -1,9 +1,9 @@
 [master]
+py-version=3.8
 load-plugins=pylint.extensions.typing
 
 [testoptions]
 min_pyver=3.8
 
 [typing]
-py-version=3.7
 runtime-typing=no

--- a/tests/functional/ext/typing/typing_deprecated_alias.rc
+++ b/tests/functional/ext/typing/typing_deprecated_alias.rc
@@ -1,8 +1,8 @@
 [master]
+py-version=3.9
 load-plugins=pylint.extensions.typing
 
 [testoptions]
-min_pyver=3.8
+min_pyver=3.9
 
 [typing]
-py-version=3.9


### PR DESCRIPTION
## Description
- Move `py-version` from `[typing]` to `[master]`
- Make sure `py-version` >= `min_pyver`
