### PR TITLE
Fix ``used-before-assignment`` for conditional self-referential typing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,11 @@ Release date: TBA
 
   Closes #3793
 
+* Fixed false positive for ``used-before-assignment`` with self-referential type
+  annotation in conditional statements within class methods.
+
+  Closes #5499
+
 * ``used-before-assignment`` now assumes that assignments in except blocks
   may not have occurred and warns accordingly.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -56,6 +56,11 @@ Other Changes
 
   Closes #3793
 
+* Fixed false positive for ``used-before-assignment`` with self-referential type
+  annotation in conditional statements within class methods.
+
+  Closes #5499
+
 * ``used-before-assignment`` now assumes that assignments in except blocks
   may not have occurred and warns accordingly.
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1805,7 +1805,7 @@ class VariablesChecker(BaseChecker):
         """
         if (
             node.frame().parent == defstmt
-            and node.statement(future=True) not in node.frame().body
+            and node.statement(future=True) == node.frame()
         ):
             # Check if used as type annotation
             # Break but don't emit message if postponed evaluation is enabled

--- a/tests/functional/u/use/used_before_assignment_typing.py
+++ b/tests/functional/u/use/used_before_assignment_typing.py
@@ -61,3 +61,16 @@ class MyOtherClass:
     def self_referential_optional_within_method(self) -> None:
         variable: Optional[MyOtherClass] = self
         print(variable)
+
+
+class MyThirdClass:
+    """Class to test self referential variable typing within conditionals.
+    This regressed, reported in: https://github.com/PyCQA/pylint/issues/5499
+    """
+
+    def function(self, var: int) -> None:
+        if var < 0.5:
+            _x: MyThirdClass = self
+
+    def other_function(self) -> None:
+        _x: MyThirdClass = self


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #5499.

I should have thought of this fix in #5342. This is much better..

