### PR TITLE
Add requirement files to list of files to run primer against

### DIFF
--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -9,6 +9,7 @@ on:
     paths:
       - "pylint/**"
       - "tests/primer/**"
+      - "requirements*"
 
 env:
   CACHE_VERSION: 3


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |

## Description

Seems like one of the new dependencies broke something in the primer.

This makes sure primer is also ran against changes to the dependencies, so we no longer unexpectedly fail on `main`.