### PR TITLE
Fix #5451: Produce a score of 0 for fatal errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,11 +38,12 @@ Release date: TBA
 * The ``PyLinter`` class will now be initialiazed with a ``TextReporter``
   as its reporter if none is provided.
 
-* Fatal errors now emit a score of 0.0 regardless if the linted module
-  contained any statements, and ``fatal`` was added to the variables permitted
-  in score evaluation expressions.
+* Fatal errors now emit a score of 0.0 regardless of whether the linted module
+  contained any statements
 
   Closes #5451
+
+* ``fatal`` was added to the variables permitted in score evaluation expressions.
 
 * Fix false positive - Allow unpacking of ``self`` in a subclass of ``typing.NamedTuple``.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,12 @@ Release date: TBA
 * The ``PyLinter`` class will now be initialiazed with a ``TextReporter``
   as its reporter if none is provided.
 
+* A perfect score produced from linting a combination of valid and invalid
+  paths now exits with a non-zero code for perfect score runs if the
+  ``--fail-under`` threshold is also 10.0.
+
+  Closes #5451
+
 * Fix false positive - Allow unpacking of ``self`` in a subclass of ``typing.NamedTuple``.
 
   Closes #5312

--- a/ChangeLog
+++ b/ChangeLog
@@ -39,7 +39,8 @@ Release date: TBA
   as its reporter if none is provided.
 
 * Fatal errors now emit a score of 0.0 regardless if the linted module
-  contained any statements.
+  contained any statements, and ``fatal`` was added to the variables permitted
+  in score evaluation expressions.
 
   Closes #5451
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -38,9 +38,8 @@ Release date: TBA
 * The ``PyLinter`` class will now be initialiazed with a ``TextReporter``
   as its reporter if none is provided.
 
-* A perfect score produced from linting a combination of valid and invalid
-  paths now exits with a non-zero code for perfect score runs if the
-  ``--fail-under`` threshold is also 10.0.
+* Fatal errors now emit a score of 0.0 regardless if the linted module
+  contained any statements.
 
   Closes #5451
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -252,7 +252,7 @@ default value by changing the mixin-class-rgx option.
 Even though the final rating Pylint renders is nominally out of ten, there's no
 lower bound on it. By default, the formula to calculate score is ::
 
-    10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+    0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
 However, this option can be changed in the Pylint rc file. If having negative
 values really bugs you, you can set the formula to be the maximum of 0 and the

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -59,11 +59,12 @@ Other Changes
 
   Closes #5065
 
-* Fatal errors now emit a score of 0.0 regardless if the linted module
-  contained any statements, and ``fatal`` was added to the variables permitted
-  in score evaluation expressions.
+* Fatal errors now emit a score of 0.0 regardless of whether the linted module
+  contained any statements
 
   Closes #5451
+
+* ``fatal`` was added to the variables permitted in score evaluation expressions.
 
 * The ``PyLinter`` class will now be initialized with a ``TextReporter``
   as its reporter if none is provided.

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -59,5 +59,11 @@ Other Changes
 
   Closes #5065
 
-* The ``PyLinter`` class will now be initialiazed with a ``TextReporter``
+* A perfect score produced from linting a combination of valid and invalid
+  paths now exits with a non-zero code for perfect score runs if the
+  ``--fail-under`` threshold is also 10.0.
+
+  Closes #5451
+
+* The ``PyLinter`` class will now be initialized with a ``TextReporter``
   as its reporter if none is provided.

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -60,7 +60,8 @@ Other Changes
   Closes #5065
 
 * Fatal errors now emit a score of 0.0 regardless if the linted module
-  contained any statements.
+  contained any statements, and ``fatal`` was added to the variables permitted
+  in score evaluation expressions.
 
   Closes #5451
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -59,9 +59,8 @@ Other Changes
 
   Closes #5065
 
-* A perfect score produced from linting a combination of valid and invalid
-  paths now exits with a non-zero code for perfect score runs if the
-  ``--fail-under`` threshold is also 10.0.
+* Fatal errors now emit a score of 0.0 regardless if the linted module
+  contained any statements.
 
   Closes #5451
 

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -90,7 +90,7 @@ enable=c-extension-no-member
 [REPORTS]
 
 # Python expression which should return a score less than or equal to 10. You
-# have access to the variables 'fatal', 'error', 'warning', 'refactor', and 'convention'
+# have access to the variables 'fatal', 'error', 'warning', 'refactor', 'convention' and 'info'
 # which contain the number of messages in each category, as well as 'statement'
 # which is the total number of statements analyzed. This score is used by the
 # global evaluation report (RP0004).

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -90,11 +90,11 @@ enable=c-extension-no-member
 [REPORTS]
 
 # Python expression which should return a score less than or equal to 10. You
-# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# have access to the variables 'fatal', 'error', 'warning', 'refactor', and 'convention'
 # which contain the number of messages in each category, as well as 'statement'
 # which is the total number of statements analyzed. This score is used by the
 # global evaluation report (RP0004).
-evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+evaluation=0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details.

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1326,6 +1326,8 @@ class PyLinter(
         except Exception as ex:  # pylint: disable=broad-except
             msg = f"An exception occurred while rating: {ex}"
         else:
+            if self.stats.by_msg.get('fatal', 0):
+                note = 0.0
             self.stats.global_note = note
             msg = f"Your code has been rated at {note:.2f}/10"
             if previous_stats:

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1326,7 +1326,7 @@ class PyLinter(
         except Exception as ex:  # pylint: disable=broad-except
             msg = f"An exception occurred while rating: {ex}"
         else:
-            if self.stats.by_msg.get('fatal', 0):
+            if self.stats.by_msg.get("fatal", 0):
                 note = 0.0
             self.stats.global_note = note
             msg = f"Your code has been rated at {note:.2f}/10"

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1315,6 +1315,7 @@ class PyLinter(
         evaluation = self.config.evaluation
         try:
             stats_dict = {
+                "fatal": self.stats.fatal,
                 "error": self.stats.error,
                 "warning": self.stats.warning,
                 "refactor": self.stats.refactor,
@@ -1326,8 +1327,6 @@ class PyLinter(
         except Exception as ex:  # pylint: disable=broad-except
             msg = f"An exception occurred while rating: {ex}"
         else:
-            if self.stats.by_msg.get("fatal", 0):
-                note = 0.0
             self.stats.global_note = note
             msg = f"Your code has been rated at {note:.2f}/10"
             if previous_stats:

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -764,7 +764,7 @@ class PyLinter(
                         self.enable(msg.msgid)
                         self.fail_on_symbols.append(msg.symbol)
                     elif msg.msgid[0] in fail_on_cats:
-                        # message starts with a cateogry value, flag (but do not enable) it
+                        # message starts with a category value, flag (but do not enable) it
                         self.fail_on_symbols.append(msg.symbol)
 
     def any_fail_on_issues(self):

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -413,12 +413,7 @@ to search for configuration file.
                 # So we use self.linter.msg_status if that is non-zero, otherwise we just return 1.
                 sys.exit(self.linter.msg_status or 1)
             elif score_value is not None:
-                if score_value == linter.config.fail_under == 10.0:
-                    # A perfect score might come with non-zero exit code if another
-                    # module had zero statements (and thus no score).
-                    # If the threshold is as high as possible, make sure to exit with it.
-                    sys.exit(self.linter.msg_status)
-                elif score_value >= linter.config.fail_under:
+                if score_value >= linter.config.fail_under:
                     sys.exit(0)
                 else:
                     # We need to make sure we return a failing exit code in this case.

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -413,7 +413,12 @@ to search for configuration file.
                 # So we use self.linter.msg_status if that is non-zero, otherwise we just return 1.
                 sys.exit(self.linter.msg_status or 1)
             elif score_value is not None:
-                if score_value >= linter.config.fail_under:
+                if score_value == linter.config.fail_under == 10.0:
+                    # A perfect score might come with non-zero exit code if another
+                    # module had zero statements (and thus no score).
+                    # If the threshold is as high as possible, make sure to exit with it.
+                    sys.exit(self.linter.msg_status)
+                elif score_value >= linter.config.fail_under:
                     sys.exit(0)
                 else:
                     # We need to make sure we return a failing exit code in this case.

--- a/pylintrc
+++ b/pylintrc
@@ -98,11 +98,11 @@ files-output=no
 reports=no
 
 # Python expression which should return a note less than 10 (10 is the highest
-# note). You have access to the variables errors warning, statement which
-# respectively contain the number of errors / warnings messages and the total
-# number of statements analyzed. This is used by the global evaluation report
-# (RP0004).
-evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+# note). You have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# and 'convention', which contain the number of messages in each category, as
+# well as 'statement', which is the total number of statements analyzed. This
+# score is used by the global evaluation report (RP0004).
+evaluation=0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details

--- a/pylintrc
+++ b/pylintrc
@@ -98,8 +98,8 @@ files-output=no
 reports=no
 
 # Python expression which should return a note less than 10 (10 is the highest
-# note). You have access to the variables 'fatal', 'error', 'warning', 'refactor',
-# and 'convention', which contain the number of messages in each category, as
+# note). You have access to the variables 'fatal', 'error', 'warning', 'refactor', 'convention'
+# and 'info', which contain the number of messages in each category, as
 # well as 'statement', which is the total number of statements analyzed. This
 # score is used by the global evaluation report (RP0004).
 evaluation=0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1154,12 +1154,9 @@ class TestRunTC:
         # and errors that are generated they don't affect the exit code.
         self._runtest([path, "--fail-under=-10"] + args, code=expected)
 
-    def test_fail_despite_perfect_score(self):
+    def test_one_module_fatal_error(self):
         """
-        Fatal errors in modules without statements don't report a score, so
-        linting a valid path and an invalid path will generate a score of 10.
-        Exit with non-zero exit code anyway.
-        https://github.com/PyCQA/pylint/issues/5451
+        Fatal errors in one of several modules linted still exits non-zero.
         """
         valid_path = join(HERE, "conftest.py")
         invalid_path = join(HERE, "garbagePath.py")

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1154,6 +1154,17 @@ class TestRunTC:
         # and errors that are generated they don't affect the exit code.
         self._runtest([path, "--fail-under=-10"] + args, code=expected)
 
+    def test_fail_despite_perfect_score(self):
+        """
+        Fatal errors in modules without statements don't report a score, so
+        linting a valid path and an invalid path will generate a score of 10.
+        Exit with non-zero exit code anyway.
+        https://github.com/PyCQA/pylint/issues/5451
+        """
+        valid_path = join(HERE, "conftest.py")
+        invalid_path = join(HERE, "garbagePath.py")
+        self._runtest([valid_path, invalid_path], code=1)
+
     @pytest.mark.parametrize(
         "args, expected",
         [


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

**Before**
Modules without statements (such as typo'd paths) don't generate scores. When a linter is run over both valid and invalid paths, this can lead to a perfect score. Scores meeting the ``--fail-under`` threshold exit with a 0 code (passing), which is counterintuitive for the case just described.

**Now**
<s>As long as ``--fail-under`` is 10.0, this PR fails runs with perfect scores if they had any non-zero exit codes.

Of course, the other approach would be to start emitting non-perfect scores for modules without statements, but this seemed less invasive.</s>

Update: new approach is to simply produce a score of 0 for fatal errors.

Closes #5451
