### PR TITLE
fix deleting files for pyreverse tests

### DIFF
--- a/tests/pyreverse/test_writer.py
+++ b/tests/pyreverse/test_writer.py
@@ -150,7 +150,13 @@ def _setup(
     writer.write(dd)
     yield
     for fname in (
-        DOT_FILES + COLORIZED_DOT_FILES + VCG_FILES + PUML_FILES + COLORIZED_PUML_FILES
+        DOT_FILES
+        + COLORIZED_DOT_FILES
+        + VCG_FILES
+        + PUML_FILES
+        + COLORIZED_PUML_FILES
+        + MMD_FILES
+        + HTML_FILES
     ):
         try:
             os.remove(fname)


### PR DESCRIPTION
This pr fix the annoying behavior introduced in pr #5272.

After this pr when pyreverse tests are executed some tests files aren't removed after execution.
