### PR TITLE
Revert "Update tbump requirement from ~=6.6.0 to ~=6.6.1"

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,7 @@
 coveralls~=3.3
 coverage~=6.2
 pre-commit~=2.16;python_full_version>="3.6.2"
-tbump~=6.6.1
+tbump~=6.6.0
 pyenchant~=3.2
 pytest-cov~=3.0
 pytest-profiling~=1.7


### PR DESCRIPTION
Reverts PyCQA/pylint#5561, we need to fix the primer but we can't block all current MR in order to do that.