### PR TITLE
Inspection for `with threading.Lock():`

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -154,6 +154,7 @@ contributors:
 
 * Martin Bašti: contributor
   Added new check for shallow copy of os.environ
+  Added new check for useless `with threading.Lock():` statement
 
 * Jacques Kvam: contributor
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -140,6 +140,11 @@ Release date: TBA
 
   Closes #5216
 
+* Added new checker ``useless-with-lock`` to find incorrect usage of with statement and threading module locks.
+  Emitted when ``with threading.Lock():`` is used instead of ``with lock_instance:``.
+
+  Closes #5208
+
 
 What's New in Pylint 2.11.2?
 ============================

--- a/doc/whatsnew/2.12.rst
+++ b/doc/whatsnew/2.12.rst
@@ -48,6 +48,10 @@ New checkers
 
   Closes #3370
 
+* Added new checker ``useless-with-lock`` to find incorrect usage of with statement and threading module locks.
+  Emitted when ``with threading.Lock():`` is used instead of ``with lock_instance:``.
+
+  Closes #5208
 
 Removed checkers
 ================

--- a/pylint/checkers/threading_checker.py
+++ b/pylint/checkers/threading_checker.py
@@ -1,0 +1,55 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+
+from astroid import nodes
+
+from pylint import interfaces
+from pylint.checkers import BaseChecker
+from pylint.checkers.utils import check_messages, safe_infer
+
+
+class ThreadingChecker(BaseChecker):
+    """Checks for threading module
+
+    - useless with lock - locking used in wrong way that has no effect (with threading.Lock():)
+    """
+
+    __implements__ = interfaces.IAstroidChecker
+    name = "threading"
+
+    LOCKS = frozenset(
+        (
+            "threading.Lock",
+            "threading.RLock",
+            "threading.Condition",
+            "threading.Semaphore",
+            "threading.BoundedSemaphore",
+        )
+    )
+
+    msgs = {
+        "W2101": (
+            "'%s()' directly created in 'with' has no effect",
+            "useless-with-lock",
+            "Used when a new lock instance is created by using with statement "
+            "which has no effect. Instead, an existing instance should be used to acquire lock.",
+        ),
+    }
+
+    @check_messages("useless-with-lock")
+    def visit_with(self, node: nodes.With) -> None:
+
+        context_managers = (c for c, _ in node.items if isinstance(c, nodes.Call))
+        for context_manager in context_managers:
+            if isinstance(context_manager, nodes.Call):
+                infered_function = safe_infer(context_manager.func)
+                if infered_function is None:
+                    continue
+                qname = infered_function.qname()
+                if qname in self.LOCKS:
+                    self.add_message("useless-with-lock", node=node, args=qname)
+
+
+def register(linter):
+    """required method to auto register this checker"""
+    linter.register_checker(ThreadingChecker(linter))

--- a/tests/functional/u/useless/useless_with_lock.py
+++ b/tests/functional/u/useless/useless_with_lock.py
@@ -1,0 +1,58 @@
+"""Tests for the useless-with-lock message"""
+# pylint: disable=missing-docstring
+import threading
+from threading import Lock, RLock, Condition, Semaphore, BoundedSemaphore
+
+
+with threading.Lock():  # [useless-with-lock]
+    ...
+
+with Lock():  # [useless-with-lock]
+    ...
+
+with threading.Lock() as this_shouldnt_matter:  # [useless-with-lock]
+    ...
+
+with threading.RLock():  # [useless-with-lock]
+    ...
+
+with RLock():  # [useless-with-lock]
+    ...
+
+with threading.Condition():  # [useless-with-lock]
+    ...
+
+with Condition():  # [useless-with-lock]
+    ...
+
+with threading.Semaphore():  # [useless-with-lock]
+    ...
+
+with Semaphore():  # [useless-with-lock]
+    ...
+
+with threading.BoundedSemaphore():  # [useless-with-lock]
+    ...
+
+with BoundedSemaphore():  # [useless-with-lock]
+    ...
+
+lock = threading.Lock()
+with lock:  # this is ok
+    ...
+
+rlock = threading.RLock()
+with rlock:  # this is ok
+    ...
+
+cond = threading.Condition()
+with cond:  # this is ok
+    ...
+
+sem = threading.Semaphore()
+with sem:  # this is ok
+    ...
+
+b_sem = threading.BoundedSemaphore()
+with b_sem:  # this is ok
+    ...

--- a/tests/functional/u/useless/useless_with_lock.txt
+++ b/tests/functional/u/useless/useless_with_lock.txt
@@ -1,0 +1,11 @@
+useless-with-lock:7:0::'threading.Lock()' directly created in 'with' has no effect:HIGH
+useless-with-lock:10:0::'threading.Lock()' directly created in 'with' has no effect:HIGH
+useless-with-lock:13:0::'threading.Lock()' directly created in 'with' has no effect:HIGH
+useless-with-lock:16:0::'threading.RLock()' directly created in 'with' has no effect:HIGH
+useless-with-lock:19:0::'threading.RLock()' directly created in 'with' has no effect:HIGH
+useless-with-lock:22:0::'threading.Condition()' directly created in 'with' has no effect:HIGH
+useless-with-lock:25:0::'threading.Condition()' directly created in 'with' has no effect:HIGH
+useless-with-lock:28:0::'threading.Semaphore()' directly created in 'with' has no effect:HIGH
+useless-with-lock:31:0::'threading.Semaphore()' directly created in 'with' has no effect:HIGH
+useless-with-lock:34:0::'threading.BoundedSemaphore()' directly created in 'with' has no effect:HIGH
+useless-with-lock:37:0::'threading.BoundedSemaphore()' directly created in 'with' has no effect:HIGH


### PR DESCRIPTION
Using `with threading.Lock():` directly has no effect.

Correct usage is:
```
lock = threading.Lock()
with lock:
    ...
```

This applies for:
  * threading.Lock
  * threading.RLock
  * threading.Condition
  * threading.Semaphore
  * threading.BoundedSemaphore

Fixes: #5208

Signed-off-by: Martin Basti <mbasti@redhat.com>


Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #5208
