### PR TITLE
Fix false positive for ``used-before-assignment`` for vars in methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,11 @@ Release date: TBA
 * Fixed a false positive for ``unused-import`` where everything
   was not analyzed properly inside typing guards.
 
+* Fixed a false-positive regression for ``used-before-assignment`` for
+  typed variables in the body of class methods that reference the same class
+
+  Closes #5342
+
 * Specified that the ``ignore-paths`` option considers "\" to represent a
   windows directory delimiter instead of a regular expression escape
   character.

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1688,7 +1688,10 @@ class VariablesChecker(BaseChecker):
             1 = Break
             2 = Break + emit message
         """
-        if node.frame().parent == defstmt:
+        if (
+            node.frame().parent == defstmt
+            and node.statement(future=True) not in node.frame().body
+        ):
             # Check if used as type annotation
             # Break but don't emit message if postponed evaluation is enabled
             if utils.is_node_in_type_annotation_context(node):

--- a/tests/functional/u/use/used_before_assignment.py
+++ b/tests/functional/u/use/used_before_assignment.py
@@ -2,37 +2,7 @@
 # pylint: disable=consider-using-f-string, missing-function-docstring
 __revision__ = None
 
-from typing import List
-
 
 MSG = "hello %s" % MSG  # [used-before-assignment]
 
 MSG2 = "hello %s" % MSG2  # [used-before-assignment]
-
-
-class MyClass:
-    """Type annotation or default values for first level methods can't refer to their own class"""
-
-    def incorrect_typing_method(
-        self, other: MyClass  # [used-before-assignment]
-    ) -> bool:
-        return self == other
-
-    def incorrect_nested_typing_method(
-        self, other: List[MyClass]  # [used-before-assignment]
-    ) -> bool:
-        return self == other[0]
-
-    def incorrect_default_method(
-        self, other=MyClass()  # [used-before-assignment]
-    ) -> bool:
-        return self == other
-
-    def correct_string_typing_method(self, other: "MyClass") -> bool:
-        return self == other
-
-    def correct_inner_typing_method(self) -> bool:
-        def inner_method(self, other: MyClass) -> bool:
-            return self == other
-
-        return inner_method(self, MyClass())

--- a/tests/functional/u/use/used_before_assignment.txt
+++ b/tests/functional/u/use/used_before_assignment.txt
@@ -1,5 +1,2 @@
-used-before-assignment:8:19:8:22::Using variable 'MSG' before assignment:UNDEFINED
-used-before-assignment:10:20:10:24::Using variable 'MSG2' before assignment:UNDEFINED
-used-before-assignment:17:21:17:28:MyClass.incorrect_typing_method:Using variable 'MyClass' before assignment:UNDEFINED
-used-before-assignment:22:26:22:33:MyClass.incorrect_nested_typing_method:Using variable 'MyClass' before assignment:UNDEFINED
-used-before-assignment:27:20:27:27:MyClass.incorrect_default_method:Using variable 'MyClass' before assignment:UNDEFINED
+used-before-assignment:6:19:6:22::Using variable 'MSG' before assignment:UNDEFINED
+used-before-assignment:8:20:8:24::Using variable 'MSG2' before assignment:UNDEFINED

--- a/tests/functional/u/use/used_before_assignment_typing.py
+++ b/tests/functional/u/use/used_before_assignment_typing.py
@@ -2,7 +2,7 @@
 # pylint: disable=missing-function-docstring
 
 
-from typing import List
+from typing import List, Optional
 
 
 class MyClass:
@@ -31,3 +31,33 @@ class MyClass:
             return self == other
 
         return inner_method(self, MyClass())
+
+
+class MySecondClass:
+    """Class to test self referential variable typing.
+    This regressed, reported in: https://github.com/PyCQA/pylint/issues/5342
+    """
+
+    def self_referential_optional_within_method(self) -> None:
+        variable: Optional[MySecondClass] = self
+        print(variable)
+
+    def correct_inner_typing_method(self) -> bool:
+        def inner_method(self, other: MySecondClass) -> bool:
+            return self == other
+
+        return inner_method(self, MySecondClass())
+
+
+class MyOtherClass:
+    """Class to test self referential variable typing, no regression."""
+
+    def correct_inner_typing_method(self) -> bool:
+        def inner_method(self, other: MyOtherClass) -> bool:
+            return self == other
+
+        return inner_method(self, MyOtherClass())
+
+    def self_referential_optional_within_method(self) -> None:
+        variable: Optional[MyOtherClass] = self
+        print(variable)

--- a/tests/functional/u/use/used_before_assignment_typing.py
+++ b/tests/functional/u/use/used_before_assignment_typing.py
@@ -1,0 +1,33 @@
+"""Tests for used-before-assignment for typing related issues"""
+# pylint: disable=missing-function-docstring
+
+
+from typing import List
+
+
+class MyClass:
+    """Type annotation or default values for first level methods can't refer to their own class"""
+
+    def incorrect_typing_method(
+        self, other: MyClass  # [used-before-assignment]
+    ) -> bool:
+        return self == other
+
+    def incorrect_nested_typing_method(
+        self, other: List[MyClass]  # [used-before-assignment]
+    ) -> bool:
+        return self == other[0]
+
+    def incorrect_default_method(
+        self, other=MyClass()  # [used-before-assignment]
+    ) -> bool:
+        return self == other
+
+    def correct_string_typing_method(self, other: "MyClass") -> bool:
+        return self == other
+
+    def correct_inner_typing_method(self) -> bool:
+        def inner_method(self, other: MyClass) -> bool:
+            return self == other
+
+        return inner_method(self, MyClass())

--- a/tests/functional/u/use/used_before_assignment_typing.txt
+++ b/tests/functional/u/use/used_before_assignment_typing.txt
@@ -1,0 +1,3 @@
+used-before-assignment:12:21:12:28:MyClass.incorrect_typing_method:Using variable 'MyClass' before assignment:UNDEFINED
+used-before-assignment:17:26:17:33:MyClass.incorrect_nested_typing_method:Using variable 'MyClass' before assignment:UNDEFINED
+used-before-assignment:22:20:22:27:MyClass.incorrect_default_method:Using variable 'MyClass' before assignment:UNDEFINED


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

/CC: @cdce8p Finally fixed that false positive. Turned out it was a minor fix after all.

Closes #5342