### PR TITLE
Fix #3675: `safe_infer()` finds ambiguity among function definitions when number of arguments differ

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,11 @@ Release date: TBA
 * Some files in ``pylint.testutils`` were deprecated. In the future imports should be done from the
   ``pylint.testutils.functional`` namespace directly.
 
+* ``safe_infer`` no longer makes an inference given two function
+  definitions with differing numbers of arguments.
+
+  Closes #3675
+
 * Fix ``unnecessary_dict_index_lookup`` false positive when deleting a dictionary's entry.
 
   Closes #4716

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,7 +14,7 @@ Release date: TBA
 * Some files in ``pylint.testutils`` were deprecated. In the future imports should be done from the
   ``pylint.testutils.functional`` namespace directly.
 
-* ``safe_infer`` no longer makes an inference given two function
+* ``safe_infer`` no longer makes an inference when given two function
   definitions with differing numbers of arguments.
 
   Closes #3675

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1260,13 +1260,13 @@ def safe_infer(node: nodes.NodeNG, context=None) -> Optional[nodes.NodeNG]:
             inferred_type = _get_python_type_of_node(inferred)
             if inferred_type not in inferred_types:
                 return None  # If there is ambiguity on the inferred node.
-            if isinstance(inferred, nodes.FunctionDef):
-                if (
-                    inferred.args.args is not None
-                    and value.args.args is not None
-                    and len(inferred.args.args) != len(value.args.args)
-                ):
-                    return None  # Different number of arguments indicates ambiguity
+            if (
+                isinstance(inferred, nodes.FunctionDef)
+                and inferred.args.args is not None
+                and value.args.args is not None
+                and len(inferred.args.args) != len(value.args.args)
+            ):
+                return None  # Different number of arguments indicates ambiguity
     except astroid.InferenceError:
         return None  # There is some kind of ambiguity
     except StopIteration:

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1260,6 +1260,19 @@ def safe_infer(node: nodes.NodeNG, context=None) -> Optional[nodes.NodeNG]:
             inferred_type = _get_python_type_of_node(inferred)
             if inferred_type not in inferred_types:
                 return None  # If there is ambiguity on the inferred node.
+            if isinstance(inferred, astroid.FunctionDef):
+                # Special case due to unexpected inference ambiguity
+                if (
+                    inferred.name == "TemporaryFile"
+                    and value.name == "NamedTemporaryFile"
+                ):
+                    continue
+                if (
+                    inferred.args.args is not None
+                    and value.args.args is not None
+                    and len(inferred.args.args) != len(value.args.args)
+                ):
+                    return None  # Different number of arguments indicates ambiguity
     except astroid.InferenceError:
         return None  # There is some kind of ambiguity
     except StopIteration:

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1260,7 +1260,7 @@ def safe_infer(node: nodes.NodeNG, context=None) -> Optional[nodes.NodeNG]:
             inferred_type = _get_python_type_of_node(inferred)
             if inferred_type not in inferred_types:
                 return None  # If there is ambiguity on the inferred node.
-            if isinstance(inferred, astroid.FunctionDef):
+            if isinstance(inferred, nodes.FunctionDef):
                 if (
                     inferred.args.args is not None
                     and value.args.args is not None

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1261,12 +1261,6 @@ def safe_infer(node: nodes.NodeNG, context=None) -> Optional[nodes.NodeNG]:
             if inferred_type not in inferred_types:
                 return None  # If there is ambiguity on the inferred node.
             if isinstance(inferred, astroid.FunctionDef):
-                # Special case due to unexpected inference ambiguity
-                if (
-                    inferred.name == "TemporaryFile"
-                    and value.name == "NamedTemporaryFile"
-                ):
-                    continue
                 if (
                     inferred.args.args is not None
                     and value.args.args is not None

--- a/tests/functional/c/consider/consider_using_with.py
+++ b/tests/functional/c/consider/consider_using_with.py
@@ -21,7 +21,7 @@ def test_urlopen():
 
 
 def test_temporary_file():
-    _ = tempfile.TemporaryFile("r")  # [consider-using-with]
+    _ = tempfile.TemporaryFile("r")  # ambiguous with NamedTemporaryFile
 
 
 def test_named_temporary_file():

--- a/tests/functional/c/consider/consider_using_with.txt
+++ b/tests/functional/c/consider/consider_using_with.txt
@@ -1,6 +1,5 @@
 consider-using-with:15:9:15:40:test_codecs_open:Consider using 'with' for resource-allocating operations:UNDEFINED
 consider-using-with:20:8:20:55:test_urlopen:Consider using 'with' for resource-allocating operations:UNDEFINED
-consider-using-with:24:8:24:35:test_temporary_file:Consider using 'with' for resource-allocating operations:UNDEFINED
 consider-using-with:28:8:28:40:test_named_temporary_file:Consider using 'with' for resource-allocating operations:UNDEFINED
 consider-using-with:32:8:32:42:test_spooled_temporary_file:Consider using 'with' for resource-allocating operations:UNDEFINED
 consider-using-with:36:8:36:37:test_temporary_directory:Consider using 'with' for resource-allocating operations:UNDEFINED

--- a/tests/functional/t/too/too_many_function_args.py
+++ b/tests/functional/t/too/too_many_function_args.py
@@ -1,0 +1,19 @@
+"""https://github.com/PyCQA/pylint/issues/3675"""
+
+
+def noop(x):  # pylint: disable=invalid-name
+    """Return value unchanged"""
+    return x
+
+
+def add(x, y):  # pylint: disable=invalid-name
+    """Add two values"""
+    return x + y
+
+
+def main(param):
+    """Should not emit too-many-function-args"""
+    tmp = noop  # matched first
+    if param == 0:
+        tmp = add
+    return tmp(1, 1.01)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

**Before**
`safe_infer` might confuse two function definitions having different numbers of arguments.

**Now**
It won't. <s>But there is an inference problem with `TemporaryFile` being inferred as `NamedTemporaryFile`, which has an extra argument (`delete`), so I special-cased it. Is that an Astroid issue?</s> Update: the way `tempfile` defines the name `TemporaryFile` conditionally based on platform means Astroid finds ambiguity.

Closes #3675
