### PR TITLE
Modify the description of HIGH confidence in pylint.interfaces

### DIFF
--- a/pylint/interfaces.py
+++ b/pylint/interfaces.py
@@ -26,6 +26,19 @@ from astroid import nodes
 if TYPE_CHECKING:
     from pylint.reporters.ureports.nodes import Section
 
+__all__ = (
+    "IRawChecker",
+    "IAstroidChecker",
+    "ITokenChecker",
+    "IReporter",
+    "IChecker",
+    "HIGH",
+    "INFERENCE",
+    "INFERENCE_FAILURE",
+    "UNDEFINED",
+    "CONFIDENCE_LEVELS",
+)
+
 Confidence = namedtuple("Confidence", ["name", "description"])
 # Warning Certainties
 HIGH = Confidence("HIGH", "No false positive possible.")
@@ -102,6 +115,3 @@ class IReporter(Interface):
 
     def display_reports(self, layout: "Section") -> None:
         """display results encapsulated in the layout tree"""
-
-
-__all__ = ("IRawChecker", "IAstroidChecker", "ITokenChecker", "IReporter", "IChecker")

--- a/pylint/interfaces.py
+++ b/pylint/interfaces.py
@@ -42,7 +42,7 @@ __all__ = (
 
 Confidence = namedtuple("Confidence", ["name", "description"])
 # Warning Certainties
-HIGH = Confidence("HIGH", "No false positive possible.")
+HIGH = Confidence("HIGH", "Warning that is not based on inference result.")
 INFERENCE = Confidence("INFERENCE", "Warning based on inference result.")
 INFERENCE_FAILURE = Confidence(
     "INFERENCE_FAILURE", "Warning based on inference with failures."

--- a/pylint/interfaces.py
+++ b/pylint/interfaces.py
@@ -75,10 +75,10 @@ class IChecker(Interface):
     """
 
     def open(self):
-        """called before visiting project (i.e set of modules)"""
+        """called before visiting project (i.e. set of modules)"""
 
     def close(self):
-        """called after visiting project (i.e set of modules)"""
+        """called after visiting project (i.e. set of modules)"""
 
 
 class IRawChecker(IChecker):
@@ -87,7 +87,7 @@ class IRawChecker(IChecker):
     def process_module(self, node: nodes.Module) -> None:
         """process a module
 
-        the module's content is accessible via astroid.stream
+        the module's content is accessible via ``astroid.stream``
         """
 
 

--- a/pylint/interfaces.py
+++ b/pylint/interfaces.py
@@ -19,11 +19,12 @@
 
 """Interfaces for Pylint objects"""
 from collections import namedtuple
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Tuple, Type, Union
 
 from astroid import nodes
 
 if TYPE_CHECKING:
+    from pylint.checkers import BaseChecker
     from pylint.reporters.ureports.nodes import Section
 
 __all__ = (
@@ -59,7 +60,10 @@ class Interface:
         return implements(instance, cls)
 
 
-def implements(obj: "Interface", interface: Tuple[type, type]) -> bool:
+def implements(
+    obj: "BaseChecker",
+    interface: Union[Type["Interface"], Tuple[Type["Interface"], ...]],
+) -> bool:
     """Return whether the given object (maybe an instance or class) implements
     the interface.
     """


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Pycharm raises a warning when we import something that is not in ``__all__``. We also need a new confidence level clearer than ``HIGH``.
