### PR TITLE
Make functional tests always go through config initialization

### DIFF
--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -2,6 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Union
 
 from pylint import reporters
@@ -15,7 +16,7 @@ def _config_initialization(
     linter: "PyLinter",
     args_list: List[str],
     reporter: Union[reporters.BaseReporter, reporters.MultiReporter, None] = None,
-    config_file: Optional[str] = None,
+    config_file: Union[None, str, Path] = None,
     verbose_mode: Optional[bool] = None,
 ) -> List[str]:
     """Parse all available options, read config files and command line arguments and

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -54,12 +54,12 @@ class LintModuleTest:
             pass
 
         try:
-            sources = [test_file.source]
+            args = [test_file.source]
         except NoFileError:
             # If we're still raising NoFileError the actual source file doesn't exist
-            sources = [""]
+            args = [""]
         _config_initialization(
-            self._linter, sources, config_file=rc_file, reporter=_test_reporter
+            self._linter, args_list=args, config_file=rc_file, reporter=_test_reporter
         )
         self._test_file = test_file
         self._config = config

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -59,10 +59,7 @@ class LintModuleTest:
             # If we're still raising NoFileError the actual source file doesn't exist
             sources = [""]
         _config_initialization(
-            self._linter,
-            sources,
-            config_file=rc_file,
-            reporter=_test_reporter,
+            self._linter, sources, config_file=rc_file, reporter=_test_reporter
         )
         self._test_file = test_file
         self._config = config

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -43,8 +43,8 @@ class LintModuleTest:
         self._linter.config.persistent = 0
         checkers.initialize(self._linter)
 
-        rc_file: Union[Path, str] = PYLINTRC
         # See if test has its own .rc file, if so we use that one
+        rc_file: Union[Path, str] = PYLINTRC
         try:
             rc_file = test_file.option_file
             self._linter.disable("suppressed-message")
@@ -54,22 +54,16 @@ class LintModuleTest:
             pass
 
         try:
-            _config_initialization(
-                self._linter,
-                [test_file.source],
-                config_file=rc_file,
-                reporter=_test_reporter,
-            )
+            sources = [test_file.source]
         except NoFileError:
-            # If we're still raising NoFileError the actual source file doesn't exist and
-            # we pass a fake name
-            _config_initialization(
-                self._linter,
-                [""],
-                config_file=rc_file,
-                reporter=_test_reporter,
-            )
-
+            # If we're still raising NoFileError the actual source file doesn't exist
+            sources = [""]
+        _config_initialization(
+            self._linter,
+            sources,
+            config_file=rc_file,
+            reporter=_test_reporter,
+        )
         self._test_file = test_file
         self._config = config
         self._check_end_position = (

--- a/pylint/testutils/testing_pylintrc
+++ b/pylint/testutils/testing_pylintrc
@@ -1,0 +1,9 @@
+# A bare minimum pylintrc used for the functional tests that don't specify
+# their own settings.
+
+[MESSAGES CONTROL]
+
+disable=
+    suppressed-message,
+    locally-disabled,
+    useless-suppression,


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Follow up to #5591. Diff should be much smaller after that has been merged (adding blocked in the meantime).

This makes it so that whenever a functional test does not have a `.rc` file we still pass a `pylintrc` file to the configuration initialiser.
This does not fix any current problems but allows me (and others) to assume that `_config_initialization` is always ran, also for functional tests that skip instantiating a `Run` object. That allows me to then work within `_config_initialization` for the implementation of `argparse` and make `argparse` and `optparse` work along side each other while we're still working on it.

