### PR TITLE
Bump pylint to 2.12.2, update changelog

### DIFF
--- a/.copyrite_aliases
+++ b/.copyrite_aliases
@@ -97,6 +97,11 @@
     "name": "Mark Byrne"
   },
   {
+    "mails": ["36848472+yushao2@users.noreply.github.com", "p.yushao2@gmail.com"],
+    "authoritative_mail": "36848472+yushao2@users.noreply.github.com",
+    "name": "Yu Shao, Pang"
+  },
+  {
     "mails": [
       "66853113+pre-commit-ci[bot]@users.noreply.github.com",
       "49699333+dependabot[bot]@users.noreply.github.com"

--- a/ChangeLog
+++ b/ChangeLog
@@ -15,12 +15,22 @@ Release date: TBA
   (Ie. not necessarily at the end)
 
 
-What's New in Pylint 2.12.2?
+What's New in Pylint 2.12.3?
 ============================
 Release date: TBA
 
 ..
   Put bug fixes that should not wait for a new minor version here
+
+
+..
+  Insert your changelog randomly, it will reduce merge conflicts
+  (Ie. not necessarily at the end)
+
+
+What's New in Pylint 2.12.2?
+============================
+Release date: 2021-11-25
 
 * Fixed a false positive for ``unused-import`` where everything
   was not analyzed properly inside typing guards.
@@ -54,9 +64,14 @@ Release date: TBA
 
   Closes #5452
 
-..
-  Insert your changelog randomly, it will reduce merge conflicts
-  (Ie. not necessarily at the end)
+* Fix false negative for ``consider-iterating-dictionary`` during membership checks encapsulated in iterables
+  or ``not in`` checks
+
+  Closes #5323
+
+* ``unused-import`` now check all ancestors for typing guards
+
+  Closes #5316
 
 
 What's New in Pylint 2.12.1?
@@ -85,11 +100,6 @@ Release date: 2021-11-24
   ``pylint/testutil/`` are still unstable and might be modified in the near future.
 
   Closes #4412 #5287
-
-* Fix false negative for ``consider-iterating-dictionary`` during membership checks encapsulated in iterables
-  or ``not in`` checks
-
-  Closes #5323
 
 * Fix ``install graphiz`` message which isn't needed for puml output format.
 

--- a/doc/whatsnew/2.12.rst
+++ b/doc/whatsnew/2.12.rst
@@ -250,3 +250,8 @@ Other Changes
 * Add ``endLine`` and ``endColumn`` keys to output of ``JSONReporter``.
 
   Closes #5380
+
+* Fix false negative for ``consider-iterating-dictionary`` during membership checks encapsulated in iterables
+  or ``not in`` checks
+
+  Closes #5323

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -20,11 +20,6 @@ Extensions
 Other Changes
 =============
 
-* Fix false negative for ``consider-iterating-dictionary`` during membership checks encapsulated in iterables
-  or ``not in`` checks
-
-  Closes #5323
-
 * Require Python ``3.6.2`` to run pylint.
 
   Closes #5065

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 from typing import Tuple
 
-__version__ = "2.12.2"
+__version__ = "2.13.0-dev0"
 
 
 def get_numversion_from_version(v: str) -> Tuple:

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 from typing import Tuple
 
-__version__ = "2.12.2-dev0"
+__version__ = "2.12.2"
 
 
 def get_numversion_from_version(v: str) -> Tuple:

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -39,10 +39,9 @@
 # Copyright (c) 2021 Samuel Freilich <sfreilich@google.com>
 # Copyright (c) 2021 Nick Pesce <nickpesce22@gmail.com>
 # Copyright (c) 2021 bot <bot@noreply.github.com>
-# Copyright (c) 2021 yushao2 <36848472+yushao2@users.noreply.github.com>
+# Copyright (c) 2021 Yu Shao, Pang <36848472+yushao2@users.noreply.github.com>
 # Copyright (c) 2021 SupImDos <62866982+SupImDos@users.noreply.github.com>
 # Copyright (c) 2021 Kayran Schmidt <59456929+yumasheta@users.noreply.github.com>
-# Copyright (c) 2021 Yu Shao, Pang <p.yushao2@gmail.com>
 # Copyright (c) 2021 Konstantina Saketou <56515303+ksaketou@users.noreply.github.com>
 # Copyright (c) 2021 James Sinclair <james@nurfherder.com>
 # Copyright (c) 2021 tiagohonorato <61059243+tiagohonorato@users.noreply.github.com>

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -23,7 +23,7 @@
 # Copyright (c) 2021 Melvin <31448155+melvio@users.noreply.github.com>
 # Copyright (c) 2021 Rebecca Turner <rbt@sent.as>
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
-# Copyright (c) 2021 yushao2 <36848472+yushao2@users.noreply.github.com>
+# Copyright (c) 2021 Yu Shao, Pang <36848472+yushao2@users.noreply.github.com>
 
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -39,7 +39,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 # Copyright (c) 2021 Will Shanks <wsha@posteo.net>
 # Copyright (c) 2021 Matus Valo <matusvalo@users.noreply.github.com>
-# Copyright (c) 2021 yushao2 <36848472+yushao2@users.noreply.github.com>
+# Copyright (c) 2021 Yu Shao, Pang <36848472+yushao2@users.noreply.github.com>
 # Copyright (c) 2021 Andrew Howe <howeaj@users.noreply.github.com>
 
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -47,7 +47,7 @@
 # Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
 # Copyright (c) 2021 David Liu <david@cs.toronto.edu>
 # Copyright (c) 2021 doranid <ddandd@gmail.com>
-# Copyright (c) 2021 yushao2 <36848472+yushao2@users.noreply.github.com>
+# Copyright (c) 2021 Yu Shao, Pang <36848472+yushao2@users.noreply.github.com>
 # Copyright (c) 2021 Andrew Haigh <nelfin@gmail.com>
 # Copyright (c) 2021 Jens H. Nielsen <Jens.Nielsen@microsoft.com>
 # Copyright (c) 2021 Ikraduya Edian <ikraduya@gmail.com>

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -42,17 +42,17 @@
 # Copyright (c) 2020 Slavfox <slavfoxman@gmail.com>
 # Copyright (c) 2020 Anthony Sottile <asottile@umich.edu>
 # Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
+# Copyright (c) 2021 bot <bot@noreply.github.com>
+# Copyright (c) 2021 Yu Shao, Pang <36848472+yushao2@users.noreply.github.com>
 # Copyright (c) 2021 Mark Byrne <31762852+mbyrnepr2@users.noreply.github.com>
 # Copyright (c) 2021 Nick Drozd <nicholasdrozd@gmail.com>
 # Copyright (c) 2021 Arianna Y <92831762+areveny@users.noreply.github.com>
 # Copyright (c) 2021 Jaehoon Hwang <jaehoonhwang@users.noreply.github.com>
 # Copyright (c) 2021 Samuel FORESTIER <HorlogeSkynet@users.noreply.github.com>
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
-# Copyright (c) 2021 bot <bot@noreply.github.com>
 # Copyright (c) 2021 David Liu <david@cs.toronto.edu>
 # Copyright (c) 2021 Matus Valo <matusvalo@users.noreply.github.com>
 # Copyright (c) 2021 Lorena B <46202743+lorena-b@users.noreply.github.com>
-# Copyright (c) 2021 yushao2 <36848472+yushao2@users.noreply.github.com>
 
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -15,6 +15,7 @@
 # Copyright (c) 2019 Zeb Nicholls <zebedee.nicholls@climate-energy-college.org>
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 # Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
+# Copyright (c) 2021 allanc65 <95424144+allanc65@users.noreply.github.com>
 # Copyright (c) 2021 Konstantina Saketou <56515303+ksaketou@users.noreply.github.com>
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 

--- a/pylint/reporters/json_reporter.py
+++ b/pylint/reporters/json_reporter.py
@@ -6,8 +6,8 @@
 # Copyright (c) 2019 Hugo van Kemenade <hugovk@users.noreply.github.com>
 # Copyright (c) 2020 hippo91 <guillaume.peillex@gmail.com>
 # Copyright (c) 2020 Clément Pit-Claudel <cpitclaudel@users.noreply.github.com>
-# Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
+# Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
 
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE

--- a/pylint/reporters/text.py
+++ b/pylint/reporters/text.py
@@ -12,8 +12,8 @@
 # Copyright (c) 2019-2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 # Copyright (c) 2019 Hugo van Kemenade <hugovk@users.noreply.github.com>
 # Copyright (c) 2020 hippo91 <guillaume.peillex@gmail.com>
-# Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 # Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
+# Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 # Copyright (c) 2021 bot <bot@noreply.github.com>
 
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/PyCQA/pylint"
 
 [version]
-current = "2.12.2"
+current = "2.13.0-dev0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/PyCQA/pylint"
 
 [version]
-current = "2.12.2-dev0"
+current = "2.12.2"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/tests/checkers/unittest_utils.py
+++ b/tests/checkers/unittest_utils.py
@@ -11,9 +11,9 @@
 # Copyright (c) 2019 Nathan Marrow <nmarrow@google.com>
 # Copyright (c) 2020 hippo91 <guillaume.peillex@gmail.com>
 # Copyright (c) 2020 Anthony Sottile <asottile@umich.edu>
+# Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
 # Copyright (c) 2021 Jaehoon Hwang <jaehoonhwang@users.noreply.github.com>
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
-# Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
 
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE

--- a/tests/unittest_reporters_json.py
+++ b/tests/unittest_reporters_json.py
@@ -7,8 +7,8 @@
 # Copyright (c) 2019-2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 # Copyright (c) 2019 Ashley Whetter <ashley@awhetter.co.uk>
 # Copyright (c) 2020 hippo91 <guillaume.peillex@gmail.com>
-# Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
+# Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
 
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE

--- a/tests/unittest_reporting.py
+++ b/tests/unittest_reporting.py
@@ -9,8 +9,8 @@
 # Copyright (c) 2019-2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 # Copyright (c) 2019 Ashley Whetter <ashley@awhetter.co.uk>
 # Copyright (c) 2020 hippo91 <guillaume.peillex@gmail.com>
-# Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
+# Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
 # Copyright (c) 2021 ruro <ruro.ruro@ya.ru>
 
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Release branche for 2.12.2 and add missing doc for https://github.com/PyCQA/pylint/pull/5316
