### PR TITLE
Move some of the Numpy tests out of ``TestParamDocChecker``

### DIFF
--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -169,37 +169,6 @@ class TestParamDocChecker(CheckerTestCase):
         ):
             self.checker.visit_functiondef(node)
 
-    def test_finds_args_without_type_numpy(self) -> None:
-        node = astroid.extract_node(
-            '''
-        def my_func(named_arg, typed_arg: bool, untyped_arg, *args):
-            """The docstring
-
-            Args
-            ----
-            named_arg : object
-                Returned
-            typed_arg
-                Other argument without numpy type annotation
-            untyped_arg
-                Other argument without any type annotation
-            *args :
-                Optional Arguments
-
-            Returns
-            -------
-                object or None
-                    Maybe named_arg
-            """
-            if args:
-                return named_arg
-        '''
-        )
-        with self.assertAddsMessages(
-            MessageTest(msg_id="missing-type-doc", node=node, args=("untyped_arg",))
-        ):
-            self.checker.visit_functiondef(node)
-
     def test_finds_args_with_xref_type_numpy(self) -> None:
         node = astroid.extract_node(
             '''

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -360,29 +360,6 @@ class TestParamDocChecker(CheckerTestCase):
         ):
             self.checker.visit_return(node)
 
-    def test_ignores_return_in_abstract_method_numpy(self) -> None:
-        """Example of an abstract method documenting the return type that an
-        implementation should return.
-        """
-        node = astroid.extract_node(
-            """
-        import abc
-        class Foo(object):
-            @abc.abstractmethod
-            def foo(self): #@
-                '''docstring ...
-
-                Returns
-                -------
-                int
-                    Ten
-                '''
-                return 10
-        """
-        )
-        with self.assertNoMessages():
-            self.checker.visit_functiondef(node)
-
     def test_ignores_return_in_abstract_method_numpy_2(self) -> None:
         """Example of a method documenting the return type that an
         implementation should return.

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -360,27 +360,6 @@ class TestParamDocChecker(CheckerTestCase):
         ):
             self.checker.visit_return(node)
 
-    def test_ignores_return_in_abstract_method_numpy_2(self) -> None:
-        """Example of a method documenting the return type that an
-        implementation should return.
-        """
-        node = astroid.extract_node(
-            """
-        class Foo(object):
-            def foo(self, arg): #@
-                '''docstring ...
-
-                Parameters
-                ----------
-                arg : int
-                    An argument.
-                '''
-                raise NotImplementedError()
-        """
-        )
-        with self.assertNoMessages():
-            self.checker.visit_functiondef(node)
-
     def test_ignores_ignored_argument_names_numpy(self) -> None:
         """Example of a method documenting the return type that an
         implementation should return.

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -112,36 +112,6 @@ class TestParamDocChecker(CheckerTestCase):
             if isinstance(body_item, nodes.FunctionDef) and hasattr(body_item, "name"):
                 self.checker.visit_functiondef(body_item)
 
-    def test_constr_params_in_class_numpy(self) -> None:
-        """Example of a class with missing constructor parameter documentation
-        (Numpy style)
-
-        Everything is completely analogous to functions.
-        """
-        node = astroid.extract_node(
-            """
-        class ClassFoo(object):
-            '''docstring foo
-
-            Parameters
-            ----------
-            y:
-                bla
-
-            missing constructor parameter documentation
-            '''
-
-            def __init__(self, x, y):
-                pass
-
-        """
-        )
-        with self.assertAddsMessages(
-            MessageTest(msg_id="missing-param-doc", node=node, args=("x",)),
-            MessageTest(msg_id="missing-type-doc", node=node, args=("x, y",)),
-        ):
-            self._visit_methods_of_class(node)
-
     def test_constr_params_and_attributes_in_class_numpy(self) -> None:
         """Example of a class with correct constructor parameter documentation
         and an attributes section (Numpy style)

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -112,59 +112,6 @@ class TestParamDocChecker(CheckerTestCase):
             if isinstance(body_item, nodes.FunctionDef) and hasattr(body_item, "name"):
                 self.checker.visit_functiondef(body_item)
 
-    def test_wrong_name_of_func_params_in_numpy_docstring(self) -> None:
-        """Example of functions with inconsistent parameter names in the
-        signature and in the Numpy style documentation
-        """
-        node = astroid.extract_node(
-            """
-        def function_foo(xarg, yarg, zarg):
-            '''function foo ...
-
-            Parameters
-            ----------
-            xarg1: int
-                bla xarg
-            yarg: float
-                bla yarg
-
-            zarg1: str
-                bla zarg
-            '''
-            return xarg + yarg
-        """
-        )
-        with self.assertAddsMessages(
-            MessageTest(msg_id="missing-param-doc", node=node, args=("xarg, zarg",)),
-            MessageTest(msg_id="missing-type-doc", node=node, args=("xarg, zarg",)),
-            MessageTest(
-                msg_id="differing-param-doc", node=node, args=("xarg1, zarg1",)
-            ),
-            MessageTest(msg_id="differing-type-doc", node=node, args=("xarg1, zarg1",)),
-        ):
-            self.checker.visit_functiondef(node)
-
-        node = astroid.extract_node(
-            """
-        def function_foo(xarg, yarg):
-            '''function foo ...
-
-            Parameters
-            ----------
-            yarg1: float
-                bla yarg
-
-            For the other parameters, see bla.
-            '''
-            return xarg + yarg
-        """
-        )
-        with self.assertAddsMessages(
-            MessageTest(msg_id="differing-param-doc", node=node, args=("yarg1",)),
-            MessageTest(msg_id="differing-type-doc", node=node, args=("yarg1",)),
-        ):
-            self.checker.visit_functiondef(node)
-
     def test_see_sentence_for_func_params_in_numpy_docstring(self) -> None:
         """Example for the usage of "For the other parameters, see" to avoid
         too many repetitions, e.g. in functions or methods adhering to a

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -112,31 +112,6 @@ class TestParamDocChecker(CheckerTestCase):
             if isinstance(body_item, nodes.FunctionDef) and hasattr(body_item, "name"):
                 self.checker.visit_functiondef(body_item)
 
-    def test_constr_params_and_attributes_in_class_numpy(self) -> None:
-        """Example of a class with correct constructor parameter documentation
-        and an attributes section (Numpy style)
-        """
-        node = astroid.extract_node(
-            """
-        class ClassFoo(object):
-            '''
-            Parameters
-            ----------
-            foo : str
-                Something.
-
-            Attributes
-            ----------
-            bar : str
-                Something.
-            '''
-            def __init__(self, foo):
-                self.bar = None
-        """
-        )
-        with self.assertNoMessages():
-            self._visit_methods_of_class(node)
-
     def test_constr_params_in_init_numpy(self) -> None:
         """Example of a class with missing constructor parameter documentation
         (Numpy style)

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -360,27 +360,6 @@ class TestParamDocChecker(CheckerTestCase):
         ):
             self.checker.visit_return(node)
 
-    def test_ignores_ignored_argument_names_numpy(self) -> None:
-        """Example of a method documenting the return type that an
-        implementation should return.
-        """
-        node = astroid.extract_node(
-            """
-        class Foo(object):
-            def foo(self, arg, _): #@
-                '''docstring ...
-
-                Parameters
-                ----------
-                arg : int
-                    An argument.
-                '''
-                pass
-        """
-        )
-        with self.assertNoMessages():
-            self.checker.visit_functiondef(node)
-
     def test_useless_docs_ignored_argument_names_numpy(self) -> None:
         """Example of a method documenting the return type that an
         implementation should return.

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -169,31 +169,6 @@ class TestParamDocChecker(CheckerTestCase):
         ):
             self.checker.visit_functiondef(node)
 
-    def test_finds_args_with_xref_type_numpy(self) -> None:
-        node = astroid.extract_node(
-            '''
-        def my_func(named_arg, *args):
-            """The docstring
-
-            Args
-            ----
-            named_arg : `example.value`
-                Returned
-            *args :
-                Optional Arguments
-
-            Returns
-            -------
-                `example.value`
-                    Maybe named_arg
-            """
-            if args:
-                return named_arg
-        '''
-        )
-        with self.assertNoMessages():
-            self.checker.visit_functiondef(node)
-
     def test_finds_kwargs_without_type_numpy(self) -> None:
         node = astroid.extract_node(
             '''

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -167,30 +167,6 @@ class TestParamDocChecker(CheckerTestCase):
         ):
             self.checker.visit_functiondef(node)
 
-    def test_ignores_optional_specifier_numpy(self) -> None:
-        node = astroid.extract_node(
-            '''
-        def do_something(param, param2='all'):
-            """Do something.
-
-            Parameters
-            ----------
-            param : str
-                Description.
-            param2 : str, optional
-                Description (the default is 'all').
-
-            Returns
-            -------
-            int
-                Description.
-            """
-            return param, param2
-        '''
-        )
-        with self.assertNoMessages():
-            self.checker.visit_functiondef(node)
-
     def test_finds_short_name_exception(self) -> None:
         node = astroid.extract_node(
             '''

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -150,54 +150,6 @@ class TestParamDocChecker(CheckerTestCase):
         with self.assertNoMessages():
             self._visit_methods_of_class(node)
 
-    def test_constr_params_in_class_and_init_numpy(self) -> None:
-        """Example of a class with missing constructor parameter documentation
-        in both the init docstring and the class docstring
-        (Numpy style)
-
-        Everything is completely analogous to functions.
-        """
-        node = astroid.extract_node(
-            """
-        class ClassFoo(object):
-            '''docstring foo
-
-            Parameters
-            ----------
-            y:
-                bla
-
-            missing constructor parameter documentation
-            '''
-
-            def __init__(self, x, y):
-                '''docstring foo
-
-                Parameters
-                ----------
-                y:
-                    bla
-
-                missing constructor parameter documentation
-                '''
-                pass
-
-        """
-        )
-        constructor_node = node.body[0]
-        with self.assertAddsMessages(
-            MessageTest(
-                msg_id="multiple-constructor-doc", node=node, args=(node.name,)
-            ),
-            MessageTest(msg_id="missing-param-doc", node=node, args=("x",)),
-            MessageTest(msg_id="missing-type-doc", node=node, args=("x, y",)),
-            MessageTest(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
-            MessageTest(
-                msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
-            ),
-        ):
-            self._visit_methods_of_class(node)
-
     def test_kwonlyargs_are_taken_in_account(self) -> None:
         node = astroid.extract_node(
             '''

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -169,31 +169,6 @@ class TestParamDocChecker(CheckerTestCase):
         ):
             self.checker.visit_functiondef(node)
 
-    def test_warns_missing_args_numpy(self) -> None:
-        node = astroid.extract_node(
-            '''
-        def my_func(named_arg, *args):
-            """The docstring
-
-            Args
-            ----
-            named_arg : object
-                Returned
-
-            Returns
-            -------
-                object or None
-                    Maybe named_arg
-            """
-            if args:
-                return named_arg
-        '''
-        )
-        with self.assertAddsMessages(
-            MessageTest(msg_id="missing-param-doc", node=node, args=("*args",))
-        ):
-            self.checker.visit_functiondef(node)
-
     def test_warns_missing_kwargs_numpy(self) -> None:
         node = astroid.extract_node(
             '''

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -25,7 +25,6 @@
 in particular the parameter documentation checker `DocstringChecker`
 """
 
-# pylint: disable=too-many-public-methods
 
 import re
 
@@ -167,31 +166,6 @@ class TestParamDocChecker(CheckerTestCase):
             ),
             MessageTest(msg_id="missing-type-doc", node=node, args=("missing_kwonly",)),
         ):
-            self.checker.visit_functiondef(node)
-
-    def test_finds_kwargs_without_type_numpy(self) -> None:
-        node = astroid.extract_node(
-            '''
-        def my_func(named_arg, **kwargs):
-            """The docstring
-
-            Args
-            ----
-            named_arg : object
-                Returned
-            **kwargs :
-                Keyword arguments
-
-            Returns
-            -------
-                object or None
-                    Maybe named_arg
-            """
-            if kwargs:
-                return named_arg
-        '''
-        )
-        with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     COMPLEX_TYPES = [

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -29,7 +29,6 @@ in particular the parameter documentation checker `DocstringChecker`
 import re
 
 import astroid
-import pytest
 from astroid import nodes
 
 from pylint.extensions.docparams import DocstringParameterChecker
@@ -166,42 +165,6 @@ class TestParamDocChecker(CheckerTestCase):
             ),
             MessageTest(msg_id="missing-type-doc", node=node, args=("missing_kwonly",)),
         ):
-            self.checker.visit_functiondef(node)
-
-    COMPLEX_TYPES = [
-        "dict(str,str)",
-        "dict[str,str]",
-        "tuple(int)",
-        "list[tokenize.TokenInfo]",
-        "dict(str, str)",
-        "dict[str, str]",
-        "int or str",
-        "tuple(int or str)",
-        "tuple(int) or list(int)",
-        "tuple(int or str) or list(int or str)",
-    ]
-
-    @pytest.mark.parametrize("complex_type", COMPLEX_TYPES)
-    def test_finds_multiple_types_numpy(self, complex_type):
-        node = astroid.extract_node(
-            f'''
-        def my_func(named_arg):
-            """The docstring
-
-            Args
-            ----
-            named_arg : {complex_type}
-                Returned
-
-            Returns
-            -------
-                {complex_type}
-                    named_arg
-            """
-            return named_arg
-        '''
-        )
-        with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
     def test_ignores_optional_specifier_numpy(self) -> None:

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -112,38 +112,6 @@ class TestParamDocChecker(CheckerTestCase):
             if isinstance(body_item, nodes.FunctionDef) and hasattr(body_item, "name"):
                 self.checker.visit_functiondef(body_item)
 
-    def test_existing_func_params_in_numpy_docstring(self) -> None:
-        """Example of a function with correctly documented parameters and
-        return values (Numpy style)
-        """
-        node = astroid.extract_node(
-            """
-        def function_foo(xarg, yarg, zarg, warg):
-            '''function foo ...
-
-            Parameters
-            ----------
-            xarg: int
-                bla xarg
-            yarg: my.qualified.type
-                bla yarg
-
-            zarg: int
-                bla zarg
-            warg: my.qualified.type
-                bla warg
-
-            Returns
-            -------
-            float
-                sum
-            '''
-            return xarg + yarg
-        """
-        )
-        with self.assertNoMessages():
-            self.checker.visit_functiondef(node)
-
     def test_wrong_name_of_func_params_in_numpy_docstring(self) -> None:
         """Example of functions with inconsistent parameter names in the
         signature and in the Numpy style documentation

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -48,33 +48,6 @@ class TestParamDocChecker(CheckerTestCase):
         "docstring_min_length": -1,
     }
 
-    def test_missing_func_params_in_numpy_docstring(self) -> None:
-        """Example of a function with missing NumPy style parameter
-        documentation in the docstring
-        """
-        node = astroid.extract_node(
-            """
-        def function_foo(x, y, z):
-            '''docstring ...
-
-            Parameters
-            ----------
-            x:
-                bla
-            z: int
-                bar
-
-            some other stuff
-            '''
-            pass
-        """
-        )
-        with self.assertAddsMessages(
-            MessageTest(msg_id="missing-param-doc", node=node, args=("y",)),
-            MessageTest(msg_id="missing-type-doc", node=node, args=("x, y",)),
-        ):
-            self.checker.visit_functiondef(node)
-
     @set_config(accept_no_param_doc=True)
     def test_tolerate_no_param_documentation_at_all(self) -> None:
         """Example of a function with no parameter documentation at all

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -112,29 +112,6 @@ class TestParamDocChecker(CheckerTestCase):
             if isinstance(body_item, nodes.FunctionDef) and hasattr(body_item, "name"):
                 self.checker.visit_functiondef(body_item)
 
-    def test_see_sentence_for_func_params_in_numpy_docstring(self) -> None:
-        """Example for the usage of "For the other parameters, see" to avoid
-        too many repetitions, e.g. in functions or methods adhering to a
-        given interface (Numpy style)
-        """
-        node = astroid.extract_node(
-            """
-        def function_foo(xarg, yarg):
-            '''function foo ...
-
-            Parameters
-            ----------
-            yarg: float
-                bla yarg
-
-            For the other parameters, see :func:`bla`
-            '''
-            return xarg + yarg
-        """
-        )
-        with self.assertNoMessages():
-            self.checker.visit_functiondef(node)
-
     def test_constr_params_in_class_numpy(self) -> None:
         """Example of a class with missing constructor parameter documentation
         (Numpy style)

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -169,31 +169,6 @@ class TestParamDocChecker(CheckerTestCase):
         ):
             self.checker.visit_functiondef(node)
 
-    def test_warns_missing_kwargs_numpy(self) -> None:
-        node = astroid.extract_node(
-            '''
-        def my_func(named_arg, **kwargs):
-            """The docstring
-
-            Args
-            ----
-            named_arg : object
-                Returned
-
-            Returns
-            -------
-                object or None
-                    Maybe named_arg
-            """
-            if kwargs:
-                return named_arg
-        '''
-        )
-        with self.assertAddsMessages(
-            MessageTest(msg_id="missing-param-doc", node=node, args=("**kwargs",))
-        ):
-            self.checker.visit_functiondef(node)
-
     def test_finds_args_without_type_numpy(self) -> None:
         node = astroid.extract_node(
             '''

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -112,38 +112,6 @@ class TestParamDocChecker(CheckerTestCase):
             if isinstance(body_item, nodes.FunctionDef) and hasattr(body_item, "name"):
                 self.checker.visit_functiondef(body_item)
 
-    def test_constr_params_in_init_numpy(self) -> None:
-        """Example of a class with missing constructor parameter documentation
-        (Numpy style)
-
-        Everything is completely analogous to functions.
-        """
-        node = astroid.extract_node(
-            """
-        class ClassFoo(object):
-            def __init__(self, x, y):
-                '''docstring foo constructor
-
-                Parameters
-                ----------
-                y:
-                    bla
-
-                missing constructor parameter documentation
-                '''
-                pass
-
-        """
-        )
-        constructor_node = node.body[0]
-        with self.assertAddsMessages(
-            MessageTest(msg_id="missing-param-doc", node=constructor_node, args=("x",)),
-            MessageTest(
-                msg_id="missing-type-doc", node=constructor_node, args=("x, y",)
-            ),
-        ):
-            self._visit_methods_of_class(node)
-
     def test_see_sentence_for_constr_params_in_class(self) -> None:
         """Example usage of "For the parameters, see" in class docstring"""
         node = astroid.extract_node(

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -360,36 +360,6 @@ class TestParamDocChecker(CheckerTestCase):
         ):
             self.checker.visit_return(node)
 
-    def test_useless_docs_ignored_argument_names_numpy(self) -> None:
-        """Example of a method documenting the return type that an
-        implementation should return.
-        """
-        node = astroid.extract_node(
-            """
-        class Foo(object):
-            def foo(self, arg, _, _ignored): #@
-                '''docstring ...
-
-                Parameters
-                ----------
-                arg : int
-                    An argument.
-
-                _ : float
-                    Another argument.
-
-                _ignored :
-                    Ignored Argument
-                '''
-                pass
-        """
-        )
-        with self.assertAddsMessages(
-            MessageTest(msg_id="useless-type-doc", node=node, args=("_",)),
-            MessageTest(msg_id="useless-param-doc", node=node, args=("_, _ignored",)),
-        ):
-            self.checker.visit_functiondef(node)
-
     @set_config_directly(no_docstring_rgx=re.compile(r"^_(?!_).*$"))
     def test_skip_no_docstring_rgx(self) -> None:
         """Example of a function that matches the default 'no-docstring-rgx' config option

--- a/tests/extensions/test_check_docs.py
+++ b/tests/extensions/test_check_docs.py
@@ -112,33 +112,6 @@ class TestParamDocChecker(CheckerTestCase):
             if isinstance(body_item, nodes.FunctionDef) and hasattr(body_item, "name"):
                 self.checker.visit_functiondef(body_item)
 
-    def test_missing_method_params_in_numpy_docstring(self) -> None:
-        """Example of a class method with missing parameter documentation in
-        the Numpy style docstring
-        """
-        node = astroid.extract_node(
-            """
-        class Foo(object):
-            def method_foo(self, x, y):
-                '''docstring ...
-
-                missing parameter documentation
-
-                Parameters
-                ----------
-                x:
-                    bla
-                '''
-                pass
-        """
-        )
-        method_node = node.body[0]
-        with self.assertAddsMessages(
-            MessageTest(msg_id="missing-param-doc", node=method_node, args=("y",)),
-            MessageTest(msg_id="missing-type-doc", node=method_node, args=("x, y",)),
-        ):
-            self._visit_methods_of_class(node)
-
     def test_existing_func_params_in_numpy_docstring(self) -> None:
         """Example of a function with correctly documented parameters and
         return values (Numpy style)

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -1,7 +1,7 @@
 """Tests for missing-param-doc and missing-type-doc for Numpy style docstrings
 with accept-no-param-doc = no
 """
-# pylint: disable=invalid-name, unused-argument, undefined-variable
+# pylint: disable=invalid-name, unused-argument, undefined-variable, too-many-arguments
 # pylint: disable=line-too-long, too-few-public-methods, missing-class-docstring
 # pylint: disable=missing-function-docstring, function-redefined, inconsistent-return-statements
 
@@ -292,3 +292,65 @@ def test_finds_kwargs_without_type_numpy(named_arg, **kwargs):
     """
     if kwargs:
         return named_arg
+
+
+def my_func(
+    named_arg_one,
+    named_arg_two,
+    named_arg_three,
+    named_arg_four,
+    named_arg_five,
+    named_arg_six,
+    named_arg_seven,
+    named_arg_eight,
+):
+    """The docstring
+
+    Args
+    ----
+    named_arg_one : dict(str,str)
+        Returned
+    named_arg_two : dict[str,str]
+        Returned
+    named_arg_three : tuple(int)
+        Returned
+    named_arg_four : list[tokenize.TokenInfo]
+        Returned
+    named_arg_five : int or str
+        Returned
+    named_arg_six : tuple(int or str)
+        Returned
+    named_arg_seven : tuple(int) or list(int)
+        Returned
+    named_arg_eight : tuple(int or str) or list(int or str)
+        Returned
+
+    Returns
+    -------
+        dict(str,str)
+            named_arg_one
+        dict[str,str]
+            named_arg_two
+        tuple(int)
+            named_arg_three
+        list[tokenize.TokenInfo]
+            named_arg_four
+        int or str
+            named_arg_five
+        tuple(int or str)
+            named_arg_six
+        tuple(int) or list(int)
+            named_arg_seven
+        tuple(int or str) or list(int or str)
+            named_arg_eight
+    """
+    return (
+        named_arg_one,
+        named_arg_two,
+        named_arg_three,
+        named_arg_four,
+        named_arg_five,
+        named_arg_six,
+        named_arg_seven,
+        named_arg_eight,
+    )

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -195,3 +195,20 @@ class ClassFoo:  # [multiple-constructor-doc, missing-param-doc, missing-type-do
 
         missing constructor parameter documentation
         """
+
+
+def test_warns_missing_args_numpy(named_arg, *args):  # [missing-param-doc]
+    """The docstring
+
+    Args
+    ----
+    named_arg : object
+        Returned
+
+    Returns
+    -------
+        object or None
+            Maybe named_arg
+    """
+    if args:
+        return named_arg

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -111,3 +111,22 @@ def test_see_sentence_for_func_params_in_numpy_docstring(xarg, yarg):
     For the other parameters, see :func:`bla`
     """
     return xarg + yarg
+
+
+class ClassFoo:  # [missing-param-doc, missing-type-doc]
+    """test_constr_params_in_class_numpy
+    Example of a class with missing constructor parameter documentation
+    (Numpy style)
+
+    Everything is completely analogous to functions.
+
+    Parameters
+    ----------
+    y:
+        bla
+
+    missing constructor parameter documentation
+    """
+
+    def __init__(self, x, y):
+        pass

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -273,3 +273,22 @@ def test_finds_args_with_xref_type_numpy(named_arg, *args):
     """
     if args:
         return named_arg
+
+
+def test_finds_kwargs_without_type_numpy(named_arg, **kwargs):
+    """The docstring
+
+    Args
+    ----
+    named_arg : object
+        Returned
+    **kwargs :
+        Keyword arguments
+
+    Returns
+    -------
+        object or None
+            Maybe named_arg
+    """
+    if kwargs:
+        return named_arg

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -21,3 +21,19 @@ def test_missing_func_params_in_numpy_docstring(  # [missing-param-doc, missing-
 
     some other stuff
     """
+
+
+class Foo:
+    def test_missing_method_params_in_numpy_docstring(  # [missing-param-doc, missing-type-doc]
+        self, x, y
+    ):
+        """Example of a class method with missing parameter documentation in
+        the Numpy style docstring
+
+        missing parameter documentation
+
+        Parameters
+        ----------
+        x:
+            bla
+        """

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -354,3 +354,21 @@ def my_func(
         named_arg_seven,
         named_arg_eight,
     )
+
+
+def test_ignores_optional_specifier_numpy(param, param2="all"):
+    """Do something.
+
+    Parameters
+    ----------
+    param : str
+        Description.
+    param2 : str, optional
+        Description (the default is 'all').
+
+    Returns
+    -------
+    int
+        Description.
+    """
+    return param, param2

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -254,3 +254,22 @@ def test_finds_args_without_type_numpy(  # [missing-type-doc]
     """
     if args:
         return named_arg
+
+
+def test_finds_args_with_xref_type_numpy(named_arg, *args):
+    """The docstring
+
+    Args
+    ----
+    named_arg : `example.value`
+        Returned
+    *args :
+        Optional Arguments
+
+    Returns
+    -------
+        `example.value`
+            Maybe named_arg
+    """
+    if args:
+        return named_arg

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -37,3 +37,27 @@ class Foo:
         x:
             bla
         """
+
+
+def test_existing_func_params_in_numpy_docstring(xarg, yarg, zarg, warg):
+    """Example of a function with correctly documented parameters and
+    return values (Numpy style)
+
+    Parameters
+    ----------
+    xarg: int
+        bla xarg
+    yarg: my.qualified.type
+        bla yarg
+
+    zarg: int
+        bla zarg
+    warg: my.qualified.type
+        bla warg
+
+    Returns
+    -------
+    float
+        sum
+    """
+    return xarg + yarg

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -4,3 +4,20 @@ with accept-no-param-doc = no
 # pylint: disable=invalid-name, unused-argument, undefined-variable
 # pylint: disable=line-too-long, too-few-public-methods, missing-class-docstring
 # pylint: disable=missing-function-docstring, function-redefined, inconsistent-return-statements
+
+
+def test_missing_func_params_in_numpy_docstring(  # [missing-param-doc, missing-type-doc]
+    x, y, z
+):
+    """Example of a function with missing NumPy style parameter
+        documentation in the docstring
+
+    Parameters
+    ----------
+    x:
+        bla
+    z: int
+        bar
+
+    some other stuff
+    """

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -130,3 +130,23 @@ class ClassFoo:  # [missing-param-doc, missing-type-doc]
 
     def __init__(self, x, y):
         pass
+
+
+class ClassFoo:
+    """test_constr_params_and_attributes_in_class_numpy
+    Example of a class with correct constructor parameter documentation
+    and an attributes section (Numpy style)
+
+    Parameters
+    ----------
+    foobar : str
+        Something.
+
+    Attributes
+    ----------
+    barfoor : str
+        Something.
+    """
+
+    def __init__(self, foobar):
+        self.barfoo = None

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -96,3 +96,18 @@ def test_wrong_name_of_func_params_in_numpy_docstring_two(  # [differing-param-d
     For the other parameters, see bla.
     """
     return xarg + yarg
+
+
+def test_see_sentence_for_func_params_in_numpy_docstring(xarg, yarg):
+    """Example for the usage of "For the other parameters, see" to avoid
+    too many repetitions, e.g. in functions or methods adhering to a
+    given interface (Numpy style)
+
+    Parameters
+    ----------
+    yarg: float
+        bla yarg
+
+    For the other parameters, see :func:`bla`
+    """
+    return xarg + yarg

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -1,0 +1,6 @@
+"""Tests for missing-param-doc and missing-type-doc for Numpy style docstrings
+with accept-no-param-doc = no
+"""
+# pylint: disable=invalid-name, unused-argument, undefined-variable
+# pylint: disable=line-too-long, too-few-public-methods, missing-class-docstring
+# pylint: disable=missing-function-docstring, function-redefined, inconsistent-return-statements

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -167,3 +167,31 @@ class ClassFoo:
 
         missing constructor parameter documentation
         """
+
+
+class ClassFoo:  # [multiple-constructor-doc, missing-param-doc, missing-type-doc]
+    """test_constr_params_in_class_and_init_numpy
+    Example of a class with missing constructor parameter documentation
+    in both the init docstring and the class docstring
+    (Numpy style)
+
+    Everything is completely analogous to functions.
+
+    Parameters
+    ----------
+    y:
+        bla
+
+    missing constructor parameter documentation
+    """
+
+    def __init__(self, x, y):  # [missing-param-doc, missing-type-doc]
+        """docstring foo
+
+        Parameters
+        ----------
+        y:
+            bla
+
+        missing constructor parameter documentation
+        """

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -150,3 +150,20 @@ class ClassFoo:
 
     def __init__(self, foobar):
         self.barfoo = None
+
+
+class ClassFoo:
+    def __init__(self, x, y):  # [missing-param-doc, missing-type-doc]
+        """test_constr_params_in_init_numpy
+        Example of a class with missing constructor parameter documentation
+        (Numpy style)
+
+        Everything is completely analogous to functions.
+
+        Parameters
+        ----------
+        y:
+            bla
+
+        missing constructor parameter documentation
+        """

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -61,3 +61,38 @@ def test_existing_func_params_in_numpy_docstring(xarg, yarg, zarg, warg):
         sum
     """
     return xarg + yarg
+
+
+def test_wrong_name_of_func_params_in_numpy_docstring(  # [missing-param-doc, missing-type-doc, differing-param-doc, differing-type-doc]
+    xarg, yarg, zarg
+):
+    """Example of functions with inconsistent parameter names in the
+    signature and in the Numpy style documentation
+
+    Parameters
+    ----------
+    xarg1: int
+        bla xarg
+    yarg: float
+        bla yarg
+
+    zarg1: str
+        bla zarg
+    """
+    return xarg + yarg
+
+
+def test_wrong_name_of_func_params_in_numpy_docstring_two(  # [differing-param-doc, differing-type-doc]
+    xarg, yarg
+):
+    """Example of functions with inconsistent parameter names in the
+    signature and in the Numpy style documentation
+
+    Parameters
+    ----------
+    yarg1: float
+        bla yarg
+
+    For the other parameters, see bla.
+    """
+    return xarg + yarg

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -212,3 +212,20 @@ def test_warns_missing_args_numpy(named_arg, *args):  # [missing-param-doc]
     """
     if args:
         return named_arg
+
+
+def test_warns_missing_kwargs_numpy(named_arg, **kwargs):  # [missing-param-doc]
+    """The docstring
+
+    Args
+    ----
+    named_arg : object
+        Returned
+
+    Returns
+    -------
+        object or None
+            Maybe named_arg
+    """
+    if kwargs:
+        return named_arg

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.py
@@ -229,3 +229,28 @@ def test_warns_missing_kwargs_numpy(named_arg, **kwargs):  # [missing-param-doc]
     """
     if kwargs:
         return named_arg
+
+
+def test_finds_args_without_type_numpy(  # [missing-type-doc]
+    named_arg, typed_arg: bool, untyped_arg, *args
+):
+    """The docstring
+
+    Args
+    ----
+    named_arg : object
+        Returned
+    typed_arg
+        Other argument without numpy type annotation
+    untyped_arg
+        Other argument without any type annotation
+    *args :
+        Optional Arguments
+
+    Returns
+    -------
+        object or None
+            Maybe named_arg
+    """
+    if args:
+        return named_arg

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.rc
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.rc
@@ -1,0 +1,7 @@
+[MASTER]
+load-plugins = pylint.extensions.docparams
+
+[BASIC]
+accept-no-param-doc=no
+docstring-min-length: -1
+no-docstring-rgx=^$

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
@@ -10,3 +10,5 @@ differing-param-doc:85:0:98:22:test_wrong_name_of_func_params_in_numpy_docstring
 differing-type-doc:85:0:98:22:test_wrong_name_of_func_params_in_numpy_docstring_two:"""yarg1"" differing in parameter type documentation":UNDEFINED
 missing-param-doc:116:0:132:12:ClassFoo:"""x"" missing in parameter documentation":UNDEFINED
 missing-type-doc:116:0:132:12:ClassFoo:"""x, y"" missing in parameter type documentation":UNDEFINED
+missing-param-doc:156:4:169:11:ClassFoo.__init__:"""x"" missing in parameter documentation":UNDEFINED
+missing-type-doc:156:4:169:11:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":UNDEFINED

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
@@ -18,3 +18,4 @@ multiple-constructor-doc:172:0:197:11:ClassFoo:"""ClassFoo"" has constructor par
 missing-param-doc:188:4:197:11:ClassFoo.__init__:"""x"" missing in parameter documentation":UNDEFINED
 missing-type-doc:188:4:197:11:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":UNDEFINED
 missing-param-doc:200:0:214:24:test_warns_missing_args_numpy:"""*args"" missing in parameter documentation":UNDEFINED
+missing-param-doc:217:0:231:24:test_warns_missing_kwargs_numpy:"""**kwargs"" missing in parameter documentation":UNDEFINED

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
@@ -1,2 +1,4 @@
 missing-param-doc:9:0:23:7:test_missing_func_params_in_numpy_docstring:"""y"" missing in parameter documentation":UNDEFINED
 missing-type-doc:9:0:23:7:test_missing_func_params_in_numpy_docstring:"""x, y"" missing in parameter type documentation":UNDEFINED
+missing-param-doc:27:4:39:11:Foo.test_missing_method_params_in_numpy_docstring:"""y"" missing in parameter documentation":UNDEFINED
+missing-type-doc:27:4:39:11:Foo.test_missing_method_params_in_numpy_docstring:"""x, y"" missing in parameter type documentation":UNDEFINED

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
@@ -8,3 +8,5 @@ missing-param-doc:66:0:82:22:test_wrong_name_of_func_params_in_numpy_docstring:"
 missing-type-doc:66:0:82:22:test_wrong_name_of_func_params_in_numpy_docstring:"""xarg, zarg"" missing in parameter type documentation":UNDEFINED
 differing-param-doc:85:0:98:22:test_wrong_name_of_func_params_in_numpy_docstring_two:"""yarg1"" differing in parameter documentation":UNDEFINED
 differing-type-doc:85:0:98:22:test_wrong_name_of_func_params_in_numpy_docstring_two:"""yarg1"" differing in parameter type documentation":UNDEFINED
+missing-param-doc:116:0:132:12:ClassFoo:"""x"" missing in parameter documentation":UNDEFINED
+missing-type-doc:116:0:132:12:ClassFoo:"""x, y"" missing in parameter type documentation":UNDEFINED

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
@@ -12,3 +12,8 @@ missing-param-doc:116:0:132:12:ClassFoo:"""x"" missing in parameter documentatio
 missing-type-doc:116:0:132:12:ClassFoo:"""x, y"" missing in parameter type documentation":UNDEFINED
 missing-param-doc:156:4:169:11:ClassFoo.__init__:"""x"" missing in parameter documentation":UNDEFINED
 missing-type-doc:156:4:169:11:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":UNDEFINED
+missing-param-doc:172:0:197:11:ClassFoo:"""x"" missing in parameter documentation":UNDEFINED
+missing-type-doc:172:0:197:11:ClassFoo:"""x, y"" missing in parameter type documentation":UNDEFINED
+multiple-constructor-doc:172:0:197:11:ClassFoo:"""ClassFoo"" has constructor parameters documented in class and __init__":UNDEFINED
+missing-param-doc:188:4:197:11:ClassFoo.__init__:"""x"" missing in parameter documentation":UNDEFINED
+missing-type-doc:188:4:197:11:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":UNDEFINED

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
@@ -1,0 +1,2 @@
+missing-param-doc:9:0:23:7:test_missing_func_params_in_numpy_docstring:"""y"" missing in parameter documentation":UNDEFINED
+missing-type-doc:9:0:23:7:test_missing_func_params_in_numpy_docstring:"""x, y"" missing in parameter type documentation":UNDEFINED

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
@@ -17,3 +17,4 @@ missing-type-doc:172:0:197:11:ClassFoo:"""x, y"" missing in parameter type docum
 multiple-constructor-doc:172:0:197:11:ClassFoo:"""ClassFoo"" has constructor parameters documented in class and __init__":UNDEFINED
 missing-param-doc:188:4:197:11:ClassFoo.__init__:"""x"" missing in parameter documentation":UNDEFINED
 missing-type-doc:188:4:197:11:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":UNDEFINED
+missing-param-doc:200:0:214:24:test_warns_missing_args_numpy:"""*args"" missing in parameter documentation":UNDEFINED

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
@@ -19,3 +19,4 @@ missing-param-doc:188:4:197:11:ClassFoo.__init__:"""x"" missing in parameter doc
 missing-type-doc:188:4:197:11:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":UNDEFINED
 missing-param-doc:200:0:214:24:test_warns_missing_args_numpy:"""*args"" missing in parameter documentation":UNDEFINED
 missing-param-doc:217:0:231:24:test_warns_missing_kwargs_numpy:"""**kwargs"" missing in parameter documentation":UNDEFINED
+missing-type-doc:234:0:256:24:test_finds_args_without_type_numpy:"""untyped_arg"" missing in parameter type documentation":UNDEFINED

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
@@ -2,3 +2,9 @@ missing-param-doc:9:0:23:7:test_missing_func_params_in_numpy_docstring:"""y"" mi
 missing-type-doc:9:0:23:7:test_missing_func_params_in_numpy_docstring:"""x, y"" missing in parameter type documentation":UNDEFINED
 missing-param-doc:27:4:39:11:Foo.test_missing_method_params_in_numpy_docstring:"""y"" missing in parameter documentation":UNDEFINED
 missing-type-doc:27:4:39:11:Foo.test_missing_method_params_in_numpy_docstring:"""x, y"" missing in parameter type documentation":UNDEFINED
+differing-param-doc:66:0:82:22:test_wrong_name_of_func_params_in_numpy_docstring:"""xarg1, zarg1"" differing in parameter documentation":UNDEFINED
+differing-type-doc:66:0:82:22:test_wrong_name_of_func_params_in_numpy_docstring:"""xarg1, zarg1"" differing in parameter type documentation":UNDEFINED
+missing-param-doc:66:0:82:22:test_wrong_name_of_func_params_in_numpy_docstring:"""xarg, zarg"" missing in parameter documentation":UNDEFINED
+missing-type-doc:66:0:82:22:test_wrong_name_of_func_params_in_numpy_docstring:"""xarg, zarg"" missing in parameter type documentation":UNDEFINED
+differing-param-doc:85:0:98:22:test_wrong_name_of_func_params_in_numpy_docstring_two:"""yarg1"" differing in parameter documentation":UNDEFINED
+differing-type-doc:85:0:98:22:test_wrong_name_of_func_params_in_numpy_docstring_two:"""yarg1"" differing in parameter type documentation":UNDEFINED

--- a/tests/functional/ext/docparams/return/missing_return_doc_Numpy.py
+++ b/tests/functional/ext/docparams/return/missing_return_doc_Numpy.py
@@ -1,6 +1,7 @@
 """Tests for missing-return-doc and missing-return-type-doc for Numpy style docstrings"""
 # pylint: disable=function-redefined, invalid-name, undefined-variable, missing-function-docstring
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument, too-few-public-methods, disallowed-name
+import abc
 
 
 def my_func(self):
@@ -103,3 +104,20 @@ def my_func(self):  # [redundant-returns-doc]
             One
     """
     yield 1
+
+
+class Foo:
+    """test_ignores_return_in_abstract_method_numpy
+    Example of an abstract method documenting the return type that an
+    implementation should return."""
+
+    @abc.abstractmethod
+    def foo(self):
+        """docstring ...
+
+        Returns
+        -------
+        int
+            Ten
+        """
+        return 10

--- a/tests/functional/ext/docparams/return/missing_return_doc_Numpy.py
+++ b/tests/functional/ext/docparams/return/missing_return_doc_Numpy.py
@@ -121,3 +121,19 @@ class Foo:
             Ten
         """
         return 10
+
+
+class Foo:
+    """test_ignores_return_in_abstract_method_numpy_2
+    Example of a method documenting the return type that an
+    implementation should return."""
+
+    def foo(self, arg):
+        """docstring ...
+
+        Parameters
+        ----------
+        arg : int
+            An argument.
+        """
+        raise NotImplementedError()

--- a/tests/functional/ext/docparams/return/missing_return_doc_Numpy.py
+++ b/tests/functional/ext/docparams/return/missing_return_doc_Numpy.py
@@ -137,3 +137,19 @@ class Foo:
             An argument.
         """
         raise NotImplementedError()
+
+
+class Foo:
+    """test_ignores_ignored_argument_names_numpy
+    Example of a method documenting the return type that an
+    implementation should return.
+    """
+
+    def foo(self, arg, _):
+        """docstring ...
+
+        Parameters
+        ----------
+        arg : int
+            An argument.
+        """

--- a/tests/functional/ext/docparams/return/missing_return_doc_Numpy.py
+++ b/tests/functional/ext/docparams/return/missing_return_doc_Numpy.py
@@ -153,3 +153,25 @@ class Foo:
         arg : int
             An argument.
         """
+
+
+class Foo:
+    """test_useless_docs_ignored_argument_names_numpy
+    Example of a method documenting the return type that an
+    implementation should return.
+    """
+
+    def foo(self, arg, _, _ignored):  # [useless-type-doc, useless-param-doc]
+        """docstring ...
+
+        Parameters
+        ----------
+        arg : int
+            An argument.
+
+        _ : float
+            Another argument.
+
+        _ignored :
+            Ignored Argument
+        """

--- a/tests/functional/ext/docparams/return/missing_return_doc_Numpy.txt
+++ b/tests/functional/ext/docparams/return/missing_return_doc_Numpy.txt
@@ -1,3 +1,5 @@
 redundant-returns-doc:62:0:70:15:my_func:Redundant returns documentation:UNDEFINED
 redundant-returns-doc:73:0:80:15:my_func:Redundant returns documentation:UNDEFINED
 redundant-returns-doc:98:0:106:11:my_func:Redundant returns documentation:UNDEFINED
+useless-param-doc:164:4:177:11:Foo.foo:"""_, _ignored"" useless ignored parameter documentation":UNDEFINED
+useless-type-doc:164:4:177:11:Foo.foo:"""_"" useless ignored parameter type documentation":UNDEFINED

--- a/tests/functional/ext/docparams/return/missing_return_doc_Numpy.txt
+++ b/tests/functional/ext/docparams/return/missing_return_doc_Numpy.txt
@@ -1,3 +1,3 @@
-redundant-returns-doc:61:0:69:15:my_func:Redundant returns documentation:UNDEFINED
-redundant-returns-doc:72:0:79:15:my_func:Redundant returns documentation:UNDEFINED
-redundant-returns-doc:97:0:105:11:my_func:Redundant returns documentation:UNDEFINED
+redundant-returns-doc:62:0:70:15:my_func:Redundant returns documentation:UNDEFINED
+redundant-returns-doc:73:0:80:15:my_func:Redundant returns documentation:UNDEFINED
+redundant-returns-doc:98:0:106:11:my_func:Redundant returns documentation:UNDEFINED


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This does not cover all numpy tests as there are some issues with those that check `raise` documentation (it seems as if tests are incorrectly passing currently).
Just to make the other PR easier to review, let's merge this first!