### PR TITLE
Fix unexpected types used in 'get_global_option'

### DIFF
--- a/tests/lint/unittest_expand_modules.py
+++ b/tests/lint/unittest_expand_modules.py
@@ -113,7 +113,7 @@ class TestExpandModules(CheckerTestCase):
             files_or_modules,
             ignore_list,
             ignore_list_re,
-            get_global_option(self, "ignore-paths"),
+            get_global_option(self.checker, "ignore-paths"),
         )
         modules.sort(key=lambda d: d["name"])
         assert modules == expected


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Found while working on #5554 
