### PR TITLE
Make ``unused-import`` check all ancestors for typing guards

### DIFF
--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -61,7 +61,7 @@ import os
 import re
 import sys
 from functools import lru_cache
-from typing import DefaultDict, List, Optional, Set, Tuple
+from typing import DefaultDict, List, Optional, Set, Tuple, Union
 
 import astroid
 from astroid import nodes
@@ -358,12 +358,13 @@ def _assigned_locally(name_node):
     return any(a.name == name_node.name for a in assign_stmts)
 
 
-def _is_type_checking_import(node):
-    parent = node.parent
-    if not isinstance(parent, nodes.If):
-        return False
-    test = parent.test
-    return test.as_string() in TYPING_TYPE_CHECKS_GUARDS
+def _is_type_checking_import(node: Union[nodes.Import, nodes.ImportFrom]) -> bool:
+    """Check if an import node is guarded by a TYPE_CHECKS guard"""
+    for ancestor in node.node_ancestors():
+        if isinstance(ancestor, nodes.If):
+            if ancestor.test.as_string() in TYPING_TYPE_CHECKS_GUARDS:
+                return True
+    return False
 
 
 def _has_locals_call_after_node(stmt, scope):

--- a/tests/functional/u/unused/unused_import.py
+++ b/tests/functional/u/unused/unused_import.py
@@ -61,3 +61,7 @@ class NonRegr(object):
     def blop(self):
         """yo"""
         print(self, 'blip')
+
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 6, 2):
+        from typing import NoReturn


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

See https://github.com/PyCQA/astroid/pull/1235#discussion_r749691526