### PR TITLE
Remove unnecessary `if` statement in variable consumption checker

### DIFF
--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1382,9 +1382,7 @@ class VariablesChecker(BaseChecker):
                     and stmt.fromlineno <= defstmt.fromlineno
                 ):
                     self.add_message(
-                        "used-before-assignment",
-                        args=node.name,
-                        node=node
+                        "used-before-assignment", args=node.name, node=node
                     )
 
                 elif current_consumer.scope_type == "lambda":

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1384,7 +1384,7 @@ class VariablesChecker(BaseChecker):
                     self.add_message(
                         "used-before-assignment",
                         args=node.name,
-                        node=node,
+                        node=node
                     )
 
                 elif current_consumer.scope_type == "lambda":

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1372,23 +1372,21 @@ class VariablesChecker(BaseChecker):
                 #   class A:
                 #      x = lambda attr: f + attr
                 #      f = 42
-                if isinstance(frame, nodes.ClassDef) and node.name in frame.locals:
-                    if isinstance(node.parent, nodes.Arguments):
-                        if stmt.fromlineno <= defstmt.fromlineno:
-                            # Doing the following is fine:
-                            #   class A:
-                            #      x = 42
-                            #      y = lambda attr=x: attr
-                            self.add_message(
-                                "used-before-assignment",
-                                args=node.name,
-                                node=node,
-                            )
-                    else:
-                        self.add_message(
-                            "undefined-variable", args=node.name, node=node
-                        )
-                        return (VariableVisitConsumerAction.CONSUME, found_nodes)
+                # We check lineno because doing the following is fine:
+                #   class A:
+                #      x = 42
+                #      y = lambda attr: x + attr
+                if (
+                    isinstance(frame, nodes.ClassDef)
+                    and node.name in frame.locals
+                    and stmt.fromlineno <= defstmt.fromlineno
+                ):
+                    self.add_message(
+                        "used-before-assignment",
+                        args=node.name,
+                        node=node,
+                    )
+
                 elif current_consumer.scope_type == "lambda":
                     self.add_message("undefined-variable", args=node.name, node=node)
                     return (VariableVisitConsumerAction.CONSUME, found_nodes)


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This removes the last uncovered part of the consumption checker as identified in #5241 

Original commit that added this code is https://github.com/PyCQA/pylint/commit/05b526d58a9b210a54ea2755eaf5104f74039e5b

I tested but I don't think `node.parent` is ever not `nodes.Arguments`. As an extra cautionary action I ran the primer with a debug statement. This can be seen in the following PR: https://github.com/DanielNoord/pylint/pull/59
Searching for `PLEASE SEE ME` would show any code that entered this `if` statement (based on this commit: https://github.com/DanielNoord/pylint/pull/59/commits/362d505d6452042b2dae40acb6fcc30a8c21b378)

This seems to be an unnecessary statement.
