### PR TITLE
Fix #5504: Fix crash if the output of items() is assigned to a 1-tuple

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,11 @@ Release date: TBA
 
   Closes #4716
 
+* Fix crash in ``unnecessary-dict-index-lookup`` checker if the output of
+  ``items()`` is assigned to a 1-tuple.
+
+  Closes #5504
+
 * The ``PyLinter`` class will now be initialiazed with a ``TextReporter``
   as its reporter if none is provided.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -26,6 +26,11 @@ Other Changes
 
   Closes #4716
 
+* Fix crash in ``unnecessary-dict-index-lookup`` checker if the output of
+  ``items()`` is assigned to a 1-tuple.
+
+  Closes #5504
+
 * Fix false negative for ``consider-iterating-dictionary`` during membership checks encapsulated in iterables
   or ``not in`` checks
 

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1882,6 +1882,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                     if isinstance(value, nodes.Name):
                         if (
                             not isinstance(node.target, nodes.Tuple)
+                            # Ignore 1-tuples: for k, in d.items()
                             or len(node.target.elts) < 2
                             or value.name != node.target.elts[0].name
                             or iterating_object_name != subscript.value.as_string()

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1882,6 +1882,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                     if isinstance(value, nodes.Name):
                         if (
                             not isinstance(node.target, nodes.Tuple)
+                            or len(node.target.elts) < 2
                             or value.name != node.target.elts[0].name
                             or iterating_object_name != subscript.value.as_string()
                         ):

--- a/tests/functional/u/unnecessary/unnecessary_dict_index_lookup.py
+++ b/tests/functional/u/unnecessary/unnecessary_dict_index_lookup.py
@@ -100,3 +100,10 @@ for key, val in outer_dict.items():
     for key_two, val_two in val.items():
         del outer_dict[key][key_two]  # [unnecessary-dict-index-lookup]
         break
+
+# Test partial unpacking of items
+# https://github.com/PyCQA/pylint/issues/5504
+
+d = {}
+for key, in d.items():
+    print(d[key])


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fixes crash if the dict view returned by `.items()` is partially unpacked to a 1-tuple, e.g. `for k, in d.items()` instead of `for k, _ in d.items()`

Closes #5504
