### PR TITLE
Add casts to ``linter.reporter`` in tests

### DIFF
--- a/tests/test_regr.py
+++ b/tests/test_regr.py
@@ -26,7 +26,7 @@ import signal
 import sys
 from contextlib import contextmanager
 from os.path import abspath, dirname, join
-from typing import Callable, Iterator, List
+from typing import Callable, Iterator, List, cast
 
 import astroid
 import pytest
@@ -54,6 +54,9 @@ def finalize_linter(linter: PyLinter) -> Iterator[PyLinter]:
     pending messages if a test finished badly
     """
     yield linter
+    linter.reporter = cast(  # Due to fixture
+        testutils.GenericTestReporter, linter.reporter
+    )
     linter.reporter.finalize()
 
 
@@ -79,6 +82,9 @@ def test_package(
     finalize_linter: PyLinter, file_names: List[str], check: Callable
 ) -> None:
     finalize_linter.check(file_names)
+    finalize_linter.reporter = cast(  # Due to fixture
+        testutils.GenericTestReporter, finalize_linter.reporter
+    )
     got = finalize_linter.reporter.finalize().strip()
     assert check(got)
 
@@ -100,6 +106,9 @@ def test_crash(finalize_linter: PyLinter, file_names: List[str]) -> None:
 )
 def test_descriptor_crash(fname: str, finalize_linter: PyLinter) -> None:
     finalize_linter.check([join(REGR_DATA, fname)])
+    finalize_linter.reporter = cast(  # Due to fixture
+        testutils.GenericTestReporter, finalize_linter.reporter
+    )
     finalize_linter.reporter.finalize().strip()
 
 


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This is necessary to allow typing of `PyLinter.reporter`. Without this change `mypy` will complain that `finalize` does not exist on any of the other reporter classes.