### PR TITLE
Fix ``_regexp_paths_csv_validator`` for already validated values

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,11 @@ Release date: TBA
   windows directory delimiter instead of a regular expression escape
   character.
 
+* Fixed a crash with the ``ignore-paths`` option when invoking the option
+  via the command line.
+
+  Closes #5437
+
 ..
   Insert your changelog randomly, it will reduce merge conflicts
   (Ie. not necessarily at the end)

--- a/pylint/config/option.py
+++ b/pylint/config/option.py
@@ -5,7 +5,7 @@ import copy
 import optparse  # pylint: disable=deprecated-module
 import pathlib
 import re
-from typing import List, Pattern
+from typing import List, Pattern, Union
 
 from pylint import utils
 
@@ -27,7 +27,11 @@ def _regexp_csv_validator(_, name, value):
     return [_regexp_validator(_, name, val) for val in _csv_validator(_, name, value)]
 
 
-def _regexp_paths_csv_validator(_, name: str, value: str) -> List[Pattern[str]]:
+def _regexp_paths_csv_validator(
+    _, name: str, value: Union[str, List[Pattern[str]]]
+) -> List[Pattern[str]]:
+    if isinstance(value, list):
+        return value
     patterns = []
     for val in _csv_validator(_, name, value):
         patterns.append(

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1259,3 +1259,13 @@ class TestRunTC:
             exit=False,
         )
         assert sorted(plugins) == sorted(runner.linter._dynamic_plugins)
+
+    @staticmethod
+    def test_regex_paths_csv_validator() -> None:
+        """Test to see if _regexp_paths_csv_validator works.
+        Previously the validator crashed when encountering already validated values.
+        Reported in https://github.com/PyCQA/pylint/issues/5437
+        """
+        with pytest.raises(SystemExit) as ex:
+            Run(["--ignore-paths", "test", join(HERE, "regrtest_data", "empty.py")])
+        assert ex.value.code == 0


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #5437

I have not done anything to the error. The error is actually based on a pattern we have made, but should never be encountered by users. Since this is also related to `optparse` I don't think it is worth the effort to improve the error code and handling of it for now.