### PR TITLE
Move ``TestVariablesChecker`` to functional tests

### DIFF
--- a/tests/functional/g/globals.py
+++ b/tests/functional/g/globals.py
@@ -1,5 +1,5 @@
 """Warnings about global statements and usage of global variables."""
-# pylint: disable=invalid-name, redefined-outer-name, missing-function-docstring
+# pylint: disable=invalid-name, redefined-outer-name, missing-function-docstring, import-outside-toplevel
 from __future__ import print_function
 
 global CSTE  # [global-at-module-level]
@@ -65,3 +65,9 @@ def override_func():
         pass
 
     FUNC()
+
+def func():
+    """Overriding a global with an import should only throw a global statement error"""
+    global sys  # [global-statement]
+
+    import sys

--- a/tests/functional/g/globals.txt
+++ b/tests/functional/g/globals.txt
@@ -9,3 +9,4 @@ global-variable-not-assigned:39:4:39:19:global_no_assign:Using global for 'CONST
 global-statement:45:4:45:19:global_operator_assign:Using the global statement:UNDEFINED
 global-statement:52:4:52:19:global_function_assign:Using the global statement:UNDEFINED
 global-statement:62:4:62:15:override_func:Using the global statement:UNDEFINED
+global-statement:71:4:71:14:func:Using the global statement:UNDEFINED

--- a/tests/functional/n/no/no_name_in_module.py
+++ b/tests/functional/n/no/no_name_in_module.py
@@ -75,3 +75,6 @@ except Exception:
 from .no_self_use import Super
 from .no_self_use import lala  # [no-name-in-module]
 from .no_self_use.bla import lala1 # [no-name-in-module]
+
+# Check ignored-modules setting
+from argparse import THIS_does_not_EXIST

--- a/tests/functional/n/no/no_name_in_module.rc
+++ b/tests/functional/n/no/no_name_in_module.rc
@@ -1,0 +1,2 @@
+[TYPECHECK]
+ignored-modules=argparse

--- a/tests/functional/r/redefined_builtin.py
+++ b/tests/functional/r/redefined_builtin.py
@@ -1,11 +1,27 @@
 """Tests for redefining builtins."""
+# pylint: disable=unused-import, wrong-import-position, reimported, import-error
+# pylint: disable=redefined-outer-name, import-outside-toplevel, wrong-import-order
 from __future__ import print_function
+
 
 def function():
     """Redefined local."""
     type = 1  # [redefined-builtin]
     print(type)
 
+
 # pylint:disable=invalid-name
 map = {}  # [redefined-builtin]
-__doc__ = 'reset the doc'
+__doc__ = "reset the doc"
+
+
+# Test redefining-builtins
+from notos import open  # [redefined-builtin]
+
+# Test default redefining-builtins-modules setting
+from os import open
+
+# Test non-default redefining-builtins-modules setting in function
+def test():
+    """Function importing a function"""
+    from os import open

--- a/tests/functional/r/redefined_builtin.rc
+++ b/tests/functional/r/redefined_builtin.rc
@@ -1,0 +1,2 @@
+[VARIABLES]
+redefining-builtins-modules=os

--- a/tests/functional/r/redefined_builtin.txt
+++ b/tests/functional/r/redefined_builtin.txt
@@ -1,2 +1,3 @@
-redefined-builtin:6:4:6:8:function:Redefining built-in 'type':UNDEFINED
-redefined-builtin:10:0:10:3::Redefining built-in 'map':UNDEFINED
+redefined-builtin:9:4:9:8:function:Redefining built-in 'type':UNDEFINED
+redefined-builtin:14:0:14:3::Redefining built-in 'map':UNDEFINED
+redefined-builtin:19:0:19:22::Redefining built-in 'open':UNDEFINED

--- a/tests/functional/u/undefined/undefined_variable_classes.py
+++ b/tests/functional/u/undefined/undefined_variable_classes.py
@@ -1,0 +1,23 @@
+"""Tests for undefined-variable related to classes"""
+# pylint: disable=missing-function-docstring, missing-class-docstring, too-few-public-methods
+
+# Test that list comprehensions in base classes are scoped correctly
+# Regression reported in https://github.com/PyCQA/pylint/issues/3434
+
+import collections
+
+l = ["a", "b", "c"]
+
+
+class Foo(collections.namedtuple("Foo", [x + "_foo" for x in l])):
+    pass
+
+
+# Test that class attributes are in scope for return type annotations.
+# Regression reported in https://github.com/PyCQA/pylint/issues/1976
+class MyObject:
+    class MyType:
+        pass
+
+    def my_method(self) -> MyType:
+        pass

--- a/tests/functional/u/undefined/undefined_variable_decorators.py
+++ b/tests/functional/u/undefined/undefined_variable_decorators.py
@@ -1,0 +1,21 @@
+"""Tests for undefined-variable related to decorators"""
+# pylint: disable=missing-function-docstring, missing-class-docstring, too-few-public-methods
+# pylint: disable=unnecessary-comprehension
+
+# Test that class attributes are in scope for listcomp in decorator.
+# Regression reported in https://github.com/PyCQA/pylint/issues/511
+
+def dec(inp):
+    def inner(func):
+        print(inp)
+        return func
+    return inner
+
+
+class Cls:
+
+    DATA = "foo"
+
+    @dec([x for x in DATA])
+    def fun(self):
+        pass

--- a/tests/functional/u/undefined/undefined_variable_typing.py
+++ b/tests/functional/u/undefined/undefined_variable_typing.py
@@ -1,0 +1,12 @@
+"""Tests for undefined-variable related to typing"""
+# pylint: disable=invalid-name, import-error
+
+# Ensure attribute lookups in type comments are accounted for.
+# Reported in https://github.com/PyCQA/pylint/issues/4603
+
+import foo
+from foo import Bar, Boo
+
+a = ...  # type: foo.Bar
+b = ...  # type: foo.Bar[Boo]
+c = ...  # type: Bar.Boo

--- a/tests/functional/u/undefined/undefined_variable_typing.rc
+++ b/tests/functional/u/undefined/undefined_variable_typing.rc
@@ -1,0 +1,2 @@
+[testoptions]
+except_implementations=PyPy

--- a/tests/functional/u/unused/unused_module.py
+++ b/tests/functional/u/unused/unused_module.py
@@ -1,0 +1,13 @@
+"""Regression test for unused-module.
+Reported in https://bitbucket.org/logilab/pylint/issue/78/
+"""
+
+from sys import path
+
+path += ["stuff"]
+
+
+def func():
+    """A function"""
+    other = 1
+    return len(other)


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

I left one tests as it seems to test specific `pylint` functionality that is not easily represented in a functional test.