### PR TITLE
Fix ``not-callable`` for attributes that alias ``NamedTuple``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -59,6 +59,10 @@ Release date: TBA
 * The ``PyLinter`` class will now be initialiazed with a ``TextReporter``
   as its reporter if none is provided.
 
+* Fix false positive ``not-callable`` with attributes that alias ``NamedTuple``
+
+  Partially closes #1730
+
 * Fatal errors now emit a score of 0.0 regardless of whether the linted module
   contained any statements
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -83,6 +83,10 @@ Other Changes
 * The ``PyLinter`` class will now be initialized with a ``TextReporter``
   as its reporter if none is provided.
 
+* Fix false positive ``not-callable`` with attributes that alias ``NamedTuple``
+
+  Partially closes #1730
+
 * The ``testutils`` for unittests now accept ``end_lineno`` and ``end_column``. Tests
   without these will trigger a ``DeprecationWarning``.
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1564,6 +1564,10 @@ accessed. Python regular expressions are accepted.",
             self._check_uninferable_call(node)
             return
 
+        if not isinstance(inferred_call, astroid.Instance):
+            self.add_message("not-callable", node=node, args=node.func.as_string())
+            return
+
         # Don't emit if we can't make sure this object is callable.
         if not has_known_bases(inferred_call):
             return

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -73,7 +73,6 @@ from typing import Any, Callable, Iterator, List, Optional, Pattern, Tuple
 
 import astroid
 from astroid import bases, nodes
-from astroid.nodes.node_ng import NodeNG
 
 from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import (
@@ -1553,7 +1552,7 @@ accessed. Python regular expressions are accepted.",
         return None
 
     def _check_not_callable(
-        self, node: nodes.Call, inferred_call: Optional[NodeNG]
+        self, node: nodes.Call, inferred_call: Optional[nodes.NodeNG]
     ) -> None:
         """Checks to see if the not-callable message should be emitted
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1559,7 +1559,7 @@ accessed. Python regular expressions are accepted.",
         Only functions, generators and objects defining __call__ are "callable"
         We ignore instances of descriptors since astroid cannot properly handle them yet
         """
-        # Handle uninferrable calls
+        # Handle uninferable calls
         if not inferred_call or inferred_call.callable():
             self._check_uninferable_call(node)
             return

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1294,16 +1294,23 @@ accessed. Python regular expressions are accepted.",
         # Ignore instances of descriptors since astroid cannot properly handle them
         # yet
         if called and not called.callable():
-            if isinstance(called, astroid.Instance) and (
-                not has_known_bases(called)
-                or (
-                    called.parent is not None
-                    and isinstance(called.scope(), nodes.ClassDef)
-                    and "__get__" in called.locals
-                )
-            ):
+            if isinstance(called, astroid.Instance):
                 # Don't emit if we can't make sure this object is callable.
-                pass
+                if not has_known_bases(called):
+                    pass
+                elif (
+                    called.parent
+                    and isinstance(called.scope(), nodes.ClassDef)
+                    and (
+                        "__get__" in called.locals
+                        or called.qname() == "typing.NamedTuple"
+                    )
+                ):
+                    pass
+                else:
+                    self.add_message(
+                        "not-callable", node=node, args=node.func.as_string()
+                    )
             else:
                 self.add_message("not-callable", node=node, args=node.func.as_string())
         else:

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1564,10 +1564,6 @@ accessed. Python regular expressions are accepted.",
             self._check_uninferable_call(node)
             return
 
-        # Ignore non instances
-        if not isinstance(inferred_call, astroid.Instance):
-            return
-
         # Don't emit if we can't make sure this object is callable.
         if not has_known_bases(inferred_call):
             return

--- a/tests/functional/n/not_callable.py
+++ b/tests/functional/n/not_callable.py
@@ -136,12 +136,24 @@ class ClassWithProperty:
 
 CLASS_WITH_PROP = ClassWithProperty().value()  # [not-callable]
 
-# Test typing.Namedtuple not callable
+# Test typing.Namedtuple is callable
 # See: https://github.com/PyCQA/pylint/issues/1295
 import typing
 
 Named = typing.NamedTuple("Named", [("foo", int), ("bar", int)])
 named = Named(1, 2)
+
+
+# NamedTuple is callable, even if it aliased to a attribute
+# See https://github.com/PyCQA/pylint/issues/1730
+class TestNamedTuple:
+    def __init__(self, field: str) -> None:
+        self.my_tuple = typing.NamedTuple("Tuple", [(field, int)])
+        self.item: self.my_tuple
+
+    def set_item(self, item: int) -> None:
+        self.item = self.my_tuple(item)
+
 
 # Test descriptor call
 def func():

--- a/tests/functional/n/not_callable.txt
+++ b/tests/functional/n/not_callable.txt
@@ -7,4 +7,4 @@ not-callable:32:12:32:17::INT is not callable:UNDEFINED
 not-callable:67:0:67:13::PROP.test is not callable:UNDEFINED
 not-callable:68:0:68:13::PROP.custom is not callable:UNDEFINED
 not-callable:137:18:137:45::ClassWithProperty().value is not callable:UNDEFINED
-not-callable:190:0:190:16::get_number(10) is not callable:UNDEFINED
+not-callable:202:0:202:16::get_number(10) is not callable:UNDEFINED


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes part of #1730, specifically this comment: https://github.com/PyCQA/pylint/issues/1730#issuecomment-489572303

I tried to destructure the `if` a little bit because I got a `too-many-boolean-expressions` warning and it became really unreadable.. This did lead to some code duplication though..