### PR TITLE
Update typing of reporter attributes in ``PyLinter``

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -5,7 +5,6 @@ import collections
 import contextlib
 import functools
 import operator
-import optparse  # pylint: disable=deprecated-module
 import os
 import sys
 import tokenize
@@ -693,10 +692,9 @@ class PyLinter(
                     meth(value)
                 return  # no need to call set_option, disable/enable methods do it
         elif optname == "output-format":
-            if not isinstance(value, str):
-                raise optparse.OptionValueError(
-                    "'output-format' should be a comma separated string of reporters"
-                )
+            assert isinstance(
+                value, str
+            ), "'output-format' should be a comma separated string of reporters"
             self._load_reporters(value)
         try:
             checkers.BaseTokenChecker.set_option(self, optname, value, action, optdict)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -5,13 +5,14 @@ import collections
 import contextlib
 import functools
 import operator
+import optparse  # pylint: disable=deprecated-module
 import os
 import sys
 import tokenize
 import traceback
 import warnings
 from io import TextIOWrapper
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Union
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Type, Union
 
 import astroid
 from astroid import AstroidError, nodes
@@ -533,8 +534,8 @@ class PyLinter(
             self.set_reporter(reporter)
         else:
             self.set_reporter(TextReporter())
-        self._reporter_names = None
-        self._reporters = {}
+        self._reporters: Dict[str, Type[reporters.BaseReporter]] = {}
+        """Dictionary of possible but non-initialized reporters"""
 
         self.msgs_store = MessageDefinitionStore()
         self._checkers = collections.defaultdict(list)
@@ -619,19 +620,21 @@ class PyLinter(
             except ModuleNotFoundError as e:
                 self.add_message("bad-plugin-value", args=(modname, e), line=0)
 
-    def _load_reporters(self) -> None:
+    def _load_reporters(self, reporter_names: str) -> None:
+        """Load the reporters if they are available on _reporters"""
+        if not self._reporters:
+            return
         sub_reporters = []
         output_files = []
         with contextlib.ExitStack() as stack:
-            for reporter_name in self._reporter_names.split(","):
+            for reporter_name in reporter_names.split(","):
                 reporter_name, *reporter_output = reporter_name.split(":", 1)
 
                 reporter = self._load_reporter_by_name(reporter_name)
                 sub_reporters.append(reporter)
                 if reporter_output:
-                    (reporter_output,) = reporter_output
                     output_file = stack.enter_context(
-                        open(reporter_output, "w", encoding="utf-8")
+                        open(reporter_output[0], "w", encoding="utf-8")
                     )
                     reporter.out = output_file
                     output_files.append(output_file)
@@ -690,18 +693,18 @@ class PyLinter(
                     meth(value)
                 return  # no need to call set_option, disable/enable methods do it
         elif optname == "output-format":
-            self._reporter_names = value
-            # If the reporters are already available, load
-            # the reporter class.
-            if self._reporters:
-                self._load_reporters()
-
+            if not isinstance(value, str):
+                raise optparse.OptionValueError(
+                    "'output-format' should be a comma separated string of reporters"
+                )
+            self._load_reporters(value)
         try:
             checkers.BaseTokenChecker.set_option(self, optname, value, action, optdict)
         except config.UnsupportedAction:
             print(f"option {optname} can't be read from config file", file=sys.stderr)
 
-    def register_reporter(self, reporter_class):
+    def register_reporter(self, reporter_class: Type[reporters.BaseReporter]) -> None:
+        """Registers a reporter class on the _reporters attribute."""
         self._reporters[reporter_class.name] = reporter_class
 
     def report_order(self):

--- a/pylint/reporters/base_reporter.py
+++ b/pylint/reporters/base_reporter.py
@@ -23,6 +23,9 @@ class BaseReporter:
 
     extension = ""
 
+    name = "base"
+    """Name of the reporter"""
+
     def __init__(self, output: Optional[TextIO] = None) -> None:
         self.linter: "PyLinter"
         self.section = 0


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Small change to these attributes and methods. `_reporter_names` was only used by `_load_reporters` so it makes more sense to just pass that option value to the method instead of creating an additional attribute.