### PR TITLE
Make parallel checker use ``MessageLocationTuple`` for ``Message``

### DIFF
--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -8,7 +8,7 @@ from typing import Any, DefaultDict, Iterable, List, Tuple
 from pylint import reporters
 from pylint.lint.utils import _patch_sys_path
 from pylint.message import Message
-from pylint.typing import FileItem
+from pylint.typing import FileItem, MessageLocationTuple
 from pylint.utils import LinterStats, merge_stats
 
 try:
@@ -138,7 +138,9 @@ def check_parallel(linter, jobs, files: Iterable[FileItem], arguments=None):
             linter.file_state.base_name = base_name
             linter.set_current_module(module, file_path)
             for msg in messages:
-                msg = Message(*msg)
+                msg = Message(
+                    msg[0], msg[1], MessageLocationTuple(*msg[2]), msg[3], msg[4]
+                )
                 linter.reporter.handle_message(msg)  # type: ignore[attr-defined]  # linter.set_reporter() call above makes linter have a reporter attr
             all_stats.append(stats)
             all_mapreduce_data[worker_idx].append(mapreduce_data)


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

No longer trigger our own `DeprecationWarning` for `Message` requiring `MessageLocationTuple`.