### PR TITLE
Add a whatsnew entry for python <3.6.2 incompatibility

### DIFF
--- a/doc/whatsnew/2.12.rst
+++ b/doc/whatsnew/2.12.rst
@@ -163,3 +163,12 @@ Other Changes
   Closes #5216
 
 * Make yn validator case insensitive, to allow for ``True`` and ``False`` in config files.
+
+* The last version compatible with python '3.6.0' and '3.6.1' is pylint '2.9.3'. We did not
+  realize that when adding incompatible typing at the time, and all versions since are broken
+  for this interpreter. 2.12.0 meta-information will permit to download pylint on those
+  interpreters but the installation will fail and tell you to install '2.9.3' instead.
+  pylint 2.12.1 will require python >= 3.6.2.
+
+  Closes #5171
+  Follow-up in #5065


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Relates to #5250, #5171
