### PR TITLE
Add additional test cases used-before-assignment with try-except

### DIFF
--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
@@ -2,6 +2,9 @@
 try blocks with return statements.
 See: https://github.com/PyCQA/pylint/issues/5500.
 """
+# pylint: disable=inconsistent-return-statements
+
+
 def function():
     """Assume except blocks execute if the try block returns."""
     try:
@@ -13,3 +16,36 @@ def function():
         print(failure_message)  # [used-before-assignment]
 
     return failure_message
+
+
+def func_ok(var):
+    """'msg' is defined in all ExceptHandlers."""
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        msg = "Attribute not defined"
+    except ZeroDivisionError:
+        msg = "Devision by 0"
+    print(msg)
+
+
+def func_ok2(var):
+    """'msg' is defined in all ExceptHandlers that don't raise an Exception."""
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError as ex:
+        raise Exception from ex
+    except ZeroDivisionError:
+        msg = "Devision by 0"
+    print(msg)
+
+
+def func_ok3(var):
+    """'msg' is defined in all ExceptHandlers that don't return."""
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        return
+    except ZeroDivisionError:
+        msg = "Devision by 0"
+    print(msg)

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
@@ -1,1 +1,1 @@
-used-before-assignment:13:14:13:29:function:Using variable 'failure_message' before assignment:UNDEFINED
+used-before-assignment:16:14:16:29:function:Using variable 'failure_message' before assignment:UNDEFINED


### PR DESCRIPTION
## Description
Followup to #5500 and #5506

Add additional tests for `used-before-assignment` cases with `try-except`.
`used-before-assignment` should **not** be emitted for variables after the `try-except` block if
* All ExceptHandlers define it
* OR all ExceptHandlers, that don't `raise` an Exception or `return`, define it.

/CC: @jacobtylerwalls I created these while trying to isolate which case you mentioned https://github.com/PyCQA/pylint/issues/5500#issuecomment-991695275 isn't yet covered.