### PR TITLE
Fix #5557: Don't emit `comparison-with-callable` if the callable raises

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -63,6 +63,11 @@ Release date: TBA
 
   Closes #3675
 
+* Fix ``comparison-with-callable`` false positive for callables that raise, such
+  as typing constants.
+
+  Closes #5557
+
 * Fix ``unnecessary_dict_index_lookup`` false positive when deleting a dictionary's entry.
 
   Closes #4716

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -99,6 +99,11 @@ Other Changes
 
 * ``fatal`` was added to the variables permitted in score evaluation expressions.
 
+* Fix ``comparison-with-callable`` false positive for callables that raise, such
+  as typing constants.
+
+  Closes #5557
+
 * The ``PyLinter`` class will now be initialized with a ``TextReporter``
   as its reporter if none is provided.
 

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -2514,12 +2514,12 @@ class ComparisonChecker(_BasicChecker):
         number_of_bare_callables = 0
         for operand in left_operand, right_operand:
             inferred = utils.safe_infer(operand)
-            if isinstance(inferred, bare_callables) and not any(
-                # Ignore callables that raise
-                isinstance(x, nodes.Raise)
-                # Or typing constants
-                or "typing._SpecialForm" in inferred.decoratornames()
-                for x in inferred.body
+            # Ignore callables that raise, as well as typing constants
+            # implemented as functions (that raise via their decorator)
+            if (
+                isinstance(inferred, bare_callables)
+                and "typing._SpecialForm" not in inferred.decoratornames()
+                and not any(isinstance(x, nodes.Raise) for x in inferred.body)
             ):
                 number_of_bare_callables += 1
         if number_of_bare_callables == 1:

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -2511,14 +2511,18 @@ class ComparisonChecker(_BasicChecker):
         left_operand, right_operand = node.left, node.ops[0][1]
         # this message should be emitted only when there is comparison of bare callable
         # with non bare callable.
-        if (
-            sum(
-                1
-                for operand in (left_operand, right_operand)
-                if isinstance(utils.safe_infer(operand), bare_callables)
-            )
-            == 1
-        ):
+        number_of_bare_callables: int = 0
+        for operand in left_operand, right_operand:
+            inferred = utils.safe_infer(operand)
+            if isinstance(inferred, bare_callables) and not any(
+                # Ignore callables that raise
+                isinstance(x, nodes.Raise)
+                # Or typing constants
+                or "typing._SpecialForm" in inferred.decoratornames()
+                for x in utils.safe_infer(operand).body
+            ):
+                number_of_bare_callables += 1
+        if number_of_bare_callables == 1:
             self.add_message("comparison-with-callable", node=node)
 
     @utils.check_messages(

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -2511,7 +2511,7 @@ class ComparisonChecker(_BasicChecker):
         left_operand, right_operand = node.left, node.ops[0][1]
         # this message should be emitted only when there is comparison of bare callable
         # with non bare callable.
-        number_of_bare_callables: int = 0
+        number_of_bare_callables = 0
         for operand in left_operand, right_operand:
             inferred = utils.safe_infer(operand)
             if isinstance(inferred, bare_callables) and not any(

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -2519,7 +2519,7 @@ class ComparisonChecker(_BasicChecker):
                 isinstance(x, nodes.Raise)
                 # Or typing constants
                 or "typing._SpecialForm" in inferred.decoratornames()
-                for x in utils.safe_infer(operand).body
+                for x in inferred.body
             ):
                 number_of_bare_callables += 1
         if number_of_bare_callables == 1:

--- a/tests/functional/c/comparison_with_callable.py
+++ b/tests/functional/c/comparison_with_callable.py
@@ -58,3 +58,12 @@ a = 666
 b = 786
 if a == b:
     pass
+
+
+def eventually_raise():
+    print()
+    raise Exception
+
+
+if a == eventually_raise:
+    pass

--- a/tests/functional/c/comparison_with_callable.py
+++ b/tests/functional/c/comparison_with_callable.py
@@ -66,4 +66,6 @@ def eventually_raise():
 
 
 if a == eventually_raise:
+    # Does not emit comparison-with-callable because the
+    # function (eventually) raises
     pass

--- a/tests/functional/c/comparison_with_callable_typing_constants.py
+++ b/tests/functional/c/comparison_with_callable_typing_constants.py
@@ -1,5 +1,4 @@
-"""
-Typing constants are actually implemented as functions, but they
+"""Typing constants are actually implemented as functions, but they
 raise when called, so Pylint uses that to avoid false positives for
 comparison-with-callable.
 """

--- a/tests/functional/c/comparison_with_callable_typing_constants.py
+++ b/tests/functional/c/comparison_with_callable_typing_constants.py
@@ -1,0 +1,19 @@
+"""
+Typing constants are actually implemented as functions, but they
+raise when called, so Pylint uses that to avoid false positives for
+comparison-with-callable.
+"""
+from typing import Any, Optional
+
+
+def check_any(type_) -> bool:
+    """See https://github.com/PyCQA/pylint/issues/5557"""
+    return type_ == Any
+
+
+def check_optional(type_) -> bool:
+    """
+    Unlike Any, Optional does not raise in its body.
+    It raises via its decorator: typing._SpecialForm.__call__()
+    """
+    return type_ == Optional


### PR DESCRIPTION


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Typing constants such as `typing.Any` raise when called, which means they should not emit `comparison-with-callable`.

This PR skips emitting that message when a callable raises in its body (or if it's a typing constant, since some typing constants only raise via their decorator, not via their body).

Closes #5557
