### PR TITLE
Add accetpance tests in CI for python 3.8+ instead of launching manually at release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -475,3 +475,37 @@ jobs:
         run: |
           . venv/bin/activate
           pytest --benchmark-disable tests/
+
+  pytest-acceptance:
+    name: Run acceptance tests Python ${{ matrix.python-version }} (Linux)
+    runs-on: ubuntu-latest
+    needs: prepare-tests-linux
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, "3.10"]
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.3.5
+      - name: Set up Python ${{ matrix.python-version }}
+        id: python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Restore Python virtual environment
+        id: cache-venv
+        uses: actions/cache@v2.1.6
+        with:
+          path: venv
+          key:
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            needs.prepare-tests-linux.outputs.python-key }}
+      - name: Fail job if Python cache restore failed
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore Python venv from cache"
+          exit 1
+      - name: Run pytest
+        run: |
+          . venv/bin/activate
+          pip install -e .
+          pytest -m acceptance -n auto

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -476,8 +476,8 @@ jobs:
           . venv/bin/activate
           pytest --benchmark-disable tests/
 
-  pytest-acceptance:
-    name: Run acceptance tests Python ${{ matrix.python-version }} (Linux)
+  pytest-primer-stlib:
+    name: Run primer tests on stdlib Python ${{ matrix.python-version }} (Linux)
     runs-on: ubuntu-latest
     needs: prepare-tests-linux
     strategy:
@@ -508,4 +508,4 @@ jobs:
         run: |
           . venv/bin/activate
           pip install -e .
-          pytest -m acceptance -n auto
+          pytest -m primer_stdlib -n auto

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ testpaths = tests
 python_files = *test_*.py
 addopts = -m "not acceptance"
 markers =
-    acceptance:
+    acceptance: Checks for crashes and errors when running pylint on stdlib
     benchmark: Baseline of pylint performance, if this regress something serious happened
 
 [isort]

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,9 +69,9 @@ test = pytest
 [tool:pytest]
 testpaths = tests
 python_files = *test_*.py
-addopts = -m "not acceptance"
+addopts = -m "not primer_stdlib"
 markers =
-    acceptance: Checks for crashes and errors when running pylint on stdlib
+    primer_stdlib: Checks for crashes and errors when running pylint on stdlib
     benchmark: Baseline of pylint performance, if this regress something serious happened
 
 [isort]

--- a/tbump.toml
+++ b/tbump.toml
@@ -36,10 +36,6 @@ cmd = "pip3 install copyrite;copyrite --contribution-threshold 1 --change-thresh
 name = "Apply pre-commit"
 cmd = "pre-commit run --all-files||echo 'Hack so this command does not fail'"
 
-[[before_commit]]
-name = "Acceptance tests"
-cmd = "pytest -m acceptance"
-
 # Or run some commands after the git tag and the branch
 # have been pushed:
 #  [[after_push]]

--- a/tests/primer/test_primer_stdlib.py
+++ b/tests/primer/test_primer_stdlib.py
@@ -50,14 +50,12 @@ def test_lib_module_no_crash(
     os.chdir(test_module_location)
     with _patch_stdout(io.StringIO()):
         try:
-            pylint.lint.Run(
-                [
-                    test_module_name,
-                    "--enable=all",
-                    "--enable-all-extensions",
-                    "--ignore=test",
-                ]
-            )
+            # We want to test all the code we can
+            enables = ["--enable-all-extensions", "--enable=all"]
+            # Duplicate code takes too long and is relatively safe
+            # We don't want to lint the test directory which are repetitive
+            disables = ["--disable=duplicate-code", "--ignore=test"]
+            pylint.lint.Run([test_module_name] + enables + disables)
         except SystemExit as ex:
             out, err = capsys.readouterr()
             assert not err, err

--- a/tests/primer/test_primer_stdlib.py
+++ b/tests/primer/test_primer_stdlib.py
@@ -39,7 +39,7 @@ MODULES_TO_CHECK = [
 MODULES_NAMES = [m[1] for m in MODULES_TO_CHECK]
 
 
-@pytest.mark.acceptance
+@pytest.mark.primer_stdlib
 @pytest.mark.parametrize(
     ("test_module_location", "test_module_name"), MODULES_TO_CHECK, ids=MODULES_NAMES
 )


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

First step before primer that will be done in #5173. We need to separate both test because they take a long time see https://github.com/PyCQA/pylint/pull/5173#issuecomment-974828609
