### PR TITLE
Fix ``invalid-name`` for ``TypeVar`` and add ``typevar-name-missing-variance`` checker

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -450,6 +450,11 @@ Release date: TBA
   Insert your changelog randomly, it will reduce merge conflicts
   (Ie. not necessarily at the end)
 
+* ``invalid-name`` check now also checks ``TypeVar`` for a pattern set with the new option
+  ``--typevar-rgx`` option or the chosen naming style (``--typevar-naming-style``).
+
+  Closes #3401
+
 * Added new checker ``typevar-name-missing-variance``. Emitted when a covariant
   or contravariant ``TypeVar`` does not end with  ``_co`` or ``_contra`` respectively or
   when a ``TypeVar`` is not either but has a suffix.

--- a/doc/user_guide/options.rst
+++ b/doc/user_guide/options.rst
@@ -39,6 +39,8 @@ name is found in, and not the type of object assigned.
 +--------------------+---------------------------------------------------------------------------------------------------+
 | ``inlinevar``      | Loop variables in list comprehensions and generator expressions.                                  |
 +--------------------+---------------------------------------------------------------------------------------------------+
+| ``typevar``        | Type variable declared with ``TypeVar``.                                                          |
++--------------------+---------------------------------------------------------------------------------------------------+
 
 Default behavior
 ~~~~~~~~~~~~~~~~
@@ -82,6 +84,8 @@ Following options are exposed:
 
 .. option:: --inlinevar-naming-style=<style>
 
+.. option:: --typevar-naming-style=<style>
+
 
 Custom regular expressions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -117,6 +121,8 @@ expression will lead to an instance of ``invalid-name``.
 .. option:: --class-const-rgx=<regex>
 
 .. option:: --inlinevar-rgx=<regex>
+
+.. option:: --typevar-rgx=<regex>
 
 Multiple naming styles for custom regular expressions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -334,6 +334,11 @@ Other Changes
 
   Closes #5360, #3877
 
+* ``invalid-name`` check now also checks ``TypeVar`` for a pattern set with the new option
+  ``--typevar-rgx`` option or the chosen naming style (``--typevar-naming-style``).
+
+  Closes #3401
+
 * Fixed a false positive (affecting unreleased development) for
   ``used-before-assignment`` involving homonyms between filtered comprehensions
   and assignments in except blocks.

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -128,6 +128,8 @@ class NamingStyle:
             "class_attribute": cls.CLASS_ATTRIBUTE_RGX,
             "class_const": cls.CONST_NAME_RGX,
             "inlinevar": cls.COMP_VAR_RGX,
+            # TODO: Create dedicated TypeVar pattern # pylint: disable=fixme
+            "typevar": cls.CLASS_NAME_RGX,
         }[name_type]
 
 
@@ -1672,6 +1674,7 @@ KNOWN_NAME_TYPES = {
     "class_attribute",
     "class_const",
     "inlinevar",
+    "typevar",
 }
 
 DEFAULT_NAMING_STYLES = {
@@ -1686,6 +1689,7 @@ DEFAULT_NAMING_STYLES = {
     "class_attribute": "any",
     "class_const": "UPPER_CASE",
     "inlinevar": "any",
+    "typevar": "PascalCase",
 }
 
 
@@ -2078,14 +2082,6 @@ class NameChecker(_BasicChecker):
     def _check_name(self, node_type, name, node, confidence=interfaces.HIGH):
         """Check for a name using the type's regexp."""
 
-        # pylint: disable=fixme
-        # TODO: move this down in the function and check TypeVar
-        # for name patterns as well.
-        # Check TypeVar names for variance suffixes
-        if node_type == "typevar":
-            self._check_typevar_variance(name, node)
-            return
-
         def _should_exempt_from_invalid_name(node):
             if node_type == "variable":
                 inferred = utils.safe_infer(node)
@@ -2110,6 +2106,10 @@ class NameChecker(_BasicChecker):
 
         if match is None and not _should_exempt_from_invalid_name(node):
             self._raise_name_warning(None, node, node_type, name, confidence)
+
+        # Check TypeVar names for variance suffixes
+        if node_type == "typevar":
+            self._check_typevar_variance(name, node)
 
     def _check_assign_to_new_keyword_violation(self, name, node):
         keyword_first_version = self._name_became_keyword_in_version(

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -113,6 +113,7 @@ class NamingStyle:
     COMP_VAR_RGX: Pattern[str] = ANY
     DEFAULT_NAME_RGX: Pattern[str] = ANY
     CLASS_ATTRIBUTE_RGX: Pattern[str] = ANY
+    TYPE_VAR_RGX: Pattern[str] = ANY
 
     @classmethod
     def get_regex(cls, name_type):
@@ -128,14 +129,16 @@ class NamingStyle:
             "class_attribute": cls.CLASS_ATTRIBUTE_RGX,
             "class_const": cls.CONST_NAME_RGX,
             "inlinevar": cls.COMP_VAR_RGX,
-            # TODO: Create dedicated TypeVar pattern # pylint: disable=fixme
-            "typevar": cls.CLASS_NAME_RGX,
+            "typevar": cls.TYPE_VAR_RGX,
         }[name_type]
 
 
 class SnakeCaseStyle(NamingStyle):
     """Regex rules for snake_case naming style."""
 
+    TYPE_VAR_RGX = re.compile(
+        r"^_{0,2}(?:[^\W\dA-Z][^\WA-Z]+)+[Tt]?(?<!Type)(?:_co(?:ntra)?)?$"
+    )
     CLASS_NAME_RGX = re.compile(r"[^\W\dA-Z][^\WA-Z]+$")
     MOD_NAME_RGX = re.compile(r"[^\W\dA-Z][^\WA-Z]*$")
     CONST_NAME_RGX = re.compile(r"([^\W\dA-Z][^\WA-Z]*|__.*__)$")
@@ -149,6 +152,9 @@ class SnakeCaseStyle(NamingStyle):
 class CamelCaseStyle(NamingStyle):
     """Regex rules for camelCase naming style."""
 
+    TYPE_VAR_RGX = re.compile(
+        r"^_{0,2}(?:[^\W\dA-Z][^\W_]+)(?:_[Tt])?(?<!Type)(?:_co(?:ntra)?)?$"
+    )
     CLASS_NAME_RGX = re.compile(r"[^\W\dA-Z][^\W_]+$")
     MOD_NAME_RGX = re.compile(r"[^\W\dA-Z][^\W_]*$")
     CONST_NAME_RGX = re.compile(r"([^\W\dA-Z][^\W_]*|__.*__)$")
@@ -160,6 +166,9 @@ class CamelCaseStyle(NamingStyle):
 class PascalCaseStyle(NamingStyle):
     """Regex rules for PascalCase naming style."""
 
+    TYPE_VAR_RGX = re.compile(
+        r"^_{0,2}(?:[^\W\da-z_]+|(?:[^\W\da-z_][^\WA-Z_]+)+T?(?<!Type))(?:_co(?:ntra)?)?$"
+    )
     CLASS_NAME_RGX = re.compile(r"[^\W\da-z][^\W_]+$")
     MOD_NAME_RGX = re.compile(r"[^\W\da-z][^\W_]+$")
     CONST_NAME_RGX = re.compile(r"([^\W\da-z][^\W_]*|__.*__)$")
@@ -171,6 +180,9 @@ class PascalCaseStyle(NamingStyle):
 class UpperCaseStyle(NamingStyle):
     """Regex rules for UPPER_CASE naming style."""
 
+    TYPE_VAR_RGX = re.compile(
+        r"^_{0,2}(?:[^\W\da-z][^\Wa-z]+)*T?(?<!Type)(?:_co(?:ntra)?)?$"
+    )
     CLASS_NAME_RGX = re.compile(r"[^\W\da-z][^\Wa-z]+$")
     MOD_NAME_RGX = re.compile(r"[^\W\da-z][^\Wa-z]+$")
     CONST_NAME_RGX = re.compile(r"([^\W\da-z][^\Wa-z]*|__.*__)$")

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -71,6 +71,7 @@ HUMAN_READABLE_TYPES = {
     "class_attribute": "class attribute",
     "class_const": "class constant",
     "inlinevar": "inline iteration",
+    "typevar": "type variable",
 }
 
 

--- a/pylint/utils/linterstats.py
+++ b/pylint/utils/linterstats.py
@@ -26,6 +26,7 @@ class BadNames(TypedDict):
     method: int
     module: int
     variable: int
+    typevar: int
 
 
 class CodeTypeCount(TypedDict):
@@ -102,6 +103,7 @@ class LinterStats:
             method=0,
             module=0,
             variable=0,
+            typevar=0,
         )
         self.by_module: Dict[str, ModuleStats] = by_module or {}
         self.by_msg: Dict[str, int] = by_msg or {}
@@ -171,6 +173,7 @@ class LinterStats:
             "method",
             "module",
             "variable",
+            "typevar",
         ],
     ) -> int:
         """Get a bad names node count."""
@@ -192,6 +195,7 @@ class LinterStats:
             "method",
             "module",
             "variable",
+            "typevar",
         }:
             raise ValueError("Node type not part of the bad_names stat")
 
@@ -208,6 +212,7 @@ class LinterStats:
                 "method",
                 "module",
                 "variable",
+                "typevar",
             ],
             node_name,
         )
@@ -230,6 +235,7 @@ class LinterStats:
             method=0,
             module=0,
             variable=0,
+            typevar=0,
         )
 
     def get_code_count(
@@ -317,6 +323,7 @@ def merge_stats(stats: List[LinterStats]):
         merged.bad_names["method"] += stat.bad_names["method"]
         merged.bad_names["module"] += stat.bad_names["module"]
         merged.bad_names["variable"] += stat.bad_names["variable"]
+        merged.bad_names["typevar"] += stat.bad_names["typevar"]
 
         for mod_key, mod_value in stat.by_module.items():
             merged.by_module[mod_key] = mod_value

--- a/pylintrc
+++ b/pylintrc
@@ -353,6 +353,13 @@ method-rgx=[a-z_][a-z0-9_]{2,}$
 # Naming hint for method names
 method-name-hint=[a-z_][a-z0-9_]{2,}$
 
+# Naming style used for type variables. Default is PascalCase.
+typevar-naming-style=PascalCase
+
+# Regular expression which can overwrite the naming style set by typevar-naming-style.
+# If left empty, type variables will be checked with the set naming style.
+typevar-rgx=
+
 # Regular expression which should only match function or class names that do
 # not require a docstring. Use ^(?!__init__$)_ to also check __init__.
 no-docstring-rgx=__.*__
@@ -363,7 +370,6 @@ docstring-min-length=-1
 
 # List of decorators that define properties, such as abc.abstractproperty.
 property-classes=abc.abstractproperty
-
 
 [TYPECHECK]
 

--- a/tests/checkers/unittest_base.py
+++ b/tests/checkers/unittest_base.py
@@ -210,17 +210,23 @@ class TestNamePresets(unittest.TestCase):
         SNAKE_CASE_NAMES | CAMEL_CASE_NAMES | UPPER_CASE_NAMES | PASCAL_CASE_NAMES
     )
 
-    def _test_name_is_correct_for_all_name_types(
+    def _test_name_is_correct_for_all_name_types_except_typevar(
         self, naming_style: Type[base.NamingStyle], name: str
     ) -> None:
         for name_type in base.KNOWN_NAME_TYPES:
-            self._test_is_correct(naming_style, name, name_type)
+            # pylint: disable-next=fixme
+            # TODO: See if there is a better way to tests these styles
+            if name_type != "typevar":
+                self._test_is_correct(naming_style, name, name_type)
 
-    def _test_name_is_incorrect_for_all_name_types(
+    def _test_name_is_incorrect_for_all_name_types_except_type_var(
         self, naming_style: Type[base.NamingStyle], name: str
     ) -> None:
         for name_type in base.KNOWN_NAME_TYPES:
-            self._test_is_incorrect(naming_style, name, name_type)
+            # pylint: disable-next=fixme
+            # TODO: See if there is a better way to tests these styles
+            if name_type != "typevar":
+                self._test_is_incorrect(naming_style, name, name_type)
 
     def _test_should_always_pass(self, naming_style: Type[base.NamingStyle]) -> None:
         always_pass_data = [
@@ -252,9 +258,13 @@ class TestNamePresets(unittest.TestCase):
         naming_style = base.SnakeCaseStyle
 
         for name in self.SNAKE_CASE_NAMES:
-            self._test_name_is_correct_for_all_name_types(naming_style, name)
+            self._test_name_is_correct_for_all_name_types_except_typevar(
+                naming_style, name
+            )
         for name in self.ALL_NAMES - self.SNAKE_CASE_NAMES:
-            self._test_name_is_incorrect_for_all_name_types(naming_style, name)
+            self._test_name_is_incorrect_for_all_name_types_except_type_var(
+                naming_style, name
+            )
 
         self._test_should_always_pass(naming_style)
 
@@ -262,9 +272,13 @@ class TestNamePresets(unittest.TestCase):
         naming_style = base.CamelCaseStyle
 
         for name in self.CAMEL_CASE_NAMES:
-            self._test_name_is_correct_for_all_name_types(naming_style, name)
+            self._test_name_is_correct_for_all_name_types_except_typevar(
+                naming_style, name
+            )
         for name in self.ALL_NAMES - self.CAMEL_CASE_NAMES:
-            self._test_name_is_incorrect_for_all_name_types(naming_style, name)
+            self._test_name_is_incorrect_for_all_name_types_except_type_var(
+                naming_style, name
+            )
 
         self._test_should_always_pass(naming_style)
 
@@ -272,10 +286,16 @@ class TestNamePresets(unittest.TestCase):
         naming_style = base.UpperCaseStyle
 
         for name in self.UPPER_CASE_NAMES:
-            self._test_name_is_correct_for_all_name_types(naming_style, name)
+            self._test_name_is_correct_for_all_name_types_except_typevar(
+                naming_style, name
+            )
         for name in self.ALL_NAMES - self.UPPER_CASE_NAMES:
-            self._test_name_is_incorrect_for_all_name_types(naming_style, name)
-        self._test_name_is_incorrect_for_all_name_types(naming_style, "UPPERcase")
+            self._test_name_is_incorrect_for_all_name_types_except_type_var(
+                naming_style, name
+            )
+        self._test_name_is_incorrect_for_all_name_types_except_type_var(
+            naming_style, "UPPERcase"
+        )
 
         self._test_should_always_pass(naming_style)
 
@@ -283,9 +303,13 @@ class TestNamePresets(unittest.TestCase):
         naming_style = base.PascalCaseStyle
 
         for name in self.PASCAL_CASE_NAMES:
-            self._test_name_is_correct_for_all_name_types(naming_style, name)
+            self._test_name_is_correct_for_all_name_types_except_typevar(
+                naming_style, name
+            )
         for name in self.ALL_NAMES - self.PASCAL_CASE_NAMES:
-            self._test_name_is_incorrect_for_all_name_types(naming_style, name)
+            self._test_name_is_incorrect_for_all_name_types_except_type_var(
+                naming_style, name
+            )
 
         self._test_should_always_pass(naming_style)
 

--- a/tests/functional/t/typevar_name_incorrect_variance.rc
+++ b/tests/functional/t/typevar_name_incorrect_variance.rc
@@ -1,0 +1,3 @@
+[BASIC]
+# TODO: Remove this option and use default style
+typevar-rgx=^_{0,2}(?:[^\W\da-z_]+|(?:[^\W\da-z_][^\WA-Z_]+)+T?(?<!Type))(?:_co(?:ntra)?)?$

--- a/tests/functional/t/typevar_name_incorrect_variance.rc
+++ b/tests/functional/t/typevar_name_incorrect_variance.rc
@@ -1,3 +1,0 @@
-[BASIC]
-# TODO: Remove this option and use default style
-typevar-rgx=^_{0,2}(?:[^\W\da-z_]+|(?:[^\W\da-z_][^\WA-Z_]+)+T?(?<!Type))(?:_co(?:ntra)?)?$

--- a/tests/functional/t/typevar_naming_style_default.py
+++ b/tests/functional/t/typevar_naming_style_default.py
@@ -1,0 +1,72 @@
+"""Test case for typevar-name-incorrect-variance with default settings"""
+# pylint: disable=too-few-public-methods
+
+from typing import TypeVar
+
+# PascalCase names with prefix
+GoodNameT = TypeVar("GoodNameT")
+_T = TypeVar("_T")
+_GoodNameT = TypeVar("_GoodNameT")
+__GoodNameT = TypeVar("__GoodNameT")
+GoodNameWithoutContra = TypeVar(  # [typevar-name-incorrect-variance]
+    "GoodNameWithoutContra", contravariant=True
+)
+GoodNameT_co = TypeVar("GoodNameT_co", covariant=True)
+GoodNameT_contra = TypeVar("GoodNameT_contra", contravariant=True)
+GoodBoundNameT = TypeVar("GoodBoundNameT", bound=int)
+GoodBoundNameT_co = TypeVar(  # [typevar-name-incorrect-variance]
+    "GoodBoundNameT_co", bound=int
+)
+GoodBoundNameT_contra = TypeVar(  # [typevar-name-incorrect-variance]
+    "GoodBoundNameT_contra", bound=int
+)
+GoodBoundNameT_co = TypeVar("GoodBoundNameT_co", bound=int, covariant=True)
+GoodBoundNameT_contra = TypeVar("GoodBoundNameT_contra", bound=int, contravariant=True)
+
+GoodBoundNameT_co = TypeVar("GoodBoundNameT_co", int, str, covariant=True)
+GoodBoundNameT_co = TypeVar(  # [typevar-name-incorrect-variance]
+    "GoodBoundNameT_co", int, str, contravariant=True
+)
+GoodBoundNameT_contra = TypeVar("GoodBoundNameT_contra", int, str, contravariant=True)
+GoodBoundNameT_contra = TypeVar(  # [typevar-name-incorrect-variance]
+    "GoodBoundNameT_contra", int, str, covariant=True
+)
+
+# Some of these will create a RunTime error but serve as a regression test
+T = TypeVar(  # [typevar-name-incorrect-variance]
+    "T", covariant=True, contravariant=True
+)
+T = TypeVar("T", covariant=False, contravariant=False)
+T_co = TypeVar("T_co", covariant=True, contravariant=True)
+T_contra = TypeVar(  # [typevar-name-incorrect-variance]
+    "T_contra", covariant=True, contravariant=True
+)
+T_co = TypeVar("T_co", covariant=True, contravariant=False)
+T_contra = TypeVar("T_contra", covariant=False, contravariant=True)
+
+# PascalCase names without prefix
+AnyStr = TypeVar("AnyStr")
+DeviceTypeT = TypeVar("DeviceTypeT")
+CALLABLE_T = TypeVar("CALLABLE_T")  # [invalid-name]
+DeviceType = TypeVar("DeviceType")  # [invalid-name]
+GoodNameWithoutContra = TypeVar(  # [typevar-name-incorrect-variance]
+    "GoodNameWithoutContra", contravariant=True
+)
+
+# camelCase names with prefix
+badName = TypeVar("badName")  # [invalid-name]
+badNameWithoutContra = TypeVar(  # [invalid-name, typevar-name-incorrect-variance]]
+    "badNameWithoutContra", contravariant=True
+)
+badName_co = TypeVar("badName_co", covariant=True)  # [invalid-name]
+badName_contra = TypeVar("badName_contra", contravariant=True)  # [invalid-name]
+
+# PascalCase names with lower letter prefix in tuple assignment
+(
+    a_BadName,  # [invalid-name]
+    a_BadNameWithoutContra,  # [invalid-name, typevar-name-incorrect-variance]
+) = TypeVar("a_BadName"), TypeVar("a_BadNameWithoutContra", contravariant=True)
+GoodName_co, a_BadName_contra = TypeVar(  # [invalid-name]
+    "GoodName_co", covariant=True
+), TypeVar("a_BadName_contra", contravariant=True)
+GoodName_co, VAR = TypeVar("GoodName_co", covariant=True), "a string"

--- a/tests/functional/t/typevar_naming_style_default.txt
+++ b/tests/functional/t/typevar_naming_style_default.txt
@@ -1,0 +1,19 @@
+typevar-name-incorrect-variance:11:0:11:21::"Type variable ""GoodNameWithoutContra"" is contravariant, use ""GoodNameWithoutContra_contra"" instead":INFERENCE
+typevar-name-incorrect-variance:17:0:17:17::"Type variable ""GoodBoundNameT_co"" is invariant, use ""GoodBoundNameT"" instead":INFERENCE
+typevar-name-incorrect-variance:20:0:20:21::"Type variable ""GoodBoundNameT_contra"" is invariant, use ""GoodBoundNameT"" instead":INFERENCE
+typevar-name-incorrect-variance:27:0:27:17::"Type variable ""GoodBoundNameT_co"" is contravariant, use ""GoodBoundNameT_contra"" instead":INFERENCE
+typevar-name-incorrect-variance:31:0:31:21::"Type variable ""GoodBoundNameT_contra"" is covariant, use ""GoodBoundNameT_co"" instead":INFERENCE
+typevar-name-incorrect-variance:36:0:36:1::"Type variable ""T"" is covariant, use ""T_co"" instead":INFERENCE
+typevar-name-incorrect-variance:41:0:41:8::"Type variable ""T_contra"" is covariant, use ""T_co"" instead":INFERENCE
+invalid-name:50:0:50:10::"Type variable name ""CALLABLE_T"" doesn't conform to PascalCase naming style":HIGH
+invalid-name:51:0:51:10::"Type variable name ""DeviceType"" doesn't conform to PascalCase naming style":HIGH
+typevar-name-incorrect-variance:52:0:52:21::"Type variable ""GoodNameWithoutContra"" is contravariant, use ""GoodNameWithoutContra_contra"" instead":INFERENCE
+invalid-name:57:0:57:7::"Type variable name ""badName"" doesn't conform to PascalCase naming style":HIGH
+invalid-name:58:0:58:20::"Type variable name ""badNameWithoutContra"" doesn't conform to PascalCase naming style":HIGH
+typevar-name-incorrect-variance:58:0:58:20::"Type variable ""badNameWithoutContra"" is contravariant, use ""badNameWithoutContra_contra"" instead":INFERENCE
+invalid-name:61:0:61:10::"Type variable name ""badName_co"" doesn't conform to PascalCase naming style":HIGH
+invalid-name:62:0:62:14::"Type variable name ""badName_contra"" doesn't conform to PascalCase naming style":HIGH
+invalid-name:66:4:66:13::"Type variable name ""a_BadName"" doesn't conform to PascalCase naming style":HIGH
+invalid-name:67:4:67:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to PascalCase naming style":HIGH
+typevar-name-incorrect-variance:67:4:67:26::"Type variable ""a_BadNameWithoutContra"" is contravariant, use ""a_BadNameWithoutContra_contra"" instead":INFERENCE
+invalid-name:69:13:69:29::"Type variable name ""a_BadName_contra"" doesn't conform to PascalCase naming style":HIGH

--- a/tests/functional/t/typevar_naming_style_rgx.py
+++ b/tests/functional/t/typevar_naming_style_rgx.py
@@ -1,0 +1,15 @@
+"""Test case for typevar-name-missing-variance with non-default settings"""
+
+from typing import TypeVar
+
+# Name set by regex pattern
+TypeVarsShouldBeLikeThis = TypeVar("TypeVarsShouldBeLikeThis")
+TypeVarsShouldBeLikeThis_contra = TypeVar(
+    "TypeVarsShouldBeLikeThis_contra", contravariant=True
+)
+TypeVarsShouldBeLikeThis_co = TypeVar("TypeVarsShouldBeLikeThis_co", covariant=True)
+
+# Name using the standard style
+GoodNameT = TypeVar("GoodNameT")  # [invalid-name]
+GoodNameT_co = TypeVar("GoodNameT_co", covariant=True)  # [invalid-name]
+GoodNameT_contra = TypeVar("GoodNameT_contra", contravariant=True)  # [invalid-name]

--- a/tests/functional/t/typevar_naming_style_rgx.rc
+++ b/tests/functional/t/typevar_naming_style_rgx.rc
@@ -1,0 +1,2 @@
+[BASIC]
+typevar-rgx=TypeVarsShouldBeLikeThis(_co(ntra)?)?$

--- a/tests/functional/t/typevar_naming_style_rgx.txt
+++ b/tests/functional/t/typevar_naming_style_rgx.txt
@@ -1,0 +1,3 @@
+invalid-name:13:0:13:9::"Type variable name ""GoodNameT"" doesn't conform to 'TypeVarsShouldBeLikeThis(_co(ntra)?)?$' pattern":HIGH
+invalid-name:14:0:14:12::"Type variable name ""GoodNameT_co"" doesn't conform to 'TypeVarsShouldBeLikeThis(_co(ntra)?)?$' pattern":HIGH
+invalid-name:15:0:15:16::"Type variable name ""GoodNameT_contra"" doesn't conform to 'TypeVarsShouldBeLikeThis(_co(ntra)?)?$' pattern":HIGH


### PR DESCRIPTION
**I'm fine with postponing this till 2.13!**

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |

## Description

This supersedes #3463 and closes #3401

This change is very large, sorry about that. We can split it up, but since I took #3463 as a baseline it was very hard to separate the changes logically. As said in the opening line, I'm fine with postponing this until `2.13` and focus on releasing `2.12` first. I just wanted to close one of the stale PRs and create a working version of it.

I noticed that many of the regex patterns in the NamingStyles might not be 100% perfect. It took several tries to create a pattern for PascalCase `TypeVar`s that actually worked and I based it on the current standard pattern...
Furthermore, I don't really like the hack I did with `_test_name_is_correct_for_all_name_types_except_typevar`. However, I didn't want to increase the size of this PR even further and I intend to revisit these checkers in a follow-up PR anyway. I feel like some edge cases are currently passing some of the regex patterns.

I will annotate some of the code to (hopefully) make reviewing this a little bit easier.