### PR TITLE
Add tempfile.TemporaryFile to CALLS_RETURNING_CONTEXT_MANAGERS

### DIFF
--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -36,6 +36,7 @@ CALLS_RETURNING_CONTEXT_MANAGERS = frozenset(
         "tempfile.NamedTemporaryFile",
         "tempfile.SpooledTemporaryFile",
         "tempfile.TemporaryDirectory",
+        "tempfile.TemporaryFile",
         "zipfile.ZipFile",
         "zipfile.PyZipFile",
         "zipfile.ZipFile.open",


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Noticed while working on #5409 that `CALLS_RETURNING_CONTEXT_MANAGERS` lacks `tempfile.TemporaryFile`.

No functional impact. (I believe that is because the stdlib defines `TemporaryFile` in if/else blocks depending on the system, and pylint doesn't have control-flow inference to do anything with it right now. But adding this here should make a future refactor safer?)
