### PR TITLE
Fix #2399: Avoid negative scores by default

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -96,6 +96,10 @@ Release date: TBA
 
 * ``fatal`` was added to the variables permitted in score evaluation expressions.
 
+* The default score expression now uses a floor of 0.
+
+  Closes #2399
+
 * Fix false positive - Allow unpacking of ``self`` in a subclass of ``typing.NamedTuple``.
 
   Closes #5312

--- a/ChangeLog
+++ b/ChangeLog
@@ -96,7 +96,7 @@ Release date: TBA
 
 * ``fatal`` was added to the variables permitted in score evaluation expressions.
 
-* The default score expression now uses a floor of 0.
+* The default score evaluation now uses a floor of 0.
 
   Closes #2399
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -249,15 +249,16 @@ default value by changing the mixin-class-rgx option.
 6.1 Pylint gave my code a negative rating out of ten. That can't be right!
 --------------------------------------------------------------------------
 
-Even though the final rating Pylint renders is nominally out of ten, there's no
-lower bound on it. By default, the formula to calculate score is ::
+Prior to Pylint 2.13.0, the score formula used by default had no lower
+bound. The new default score formula is ::
 
-    0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+    max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
 
-However, this option can be changed in the Pylint rc file. If having negative
-values really bugs you, you can set the formula to be the maximum of 0 and the
-above expression.
-
+If your project contains a pylint rc file created by an earlier version of
+Pylint, you can set ``expression`` to the above expression to get the new
+behavior. Likewise, since negative values are still technically supported,
+``expression`` can be set to a version of the above expression that does not
+enforce a floor of zero.
 
 6.2 I think I found a bug in Pylint. What should I do?
 -------------------------------------------------------

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -254,10 +254,10 @@ bound. The new default score formula is ::
 
     max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
 
-If your project contains a pylint rc file created by an earlier version of
-Pylint, you can set ``expression`` to the above expression to get the new
+If your project contains a configuration file created by an earlier version of
+Pylint, you can set ``evaluation`` to the above expression to get the new
 behavior. Likewise, since negative values are still technically supported,
-``expression`` can be set to a version of the above expression that does not
+``evaluation`` can be set to a version of the above expression that does not
 enforce a floor of zero.
 
 6.2 I think I found a bug in Pylint. What should I do?

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -104,7 +104,7 @@ Other Changes
 
 * ``fatal`` was added to the variables permitted in score evaluation expressions.
 
-* The default score expression now uses a floor of 0.
+* The default score evaluation now uses a floor of 0.
 
   Closes #2399
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -104,6 +104,10 @@ Other Changes
 
 * ``fatal`` was added to the variables permitted in score evaluation expressions.
 
+* The default score expression now uses a floor of 0.
+
+  Closes #2399
+
 * Fix ``comparison-with-callable`` false positive for callables that raise, such
   as typing constants.
 

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -94,7 +94,7 @@ enable=c-extension-no-member
 # which contain the number of messages in each category, as well as 'statement'
 # which is the total number of statements analyzed. This score is used by the
 # global evaluation report (RP0004).
-evaluation=0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details.

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -310,8 +310,8 @@ class PyLinter(
                     "metavar": "<python_expression>",
                     "group": "Reports",
                     "level": 1,
-                    "default": "0 if fatal else 10.0 - ((float(5 * error + warning + refactor + "
-                    "convention) / statement) * 10)",
+                    "default": "max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + "
+                    "convention) / statement) * 10))",
                     "help": "Python expression which should return a score less "
                     "than or equal to 10. You have access to the variables 'fatal', "
                     "'error', 'warning', 'refactor', 'convention', and 'info' which "

--- a/pylintrc
+++ b/pylintrc
@@ -120,7 +120,7 @@ reports=no
 # and 'info', which contain the number of messages in each category, as
 # well as 'statement', which is the total number of statements analyzed. This
 # score is used by the global evaluation report (RP0004).
-evaluation=0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -777,6 +777,9 @@ class TestRunTC:
                 f"--fail-on={fo_msgs}",
                 "--enable=all",
                 join(HERE, "regrtest_data", fname),
+                # Use the old form of the evaluation that can go negative
+                "--evaluation",
+                "0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)",
             ],
             code=out,
         )

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -718,11 +718,15 @@ class TestRunTC:
             ],
             code=0,
         )
+        # Need the old evaluation formula to test a negative score
+        # failing below a negative --fail-under threshold
         self._runtest(
             [
                 "--fail-under",
                 "-9",
                 "--enable=all",
+                "--evaluation",
+                "0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)",
                 join(HERE, "regrtest_data", "fail_under_minus10.py"),
             ],
             code=22,
@@ -732,6 +736,8 @@ class TestRunTC:
                 "--fail-under",
                 "-5",
                 "--enable=all",
+                "--evaluation",
+                "0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)",
                 join(HERE, "regrtest_data", "fail_under_minus10.py"),
             ],
             code=22,

--- a/tests/unittest_reporting.py
+++ b/tests/unittest_reporting.py
@@ -333,7 +333,7 @@ def test_multi_format_output(tmp_path):
         "\n"
         "\n"
         "-------------------------------------\n"
-        "Your code has been rated at -10.00/10\n"
+        "Your code has been rated at 0.00/10\n"
         "\n"
         "direct output\n"
     )

--- a/tests/unittest_reporting.py
+++ b/tests/unittest_reporting.py
@@ -332,7 +332,7 @@ def test_multi_format_output(tmp_path):
         "\n"
         "\n"
         "\n"
-        "-------------------------------------\n"
+        "-----------------------------------\n"
         "Your code has been rated at 0.00/10\n"
         "\n"
         "direct output\n"


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Change the default score formula to use a floor of 0. Negative scores are still supported, on an opt-in basis. Users can set `evaluation=` in their pylint rc to get the old behavior. (Or to get the new behavior if they have an old rc file!)

Closes #2399 (*)

(*) Of course, the issue could be kept open for further discussion, but at least the negative part is solved. Better defaults and gamification and nifty scoring formulas could tracked elsewhere (e.g. #3512 or #746).
