### PR TITLE
Update functional test updater to print actual string

### DIFF
--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -114,4 +114,11 @@ class OutputLine(NamedTuple):
             raise MalformedOutputLineException(row, e) from e
 
     def to_csv(self) -> Tuple[str, str, str, str, str, str]:
-        return tuple(str(i) for i in self)  # type: ignore[return-value] # pylint: disable=not-an-iterable
+        return (
+            str(self.symbol),
+            str(self.lineno),
+            str(self.column),
+            str(self.object),
+            str(self.msg),
+            str(self.confidence),
+        )

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -65,9 +65,8 @@ class LintModuleOutputUpdate(testutils.LintModuleTest):
                 os.remove(self._test_file.expected_output)
             return
         with open(self._test_file.expected_output, "w", encoding="utf-8") as f:
-            writer = csv.writer(f, dialect="test")
             for line in actual_output:
-                writer.writerow(line.to_csv())
+                print(":".join(line.to_csv()), file=f)
 
 
 def get_tests():


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

@Pierre-Sassoulas 

The problem was we're using the `csv` module which tries to escape delimiters and quote characters. See https://docs.python.org/3/library/csv.html
This is problematic for use as we're using `'` and `"` interchangeably in the messages we put out (something to be fixed soon™.

For now I think this also works. I tested with some of the files in the other PR and the results seemed satisfactory. You can use this fix and update `tests/functional/a/async_functions.txt` to see if it works. That output has both `'` and `"`.