### PR TITLE
Use single worker if importing `multiprocessing.synchronize` fails

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -574,3 +574,5 @@ contributors:
 * Ikraduya Edian: contributor
 
 * Antonio Quarta (sgheppy): contributor
+
+* Harshil (harshil21): contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -135,6 +135,11 @@ Release date: TBA
 
   Closes #3370
 
+* The ``--jobs`` parameter now fallbacks to 1 if the host operating system does not
+  have functioning shared semaphore implementation.
+
+  Closes #5216
+
 
 What's New in Pylint 2.11.2?
 ============================

--- a/doc/whatsnew/2.12.rst
+++ b/doc/whatsnew/2.12.rst
@@ -135,7 +135,7 @@ Other Changes
 
   Closes #5222
 
-* The ``--jobs`` parameter now fallbacks to 1 if the host operating system does not
+* The ``--jobs`` parameter now falls back to 1 if the host operating system does not
   have functioning shared semaphore implementation.
 
   Closes #5216

--- a/doc/whatsnew/2.12.rst
+++ b/doc/whatsnew/2.12.rst
@@ -134,3 +134,8 @@ Other Changes
   explicit typing
 
   Closes #5222
+
+* The ``--jobs`` parameter now fallbacks to 1 if the host operating system does not
+  have functioning shared semaphore implementation.
+
+  Closes #5216

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -13,6 +13,7 @@ from pylint.utils import print_full_documentation, utils
 
 try:
     import multiprocessing
+    from multiprocessing import synchronize  # noqa pylint: disable=unused-import
 except ImportError:
     multiprocessing = None  # type: ignore
 


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Simply tests the import `from multiprocessing import synchronize` to see if the host OS supports shared semaphores. The other part of the code already handles the jobs being set back to 1.

Closes #5216

