### PR TITLE
Don't assume direct parentage when emitting `used-before-assignment`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,12 @@ Release date: TBA
 
   Closes #85, #2615
 
+* Fixed false negative for ``used-before-assignment`` when a conditional
+  or context manager intervened before the try statement that suggested
+  it might fail.
+
+  Closes #4045
+
 * Fixed extremely long processing of long lines with comma's.
 
   Closes #5483

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -63,6 +63,12 @@ Other Changes
 
   Closes #85, #2615
 
+* Fixed false negative for ``used-before-assignment`` when a conditional
+  or context manager intervened before the try statement that suggested
+  it might fail.
+
+  Closes #4045
+
 * Fix a false positive for ``assigning-non-slot`` when the slotted class
   defined ``__setattr__``.
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1723,15 +1723,15 @@ def get_node_first_ancestor_of_type(
 
 def get_node_first_ancestor_of_type_and_its_child(
     node: nodes.NodeNG, ancestor_type: Union[Type[T_Node], Tuple[Type[T_Node]]]
-) -> Tuple[Optional[T_Node], Optional[T_Node]]:
+) -> Union[Tuple[None, None], Tuple[T_Node, nodes.NodeNG]]:
     """Modified version of get_node_first_ancestor_of_type to also return the
     descendant visited directly before reaching the sought ancestor. Useful
     for extracting whether a statement is guarded by a try, except, or finally
     when searching for a TryFinally ancestor.
     """
-    last_ancestor = node
+    child = node
     for ancestor in node.node_ancestors():
         if isinstance(ancestor, ancestor_type):
-            return (ancestor, last_ancestor)
-        last_ancestor = ancestor
+            return (ancestor, child)
+        child = ancestor
     return None, None

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1719,3 +1719,19 @@ def get_node_first_ancestor_of_type(
         if isinstance(ancestor, ancestor_type):
             return ancestor
     return None
+
+
+def get_node_first_ancestor_of_type_and_its_child(
+    node: nodes.NodeNG, ancestor_type: Union[Type[T_Node], Tuple[Type[T_Node]]]
+) -> Tuple[Optional[T_Node], Optional[T_Node]]:
+    """Modified version of get_node_first_ancestor_of_type to also return the
+    descendant visited directly before reaching the sought ancestor. Useful
+    for extracting whether a statement is guarded by a try, except, or finally
+    when searching for a TryFinally ancestor.
+    """
+    last_ancestor = node
+    for ancestor in node.node_ancestors():
+        if isinstance(ancestor, ancestor_type):
+            return (ancestor, last_ancestor)
+        last_ancestor = ancestor
+    return None, None

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -755,6 +755,8 @@ scope_type : {self._atomic.scope_type}
             other_node_try_ancestor = utils.get_node_first_ancestor_of_type(
                 other_node_statement, nodes.TryExcept
             )
+            if other_node_try_ancestor is None:
+                continue
             if not any(
                 closest_except_handler in other_node_try_ancestor.handlers
                 or other_node_try_ancestor_except_handler

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -689,7 +689,7 @@ scope_type : {self._atomic.scope_type}
         found_nodes: List[nodes.NodeNG],
         node: nodes.NodeNG,
         node_statement: nodes.Statement,
-    ):
+    ) -> List[nodes.NodeNG]:
         """Return any nodes in ``found_nodes`` that should be treated as uncertain
         because they are in an except block.
         """

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -690,7 +690,11 @@ scope_type : {self._atomic.scope_type}
         return found_nodes
 
     @staticmethod
-    def _uncertain_nodes_in_except_blocks(found_nodes, node, node_statement):
+    def _uncertain_nodes_in_except_blocks(
+        found_nodes: List[nodes.NodeNG],
+        node: nodes.NodeNG,
+        node_statement: nodes.Statement,
+    ):
         """
         Return any nodes in ``found_nodes`` that should be treated as uncertain
         because they are in an except block.
@@ -736,7 +740,7 @@ scope_type : {self._atomic.scope_type}
 
     @staticmethod
     def _uncertain_nodes_in_try_blocks_when_evaluating_except_blocks(
-        found_nodes: List[nodes.NodeNG], node_statement
+        found_nodes: List[nodes.NodeNG], node_statement: nodes.Statement
     ) -> List[nodes.NodeNG]:
         """Return any nodes in ``found_nodes`` that should be treated as uncertain
         because they are in a try block and the ``node_statement`` being evaluated

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -738,20 +738,19 @@ scope_type : {self._atomic.scope_type}
     def _uncertain_nodes_in_try_blocks_when_evaluating_except_blocks(
         found_nodes, node_statement
     ):
-        """
-        Return any nodes in ``found_nodes`` that should be treated as uncertain
+        """Return any nodes in ``found_nodes`` that should be treated as uncertain
         because they are in a try block and the ``node_statement`` being evaluated
         is in one of its except handlers.
         """
+        uncertain_nodes = []
         closest_except_handler = utils.get_node_first_ancestor_of_type(
             node_statement, nodes.ExceptHandler
         )
         if closest_except_handler is None:
-            return []
+            return uncertain_nodes
         closest_try_ancestor = utils.get_node_first_ancestor_of_type(
             node_statement, nodes.TryExcept
         )
-        uncertain_nodes = []
         for other_node in found_nodes:
             other_node_statement = other_node.statement(future=True)
             if other_node_statement is closest_except_handler:

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -738,6 +738,11 @@ scope_type : {self._atomic.scope_type}
     def _uncertain_nodes_in_try_blocks_when_evaluating_except_blocks(
         found_nodes, node_statement
     ):
+        """
+        Return any nodes in ``found_nodes`` that should be treated as uncertain
+        because they are in a try block and the ``node_statement`` being evaluated
+        is in one of its except handlers.
+        """
         closest_except_handler = utils.get_node_first_ancestor_of_type(
             node_statement, nodes.ExceptHandler
         )

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -748,9 +748,6 @@ scope_type : {self._atomic.scope_type}
         )
         if closest_except_handler is None:
             return uncertain_nodes
-        closest_try_ancestor = utils.get_node_first_ancestor_of_type(
-            node_statement, nodes.TryExcept
-        )
         for other_node in found_nodes:
             other_node_statement = other_node.statement(future=True)
             if other_node_statement is closest_except_handler:
@@ -758,7 +755,12 @@ scope_type : {self._atomic.scope_type}
             other_node_try_ancestor = utils.get_node_first_ancestor_of_type(
                 other_node_statement, nodes.TryExcept
             )
-            if other_node_try_ancestor is not closest_try_ancestor:
+            if not any(
+                closest_except_handler in other_node_try_ancestor.handlers
+                or other_node_try_ancestor_except_handler
+                in closest_except_handler.node_ancestors()
+                for other_node_try_ancestor_except_handler in other_node_try_ancestor.handlers
+            ):
                 continue
             other_node_except_handler = utils.get_node_first_ancestor_of_type(
                 other_node_statement, nodes.ExceptHandler

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -777,12 +777,6 @@ scope_type : {self._atomic.scope_type}
                 for other_node_try_ancestor_except_handler in other_node_try_ancestor.handlers
             ):
                 continue
-            # Skip if other_node and this node are guarded by the same except handler
-            other_node_except_handler = utils.get_node_first_ancestor_of_type(
-                other_node_statement, nodes.ExceptHandler
-            )
-            if other_node_except_handler is closest_except_handler:
-                continue
             # Passed all tests for uncertain execution
             uncertain_nodes.append(other_node)
         return uncertain_nodes

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -754,12 +754,18 @@ scope_type : {self._atomic.scope_type}
             if other_node_statement is closest_except_handler:
                 continue
             # Ensure other_node is in a try block
-            other_node_try_ancestor, other_node_try_ancestor_visited_child = utils.get_node_first_ancestor_of_type_and_its_child(
+            (
+                other_node_try_ancestor,
+                other_node_try_ancestor_visited_child,
+            ) = utils.get_node_first_ancestor_of_type_and_its_child(
                 other_node_statement, nodes.TryExcept
             )
             if other_node_try_ancestor is None:
                 continue
-            if other_node_try_ancestor_visited_child not in other_node_try_ancestor.body:
+            if (
+                other_node_try_ancestor_visited_child
+                not in other_node_try_ancestor.body
+            ):
                 continue
             # Make sure nesting is correct -- there should be at least one
             # except handler that is a sibling attached to the try ancestor,

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -736,13 +736,13 @@ scope_type : {self._atomic.scope_type}
 
     @staticmethod
     def _uncertain_nodes_in_try_blocks_when_evaluating_except_blocks(
-        found_nodes, node_statement
-    ):
+        found_nodes: List[nodes.NodeNG], node_statement
+    ) -> List[nodes.NodeNG]:
         """Return any nodes in ``found_nodes`` that should be treated as uncertain
         because they are in a try block and the ``node_statement`` being evaluated
         is in one of its except handlers.
         """
-        uncertain_nodes = []
+        uncertain_nodes: List[nodes.NodeNG] = []
         closest_except_handler = utils.get_node_first_ancestor_of_type(
             node_statement, nodes.ExceptHandler
         )

--- a/tests/functional/u/use/used_before_assignment_issue2615.py
+++ b/tests/functional/u/use/used_before_assignment_issue2615.py
@@ -14,7 +14,8 @@ def main():
 
 
 def nested_except_blocks():
-    """Don't confuse except blocks with each other."""
+    """Assignments in an except are tested against possibly failing
+    assignments in try blocks at two different nesting levels."""
     try:
         res = 1 / 0
         res = 42
@@ -29,6 +30,20 @@ def nested_except_blocks():
             print(more_bad_division)  # [used-before-assignment]
             print(res)  # [used-before-assignment]
     print(res)
+
+
+def consecutive_except_blocks():
+    """An assignment assumed to execute in one TryExcept should continue to be
+    assumed to execute in a consecutive TryExcept.
+    """
+    try:
+        res = 100
+    except ZeroDivisionError:
+        pass
+    try:
+        pass
+    except ValueError:
+        print(res)
 
 
 def name_earlier_in_except_block():

--- a/tests/functional/u/use/used_before_assignment_issue2615.py
+++ b/tests/functional/u/use/used_before_assignment_issue2615.py
@@ -27,7 +27,7 @@ def nested_except_blocks():
             more_bad_division = 1 / 0
         except ZeroDivisionError:
             print(more_bad_division)  # [used-before-assignment]
-            print(res)  # currently too nested to make confident inferences
+            print(res)  # [used-before-assignment]
     print(res)
 
 

--- a/tests/functional/u/use/used_before_assignment_issue2615.py
+++ b/tests/functional/u/use/used_before_assignment_issue2615.py
@@ -27,7 +27,7 @@ def nested_except_blocks():
             more_bad_division = 1 / 0
         except ZeroDivisionError:
             print(more_bad_division)  # [used-before-assignment]
-            print(res)  # don't emit: too nested to make confident inferences
+            print(res)  # currently too nested to make confident inferences
     print(res)
 
 

--- a/tests/functional/u/use/used_before_assignment_issue2615.py
+++ b/tests/functional/u/use/used_before_assignment_issue2615.py
@@ -4,6 +4,42 @@ def main():
     try:
         res = 1 / 0
         res = 42
+        if main():
+            res = None
+        with open(__file__, encoding="utf-8") as opened_file:
+            res = opened_file.readlines()
     except ZeroDivisionError:
         print(res)  # [used-before-assignment]
     print(res)
+
+
+def nested_except_blocks():
+    """Don't confuse except blocks with each other."""
+    try:
+        res = 1 / 0
+        res = 42
+        if main():
+            res = None
+        with open(__file__, encoding="utf-8") as opened_file:
+            res = opened_file.readlines()
+    except ZeroDivisionError:
+        try:
+            more_bad_division = 1 / 0
+        except ZeroDivisionError:
+            print(more_bad_division)  # [used-before-assignment]
+            print(res)  # don't emit: too nested to make confident inferences
+    print(res)
+
+
+def name_earlier_in_except_block():
+    """Permit the name that might not have been assigned during the try block
+    to be defined inside a conditional inside the except block.
+    """
+    try:
+        res = 1 / 0
+    except ZeroDivisionError:
+        if main():
+            res = 10
+        else:
+            res = 11
+        print(res)

--- a/tests/functional/u/use/used_before_assignment_issue2615.txt
+++ b/tests/functional/u/use/used_before_assignment_issue2615.txt
@@ -1,1 +1,2 @@
-used-before-assignment:8:14:8:17:main:Using variable 'res' before assignment:UNDEFINED
+used-before-assignment:12:14:12:17:main:Using variable 'res' before assignment:UNDEFINED
+used-before-assignment:29:18:29:35:nested_except_blocks:Using variable 'more_bad_division' before assignment:UNDEFINED

--- a/tests/functional/u/use/used_before_assignment_issue2615.txt
+++ b/tests/functional/u/use/used_before_assignment_issue2615.txt
@@ -1,3 +1,3 @@
 used-before-assignment:12:14:12:17:main:Using variable 'res' before assignment:UNDEFINED
-used-before-assignment:29:18:29:35:nested_except_blocks:Using variable 'more_bad_division' before assignment:UNDEFINED
-used-before-assignment:30:18:30:21:nested_except_blocks:Using variable 'res' before assignment:UNDEFINED
+used-before-assignment:30:18:30:35:nested_except_blocks:Using variable 'more_bad_division' before assignment:UNDEFINED
+used-before-assignment:31:18:31:21:nested_except_blocks:Using variable 'res' before assignment:UNDEFINED

--- a/tests/functional/u/use/used_before_assignment_issue2615.txt
+++ b/tests/functional/u/use/used_before_assignment_issue2615.txt
@@ -1,2 +1,3 @@
 used-before-assignment:12:14:12:17:main:Using variable 'res' before assignment:UNDEFINED
 used-before-assignment:29:18:29:35:nested_except_blocks:Using variable 'more_bad_division' before assignment:UNDEFINED
+used-before-assignment:30:18:30:21:nested_except_blocks:Using variable 'res' before assignment:UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

**Before**
In Pylint 2.13.0 (unreleased) we are starting to be more confident in emitting `used-before-assignment` by making control flow inferences. (See e.g. #5384) We started cautiously, just checking direct parents of statements in try blocks to find out if that was the same `TryExcept` ancestor that was the parent of the node being visited in the except block. This left out possibly failing statements in the try block indented under `if`/`with`, etc.

**Now**
@DanielNoord suggested using `get_node_first_ancestor_of_type()` to be able to leapfrog over `if` and `with` statements to arrive at the relevant try ancestor. With this PR, we can now emit `used-before-assignment` even when the possibly failing statements in a try block are inside if/with statements.

One refactor commit and one behavior change commit.

Closes #4045
