### PR TITLE
Fix #1555: Fix false negatives for `no-member` from self-referencing assignments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,10 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.14.rst'
 
+* Fix false negative for ``no-member`` when attempting to assign an instance
+  attribute to itself without any prior assignment.
 
+  Closes #1555
 
 ..
   Insert your changelog randomly, it will reduce merge conflicts

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -23,3 +23,8 @@ Extensions
 
 Other Changes
 =============
+
+* Fix false negative for ``no-member`` when attempting to assign an instance
+  attribute to itself without any prior assignment.
+
+  Closes #1555

--- a/tests/functional/n/no/no_member_assign_same_line.py
+++ b/tests/functional/n/no/no_member_assign_same_line.py
@@ -1,0 +1,37 @@
+"""Tests for no-member for self-referencing instance attributes
+See https://github.com/PyCQA/pylint/issues/1555
+"""
+# pylint: disable=too-few-public-methods
+
+
+class ClassWithMember:
+    """Member defined in superclass."""
+    def __init__(self):
+        self.member = True
+
+
+class AssignMemberInSameLine:
+    """This class attempts to assign and access a member in the same line."""
+    def __init__(self):
+        self.member = self.member  # [no-member]
+
+
+class AssignMemberInSameLineAfterTypeAnnotation:
+    """This might emit a message like `maybe-no-member` in the future."""
+    def __init__(self):
+        self.member: bool
+        self.member = self.member
+
+
+class AssignMemberFromSuper1(ClassWithMember):
+    """This assignment is valid due to inheritance."""
+    def __init__(self):
+        self.member = self.member
+        super().__init__()
+
+
+class AssignMemberFromSuper2(ClassWithMember):
+    """This assignment is valid due to inheritance."""
+    def __init__(self):
+        super().__init__()
+        self.member = self.member

--- a/tests/functional/n/no/no_member_assign_same_line.txt
+++ b/tests/functional/n/no/no_member_assign_same_line.txt
@@ -1,0 +1,1 @@
+no-member:16:22:16:33:AssignMemberInSameLine.__init__:Instance of 'AssignMemberInSameLine' has no 'member' member:INFERENCE


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Emits `no-member` when attempting to assign an instance attribute to itself before it has been defined, since at the moment of attempted assignment, there is no such member.

Closes #1555
