### PR TITLE
use isorts black profile

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,10 +75,8 @@ markers =
     benchmark: Baseline of pylint performance, if this regress something serious happened
 
 [isort]
-multi_line_output = 3
-line_length = 88
+profile = black
 known_third_party = platformdirs, astroid, sphinx, isort, pytest, mccabe, six, toml
-include_trailing_comma = True
 skip_glob = tests/functional/**,tests/input/**,tests/extensions/data/**,tests/regrtest_data/**,tests/data/**,astroid/**,venv/**
 src_paths = pylint
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

isort has a special black profile, this prevents that isorts changes a line and black changes it back.

See https://pycqa.github.io/isort/docs/configuration/black_compatibility.html
