### PR TITLE
Add missing settings to pylintrc

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -371,7 +371,7 @@ property-classes=abc.abstractproperty
 # A class is considered mixin if its name matches the mixin-class-rgx option.
 ignore-mixin-members=yes
 
-# Regex pattern to define which classes are considered mixins ignore-mixin-
+# Regex pattern to define which classes are considered mixins if ignore-mixin-
 # members is set to 'yes'
 mixin-class-rgx=.*MixIn
 

--- a/pylintrc
+++ b/pylintrc
@@ -11,6 +11,14 @@
 # paths.
 ignore=CVS
 
+# Add files or directories matching the regex patterns to the ignore-list. The
+# regex matches against paths and can be in Posix or Windows format.
+ignore-paths=
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths.
+ignore-patterns=^\.#
+
 # Pickle collected data for later comparisons.
 persistent=yes
 
@@ -27,7 +35,8 @@ load-plugins=
     pylint.extensions.redefined_variable_type,
     pylint.extensions.comparison_placement,
 
-# Use multiple processes to speed up Pylint.
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
 jobs=1
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
@@ -46,6 +55,19 @@ extension-pkg-allow-list=
 # Minimum supported python version
 py-version = 3.6.2
 
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10.0
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
 
 [MESSAGES CONTROL]
 
@@ -55,7 +77,8 @@ confidence=
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
-# multiple time. See also the "--disable" option for examples.
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
 enable=
     use-symbolic-message-instead,
     useless-suppression,
@@ -89,11 +112,6 @@ disable=
 # mypackage.mymodule.MyReporterClass.
 output-format=text
 
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
-
 # Tells whether to display a full report or only the messages
 reports=no
 
@@ -108,6 +126,9 @@ evaluation=0 if fatal else 10.0 - ((float(5 * error + warning + refactor + conve
 # used to format the message information. See doc for all details
 #msg-template=
 
+# Activate the evaluation score.
+score=yes
+
 
 [LOGGING]
 
@@ -115,11 +136,18 @@ evaluation=0 if fatal else 10.0 - ((float(5 * error + warning + refactor + conve
 # function parameter format
 logging-modules=logging
 
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
 
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
 notes=FIXME,XXX,TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
 
 
 [SIMILARITIES]
@@ -135,6 +163,9 @@ ignore-docstrings=yes
 
 # Ignore imports when computing similarities.
 ignore-imports=no
+
+# Signatures are removed from the similarity computation
+ignore-signatures=no
 
 
 [VARIABLES]
@@ -154,6 +185,20 @@ additional-builtins=
 # name must start or end with one of those strings.
 callbacks=cb_,_cb
 
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
 
 [FORMAT]
 
@@ -166,6 +211,10 @@ ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
 single-line-if-stmt=no
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
 
 # List of optional constructs for which whitespace checking is disabled
 no-space-check=trailing-comma,dict-separator
@@ -189,8 +238,16 @@ expected-line-ending-format=
 # Good variable names which should always be accepted, separated by a comma
 good-names=i,j,k,ex,Run,_
 
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
 
 # Colon-delimited sets of names that determine each other's naming style when
 # the name regexes allow several styles.
@@ -199,11 +256,17 @@ name-group=
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no
 
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
 # Regular expression matching correct function names
 function-rgx=[a-z_][a-z0-9_]{2,30}$
 
 # Naming hint for function names
 function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
 
 # Regular expression matching correct variable names
 variable-rgx=[a-z_][a-z0-9_]{2,30}$
@@ -211,11 +274,17 @@ variable-rgx=[a-z_][a-z0-9_]{2,30}$
 # Naming hint for variable names
 variable-name-hint=[a-z_][a-z0-9_]{2,30}$
 
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
 # Regular expression matching correct constant names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
 # Naming hint for constant names
 const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
 
 # Regular expression matching correct attribute names
 attr-rgx=[a-z_][a-z0-9_]{2,}$
@@ -223,11 +292,17 @@ attr-rgx=[a-z_][a-z0-9_]{2,}$
 # Naming hint for attribute names
 attr-name-hint=[a-z_][a-z0-9_]{2,}$
 
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
 # Regular expression matching correct argument names
 argument-rgx=[a-z_][a-z0-9_]{2,30}$
 
 # Naming hint for argument names
 argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
 
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
@@ -235,11 +310,24 @@ class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 # Naming hint for class attribute names
 class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style.
+#class-const-rgx=
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
 # Naming hint for inline iteration names
 inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
 
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
@@ -247,11 +335,17 @@ class-rgx=[A-Z_][a-zA-Z0-9]+$
 # Naming hint for class names
 class-name-hint=[A-Z_][a-zA-Z0-9]+$
 
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
 # Regular expression matching correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
 # Naming hint for module names
 module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
 
 # Regular expression matching correct method names
 method-rgx=[a-z_][a-z0-9_]{2,}$
@@ -277,16 +371,19 @@ property-classes=abc.abstractproperty
 # A class is considered mixin if its name matches the mixin-class-rgx option.
 ignore-mixin-members=yes
 
-# Regex pattern to define which classes are considered mixins.
+# Regex pattern to define which classes are considered mixins ignore-mixin-
+# members is set to 'yes'
 mixin-class-rgx=.*MixIn
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis)
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
 ignored-modules=
 
-# List of classes names for which member attributes should not be checked
-# (useful for classes with attributes dynamically set).
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
 ignored-classes=SQLObject, optparse.Values, thread._local, _thread._local
 
 # List of members which are set dynamically and missed by pylint inference
@@ -298,6 +395,29 @@ generated-members=REQUEST,acl_users,aq_parent
 # contextlib.contextmanager.
 contextmanager-decorators=contextlib.contextmanager
 
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
 
 [SPELLING]
 
@@ -308,6 +428,10 @@ spelling-dict=
 # List of comma separated words that should not be checked.
 spelling-ignore-words=
 
+# List of comma separated words that should be considered directives if they
+# appear and the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
 # A path to a file that contains private dictionary; one word per line.
 spelling-private-dict-file=
 
@@ -315,15 +439,14 @@ spelling-private-dict-file=
 # --spelling-private-dict-file option instead of raising a message.
 spelling-store-unknown-words=no
 
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
 
 [DESIGN]
 
 # Maximum number of arguments for function / method
 max-args=10
-
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore
-ignored-argument-names=_.*
 
 # Maximum number of locals for function / method body
 max-locals=25
@@ -352,6 +475,9 @@ min-public-methods=2
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=25
 
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
 # List of regular expressions of class ancestor names to
 # ignore when counting public methods (see R0903).
 exclude-too-few-public-methods=
@@ -371,8 +497,22 @@ valid-metaclass-classmethod-first-arg=mcs
 # warning.
 exclude-protected=_asdict,_fields,_replace,_source,_make
 
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
 
 [IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
 
 # Deprecated modules which should not be used, separated by a comma
 deprecated-modules=regsub,TERMIOS,Bastion,rexec
@@ -389,6 +529,16 @@ ext-import-graph=
 # not be disabled)
 int-import-graph=
 
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
 
 [EXCEPTIONS]
 
@@ -399,11 +549,47 @@ overgeneral-exceptions=Exception
 
 [TYPING]
 
-# Annotations are used exclusively for type checking
+# Set to ``no`` if the app / library does **NOT** need to support runtime
+# introspection of type annotations. If you use type annotations
+# **exclusively** for type checking of an application, you're probably fine.
+# For libraries, evaluate if some users what to access the type hints at
+# runtime first, e.g., through ``typing.get_type_hints``. Applies to Python
+# versions 3.7 - 3.9
 runtime-typing = no
 
 
-[pylint.DEPRECATED_BUILTINS]
+[DEPRECATED_BUILTINS]
 
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,input
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[CODE_STYLE]
+
+# Max line length for which to sill emit suggestions. Used to prevent optional
+# suggestions which would get split by a code formatter (e.g., black). Will
+# default to the setting for ``max-line-length``.
+#max-line-length-suggestions=


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

There were many settings documented in `examples/pylintrc` that were not used in our own `pylintrc`. Similarly, there were commands in our `pylintrc` that were not in the example. This brings both documents in line with each other. 

As new users may look at our own configuration I think it is good to have all options in here, even if they are commented out. Please also look at the values of the new settings, as they essentially become default/suggested values.