### PR TITLE
Unify all `<y or n>` metavars

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -568,3 +568,5 @@ contributors:
 * Mike Fiedler (miketheman): contributor
 
 * Takahide Nojima: contributor
+
+* Tushar Sadhwani (tusharsadhwani): contributor

--- a/doc/how_tos/custom_checkers.rst
+++ b/doc/how_tos/custom_checkers.rst
@@ -58,7 +58,7 @@ Firstly we will need to fill in some required boilerplate:
           (
               'ignore-ints',
               {
-                  'default': False, 'type': 'yn', 'metavar' : '<y_or_n>',
+                  'default': False, 'type': 'yn', 'metavar' : '<y or n>',
                   'help': 'Allow returning non-unique integers',
               }
           ),

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -62,7 +62,7 @@ A couple of the options that we'll focus on here are: ::
   Messages control:
     --disable=<msg-ids>
   Reports:
-    --reports=<y_or_n>
+    --reports=<y or n>
     --output-format=<format>
 
 If you need more detail, you can also ask for an even longer help message,

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1816,7 +1816,7 @@ class NameChecker(_BasicChecker):
             {
                 "default": False,
                 "type": "yn",
-                "metavar": "<y_or_n>",
+                "metavar": "<y or n>",
                 "help": "Include a hint for the correct naming format with invalid-name.",
             },
         ),

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -270,7 +270,7 @@ class FormatChecker(BaseTokenChecker):
             {
                 "default": False,
                 "type": "yn",
-                "metavar": "<y_or_n>",
+                "metavar": "<y or n>",
                 "help": (
                     "Allow the body of an if to be on the same "
                     "line as the test if there is no else."
@@ -282,7 +282,7 @@ class FormatChecker(BaseTokenChecker):
             {
                 "default": False,
                 "type": "yn",
-                "metavar": "<y_or_n>",
+                "metavar": "<y or n>",
                 "help": (
                     "Allow the body of a class to be on the same "
                     "line as the declaration if body contains "

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -405,7 +405,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             {
                 "default": False,
                 "type": "yn",
-                "metavar": "<y_or_n>",
+                "metavar": "<y or n>",
                 "help": "Analyse import fallback blocks. This can be used to "
                 "support both Python 2 and 3 compatible code, which "
                 "means that the block might have code that exists "
@@ -418,7 +418,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             {
                 "default": False,
                 "type": "yn",
-                "metavar": "<y_or_n>",
+                "metavar": "<y or n>",
                 "help": "Allow wildcard imports from modules that define __all__.",
             },
         ),

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -259,7 +259,7 @@ class SpellingChecker(BaseTokenChecker):
             {
                 "default": "n",
                 "type": "yn",
-                "metavar": "<y_or_n>",
+                "metavar": "<y or n>",
                 "help": "Tells whether to store unknown words to the "
                 "private dictionary (see the "
                 "--spelling-private-dict-file option) instead of "

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -681,7 +681,7 @@ class StringConstantChecker(BaseTokenChecker):
             {
                 "default": False,
                 "type": "yn",
-                "metavar": "<y_or_n>",
+                "metavar": "<y or n>",
                 "help": "This flag controls whether the "
                 "implicit-str-concat should generate a warning "
                 "on implicit string concatenation in sequences defined over "
@@ -693,7 +693,7 @@ class StringConstantChecker(BaseTokenChecker):
             {
                 "default": False,
                 "type": "yn",
-                "metavar": "<y_or_n>",
+                "metavar": "<y or n>",
                 "help": "This flag controls whether inconsistent-quotes generates a "
                 "warning when the character used as a quote delimiter is used "
                 "inconsistently within a module.",

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -777,7 +777,7 @@ class TypeChecker(BaseChecker):
             {
                 "default": True,
                 "type": "yn",
-                "metavar": "<y_or_n>",
+                "metavar": "<y or n>",
                 "help": "This flag controls whether pylint should warn about "
                 "no-member and similar checks whenever an opaque object "
                 "is returned when inferring. The inference can return "
@@ -802,7 +802,7 @@ class TypeChecker(BaseChecker):
             {
                 "default": True,
                 "type": "yn",
-                "metavar": "<y_or_n>",
+                "metavar": "<y or n>",
                 "help": "Tells whether missing members accessed in mixin "
                 "class should be ignored. A class is considered mixin if its name matches "
                 "the mixin-class-rgx option.",
@@ -813,7 +813,7 @@ class TypeChecker(BaseChecker):
             {
                 "default": True,
                 "type": "yn",
-                "metavar": "<y_or_n>",
+                "metavar": "<y or n>",
                 "help": "Tells whether to warn about missing members when the owner "
                 "of the attribute is inferred to be None.",
             },

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -629,7 +629,7 @@ class VariablesChecker(BaseChecker):
             {
                 "default": 0,
                 "type": "yn",
-                "metavar": "<y_or_n>",
+                "metavar": "<y or n>",
                 "help": "Tells whether we should check for unused import in "
                 "__init__ files.",
             },
@@ -697,7 +697,7 @@ class VariablesChecker(BaseChecker):
             {
                 "default": True,
                 "type": "yn",
-                "metavar": "<y_or_n>",
+                "metavar": "<y or n>",
                 "help": "Tells whether unused global variables should be treated as a violation.",
             },
         ),

--- a/pylint/extensions/typing.py
+++ b/pylint/extensions/typing.py
@@ -108,7 +108,7 @@ class TypingChecker(BaseChecker):
             {
                 "default": True,
                 "type": "yn",
-                "metavar": "<y_or_n>",
+                "metavar": "<y or n>",
                 "help": (
                     "Set to ``no`` if the app / library does **NOT** need to "
                     "support runtime introspection of type annotations. "

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -240,7 +240,7 @@ class PyLinter(
                 {
                     "default": True,
                     "type": "yn",
-                    "metavar": "<y_or_n>",
+                    "metavar": "<y or n>",
                     "level": 1,
                     "help": "Pickle collected data for later comparisons.",
                 },
@@ -276,7 +276,7 @@ class PyLinter(
                 {
                     "default": False,
                     "type": "yn",
-                    "metavar": "<y_or_n>",
+                    "metavar": "<y or n>",
                     "short": "r",
                     "group": "Reports",
                     "help": "Tells whether to display a full report or only the "
@@ -306,7 +306,7 @@ class PyLinter(
                 {
                     "default": True,
                     "type": "yn",
-                    "metavar": "<y_or_n>",
+                    "metavar": "<y or n>",
                     "short": "s",
                     "group": "Reports",
                     "help": "Activate the evaluation score.",
@@ -409,7 +409,7 @@ class PyLinter(
                 "unsafe-load-any-extension",
                 {
                     "type": "yn",
-                    "metavar": "<yn>",
+                    "metavar": "<y or n>",
                     "default": False,
                     "hide": True,
                     "help": (
@@ -465,7 +465,7 @@ class PyLinter(
                 "suggestion-mode",
                 {
                     "type": "yn",
-                    "metavar": "<yn>",
+                    "metavar": "<y or n>",
                     "default": True,
                     "help": (
                         "When enabled, pylint would attempt to guess common "

--- a/pylint/pyreverse/main.py
+++ b/pylint/pyreverse/main.py
@@ -116,7 +116,7 @@ OPTIONS = (
             short="m",
             default=None,
             type="yn",
-            metavar="[yn]",
+            metavar="<y or n>",
             help="include module name in representation of classes",
         ),
     ),


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Okay, this was bugging me for a while that the metavars for yes/no options were inconsistent across pylint. This simply re-labels all of them.

I looked across the codebase and found that the most common convention was to have spaces in your metavars, instead of dashes or underscores, so I went witht that.