### PR TITLE
Revert "Update functional test updater to print actual string"

### DIFF
--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -114,11 +114,4 @@ class OutputLine(NamedTuple):
             raise MalformedOutputLineException(row, e) from e
 
     def to_csv(self) -> Tuple[str, str, str, str, str, str]:
-        return (
-            str(self.symbol),
-            str(self.lineno),
-            str(self.column),
-            str(self.object),
-            str(self.msg),
-            str(self.confidence),
-        )
+        return tuple(str(i) for i in self)  # type: ignore[return-value] # pylint: disable=not-an-iterable

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -65,8 +65,9 @@ class LintModuleOutputUpdate(testutils.LintModuleTest):
                 os.remove(self._test_file.expected_output)
             return
         with open(self._test_file.expected_output, "w", encoding="utf-8") as f:
+            writer = csv.writer(f, dialect="test")
             for line in actual_output:
-                print(":".join(line.to_csv()), file=f)
+                writer.writerow(line.to_csv())
 
 
 def get_tests():


### PR DESCRIPTION
Reverts PyCQA/pylint#5351

See:
https://github.com/PyCQA/pylint/pull/5351#issuecomment-974827473