### PR TITLE
Remove ``render: python`` from bug description

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -23,7 +23,6 @@ body:
         # Please disable message unrelated to the bug
         # pylint: disable=missing-docstring,
         <a> = b + 1
-      render: python
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Description

This is non intuitive and I always need to change my issues to make them text again.