### PR TITLE
Remove dependency to ``typed-ast`` when testing with pypy and let the tox use the newer pip by adjusting tox.ini.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 minversion = 2.4
 envlist = formatting, py36, py37, py38, py39, py310, pypy, benchmark
 skip_missing_interpreters = true
+requires = pip >=21.3.1
 
 [testenv:pylint]
 deps =
@@ -29,7 +30,8 @@ commands =
 setenv =
     COVERAGE_FILE = {toxinidir}/.coverage.{envname}
 deps =
-    -r {toxinidir}/requirements_test.txt
+    !pypy: -r {toxinidir}/requirements_test.txt
+    pypy: -r {toxinidir}/requirements_test_min.txt
 commands =
     ; Run tests, ensuring all benchmark tests do not run
     pytest --benchmark-disable {toxinidir}/tests/ {posargs:}


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

1.  The ``tox -e pyp`` always fails  because the ``requirements.txt`` includes ``requirements_pre_commit.txt.``
    The ``requirements_pre_commit.txt`` is only necessary for the ``formatting`` test phase. In other tests, 
     it is no need at all. If ``tox`` uses ``requirements_pre_commit.txt`` with pypy, 
     pypy runs  installation of ``typed-ast.`` That always fails because ``typed-ast`` doesn't support pypy anymore,
     See.  Incompatibility section of https://github.com/python/typed_ast
    
     This PR removes ``requirements_pre_commit.txt`` from ``requirements.txt`` due to resolve this problem.

2. Sometimes test fails because the tox happens to set up the too old version of pip using ``virtualenv.`` 
    For the better quality of tests, tox should use the recent version of pip. 
     This PR adds a ``requires`` statement of pip to ``tox.ini``, so tox comes to install the current version of pip 
    when the tests begin. 
     Also see  https://github.com/pypa/virtualenv/issues/2214

Closes #5190 
