### PR TITLE
Fix crash on uninferable decorators on Python 3.6 and 3.7

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -79,6 +79,8 @@ Release date: TBA
 
   Closes #5323
 
+* Fixed crash on uninferable decorators on Python 3.6 and 3.7
+
 * Add checker ``unnecessary-ellipsis``: Emitted when the ellipsis constant is used unnecessarily.
 
   Closes #5460

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -73,6 +73,8 @@ Other Changes
 
   Closes #5065
 
+* Fixed crash on uninferable decorators on Python 3.6 and 3.7
+
 * Fatal errors now emit a score of 0.0 regardless of whether the linted module
   contained any statements
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -876,7 +876,11 @@ def uninferable_final_decorators(
             except AttributeError:
                 continue
         elif isinstance(decorator, nodes.Name):
-            import_node = decorator.lookup(decorator.name)[1][0]
+            lookup_values = decorator.lookup(decorator.name)
+            if lookup_values[1]:
+                import_node = decorator.lookup(decorator.name)[1][0]
+            else:
+                continue
         else:
             continue
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -880,7 +880,7 @@ def uninferable_final_decorators(
             if lookup_values[1]:
                 import_node = decorator.lookup(decorator.name)[1][0]
             else:
-                continue
+                continue  # pragma: no cover # Covered on Python < 3.8
         else:
             continue
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -878,7 +878,7 @@ def uninferable_final_decorators(
         elif isinstance(decorator, nodes.Name):
             lookup_values = decorator.lookup(decorator.name)
             if lookup_values[1]:
-                import_node = decorator.lookup(decorator.name)[1][0]
+                import_node = lookup_values[1][0]
             else:
                 continue  # pragma: no cover # Covered on Python < 3.8
         else:

--- a/tests/functional/o/overridden_final_method_regression.py
+++ b/tests/functional/o/overridden_final_method_regression.py
@@ -1,0 +1,6 @@
+"""Test a crash regression for the overridden-final-method checker on uninferable decorators"""
+
+
+@unknown_decorator  # [undefined-variable]
+def crash_test():
+    """A docstring"""

--- a/tests/functional/o/overridden_final_method_regression.txt
+++ b/tests/functional/o/overridden_final_method_regression.txt
@@ -1,0 +1,1 @@
+undefined-variable:4:1:4:18:crash_test:Undefined variable 'unknown_decorator':UNDEFINED


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Crash identified while working on #5547 

Tagging @mbyrnepr2 since you contributed this checker and I wonder if you have an opinion on this fix. 