### PR TITLE
Fix #85, #2615: Emit `used-before-assignment` in final or except blocks where try statements could have failed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,11 @@ Release date: TBA
 
   Closes #4761
 
+* ``used-before-assignment`` now considers that assignments in a try block
+  may not have occurred when the except or finally blocks are executed.
+
+  Closes #85, #2615
+
 * ``used-before-assignment`` now checks names in try blocks.
 
 * Some files in ``pylint.testutils`` were deprecated. In the future imports should be done from the

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -36,6 +36,11 @@ Other Changes
 
   Closes #4761
 
+* ``used-before-assignment`` now considers that assignments in a try block
+  may not have occurred when the except or finally blocks are executed.
+
+  Closes #85, #2615
+
 * ``used-before-assignment`` now checks names in try blocks.
 
 * Require Python ``3.6.2`` to run pylint.

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -405,8 +405,11 @@ MSGS = {
     "E0601": (
         "Using variable %r before assignment",
         "used-before-assignment",
-        "Used when a local variable is accessed before its assignment or within "
-        "except or finally blocks without being defined before the try block.",
+        "Emitted when a local variable is accessed before its assignment took place. "
+        "Assignments in try blocks are assumed not to have occurred when evaluating "
+        "associated except/finally blocks. Assignments in except blocks are assumed "
+        "not to have occurred, except when the associated try block contains a return "
+        "statement.",
     ),
     "E0602": (
         "Undefined variable %r",

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -698,7 +698,6 @@ scope_type : {self._atomic.scope_type}
                     and n.statement(future=True) in n.statement(future=True).parent.body
                     and node.statement(future=True).parent
                     in n.statement(future=True).parent.handlers
-                    and n.statement(future=True) in n.statement(future=True).parent.body
                 )
             ]
             filtered_nodes_set = set(filtered_nodes)

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -408,8 +408,7 @@ MSGS = {
         "Emitted when a local variable is accessed before its assignment took place. "
         "Assignments in try blocks are assumed not to have occurred when evaluating "
         "associated except/finally blocks. Assignments in except blocks are assumed "
-        "not to have occurred, except when the associated try block contains a return "
-        "statement.",
+        "not to have occurred when evaluating statements outside the block.",
     ),
     "E0602": (
         "Undefined variable %r",

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -581,12 +581,10 @@ scope_type : {self._atomic.scope_type}
     def consumed_uncertain(self) -> DefaultDict[str, List[nodes.NodeNG]]:
         """
         Retrieves nodes filtered out by get_next_to_consume() that may not
-        have executed, such as statements in except blocks. Checkers that
-        want to treat the statements as executed (e.g. for unused-variable)
-        may need to add them back.
-
-        TODO: A pending PR will extend this to nodes in try blocks when
-        evaluating their corresponding except and finally blocks.
+        have executed, such as statements in except blocks, or statements
+        in try blocks (when evaluating their corresponding except and finally
+        blocks). Checkers that want to treat the statements as executed
+        (e.g. for unused-variable) may need to add them back.
         """
         return self._atomic.consumed_uncertain
 

--- a/tests/functional/u/use/used_before_assignment_issue2615.py
+++ b/tests/functional/u/use/used_before_assignment_issue2615.py
@@ -1,0 +1,9 @@
+"""https://github.com/PyCQA/pylint/issues/2615"""
+def main():
+    """When evaluating except blocks, assume try statements fail."""
+    try:
+        res = 1 / 0
+        res = 42
+    except ZeroDivisionError:
+        print(res)  # [used-before-assignment]
+    print(res)

--- a/tests/functional/u/use/used_before_assignment_issue2615.txt
+++ b/tests/functional/u/use/used_before_assignment_issue2615.txt
@@ -1,0 +1,1 @@
+used-before-assignment:8:14:8:17:main:Using variable 'res' before assignment:UNDEFINED

--- a/tests/functional/u/use/used_before_assignment_issue85.py
+++ b/tests/functional/u/use/used_before_assignment_issue85.py
@@ -1,0 +1,9 @@
+"""https://github.com/PyCQA/pylint/issues/85"""
+def main():
+    """When evaluating finally blocks, assume try statements fail."""
+    try:
+        res = 1 / 0
+        res = 42
+    finally:
+        print(res)  # [used-before-assignment]
+    print(res)

--- a/tests/functional/u/use/used_before_assignment_issue85.txt
+++ b/tests/functional/u/use/used_before_assignment_issue85.txt
@@ -1,0 +1,1 @@
+used-before-assignment:8:14:8:17:main:Using variable 'res' before assignment:UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

**Previously**
Pylint assumed assignments in the Try block of a Try/Finally or Try/Except pair would succeed. In cases of failure, though, attempting to use such names in a final or except block would raise `UnboundLocalError`.

**Now**
Pylint emits `used-before-assignment` to account for the fact that the statement might have been interrupted by an exception.

Closes #85, Closes #2615
