### PR TITLE
Fix a crash on psycopg2 for elif used 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,11 @@ Release date: TBA
 
 * Fix ``install graphiz`` message which isn't needed for puml output format.
 
+* Fix a crash in the ``check_elif`` extensions where an undetected ifs in comprehension
+  containing an if within a fstring resulted in a out of range error. The checker do not
+  rely on counting ifs anymore and use known ifs locations instead. It should not crash
+  on badly parsed ifs anymore.
+
 * Fix ``simplify-boolean-expression`` when condition can be inferred as False.
 
   Closes #5200

--- a/ChangeLog
+++ b/ChangeLog
@@ -17,10 +17,10 @@ Release date: TBA
 
 * Fix ``install graphiz`` message which isn't needed for puml output format.
 
-* Fix a crash in the ``check_elif`` extensions where an undetected ifs in comprehension
-  containing an if within a fstring resulted in a out of range error. The checker do not
-  rely on counting ifs anymore and use known ifs locations instead. It should not crash
-  on badly parsed ifs anymore.
+* Fix a crash in the ``check_elif`` extensions where an undetected if in a comprehension
+  with an if statement within a f-string resulted in an out of range error. The checker no
+  longer relies on counting if statements anymore and uses known if statements locations instead.
+  It should not crash on badly parsed if statements anymore.
 
 * Fix ``simplify-boolean-expression`` when condition can be inferred as False.
 

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -1848,20 +1848,18 @@ a metaclass class method.",
                     "bad-mcs-method-argument",
                     node.name,
                 )
-        # regular class
-        else:  # pylint: disable=else-if-used
-            # class method
-            if node.type == "classmethod" or node.name == "__class_getitem__":
-                self._check_first_arg_config(
-                    first,
-                    self.config.valid_classmethod_first_arg,
-                    node,
-                    "bad-classmethod-argument",
-                    node.name,
-                )
-            # regular method without self as argument
-            elif first != "self":
-                self.add_message("no-self-argument", node=node)
+        # regular class with class method
+        elif node.type == "classmethod" or node.name == "__class_getitem__":
+            self._check_first_arg_config(
+                first,
+                self.config.valid_classmethod_first_arg,
+                node,
+                "bad-classmethod-argument",
+                node.name,
+            )
+        # regular class with regular method without self as argument
+        elif first != "self":
+            self.add_message("no-self-argument", node=node)
 
     def _check_first_arg_config(self, first, config, node, message, method_name):
         if first not in config:

--- a/pylint/extensions/check_elif.py
+++ b/pylint/extensions/check_elif.py
@@ -42,11 +42,9 @@ class ElseifUsedChecker(BaseTokenChecker):
 
     def process_tokens(self, tokens):
         """Process tokens and look for 'if' or 'elif'"""
-        for _, token, begin, _, _ in tokens:
-            if token == "elif":
-                self._elifs[begin] = True
-            elif token == "if":
-                self._elifs[begin] = False
+        self._elifs = {
+            begin: token for _, token, begin, _, _ in tokens if token in {"elif", "if"}
+        }
 
     def leave_module(self, _: nodes.Module) -> None:
         self._init()
@@ -58,7 +56,7 @@ class ElseifUsedChecker(BaseTokenChecker):
             isinstance(node.parent, nodes.If)
             and node.parent.orelse == [node]
             and (node.lineno, node.col_offset) in self._elifs
-            and not self._elifs[(node.lineno, node.col_offset)]
+            and self._elifs[(node.lineno, node.col_offset)] == "if"
         ):
             self.add_message("else-if-used", node=node, confidence=HIGH)
 

--- a/pylint/extensions/check_elif.py
+++ b/pylint/extensions/check_elif.py
@@ -66,7 +66,10 @@ class ElseifUsedChecker(BaseTokenChecker):
             orelse = node.parent.orelse
             # current if node must directly follow an "else"
             if orelse and orelse == [node]:
-                if not self._elifs[self._if_counter]:
+                if (
+                    self._if_counter < len(self._elifs)
+                    and not self._elifs[self._if_counter]
+                ):
                     self.add_message("else-if-used", node=node)
         self._if_counter += 1
 

--- a/pylint/extensions/check_elif.py
+++ b/pylint/extensions/check_elif.py
@@ -15,7 +15,7 @@ from astroid import nodes
 
 from pylint.checkers import BaseTokenChecker
 from pylint.checkers.utils import check_messages
-from pylint.interfaces import IAstroidChecker, ITokenChecker
+from pylint.interfaces import HIGH, IAstroidChecker, ITokenChecker
 
 
 class ElseifUsedChecker(BaseTokenChecker):
@@ -60,7 +60,7 @@ class ElseifUsedChecker(BaseTokenChecker):
             and (node.lineno, node.col_offset) in self._elifs
             and not self._elifs[(node.lineno, node.col_offset)]
         ):
-            self.add_message("else-if-used", node=node)
+            self.add_message("else-if-used", node=node, confidence=HIGH)
 
 
 def register(linter):

--- a/pylint/extensions/check_elif.py
+++ b/pylint/extensions/check_elif.py
@@ -59,6 +59,7 @@ class ElseifUsedChecker(BaseTokenChecker):
 
     def visit_comprehension(self, node: nodes.Comprehension) -> None:
         self._if_counter += len(node.ifs)
+        self._elifs.insert(self._if_counter, True)
 
     @check_messages("else-if-used")
     def visit_if(self, node: nodes.If) -> None:
@@ -67,6 +68,8 @@ class ElseifUsedChecker(BaseTokenChecker):
             # current if node must directly follow an "else"
             if orelse and orelse == [node]:
                 if (
+                    # Safeguard if we missed an if in self._elifs
+                    # See https://github.com/PyCQA/pylint/pull/5369
                     self._if_counter < len(self._elifs)
                     and not self._elifs[self._if_counter]
                 ):

--- a/pylint/extensions/check_elif.py
+++ b/pylint/extensions/check_elif.py
@@ -57,6 +57,7 @@ class ElseifUsedChecker(BaseTokenChecker):
         if (
             isinstance(node.parent, nodes.If)
             and node.parent.orelse == [node]
+            and (node.lineno, node.col_offset) in self._elifs
             and not self._elifs[(node.lineno, node.col_offset)]
         ):
             self.add_message("else-if-used", node=node)

--- a/tests/functional/ext/check_elif/check_elif.py
+++ b/tests/functional/ext/check_elif/check_elif.py
@@ -51,4 +51,26 @@ def _if_in_fstring_comprehension_with_elif():
         if "t" not in "false":  # [else-if-used]
             raise TypeError("d")
         else:
-            print("e")
+            if "y" in "life":  # [else-if-used]
+                print("e")
+
+
+def simple_if_else(node) -> None:
+    """This should not emit anything"""
+    if isinstance(node, str):
+        node_name = node
+    elif (
+        isinstance(node, int)
+        and node.op == "not"
+        and isinstance(node, float)
+    ):
+        node_name = node.test.operand
+    elif (
+        isinstance(node.test, list)
+        and isinstance(node.test.left, dict)
+        and len(node.test.ops) == 1
+    ):
+        node_name = node.test.left
+    else:
+        return node
+    return node_name

--- a/tests/functional/ext/check_elif/check_elif.py
+++ b/tests/functional/ext/check_elif/check_elif.py
@@ -37,3 +37,18 @@ def _if_in_fstring_comprehension():
         )
     elif "i" in "true":
         raise TypeError("d")
+
+
+def _if_in_fstring_comprehension_with_elif():
+    order = {}
+    if "z" not in "false":
+        raise TypeError(
+            f" {', '.join(sorted(i for i in order or () if i not in vars))}"
+        )
+    elif "z" not in "true":
+        pass
+    else:
+        if "t" not in "false":  # [else-if-used]
+            raise TypeError("d")
+        else:
+            print("e")

--- a/tests/functional/ext/check_elif/check_elif.py
+++ b/tests/functional/ext/check_elif/check_elif.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-else-raise,unsupported-membership-test,using-constant-test
 
 """Checks use of "else if" triggers a refactor message"""
+from typing import Union, Sequence, Any, Mapping
 
 
 def my_function():
@@ -29,11 +30,13 @@ def my_function():
                 myint = 4
 
 
-def _if_in_fstring_comprehension_with_elif():
+def _if_in_fstring_comprehension_with_elif(
+    params: Union[Sequence[Any], Mapping[str, Any]]
+):
     order = {}
     if "z" not in "false":
         raise TypeError(
-            f" {', '.join(sorted(i for i in order or () if i not in vars))}"
+            f" {', '.join(sorted(i for i in order or () if i not in params))}"
         )
     elif "z" not in "true":
         pass

--- a/tests/functional/ext/check_elif/check_elif.py
+++ b/tests/functional/ext/check_elif/check_elif.py
@@ -1,3 +1,5 @@
+# pylint: disable=no-else-raise,unsupported-membership-test,using-constant-test
+
 """Checks use of "else if" triggers a refactor message"""
 
 
@@ -7,7 +9,7 @@ def my_function():
     if myint > 5:
         pass
     else:
-        if myint <= 5:  #  [else-if-used]
+        if myint <= 5:  # [else-if-used]
             pass
         else:
             myint = 3
@@ -25,3 +27,13 @@ def my_function():
                 if myint:
                     pass
                 myint = 4
+
+
+def _if_in_fstring_comprehension():
+    order = {}
+    if "z" not in "false":
+        raise TypeError(
+            f" {', '.join(sorted(i for i in order or () if i not in vars))}"
+        )
+    elif "i" in "true":
+        raise TypeError("d")

--- a/tests/functional/ext/check_elif/check_elif.py
+++ b/tests/functional/ext/check_elif/check_elif.py
@@ -29,16 +29,6 @@ def my_function():
                 myint = 4
 
 
-def _if_in_fstring_comprehension():
-    order = {}
-    if "z" not in "false":
-        raise TypeError(
-            f" {', '.join(sorted(i for i in order or () if i not in vars))}"
-        )
-    elif "i" in "true":
-        raise TypeError("d")
-
-
 def _if_in_fstring_comprehension_with_elif():
     order = {}
     if "z" not in "false":
@@ -53,24 +43,3 @@ def _if_in_fstring_comprehension_with_elif():
         else:
             if "y" in "life":  # [else-if-used]
                 print("e")
-
-
-def simple_if_else(node) -> None:
-    """This should not emit anything"""
-    if isinstance(node, str):
-        node_name = node
-    elif (
-        isinstance(node, int)
-        and node.op == "not"
-        and isinstance(node, float)
-    ):
-        node_name = node.test.operand
-    elif (
-        isinstance(node.test, list)
-        and isinstance(node.test.left, dict)
-        and len(node.test.ops) == 1
-    ):
-        node_name = node.test.left
-    else:
-        return node
-    return node_name

--- a/tests/functional/ext/check_elif/check_elif.txt
+++ b/tests/functional/ext/check_elif/check_elif.txt
@@ -1,4 +1,4 @@
 else-if-used:12:8:my_function:"Consider using ""elif"" instead of ""else if""":HIGH
 else-if-used:24:20:my_function:"Consider using ""elif"" instead of ""else if""":HIGH
-else-if-used:51:8:_if_in_fstring_comprehension_with_elif:"Consider using ""elif"" instead of ""else if""":HIGH
-else-if-used:54:12:_if_in_fstring_comprehension_with_elif:"Consider using ""elif"" instead of ""else if""":HIGH
+else-if-used:41:8:_if_in_fstring_comprehension_with_elif:"Consider using ""elif"" instead of ""else if""":HIGH
+else-if-used:44:12:_if_in_fstring_comprehension_with_elif:"Consider using ""elif"" instead of ""else if""":HIGH

--- a/tests/functional/ext/check_elif/check_elif.txt
+++ b/tests/functional/ext/check_elif/check_elif.txt
@@ -1,2 +1,3 @@
 else-if-used:12:8:my_function:"Consider using ""elif"" instead of ""else if""":HIGH
 else-if-used:24:20:my_function:"Consider using ""elif"" instead of ""else if""":HIGH
+else-if-used:50:8:_if_in_fstring_comprehension_with_elif:"Consider using ""elif"" instead of ""else if""":HIGH

--- a/tests/functional/ext/check_elif/check_elif.txt
+++ b/tests/functional/ext/check_elif/check_elif.txt
@@ -1,2 +1,2 @@
-else-if-used:10:8:my_function:"Consider using ""elif"" instead of ""else if""":HIGH
-else-if-used:22:20:my_function:"Consider using ""elif"" instead of ""else if""":HIGH
+else-if-used:12:8:my_function:"Consider using ""elif"" instead of ""else if""":HIGH
+else-if-used:24:20:my_function:"Consider using ""elif"" instead of ""else if""":HIGH

--- a/tests/functional/ext/check_elif/check_elif.txt
+++ b/tests/functional/ext/check_elif/check_elif.txt
@@ -1,3 +1,4 @@
 else-if-used:12:8:my_function:"Consider using ""elif"" instead of ""else if""":HIGH
 else-if-used:24:20:my_function:"Consider using ""elif"" instead of ""else if""":HIGH
-else-if-used:50:8:_if_in_fstring_comprehension_with_elif:"Consider using ""elif"" instead of ""else if""":HIGH
+else-if-used:51:8:_if_in_fstring_comprehension_with_elif:"Consider using ""elif"" instead of ""else if""":HIGH
+else-if-used:54:12:_if_in_fstring_comprehension_with_elif:"Consider using ""elif"" instead of ""else if""":HIGH

--- a/tests/functional/ext/check_elif/check_elif.txt
+++ b/tests/functional/ext/check_elif/check_elif.txt
@@ -1,4 +1,4 @@
-else-if-used:12:8:my_function:"Consider using ""elif"" instead of ""else if""":HIGH
-else-if-used:24:20:my_function:"Consider using ""elif"" instead of ""else if""":HIGH
-else-if-used:41:8:_if_in_fstring_comprehension_with_elif:"Consider using ""elif"" instead of ""else if""":HIGH
-else-if-used:44:12:_if_in_fstring_comprehension_with_elif:"Consider using ""elif"" instead of ""else if""":HIGH
+else-if-used:13:8:my_function:"Consider using ""elif"" instead of ""else if""":HIGH
+else-if-used:25:20:my_function:"Consider using ""elif"" instead of ""else if""":HIGH
+else-if-used:44:8:_if_in_fstring_comprehension_with_elif:"Consider using ""elif"" instead of ""else if""":HIGH
+else-if-used:47:12:_if_in_fstring_comprehension_with_elif:"Consider using ""elif"" instead of ""else if""":HIGH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Description

https://github.com/psycopg/psycopg/blob/master/psycopg/psycopg/_queries.py#L281

Exception on node <If l.281 at 0x7f2f9141a550> 

pylint crashed with a ``IndexError`` and with the following stacktrace:
```
Traceback (most recent call last):
  File "/home/pierre/pylint/pylint/lint/pylinter.py", line 1035, in _check_files
    self._check_file(get_ast, check_astroid_module, file)
  File "/home/pierre/pylint/pylint/lint/pylinter.py", line 1070, in _check_file
    check_astroid_module(ast_node)
  File "/home/pierre/pylint/pylint/lint/pylinter.py", line 1204, in check_astroid_module
    retval = self._check_astroid_module(
  File "/home/pierre/pylint/pylint/lint/pylinter.py", line 1251, in _check_astroid_module
    walker.walk(node)
  File "/home/pierre/pylint/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  File "/home/pierre/pylint/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  File "/home/pierre/pylint/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  [Previous line repeated 1 more time]
  File "/home/pierre/pylint/pylint/utils/ast_walker.py", line 72, in walk
    callback(astroid)
  File "/home/pierre/pylint/pylint/extensions/check_elif.py", line 69, in visit_if
    if not self._elifs[self._if_counter]:
IndexError: list index out of range
```

The hot fix would be:
```diff
--- a/pylint/extensions/check_elif.py
+++ b/pylint/extensions/check_elif.py
@@ -66,7 +66,7 @@ class ElseifUsedChecker(BaseTokenChecker):
             orelse = node.parent.orelse
             # current if node must directly follow an "else"
             if orelse and orelse == [node]:
-                if not self._elifs[self._if_counter]:
+                if self._if_counter < len(self._elifs) and not self._elifs[self._if_counter]:
                     self.add_message("else-if-used", node=node)
         self._if_counter += 1
```

It seem to me that counting the if/elif properly would take some time. I created a minimal reproduction example:
```
def _if_in_fstring_comprehension():
    order = {}
    if not "false":
        raise TypeError(
            f" {', '.join(sorted(i for i in order or () if i not in vars))}"
        )
    elif "true":
        raise TypeError("d")
```
The issue come from the f string with a comprehension inside it that is not separated for the token processing.        

Detected in #5173 
