### PR TITLE
Add mermaidjs as format output for pyreverse

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     rev: v4.0.1
     hooks:
       - id: trailing-whitespace
-        exclude: "tests/functional/t/trailing_whitespaces.py"
+        exclude: "tests/functional/t/trailing_whitespaces.py|tests/pyreverse/data/.*.html"
       - id: end-of-file-fixer
         exclude: "tests/functional/m/missing/missing_final_newline.py|tests/functional/t/trailing_newlines.py"
   - repo: https://github.com/myint/autoflake
@@ -94,3 +94,4 @@ repos:
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]
+        exclude: tests(/.*)*/data

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ What's New in Pylint 2.13.0?
 ============================
 Release date: TBA
 
+* Pyreverse - add output in mermaidjs format
+
 ..
   Put new features here and also in 'doc/whatsnew/2.13.rst'
 

--- a/doc/additional_commands/index.rst
+++ b/doc/additional_commands/index.rst
@@ -9,7 +9,7 @@ Pyreverse
 ---------
 
 ``pyreverse`` analyzes your source code and generates package and class diagrams.
-It supports output to ``.dot``/``.gv``, ``.vcg`` and ``.puml``/``.plantuml`` (PlantUML) file formats.
+It supports output to ``.dot``/``.gv``, ``.vcg``, ``.puml``/``.plantuml`` (PlantUML) and ``.mmd``/``.html`` (MermaidJS) file formats.
 If Graphviz (or the ``dot`` command) is installed, all `output formats supported by Graphviz <https://graphviz.org/docs/outputs/>`_
 can be used as well. In this case, ``pyreverse`` first generates a temporary ``.gv`` file, which is then
 fed to Graphviz to generate the final image.

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -17,6 +17,8 @@ Removed checkers
 Extensions
 ==========
 
+* Pyreverse - add output in mermaid-js format
+
 Other Changes
 =============
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -17,7 +17,7 @@ Removed checkers
 Extensions
 ==========
 
-* Pyreverse - add output in mermaid-js format
+* Pyreverse - add output in mermaid-js format and html which is an mermaid js diagram with html boilerplate
 
 Other Changes
 =============

--- a/pylint/pyreverse/main.py
+++ b/pylint/pyreverse/main.py
@@ -206,7 +206,7 @@ class Run(ConfigurationMixIn):
         super().__init__(usage=__doc__)
         insert_default_options()
         args = self.load_command_line_configuration(args)
-        if self.config.output_format not in ("dot", "vcg", "puml", "plantuml", "mmd"):
+        if self.config.output_format not in ("dot", "vcg", "puml", "plantuml", "mmd", "html"):
             check_graphviz_availability()
 
         sys.exit(self.run(args))

--- a/pylint/pyreverse/main.py
+++ b/pylint/pyreverse/main.py
@@ -206,7 +206,14 @@ class Run(ConfigurationMixIn):
         super().__init__(usage=__doc__)
         insert_default_options()
         args = self.load_command_line_configuration(args)
-        if self.config.output_format not in ("dot", "vcg", "puml", "plantuml", "mmd", "html"):
+        if self.config.output_format not in (
+            "dot",
+            "vcg",
+            "puml",
+            "plantuml",
+            "mmd",
+            "html",
+        ):
             check_graphviz_availability()
 
         sys.exit(self.run(args))

--- a/pylint/pyreverse/main.py
+++ b/pylint/pyreverse/main.py
@@ -206,7 +206,7 @@ class Run(ConfigurationMixIn):
         super().__init__(usage=__doc__)
         insert_default_options()
         args = self.load_command_line_configuration(args)
-        if self.config.output_format not in ("dot", "vcg", "puml", "plantuml"):
+        if self.config.output_format not in ("dot", "vcg", "puml", "plantuml", "mmd"):
             check_graphviz_availability()
 
         sys.exit(self.run(args))

--- a/pylint/pyreverse/mermaidjs_printer.py
+++ b/pylint/pyreverse/mermaidjs_printer.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2021 Antonio Quarta <andi.finkler@gmail.com>
+
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+
+"""
+Class to generate files in mermaidjs format
+"""
+from typing import Dict, Optional
+
+from pylint.pyreverse.printer import EdgeType, NodeProperties, NodeType, Printer
+from pylint.pyreverse.utils import get_annotation_label
+
+
+class MermaidJSPrinter(Printer):
+    """Printer for MermaidJS diagrams"""
+
+    DEFAULT_COLOR = "black"
+
+    NODES: Dict[NodeType, str] = {
+        NodeType.CLASS: "class",
+        NodeType.INTERFACE: "class",
+        NodeType.PACKAGE: "package",
+    }
+    ARROWS: Dict[EdgeType, str] = {
+        EdgeType.INHERITS: "--|>",
+        EdgeType.IMPLEMENTS: "..|>",
+        EdgeType.ASSOCIATION: "--*",
+        EdgeType.USES: "-->",
+    }
+
+    def _open_graph(self) -> None:
+        """Emit the header lines"""
+        self.emit("classDiagram ")
+        self._inc_indent()
+
+    def emit_node(
+        self,
+        name: str,
+        type_: NodeType,
+        properties: Optional[NodeProperties] = None,
+    ) -> None:
+        """Create a new node. Nodes can be classes, packages, participants etc."""
+        if properties is None:
+            properties = NodeProperties(label=name)
+        stereotype = "~~Interface~~" if type_ is NodeType.INTERFACE else ""
+        nodetype = self.NODES[type_]
+        body = []
+        if properties.attrs:
+            body.extend(properties.attrs)
+        if properties.methods:
+            for func in properties.methods:
+                args = self._get_method_arguments(func)
+                line = f"{func.name}({', '.join(args)})"
+                if func.returns:
+                    line += " -> " + get_annotation_label(func.returns)
+                body.append(line)
+        name = name.split(".")[-1]
+        self.emit(f"{nodetype} {name}{stereotype} {{")
+        self._inc_indent()
+        for line in body:
+            self.emit(line)
+        self._dec_indent()
+        self.emit("}")
+
+    def emit_edge(
+        self,
+        from_node: str,
+        to_node: str,
+        type_: EdgeType,
+        label: Optional[str] = None,
+    ) -> None:
+        """Create an edge from one node to another to display relationships."""
+        from_node = from_node.split(".")[-1]
+        to_node = to_node.split(".")[-1]
+        edge = f"{from_node} {self.ARROWS[type_]} {to_node}"
+        if label:
+            edge += f" : {label}"
+        self.emit(edge)
+
+    def _close_graph(self) -> None:
+        """Emit the lines needed to properly close the graph."""
+        self._dec_indent()

--- a/pylint/pyreverse/mermaidjs_printer.py
+++ b/pylint/pyreverse/mermaidjs_printer.py
@@ -81,3 +81,27 @@ class MermaidJSPrinter(Printer):
     def _close_graph(self) -> None:
         """Emit the lines needed to properly close the graph."""
         self._dec_indent()
+
+
+class HTMLMermaidJSPrinter(MermaidJSPrinter):
+    """Printer for MermaidJS diagrams wrapped in an html boilerplate"""
+
+    HTML_OPEN_BOILERPLATE = """
+    <html>
+        <body>
+            <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+        <div class="mermaid">
+    """
+
+    HTML_CLOSE_BOILERPLATE = """
+            </div>
+        </body>
+    </html>
+"""
+
+    def _open_graph(self) -> None:
+        self.emit(self.HTML_OPEN_BOILERPLATE)
+        super()._open_graph()
+
+    def _close_graph(self) -> None:
+        self.emit(self.HTML_CLOSE_BOILERPLATE)

--- a/pylint/pyreverse/mermaidjs_printer.py
+++ b/pylint/pyreverse/mermaidjs_printer.py
@@ -20,7 +20,7 @@ class MermaidJSPrinter(Printer):
     NODES: Dict[NodeType, str] = {
         NodeType.CLASS: "class",
         NodeType.INTERFACE: "class",
-        NodeType.PACKAGE: "package",
+        NodeType.PACKAGE: "class",
     }
     ARROWS: Dict[EdgeType, str] = {
         EdgeType.INHERITS: "--|>",

--- a/pylint/pyreverse/mermaidjs_printer.py
+++ b/pylint/pyreverse/mermaidjs_printer.py
@@ -31,7 +31,7 @@ class MermaidJSPrinter(Printer):
 
     def _open_graph(self) -> None:
         """Emit the header lines"""
-        self.emit("classDiagram ")
+        self.emit("classDiagram")
         self._inc_indent()
 
     def emit_node(
@@ -86,22 +86,25 @@ class MermaidJSPrinter(Printer):
 class HTMLMermaidJSPrinter(MermaidJSPrinter):
     """Printer for MermaidJS diagrams wrapped in an html boilerplate"""
 
-    HTML_OPEN_BOILERPLATE = """
-    <html>
-        <body>
-            <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
-        <div class="mermaid">
+    HTML_OPEN_BOILERPLATE = """<html>
+  <body>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+      <div class="mermaid">
     """
-
     HTML_CLOSE_BOILERPLATE = """
-            </div>
-        </body>
-    </html>
+       </div>
+  </body>
+</html>
 """
+    GRAPH_INDENT_LEVEL = 4
 
     def _open_graph(self) -> None:
         self.emit(self.HTML_OPEN_BOILERPLATE)
+        for _ in range(self.GRAPH_INDENT_LEVEL):
+            self._inc_indent()
         super()._open_graph()
 
     def _close_graph(self) -> None:
+        for _ in range(self.GRAPH_INDENT_LEVEL):
+            self._dec_indent()
         self.emit(self.HTML_CLOSE_BOILERPLATE)

--- a/pylint/pyreverse/printer_factory.py
+++ b/pylint/pyreverse/printer_factory.py
@@ -11,13 +11,14 @@ from pylint.pyreverse.dot_printer import DotPrinter
 from pylint.pyreverse.plantuml_printer import PlantUmlPrinter
 from pylint.pyreverse.printer import Printer
 from pylint.pyreverse.vcg_printer import VCGPrinter
-from pylint.pyreverse.mermaidjs_printer import MermaidJSPrinter
+from pylint.pyreverse.mermaidjs_printer import MermaidJSPrinter, HTMLMermaidJSPrinter
 
 filetype_to_printer: Dict[str, Type[Printer]] = {
     "vcg": VCGPrinter,
     "plantuml": PlantUmlPrinter,
     "puml": PlantUmlPrinter,
     "mmd": MermaidJSPrinter,
+    "html": HTMLMermaidJSPrinter,
     "dot": DotPrinter,
 }
 

--- a/pylint/pyreverse/printer_factory.py
+++ b/pylint/pyreverse/printer_factory.py
@@ -8,10 +8,10 @@
 from typing import Dict, Type
 
 from pylint.pyreverse.dot_printer import DotPrinter
+from pylint.pyreverse.mermaidjs_printer import HTMLMermaidJSPrinter, MermaidJSPrinter
 from pylint.pyreverse.plantuml_printer import PlantUmlPrinter
 from pylint.pyreverse.printer import Printer
 from pylint.pyreverse.vcg_printer import VCGPrinter
-from pylint.pyreverse.mermaidjs_printer import MermaidJSPrinter, HTMLMermaidJSPrinter
 
 filetype_to_printer: Dict[str, Type[Printer]] = {
     "vcg": VCGPrinter,

--- a/pylint/pyreverse/printer_factory.py
+++ b/pylint/pyreverse/printer_factory.py
@@ -11,11 +11,13 @@ from pylint.pyreverse.dot_printer import DotPrinter
 from pylint.pyreverse.plantuml_printer import PlantUmlPrinter
 from pylint.pyreverse.printer import Printer
 from pylint.pyreverse.vcg_printer import VCGPrinter
+from pylint.pyreverse.mermaidjs_printer import MermaidJSPrinter
 
 filetype_to_printer: Dict[str, Type[Printer]] = {
     "vcg": VCGPrinter,
     "plantuml": PlantUmlPrinter,
     "puml": PlantUmlPrinter,
+    "mmd": MermaidJSPrinter,
     "dot": DotPrinter,
 }
 

--- a/tests/pyreverse/conftest.py
+++ b/tests/pyreverse/conftest.py
@@ -43,6 +43,14 @@ def colorized_puml_config() -> PyreverseConfig:
     )
 
 
+@pytest.fixture()
+def mmd_config() -> PyreverseConfig:
+    return PyreverseConfig(
+        output_format="mmd",
+        colorized=False,
+    )
+
+
 @pytest.fixture(scope="session")
 def get_project() -> Callable:
     def _get_project(module: str, name: Optional[str] = "No Name") -> Project:

--- a/tests/pyreverse/conftest.py
+++ b/tests/pyreverse/conftest.py
@@ -51,6 +51,14 @@ def mmd_config() -> PyreverseConfig:
     )
 
 
+@pytest.fixture()
+def html_config() -> PyreverseConfig:
+    return PyreverseConfig(
+        output_format="html",
+        colorized=False,
+    )
+
+
 @pytest.fixture(scope="session")
 def get_project() -> Callable:
     def _get_project(module: str, name: Optional[str] = "No Name") -> Project:

--- a/tests/pyreverse/data/classes_No_Name.html
+++ b/tests/pyreverse/data/classes_No_Name.html
@@ -1,0 +1,47 @@
+
+<html>
+    <body>
+        <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+    <div class="mermaid">
+classDiagram 
+  class Ancestor {
+    attr : str
+    cls_member
+    get_value()
+    set_value(value)
+  }
+  class CustomException {
+  }
+  class DoNothing {
+  }
+  class DoNothing2 {
+  }
+  class DoSomething {
+    my_int : Optional[int]
+    my_int_2 : Optional[int]
+    my_string : str
+    do_it(new_int: int) -> int
+  }
+  class Interface {
+    get_value()
+    set_value(value)
+  }
+  class PropertyPatterns {
+    prop1
+    prop2
+  }
+  class Specialization {
+    TYPE : str
+    relation
+    relation2
+    top : str
+  }
+  Specialization --|> Ancestor
+  Ancestor ..|> Interface
+  DoNothing --* Ancestor : cls_member
+  DoNothing --* Specialization : relation
+  DoNothing2 --* Specialization : relation2
+  
+        </div>
+    </body>
+</html>

--- a/tests/pyreverse/data/classes_No_Name.html
+++ b/tests/pyreverse/data/classes_No_Name.html
@@ -1,47 +1,47 @@
-
 <html>
-    <body>
-        <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
-    <div class="mermaid">
-classDiagram 
-  class Ancestor {
-    attr : str
-    cls_member
-    get_value()
-    set_value(value)
-  }
-  class CustomException {
-  }
-  class DoNothing {
-  }
-  class DoNothing2 {
-  }
-  class DoSomething {
-    my_int : Optional[int]
-    my_int_2 : Optional[int]
-    my_string : str
-    do_it(new_int: int) -> int
-  }
-  class Interface {
-    get_value()
-    set_value(value)
-  }
-  class PropertyPatterns {
-    prop1
-    prop2
-  }
-  class Specialization {
-    TYPE : str
-    relation
-    relation2
-    top : str
-  }
-  Specialization --|> Ancestor
-  Ancestor ..|> Interface
-  DoNothing --* Ancestor : cls_member
-  DoNothing --* Specialization : relation
-  DoNothing2 --* Specialization : relation2
-  
-        </div>
-    </body>
+  <body>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+      <div class="mermaid">
+
+        classDiagram
+          class Ancestor {
+            attr : str
+            cls_member
+            get_value()
+            set_value(value)
+          }
+          class CustomException {
+          }
+          class DoNothing {
+          }
+          class DoNothing2 {
+          }
+          class DoSomething {
+            my_int : Optional[int]
+            my_int_2 : Optional[int]
+            my_string : str
+            do_it(new_int: int) -> int
+          }
+          class Interface {
+            get_value()
+            set_value(value)
+          }
+          class PropertyPatterns {
+            prop1
+            prop2
+          }
+          class Specialization {
+            TYPE : str
+            relation
+            relation2
+            top : str
+          }
+          Specialization --|> Ancestor
+          Ancestor ..|> Interface
+          DoNothing --* Ancestor : cls_member
+          DoNothing --* Specialization : relation
+          DoNothing2 --* Specialization : relation2
+
+       </div>
+  </body>
 </html>

--- a/tests/pyreverse/data/classes_No_Name.mmd
+++ b/tests/pyreverse/data/classes_No_Name.mmd
@@ -1,0 +1,38 @@
+classDiagram 
+  class Ancestor {
+    attr : str
+    cls_member
+    get_value()
+    set_value(value)
+  }
+  class CustomException {
+  }
+  class DoNothing {
+  }
+  class DoNothing2 {
+  }
+  class DoSomething {
+    my_int : Optional[int]
+    my_int_2 : Optional[int]
+    my_string : str
+    do_it(new_int: int) -> int
+  }
+  class Interface {
+    get_value()
+    set_value(value)
+  }
+  class PropertyPatterns {
+    prop1
+    prop2
+  }
+  class Specialization {
+    TYPE : str
+    relation
+    relation2
+    top : str
+  }
+  Specialization --|> Ancestor
+  Ancestor ..|> Interface
+  DoNothing --* Ancestor : cls_member
+  DoNothing --* Specialization : relation
+  DoNothing2 --* Specialization : relation2

--- a/tests/pyreverse/data/classes_No_Name.mmd
+++ b/tests/pyreverse/data/classes_No_Name.mmd
@@ -1,4 +1,4 @@
-classDiagram 
+classDiagram
   class Ancestor {
     attr : str
     cls_member

--- a/tests/pyreverse/data/packages_No_Name.html
+++ b/tests/pyreverse/data/packages_No_Name.html
@@ -1,19 +1,19 @@
-
 <html>
-    <body>
-        <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
-    <div class="mermaid">
-classDiagram 
-  class data {
-  }
-  class clientmodule_test {
-  }
-  class property_pattern {
-  }
-  class suppliermodule_test {
-  }
-  clientmodule_test --> suppliermodule_test
-  
-        </div>
-    </body>
+  <body>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+      <div class="mermaid">
+
+        classDiagram
+          class data {
+          }
+          class clientmodule_test {
+          }
+          class property_pattern {
+          }
+          class suppliermodule_test {
+          }
+          clientmodule_test --> suppliermodule_test
+
+       </div>
+  </body>
 </html>

--- a/tests/pyreverse/data/packages_No_Name.html
+++ b/tests/pyreverse/data/packages_No_Name.html
@@ -1,0 +1,19 @@
+
+<html>
+    <body>
+        <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+    <div class="mermaid">
+classDiagram 
+  class data {
+  }
+  class clientmodule_test {
+  }
+  class property_pattern {
+  }
+  class suppliermodule_test {
+  }
+  clientmodule_test --> suppliermodule_test
+  
+        </div>
+    </body>
+</html>

--- a/tests/pyreverse/data/packages_No_Name.mmd
+++ b/tests/pyreverse/data/packages_No_Name.mmd
@@ -1,4 +1,4 @@
-classDiagram 
+classDiagram
   class data {
   }
   class clientmodule_test {

--- a/tests/pyreverse/data/packages_No_Name.mmd
+++ b/tests/pyreverse/data/packages_No_Name.mmd
@@ -1,0 +1,10 @@
+classDiagram 
+  class data {
+  }
+  class clientmodule_test {
+  }
+  class property_pattern {
+  }
+  class suppliermodule_test {
+  }
+  clientmodule_test --> suppliermodule_test

--- a/tests/pyreverse/test_writer.py
+++ b/tests/pyreverse/test_writer.py
@@ -58,8 +58,8 @@ COLORIZED_DOT_FILES = ["packages_colorized.dot", "classes_colorized.dot"]
 VCG_FILES = ["packages_No_Name.vcg", "classes_No_Name.vcg"]
 PUML_FILES = ["packages_No_Name.puml", "classes_No_Name.puml"]
 COLORIZED_PUML_FILES = ["packages_colorized.puml", "classes_colorized.puml"]
-MMD_FILES = ["packages.mmd", "classes.mmd"]
-HTML_FILES = ["packages.html", "classes.html"]
+MMD_FILES = ["packages_No_Name.mmd", "classes_No_Name.mmd"]
+HTML_FILES = ["packages_No_Name.html", "classes_No_Name.html"]
 
 
 class Config:

--- a/tests/pyreverse/test_writer.py
+++ b/tests/pyreverse/test_writer.py
@@ -58,6 +58,7 @@ COLORIZED_DOT_FILES = ["packages_colorized.dot", "classes_colorized.dot"]
 VCG_FILES = ["packages_No_Name.vcg", "classes_No_Name.vcg"]
 PUML_FILES = ["packages_No_Name.puml", "classes_No_Name.puml"]
 COLORIZED_PUML_FILES = ["packages_colorized.puml", "classes_colorized.puml"]
+MMD_FILES = ["packages.mmd", "classes.mmd"]
 
 
 class Config:
@@ -121,6 +122,14 @@ def setup_colorized_puml(
     yield from _setup(project, colorized_puml_config, writer)
 
 
+@pytest.fixture()
+def setup_mmd(mmd_config: PyreverseConfig, get_project: Callable) -> Iterator:
+    writer = DiagramWriter(mmd_config)
+
+    project = get_project(TEST_DATA_DIR)
+    yield from _setup(project, mmd_config, writer)
+
+
 def _setup(
     project: Project, config: PyreverseConfig, writer: DiagramWriter
 ) -> Iterator:
@@ -161,6 +170,12 @@ def test_vcg_files(generated_file: str) -> None:
 @pytest.mark.usefixtures("setup_puml")
 @pytest.mark.parametrize("generated_file", PUML_FILES)
 def test_puml_files(generated_file: str) -> None:
+    _assert_files_are_equal(generated_file)
+
+
+@pytest.mark.usefixtures("setup_mmd")
+@pytest.mark.parametrize("generated_file", MMD_FILES)
+def test_mmd_files(generated_file: str) -> None:
     _assert_files_are_equal(generated_file)
 
 

--- a/tests/pyreverse/test_writer.py
+++ b/tests/pyreverse/test_writer.py
@@ -134,7 +134,7 @@ def setup_mmd(mmd_config: PyreverseConfig, get_project: Callable) -> Iterator:
 @pytest.fixture()
 def setup_html(html_config: PyreverseConfig, get_project: Callable) -> Iterator:
     writer = DiagramWriter(html_config)
-    
+
     project = get_project(TEST_DATA_DIR)
     yield from _setup(project, html_config, writer)
 
@@ -186,6 +186,7 @@ def test_puml_files(generated_file: str) -> None:
 @pytest.mark.parametrize("generated_file", MMD_FILES)
 def test_mmd_files(generated_file: str) -> None:
     _assert_files_are_equal(generated_file)
+
 
 @pytest.mark.usefixtures("setup_html")
 @pytest.mark.parametrize("generated_file", HTML_FILES)

--- a/tests/pyreverse/test_writer.py
+++ b/tests/pyreverse/test_writer.py
@@ -59,6 +59,7 @@ VCG_FILES = ["packages_No_Name.vcg", "classes_No_Name.vcg"]
 PUML_FILES = ["packages_No_Name.puml", "classes_No_Name.puml"]
 COLORIZED_PUML_FILES = ["packages_colorized.puml", "classes_colorized.puml"]
 MMD_FILES = ["packages.mmd", "classes.mmd"]
+HTML_FILES = ["packages.html", "classes.html"]
 
 
 class Config:
@@ -130,6 +131,14 @@ def setup_mmd(mmd_config: PyreverseConfig, get_project: Callable) -> Iterator:
     yield from _setup(project, mmd_config, writer)
 
 
+@pytest.fixture()
+def setup_html(html_config: PyreverseConfig, get_project: Callable) -> Iterator:
+    writer = DiagramWriter(html_config)
+    
+    project = get_project(TEST_DATA_DIR)
+    yield from _setup(project, html_config, writer)
+
+
 def _setup(
     project: Project, config: PyreverseConfig, writer: DiagramWriter
 ) -> Iterator:
@@ -176,6 +185,11 @@ def test_puml_files(generated_file: str) -> None:
 @pytest.mark.usefixtures("setup_mmd")
 @pytest.mark.parametrize("generated_file", MMD_FILES)
 def test_mmd_files(generated_file: str) -> None:
+    _assert_files_are_equal(generated_file)
+
+@pytest.mark.usefixtures("setup_html")
+@pytest.mark.parametrize("generated_file", HTML_FILES)
+def test_html_files(generated_file: str) -> None:
     _assert_files_are_equal(generated_file)
 
 


### PR DESCRIPTION
This pull request add the [mermaidjs](https://mermaid-js.github.io/mermaid/#/classDiagram) output format (as text like plantuml)

For the packages graph the classDiagram type of diagram is used for mermaidjs, because is the nearest type of graph to the package diagram for this tool.