### PR TITLE
Make ``self-cls-assignment`` consider tuple assign. & ignore ``typing.cast()``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -127,6 +127,9 @@ Release date: TBA
 
   Closes #4426
 
+* ``self-cls-assignment`` now also considers tuple assignment and does not raise a false positive on
+  ``typing.cast()``
+
 * Fix ``missing-function-docstring`` not being able to check ``__init__`` and other
   magic methods even if the ``no-docstring-rgx`` setting was set to do so
 

--- a/doc/whatsnew/2.12.rst
+++ b/doc/whatsnew/2.12.rst
@@ -108,6 +108,9 @@ Other Changes
 
   Fixes part of #3688
 
+* ``self-cls-assignment`` now also considers tuple assignment and does not raise a false positive on
+  ``typing.cast()``
+
 * ``undefined-variable`` now correctly triggers for assignment expressions in if ... else statements
   This includes a basic form of control flow inference for if ... else statements using
   constant boolean values

--- a/tests/functional/s/self/self_cls_assignment.py
+++ b/tests/functional/s/self/self_cls_assignment.py
@@ -1,5 +1,8 @@
 """Warning about assigning self/cls variable."""
 from __future__ import print_function
+
+from typing import cast
+
 # pylint: disable=too-few-public-methods, useless-object-inheritance
 
 class Foo(object):
@@ -14,6 +17,8 @@ class Foo(object):
     def self_foofoo(self, lala):
         """Instance method, should warn for self"""
         self = lala  # [self-cls-assignment]
+        self, var = lala, 1  # [self-cls-assignment]
+        print(var)
 
     @classmethod
     def cls_foo(cls):
@@ -45,3 +50,14 @@ class TestNonLocal:
 
         _set_param(param)
         return self
+
+
+class TestTypingCast:
+    """Test class for use of typing.cast"""
+
+    def function(self):
+        """This function uses typing.cast to reassign self"""
+
+        self = cast(TestTypingCast, self)
+        self, var = cast(TestTypingCast, self), 1
+        print(var)

--- a/tests/functional/s/self/self_cls_assignment.txt
+++ b/tests/functional/s/self/self_cls_assignment.txt
@@ -1,4 +1,5 @@
-self-cls-assignment:11:8:Foo.self_foo:Invalid assignment to bar_ in method
-self-cls-assignment:16:8:Foo.self_foofoo:Invalid assignment to self in method
-self-cls-assignment:21:8:Foo.cls_foo:Invalid assignment to cls in method
-self-cls-assignment:44:12:TestNonLocal.function._set_param:Invalid assignment to self in method
+self-cls-assignment:14:8:Foo.self_foo:Invalid assignment to bar_ in method:HIGH
+self-cls-assignment:19:8:Foo.self_foofoo:Invalid assignment to self in method:HIGH
+self-cls-assignment:20:8:Foo.self_foofoo:Invalid assignment to self in method:HIGH
+self-cls-assignment:26:8:Foo.cls_foo:Invalid assignment to cls in method:HIGH
+self-cls-assignment:49:12:TestNonLocal.function._set_param:Invalid assignment to self in method:HIGH


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Found while working on https://github.com/PyCQA/astroid/pull/1217

I don't think `typing.cast()` should raise this warning. While I was at it I thought I might as well fix this checker for tuple assignments as well.

I would like for this to go in `2.12` so we can get https://github.com/PyCQA/astroid/pull/1217 in `astroid` `2.8.5` and thereby in `2.12.1`.