### PR TITLE
Fix user specific path in functional conf tests for tox

### DIFF
--- a/pylint/testutils/configuration_test.py
+++ b/pylint/testutils/configuration_test.py
@@ -12,7 +12,6 @@ from unittest.mock import Mock
 
 from pylint.lint import Run
 
-USER_SPECIFIC_PATH = Path(__file__).parent.parent.parent
 # We use Any in this typing because the configuration contains real objects and constants
 # that could be a lot of things.
 ConfigurationValue = Any
@@ -71,7 +70,9 @@ def get_expected_configuration(
     return result
 
 
-def get_expected_output(configuration_path: str) -> Tuple[int, str]:
+def get_expected_output(
+    configuration_path: str, user_specific_path: Path
+) -> Tuple[int, str]:
     """Get the expected output of a functional test."""
     output = get_expected_or_default(configuration_path, suffix="out", default="")
     if output:
@@ -87,7 +88,7 @@ def get_expected_output(configuration_path: str) -> Tuple[int, str]:
         exit_code = 0
     return exit_code, output.format(
         abspath=configuration_path,
-        relpath=Path(configuration_path).relative_to(USER_SPECIFIC_PATH),
+        relpath=Path(configuration_path).relative_to(user_specific_path),
     )
 
 

--- a/tests/config/test_functional_config_loading.py
+++ b/tests/config/test_functional_config_loading.py
@@ -32,6 +32,7 @@ from pylint.testutils.configuration_test import (
 )
 
 HERE = Path(__file__).parent
+USER_SPECIFIC_PATH = HERE.parent.parent
 FUNCTIONAL_DIR = HERE / "functional"
 # We use string then recast to path so we can use -k in pytest.
 # Otherwise we get 'configuration_path0' as a test name. The path is relative to the functional
@@ -71,7 +72,9 @@ def test_functional_config_loading(
     caplog.set_level(logging.INFO)
     configuration_path = str(FUNCTIONAL_DIR / configuration_path)
     msg = f"Wrong result with configuration {configuration_path}"
-    expected_code, expected_output = get_expected_output(configuration_path)
+    expected_code, expected_output = get_expected_output(
+        configuration_path, USER_SPECIFIC_PATH
+    )
     expected_loaded_configuration = get_expected_configuration(
         configuration_path, default_configuration
     )


### PR DESCRIPTION


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Detected in https://github.com/PyCQA/pylint/pull/5287#issuecomment-968093640

Tox use its own directory for test so we need to define the user specific path inside tests.
