### PR TITLE
Fix #5371: Correctly count arguments to static methods missing @staticmethod decorator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,11 @@ Release date: TBA
   Put new features here and also in 'doc/whatsnew/2.13.rst'
 
 
+* Fixed detection of ``arguments-differ`` when superclass static
+  methods lacked a ``@staticmethod`` decorator.
+
+  Closes #5371
+
 ..
   Insert your changelog randomly, it will reduce merge conflicts
   (Ie. not necessarily at the end)
@@ -21,11 +26,6 @@ Release date: TBA
 
 ..
   Put bug fixes that should not wait for a new minor version here
-
-* Fixed detection of ``arguments-differ`` when superclass static
-  methods lacked a ``@staticmethod`` decorator.
-
-  Closes #5371
 
 * Fixed a false positive for ``unused-import`` where everything
   was not analyzed properly inside typing guards.

--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,11 @@ Release date: TBA
 ..
   Put bug fixes that should not wait for a new minor version here
 
+* Fixed detection of ``arguments-differ`` when superclass static
+  methods lacked a ``@staticmethod`` decorator.
+
+  Closes #5371
+
 * Fixed a false positive for ``unused-import`` where everything
   was not analyzed properly inside typing guards.
 

--- a/pylint/checkers/classes.py
+++ b/pylint/checkers/classes.py
@@ -178,7 +178,7 @@ def _definition_equivalent_to_call(definition, call):
 
 def _positional_parameters(method):
     positional = method.args.args
-    if method.type in {"classmethod", "method"}:
+    if method.is_bound() and method.type in {"classmethod", "method"}:
         positional = positional[1:]
     return positional
 

--- a/pylint/checkers/mapreduce_checker.py
+++ b/pylint/checkers/mapreduce_checker.py
@@ -14,7 +14,6 @@ class MapReduceMixin(metaclass=abc.ABCMeta):
     def get_map_data(self):
         """Returns mergable/reducible data that will be examined"""
 
-    @classmethod
     @abc.abstractmethod
-    def reduce_map_data(cls, linter, data):
+    def reduce_map_data(self, linter, data):
         """For a given Checker, receives data for all mapped runs"""

--- a/tests/functional/a/arguments_differ.py
+++ b/tests/functional/a/arguments_differ.py
@@ -152,7 +152,6 @@ class SuperClass(object):
         return arg1 + arg2
 
     def should_have_been_decorated_as_static(arg1, arg2):  # pylint: disable=no-self-argument
-        # Enum._generate_next_value in stdlib should be static
         return arg1 + arg2
 
 

--- a/tests/functional/a/arguments_differ.py
+++ b/tests/functional/a/arguments_differ.py
@@ -141,7 +141,7 @@ class PropertySetter(Property):
 
 class StaticmethodChild2(Staticmethod):
 
-    def func(self, data):
+    def func(self, data):  # [arguments-differ]
         super().func(data)
 
 
@@ -151,14 +151,23 @@ class SuperClass(object):
     def impl(arg1, arg2, **kwargs):
         return arg1 + arg2
 
+    def should_have_been_decorated_as_static(arg1, arg2):  # pylint: disable=no-self-argument
+        # Enum._generate_next_value in stdlib should be static
+        return arg1 + arg2
+
 
 class MyClass(SuperClass):
 
-    def impl(self, *args, **kwargs):
+    @staticmethod
+    def impl(*args, **kwargs):
         """
         Acceptable use of vararg in subclass because it does not violate LSP.
         """
         super().impl(*args, **kwargs)
+
+    @staticmethod
+    def should_have_been_decorated_as_static(arg1, arg2):
+        return arg1 + arg2
 
 
 class FirstHasArgs(object):

--- a/tests/functional/a/arguments_differ.txt
+++ b/tests/functional/a/arguments_differ.txt
@@ -4,9 +4,9 @@ arguments-differ:41:4:42:12:ClassmethodChild.func:Number of parameters was 2 in 
 arguments-differ:68:4:69:64:VarargsChild.has_kwargs:Variadics removed in overridden 'VarargsChild.has_kwargs' method:UNDEFINED
 arguments-renamed:71:4:72:89:VarargsChild.no_kwargs:Parameter 'args' has been renamed to 'arg' in overridden 'VarargsChild.no_kwargs' method:UNDEFINED
 arguments-differ:144:4:145:26:StaticmethodChild2.func:Number of parameters was 1 in 'Staticmethod.func' and is now 2 in overridden 'StaticmethodChild2.func' method:UNDEFINED
-arguments-differ:181:4:182:12:SecondChangesArgs.test:Number of parameters was 2 in 'FirstHasArgs.test' and is now 4 in overridden 'SecondChangesArgs.test' method:UNDEFINED
-arguments-differ:307:4:308:60:Foo.kwonly_1:Number of parameters was 4 in 'AbstractFoo.kwonly_1' and is now 3 in overridden 'Foo.kwonly_1' method:UNDEFINED
-arguments-differ:310:4:311:82:Foo.kwonly_2:Number of parameters was 3 in 'AbstractFoo.kwonly_2' and is now 2 in overridden 'Foo.kwonly_2' method:UNDEFINED
-arguments-differ:313:4:314:32:Foo.kwonly_3:Number of parameters was 3 in 'AbstractFoo.kwonly_3' and is now 3 in overridden 'Foo.kwonly_3' method:UNDEFINED
-arguments-differ:316:4:317:32:Foo.kwonly_4:Number of parameters was 3 in 'AbstractFoo.kwonly_4' and is now 3 in overridden 'Foo.kwonly_4' method:UNDEFINED
-arguments-differ:319:4:320:41:Foo.kwonly_5:Variadics removed in overridden 'Foo.kwonly_5' method:UNDEFINED
+arguments-differ:180:4:181:12:SecondChangesArgs.test:Number of parameters was 2 in 'FirstHasArgs.test' and is now 4 in overridden 'SecondChangesArgs.test' method:UNDEFINED
+arguments-differ:306:4:307:60:Foo.kwonly_1:Number of parameters was 4 in 'AbstractFoo.kwonly_1' and is now 3 in overridden 'Foo.kwonly_1' method:UNDEFINED
+arguments-differ:309:4:310:82:Foo.kwonly_2:Number of parameters was 3 in 'AbstractFoo.kwonly_2' and is now 2 in overridden 'Foo.kwonly_2' method:UNDEFINED
+arguments-differ:312:4:313:32:Foo.kwonly_3:Number of parameters was 3 in 'AbstractFoo.kwonly_3' and is now 3 in overridden 'Foo.kwonly_3' method:UNDEFINED
+arguments-differ:315:4:316:32:Foo.kwonly_4:Number of parameters was 3 in 'AbstractFoo.kwonly_4' and is now 3 in overridden 'Foo.kwonly_4' method:UNDEFINED
+arguments-differ:318:4:319:41:Foo.kwonly_5:Variadics removed in overridden 'Foo.kwonly_5' method:UNDEFINED

--- a/tests/functional/a/arguments_differ.txt
+++ b/tests/functional/a/arguments_differ.txt
@@ -3,9 +3,10 @@ arguments-differ:23:4:24:12:ChildDefaults.test:Number of parameters was 3 in 'Pa
 arguments-differ:41:4:42:12:ClassmethodChild.func:Number of parameters was 2 in 'Classmethod.func' and is now 0 in overridden 'ClassmethodChild.func' method:UNDEFINED
 arguments-differ:68:4:69:64:VarargsChild.has_kwargs:Variadics removed in overridden 'VarargsChild.has_kwargs' method:UNDEFINED
 arguments-renamed:71:4:72:89:VarargsChild.no_kwargs:Parameter 'args' has been renamed to 'arg' in overridden 'VarargsChild.no_kwargs' method:UNDEFINED
-arguments-differ:172:4:173:12:SecondChangesArgs.test:Number of parameters was 2 in 'FirstHasArgs.test' and is now 4 in overridden 'SecondChangesArgs.test' method:UNDEFINED
-arguments-differ:298:4:299:60:Foo.kwonly_1:Number of parameters was 4 in 'AbstractFoo.kwonly_1' and is now 3 in overridden 'Foo.kwonly_1' method:UNDEFINED
-arguments-differ:301:4:302:82:Foo.kwonly_2:Number of parameters was 3 in 'AbstractFoo.kwonly_2' and is now 2 in overridden 'Foo.kwonly_2' method:UNDEFINED
-arguments-differ:304:4:305:32:Foo.kwonly_3:Number of parameters was 3 in 'AbstractFoo.kwonly_3' and is now 3 in overridden 'Foo.kwonly_3' method:UNDEFINED
-arguments-differ:307:4:308:32:Foo.kwonly_4:Number of parameters was 3 in 'AbstractFoo.kwonly_4' and is now 3 in overridden 'Foo.kwonly_4' method:UNDEFINED
-arguments-differ:310:4:311:41:Foo.kwonly_5:Variadics removed in overridden 'Foo.kwonly_5' method:UNDEFINED
+arguments-differ:144:4:145:26:StaticmethodChild2.func:Number of parameters was 1 in 'Staticmethod.func' and is now 2 in overridden 'StaticmethodChild2.func' method:UNDEFINED
+arguments-differ:181:4:182:12:SecondChangesArgs.test:Number of parameters was 2 in 'FirstHasArgs.test' and is now 4 in overridden 'SecondChangesArgs.test' method:UNDEFINED
+arguments-differ:307:4:308:60:Foo.kwonly_1:Number of parameters was 4 in 'AbstractFoo.kwonly_1' and is now 3 in overridden 'Foo.kwonly_1' method:UNDEFINED
+arguments-differ:310:4:311:82:Foo.kwonly_2:Number of parameters was 3 in 'AbstractFoo.kwonly_2' and is now 2 in overridden 'Foo.kwonly_2' method:UNDEFINED
+arguments-differ:313:4:314:32:Foo.kwonly_3:Number of parameters was 3 in 'AbstractFoo.kwonly_3' and is now 3 in overridden 'Foo.kwonly_3' method:UNDEFINED
+arguments-differ:316:4:317:32:Foo.kwonly_4:Number of parameters was 3 in 'AbstractFoo.kwonly_4' and is now 3 in overridden 'Foo.kwonly_4' method:UNDEFINED
+arguments-differ:319:4:320:41:Foo.kwonly_5:Variadics removed in overridden 'Foo.kwonly_5' method:UNDEFINED

--- a/tests/functional/a/arguments_differ_issue5371.py
+++ b/tests/functional/a/arguments_differ_issue5371.py
@@ -1,0 +1,13 @@
+"""https://github.com/PyCQA/pylint/issues/5371"""
+from enum import Enum
+
+
+class MyEnum(Enum):
+    """
+    Enum._generate_next_value_() in the stdlib currently lacks a
+    @staticmethod decorator.
+    """
+
+    @staticmethod
+    def _generate_next_value_(name: str, start: int, count: int, last_values: list):
+        return 42

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -13,6 +13,7 @@
 
 import os
 from typing import List
+from pylint.checkers.mapreduce_checker import MapReduceMixin
 
 import pytest
 from astroid import nodes
@@ -73,7 +74,7 @@ class SequentialTestChecker(BaseChecker):
         self.data.append(record)
 
 
-class ParallelTestChecker(BaseChecker):
+class ParallelTestChecker(BaseChecker, MapReduceMixin):
     """A checker that does need to consolidate data.
 
     To simulate the need to consolidate data, this checker only

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -13,7 +13,6 @@
 
 import os
 from typing import List
-from pylint.checkers.mapreduce_checker import MapReduceMixin
 
 import pytest
 from astroid import nodes
@@ -21,6 +20,7 @@ from astroid import nodes
 import pylint.interfaces
 import pylint.lint.parallel
 from pylint.checkers.base_checker import BaseChecker
+from pylint.checkers.mapreduce_checker import MapReduceMixin
 from pylint.lint import PyLinter
 from pylint.lint.parallel import _worker_check_single_file as worker_check_single_file
 from pylint.lint.parallel import _worker_initialize as worker_initialize


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

**Before**
Static methods lacking a `@staticmethod` decorator, such as `Enum._generate_next_value()` in the stdlib would have their first argument stripped when counting their arguments, even though it wasn't `self` or `cls`. This caused comparison issues in `arguments-differ`, including both false negatives and positives.

**Now**
Check if the method is bound before stripping the first argument.

Closes #5371
