### PR TITLE
Add typing to checker and plugin attributes of ``PyLinter``

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -11,7 +11,19 @@ import tokenize
 import traceback
 import warnings
 from io import TextIOWrapper
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Type, Union
+from typing import (
+    Any,
+    DefaultDict,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Type,
+    Union,
+)
 
 import astroid
 from astroid import AstroidError, nodes
@@ -537,8 +549,15 @@ class PyLinter(
         self._reporters: Dict[str, Type[reporters.BaseReporter]] = {}
         """Dictionary of possible but non-initialized reporters"""
 
+        # Attributes for checkers and plugins
+        self._checkers: DefaultDict[
+            str, List[checkers.BaseChecker]
+        ] = collections.defaultdict(list)
+        """Dictionary of registered and initialized checkers"""
+        self._dynamic_plugins: Set[str] = set()
+        """Set of loaded plugin names"""
+
         self.msgs_store = MessageDefinitionStore()
-        self._checkers = collections.defaultdict(list)
         self._pragma_lineno = {}
         self._ignore_file = False
         # visit variables
@@ -583,7 +602,6 @@ class PyLinter(
             ("RP0003", "Messages", report_messages_stats),
         )
         self.register_checker(self)
-        self._dynamic_plugins = set()
         self._error_mode = False
         self.load_provider_defaults()
 
@@ -720,7 +738,7 @@ class PyLinter(
 
     # checkers manipulation methods ############################################
 
-    def register_checker(self, checker):
+    def register_checker(self, checker: checkers.BaseChecker) -> None:
         """register a new checker
 
         checker is an object implementing IRawChecker or / and IAstroidChecker

--- a/pylint/reporters/reports_handler_mix_in.py
+++ b/pylint/reporters/reports_handler_mix_in.py
@@ -4,15 +4,15 @@
 import collections
 from typing import TYPE_CHECKING, Callable, DefaultDict, Dict, List, Optional, Tuple
 
+from pylint import checkers
 from pylint.exceptions import EmptyReportError
-from pylint.interfaces import IChecker
 from pylint.reporters.ureports.nodes import Section
 from pylint.utils import LinterStats
 
 if TYPE_CHECKING:
     from pylint.lint.pylinter import PyLinter
 
-ReportsDict = DefaultDict[IChecker, List[Tuple[str, str, Callable]]]
+ReportsDict = DefaultDict[checkers.BaseChecker, List[Tuple[str, str, Callable]]]
 
 
 class ReportsHandlerMixIn:
@@ -24,12 +24,12 @@ class ReportsHandlerMixIn:
         self._reports: ReportsDict = collections.defaultdict(list)
         self._reports_state: Dict[str, bool] = {}
 
-    def report_order(self) -> List[IChecker]:
+    def report_order(self) -> List[checkers.BaseChecker]:
         """Return a list of reporters"""
         return list(self._reports)
 
     def register_report(
-        self, reportid: str, r_title: str, r_cb: Callable, checker: IChecker
+        self, reportid: str, r_title: str, r_cb: Callable, checker: checkers.BaseChecker
     ) -> None:
         """register a report
 


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Seems like we made an error in https://github.com/PyCQA/pylint/pull/5004 that I didn't catch in my review.

Checkers ``__implements__`` `Ichecker`, but this isn't picked up on by `mypy`. The typing should thus be `BaseChecker`.