### PR TITLE
Ignore files with name that starts like an emacs lock files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,12 @@ Release date: TBA
 
   Closes #5499
 
+* pylint do not take into account files starting with ``.#`` anymore. Those are
+  considered `emacs file lock`. See
+  https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html.
+
+  Closes #367
+
 * ``used-before-assignment`` now assumes that assignments in except blocks
   may not have occurred and warns accordingly.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -30,8 +30,8 @@ Release date: TBA
 
   Closes #5499
 
-* By default, pylint do not take into account files starting with ``.#`` anymore. Those are
-  considered `emacs file lock`. See
+* By default, pylint does no longer take files starting with ``.#`` into account. Those are
+  considered `emacs file locks`. See
   https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html.
   This behavior can be reverted by redefining the ``ignore-patterns`` option.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -30,9 +30,10 @@ Release date: TBA
 
   Closes #5499
 
-* pylint do not take into account files starting with ``.#`` anymore. Those are
+* By default, pylint do not take into account files starting with ``.#`` anymore. Those are
   considered `emacs file lock`. See
   https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html.
+  This behavior can be reverted by redefining the ``ignore-patterns`` option.
 
   Closes #367
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -32,6 +32,13 @@ Extensions
 Other Changes
 =============
 
+* pylint do not take into account files starting with ``.#`` anymore. Those are
+  considered `emacs file lock`_.
+
+  Closes #367
+
+.. _`emacs file lock`: https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html
+
 * Fixed extremely long processing of long lines with comma's.
 
   Closes #5483

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -32,13 +32,13 @@ Extensions
 Other Changes
 =============
 
-* By default, pylint do not take into account files starting with ``.#`` anymore. Those are
-  considered `emacs file lock`_. This behavior can be reverted by redefining the
+* By default, pylint does no longer take files starting with ``.#`` into account. Those are
+  considered `emacs file locks`_. This behavior can be reverted by redefining the
   ``ignore-patterns`` option.
 
   Closes #367
 
-.. _`emacs file lock`: https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html
+.. _`emacs file locks`: https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html
 
 * Fixed extremely long processing of long lines with comma's.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -32,8 +32,9 @@ Extensions
 Other Changes
 =============
 
-* pylint do not take into account files starting with ``.#`` anymore. Those are
-  considered `emacs file lock`_.
+* By default, pylint do not take into account files starting with ``.#`` anymore. Those are
+  considered `emacs file lock`_. This behavior can be reverted by redefining the
+  ``ignore-patterns`` option.
 
   Closes #367
 

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -52,8 +52,6 @@ def expand_modules(
         basename = os.path.basename(something)
         if (
             basename in ignore_list
-            # Emacs file locks see #367
-            or basename.startswith(".#")
             or _is_in_ignore_list_re(os.path.basename(something), ignore_list_re)
             or _is_in_ignore_list_re(something, ignore_list_paths_re)
         ):

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -8,8 +8,8 @@ from pylint.typing import ErrorDescriptionDict, ModuleDescriptionDict
 
 
 def _modpath_from_file(filename, is_namespace, path=None):
-    def _is_package_cb(path, parts):
-        return modutils.check_modpath_has_init(path, parts) or is_namespace
+    def _is_package_cb(inner_path, parts):
+        return modutils.check_modpath_has_init(inner_path, parts) or is_namespace
 
     return modutils.modpath_from_file_with_callback(
         filename, path=path, is_package_cb=_is_package_cb

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -48,11 +48,12 @@ def expand_modules(
     result: List[ModuleDescriptionDict] = []
     errors: List[ErrorDescriptionDict] = []
     path = sys.path.copy()
-
     for something in files_or_modules:
         basename = os.path.basename(something)
         if (
             basename in ignore_list
+            # Emacs file locks see #367
+            or basename.startswith(".#")
             or _is_in_ignore_list_re(os.path.basename(something), ignore_list_re)
             or _is_in_ignore_list_re(something, ignore_list_paths_re)
         ):

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -48,6 +48,7 @@ def expand_modules(
     result: List[ModuleDescriptionDict] = []
     errors: List[ErrorDescriptionDict] = []
     path = sys.path.copy()
+
     for something in files_or_modules:
         basename = os.path.basename(something)
         if (

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -223,7 +223,7 @@ class PyLinter(
                     "type": "regexp_csv",
                     "metavar": "<pattern>[,<pattern>...]",
                     "dest": "black_list_re",
-                    "default": (),
+                    "default": (r"^\.#",),
                     "help": "Files or directories matching the regex patterns are"
                     " skipped. The regex matches against base names, not paths.",
                 },

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -225,7 +225,8 @@ class PyLinter(
                     "dest": "black_list_re",
                     "default": (r"^\.#",),
                     "help": "Files or directories matching the regex patterns are"
-                    " skipped. The regex matches against base names, not paths.",
+                    " skipped. The regex matches against base names, not paths. The default value "
+                    "ignores emacs file locks",
                 },
             ),
             (

--- a/pylint/testutils/configuration_test.py
+++ b/pylint/testutils/configuration_test.py
@@ -21,7 +21,7 @@ PylintConfiguration = Dict[str, ConfigurationValue]
 
 
 if not PY38_PLUS:
-    # We need to deepcopy a compiled regex pattern
+    # We need to deepcopy a compiled regex pattern
     # In python 3.6 and 3.7 this require a hack
     # See https://stackoverflow.com/a/56935186
     copy._deepcopy_dispatch[type(re.compile(""))] = lambda r, _: r  # type: ignore[attr-defined]

--- a/pylint/testutils/configuration_test.py
+++ b/pylint/testutils/configuration_test.py
@@ -31,7 +31,7 @@ def get_expected_or_default(
         with open(expected_result_path, encoding="utf8") as f:
             expected = f.read()
         # logging is helpful to realize your file is not taken into
-        # account after a misspell of the file name. The output of the
+        # account after a misspelling of the file name. The output of the
         # program is checked during the test so printing messes with the result.
         logging.info("%s exists.", expected_result_path)
     else:
@@ -139,7 +139,7 @@ def run_using_a_configuration_file(
     # would not be accessible outside the `with` block.
     with unittest.mock.patch("sys.exit") as mocked_exit:
         # Do not actually run checks, that could be slow. We don't mock
-        # `Pylinter.check`: it calls `Pylinter.initialize` which is
+        # `PyLinter.check`: it calls `PyLinter.initialize` which is
         # needed to properly set up messages inclusion/exclusion
         # in `_msg_states`, used by `is_message_enabled`.
         check = "pylint.lint.pylinter.check_parallel"

--- a/pylint/testutils/configuration_test.py
+++ b/pylint/testutils/configuration_test.py
@@ -21,6 +21,8 @@ PylintConfiguration = Dict[str, ConfigurationValue]
 
 
 if not PY38_PLUS:
+    # We need to deepcopy a compiled regex pattern
+    # In python 3.6 and 3.7 this require a hack
     # See https://stackoverflow.com/a/56935186
     copy._deepcopy_dispatch[type(re.compile(""))] = lambda r, _: r  # type: ignore[attr-defined]
 

--- a/pylint/testutils/configuration_test.py
+++ b/pylint/testutils/configuration_test.py
@@ -5,17 +5,24 @@
 import copy
 import json
 import logging
+import re
 import unittest
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 from unittest.mock import Mock
 
+from pylint.constants import PY38_PLUS
 from pylint.lint import Run
 
 # We use Any in this typing because the configuration contains real objects and constants
 # that could be a lot of things.
 ConfigurationValue = Any
 PylintConfiguration = Dict[str, ConfigurationValue]
+
+
+if not PY38_PLUS:
+    # See https://stackoverflow.com/a/56935186
+    copy._deepcopy_dispatch[type(re.compile(""))] = lambda r, _: r  # type: ignore[attr-defined]
 
 
 def get_expected_or_default(

--- a/pylint/utils/linterstats.py
+++ b/pylint/utils/linterstats.py
@@ -155,7 +155,7 @@ class LinterStats:
         {self.percent_duplicated_lines}"""
 
     def init_single_module(self, module_name: str) -> None:
-        """Use through Pylinter.set_current_module so Pyliner.current_name is consistent."""
+        """Use through PyLinter.set_current_module so PyLinter.current_name is consistent."""
         self.by_module[module_name] = ModuleStats(
             convention=0, error=0, fatal=0, info=0, refactor=0, statement=0, warning=0
         )

--- a/tests/functional/e/.#emacs_file_lock.py
+++ b/tests/functional/e/.#emacs_file_lock.py
@@ -1,0 +1,4 @@
+# There is no module docstring, but we should not analyse this file
+# Because it starts like an emacs file lock
+# https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html
+# See #367

--- a/tests/functional/e/.#emacs_file_lock.py
+++ b/tests/functional/e/.#emacs_file_lock.py
@@ -1,4 +1,4 @@
 # The name is invalid, but we should not analyse this file
-# Because it starts like an emacs file lock ignored by default
+# Because its filename reseambles an emacs file lock ignored by default
 # https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html
-# See #367
+# See https://github.com/PyCQA/pylint/issues/367

--- a/tests/functional/e/.#emacs_file_lock.py
+++ b/tests/functional/e/.#emacs_file_lock.py
@@ -1,4 +1,4 @@
-# There is no module docstring, but we should not analyse this file
-# Because it starts like an emacs file lock
+# The name is invalid, but we should not analyse this file
+# Because it starts like an emacs file lock ignored by default
 # https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html
 # See #367

--- a/tests/functional/e/.#emacs_file_lock_by_conf.py
+++ b/tests/functional/e/.#emacs_file_lock_by_conf.py
@@ -1,0 +1,2 @@
+# The name is invalid, but we should not analyse this file
+# Because it starts like an emacs file lock ignored in the configuration

--- a/tests/functional/e/.#emacs_file_lock_by_conf.py
+++ b/tests/functional/e/.#emacs_file_lock_by_conf.py
@@ -1,2 +1,3 @@
 # The name is invalid, but we should not analyse this file
-# Because it starts like an emacs file lock ignored in the configuration
+# Because it resembles an emacs file lock and is ignored by the configuration
+# See https://github.com/PyCQA/pylint/issues/367

--- a/tests/functional/e/.#emacs_file_lock_by_conf.rc
+++ b/tests/functional/e/.#emacs_file_lock_by_conf.rc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore-patterns=^\.#

--- a/tests/functional/e/.#emacs_file_lock_redefined_conf.py
+++ b/tests/functional/e/.#emacs_file_lock_redefined_conf.py
@@ -1,3 +1,3 @@
 # [invalid-name]
-# The name is invalid, and we should analyse this file
-# as the ignore-patterns is redefined in the configuration
+# The name is invalid and we should analyse this file
+# as ignore-patterns is redefined in the configuration

--- a/tests/functional/e/.#emacs_file_lock_redefined_conf.py
+++ b/tests/functional/e/.#emacs_file_lock_redefined_conf.py
@@ -1,0 +1,3 @@
+# [invalid-name]
+# The name is invalid, and we should analyse this file
+# as the ignore-patterns is redefined in the configuration

--- a/tests/functional/e/.#emacs_file_lock_redefined_conf.rc
+++ b/tests/functional/e/.#emacs_file_lock_redefined_conf.rc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore-patterns=""

--- a/tests/functional/e/.#emacs_file_lock_redefined_conf.txt
+++ b/tests/functional/e/.#emacs_file_lock_redefined_conf.txt
@@ -1,0 +1,1 @@
+invalid-name:1:0:None:None::Module name "#emacs_file_lock_redefined_conf" doesn't conform to snake_case naming style:HIGH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This ignore the file starting like emacs file lock. It's a problem in emacs not in pylint but this kind of file name can almost exclusively come from emacs as it's not a valid module name so we may as well ease the life of our emacs users.

Closes #367
