### PR TITLE
Fix reported node for `unnecessary-comprehension`

### DIFF
--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1594,7 +1594,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             ):
                 args = (f"{node.iter.as_string()}",)
             if args:
-                self.add_message("unnecessary-comprehension", node=node, args=args)
+                self.add_message("unnecessary-comprehension", node=node.parent, args=args)
                 return
 
             if isinstance(node.parent, nodes.DictComp):
@@ -1608,7 +1608,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
 
             self.add_message(
                 "unnecessary-comprehension",
-                node=node,
+                node=node.parent,
                 args=(f"{func}({node.iter.as_string()})",),
             )
 

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1594,7 +1594,9 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             ):
                 args = (f"{node.iter.as_string()}",)
             if args:
-                self.add_message("unnecessary-comprehension", node=node.parent, args=args)
+                self.add_message(
+                    "unnecessary-comprehension", node=node.parent, args=args
+                )
                 return
 
             if isinstance(node.parent, nodes.DictComp):

--- a/tests/functional/u/unnecessary/unnecessary_comprehension.py
+++ b/tests/functional/u/unnecessary/unnecessary_comprehension.py
@@ -14,14 +14,14 @@
 [(x, y, 1) for x, y in iterable]  # exclude useful comprehensions
 # Test case for issue #4499
 a_dict = {}
-[(k, v) for k, v in a_dict.items()]  # [unnecessary-comprehension]
+item = [(k, v) for k, v in a_dict.items()]  # [unnecessary-comprehension]
 
 # Set comprehensions
 {x for x in iterable}  # [unnecessary-comprehension]
 {y for x in iterable}  # expression != target_list
 {x for x,y,z in iterable}  # expression != target_list
 {(x,y,z) for x,y,z in iterable}  # [unnecessary-comprehension]
-{(x,y,z) for (x, y, z) in iterable}  # [unnecessary-comprehension]
+item = {(x,y,z) for (x, y, z) in iterable}  # [unnecessary-comprehension]
 {(x,y,z) for x in iterable}  # expression != target_list
 {(x,y,(a,b,c)) for x in iterable}  # expression != target_list
 {x for x, *y in iterable}  # expression != target_list
@@ -44,6 +44,6 @@ my_dict = {}
 my_set = set()
 
 [elem for elem in my_list]  # [unnecessary-comprehension]
-{k: v for k, v in my_dict.items()} # [unnecessary-comprehension]
+items = {k: v for k, v in my_dict.items()} # [unnecessary-comprehension]
 {k: my_dict[k] for k in my_dict} # [consider-using-dict-items]
 {elem for elem in my_set}  # [unnecessary-comprehension]

--- a/tests/functional/u/unnecessary/unnecessary_comprehension.txt
+++ b/tests/functional/u/unnecessary/unnecessary_comprehension.txt
@@ -1,13 +1,13 @@
-unnecessary-comprehension:5:0:None:None::Unnecessary use of a comprehension, use list(iterable) instead.:UNDEFINED
-unnecessary-comprehension:8:0:None:None::Unnecessary use of a comprehension, use list(iterable) instead.:UNDEFINED
-unnecessary-comprehension:9:0:None:None::Unnecessary use of a comprehension, use list(iterable) instead.:UNDEFINED
-unnecessary-comprehension:17:0:None:None::Unnecessary use of a comprehension, use list(a_dict.items()) instead.:UNDEFINED
-unnecessary-comprehension:20:0:None:None::Unnecessary use of a comprehension, use set(iterable) instead.:UNDEFINED
-unnecessary-comprehension:23:0:None:None::Unnecessary use of a comprehension, use set(iterable) instead.:UNDEFINED
-unnecessary-comprehension:24:0:None:None::Unnecessary use of a comprehension, use set(iterable) instead.:UNDEFINED
-unnecessary-comprehension:32:0:None:None::Unnecessary use of a comprehension, use dict(iterable) instead.:UNDEFINED
-unnecessary-comprehension:34:0:None:None::Unnecessary use of a comprehension, use dict(iterable) instead.:UNDEFINED
-unnecessary-comprehension:46:0:None:None::Unnecessary use of a comprehension, use my_list instead.:UNDEFINED
-unnecessary-comprehension:47:0:None:None::Unnecessary use of a comprehension, use my_dict instead.:UNDEFINED
+unnecessary-comprehension:5:0:5:21::Unnecessary use of a comprehension, use list(iterable) instead.:UNDEFINED
+unnecessary-comprehension:8:0:8:31::Unnecessary use of a comprehension, use list(iterable) instead.:UNDEFINED
+unnecessary-comprehension:9:0:9:33::Unnecessary use of a comprehension, use list(iterable) instead.:UNDEFINED
+unnecessary-comprehension:17:7:17:42::Unnecessary use of a comprehension, use list(a_dict.items()) instead.:UNDEFINED
+unnecessary-comprehension:20:0:20:21::Unnecessary use of a comprehension, use set(iterable) instead.:UNDEFINED
+unnecessary-comprehension:23:0:23:31::Unnecessary use of a comprehension, use set(iterable) instead.:UNDEFINED
+unnecessary-comprehension:24:7:24:42::Unnecessary use of a comprehension, use set(iterable) instead.:UNDEFINED
+unnecessary-comprehension:32:0:32:27::Unnecessary use of a comprehension, use dict(iterable) instead.:UNDEFINED
+unnecessary-comprehension:34:0:34:29::Unnecessary use of a comprehension, use dict(iterable) instead.:UNDEFINED
+unnecessary-comprehension:46:0:46:26::Unnecessary use of a comprehension, use my_list instead.:UNDEFINED
+unnecessary-comprehension:47:8:47:42::Unnecessary use of a comprehension, use my_dict instead.:UNDEFINED
 consider-using-dict-items:48:0:None:None::Consider iterating with .items():UNDEFINED
-unnecessary-comprehension:49:0:None:None::Unnecessary use of a comprehension, use my_set instead.:UNDEFINED
+unnecessary-comprehension:49:0:49:25::Unnecessary use of a comprehension, use my_set instead.:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The issue location of `unnecessary-comprehension` was being raised at `line:0`, even if the comprehension wasn't present at column 0.

This would give the wrong location, for example:

```python
item = [(k, v) for k, v in a_dict.items()]
```

```text
************* Module mytest
mytest.py:1:0: R1721: Unnecessary use of a comprehension, use list(a_dict.items()) instead. (unnecessary-comprehension)
```

The expected position would be `1:7`, not `1:0`.

Weirdly, the test cases had zero examples of a comprehension that wasn't at column zero, so I tweaked some of those as well.