### PR TITLE
Add caching to bottlenecks in the message store

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1391,8 +1391,9 @@ class PyLinter(
     def _is_one_message_enabled(self, msgid: str, line: Optional[int]) -> bool:
         """Checks state of a single message for the current file
 
-        This function can't be cached it depends on self.file_state that can
-        changes."""
+        This function can't be cached as it depends on self.file_state which can
+        change.
+        """
         if line is None:
             return self._msgs_state.get(msgid, True)
         try:
@@ -1429,14 +1430,14 @@ class PyLinter(
         line: Optional[int] = None,
         confidence: Optional[interfaces.Confidence] = None,
     ) -> bool:
-        """Is this message enabled for the current file / line / confidence ?
+        """Return whether this message is enabled for the current file, line and confidence level.
 
         This function can't be cached right now as the line is the line of
-        the current analysed file (self.file_state), if it changes, then the
-        result for the same msg_descr/line need to change.
+        the currently analysed file (self.file_state), if it changes, then the
+        result for the same msg_descr/line might need to change.
 
-        :param msg_descr: may be either the msgid or the symbol for a MessageDefinition.
-        :param line: the line is the line of the currently analysed file
+        :param msg_descr: Either the msgid or the symbol for a MessageDefinition
+        :param line: The line of the currently analysed file
         :param confidence: The confidence of the message
         """
         if self.config.confidence and confidence:

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1389,7 +1389,10 @@ class PyLinter(
         return None
 
     def _is_one_message_enabled(self, msgid: str, line: Optional[int]) -> bool:
-        """Checks state of a single message"""
+        """Checks state of a single message for the current file
+
+        This function can't be cached it depends on self.file_state that can
+        changes."""
         if line is None:
             return self._msgs_state.get(msgid, True)
         try:
@@ -1426,10 +1429,15 @@ class PyLinter(
         line: Optional[int] = None,
         confidence: Optional[interfaces.Confidence] = None,
     ) -> bool:
-        """return whether the message associated to the given message id is
-        enabled
+        """Is this message enabled for the current file / line / confidence ?
 
-        msgid may be either a numeric or symbolic message id.
+        This function can't be cached right now as the line is the line of
+        the current analysed file (self.file_state), if it changes, then the
+        result for the same msg_descr/line need to change.
+
+        :param msg_descr: may be either the msgid or the symbol for a MessageDefinition.
+        :param line: the line is the line of the currently analysed file
+        :param confidence: The confidence of the message
         """
         if self.config.confidence and confidence:
             if confidence.name not in self.config.confidence:

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -51,10 +51,9 @@ class MessageDefinitionStore:
     def get_message_definitions(self, msgid_or_symbol: str) -> List[MessageDefinition]:
         """Returns the Message definition for either a numeric or symbolic id.
 
-        The cache has no limit as it will never go very high. It's a set number of
-        message from our own code and from user's checkers. How many message can
-        the user generate ? I guess it will never be more than 1000, and if each
-        messages has around 1000 characters, it's still ~= 1 Mb to cache.
+        The cache has no limit as its size will likely stay minimal. For each message we store
+        about 1000 characters, so even if we would have 1000 messages the cache would only
+        take up ~= 1 Mb.
         """
         return [
             self._messages_definitions[m]

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -49,7 +49,13 @@ class MessageDefinitionStore:
 
     @functools.lru_cache()
     def get_message_definitions(self, msgid_or_symbol: str) -> List[MessageDefinition]:
-        """Returns the Message definition for either a numeric or symbolic id."""
+        """Returns the Message definition for either a numeric or symbolic id.
+
+        The cache has no limit as it will never go very high. It's a set number of
+        message from our own code and from user's checkers. How many message can
+        the user generate ? I guess it will never be more than 1000, and if each
+        messages has around 1000 characters, it's still ~= 1 Mb to cache.
+        """
         return [
             self._messages_definitions[m]
             for m in self.message_id_store.get_active_msgids(msgid_or_symbol)

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -2,6 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import collections
+import functools
 from typing import TYPE_CHECKING, Dict, List, Tuple, ValuesView
 
 from pylint.exceptions import UnknownMessageError
@@ -46,6 +47,7 @@ class MessageDefinitionStore:
         self._messages_definitions[message.msgid] = message
         self._msgs_by_category[message.msgid[0]].append(message.msgid)
 
+    @functools.lru_cache()
     def get_message_definitions(self, msgid_or_symbol: str) -> List[MessageDefinition]:
         """Returns the Message definition for either a numeric or symbolic id."""
         return [

--- a/pylint/message/message_id_store.py
+++ b/pylint/message/message_id_store.py
@@ -104,17 +104,23 @@ class MessageIdStore:
 
     @functools.lru_cache()
     def get_active_msgids(self, msgid_or_symbol: str) -> List[str]:
-        """Return msgids but the input can be a symbol."""
-        # Only msgid can have a digit as second letter
-        is_msgid: bool = msgid_or_symbol[1:].isdigit()
-        msgid = None
-        if is_msgid:
+        """Return msgids but the input can be a symbol.
+
+        The cache has no limit as it will never go very high. It's a set number of
+        msgid/symbol pair from our own code and from user's checkers. How many msgid can
+        the user generate ? I guess it will never be more than 1000, and if each
+        msgid/symbol pair has around 50 characters, it's still ~= 5 kb to cache.
+        """
+        msgid: Optional[str]
+        symbol: Optional[str]
+        if msgid_or_symbol[1:].isdigit():
+            # Only msgid can have a digit as second letter
             msgid = msgid_or_symbol.upper()
             symbol = self.__msgid_to_symbol.get(msgid)
         else:
             msgid = self.__symbol_to_msgid.get(msgid_or_symbol)
             symbol = msgid_or_symbol
-        if msgid is None or symbol is None or not msgid or not symbol:
+        if not msgid or not symbol:
             error_msg = f"No such message id or symbol '{msgid_or_symbol}'."
             raise UnknownMessageError(error_msg)
         return self.__old_names.get(msgid, [msgid])

--- a/pylint/message/message_id_store.py
+++ b/pylint/message/message_id_store.py
@@ -111,7 +111,6 @@ class MessageIdStore:
         take up ~= 1 Mb.
         """
         msgid: Optional[str]
-        symbol: Optional[str]
         if msgid_or_symbol[1:].isdigit():
             # Only msgid can have a digit as second letter
             msgid = msgid_or_symbol.upper()

--- a/pylint/message/message_id_store.py
+++ b/pylint/message/message_id_store.py
@@ -106,10 +106,9 @@ class MessageIdStore:
     def get_active_msgids(self, msgid_or_symbol: str) -> List[str]:
         """Return msgids but the input can be a symbol.
 
-        The cache has no limit as it will never go very high. It's a set number of
-        msgid/symbol pair from our own code and from user's checkers. How many msgid can
-        the user generate ? I guess it will never be more than 1000, and if each
-        msgid/symbol pair has around 50 characters, it's still ~= 5 kb to cache.
+        The cache has no limit as its size will likely stay minimal. For each message we store
+        about 1000 characters, so even if we would have 1000 messages the cache would only
+        take up ~= 1 Mb.
         """
         msgid: Optional[str]
         symbol: Optional[str]

--- a/pylint/message/message_id_store.py
+++ b/pylint/message/message_id_store.py
@@ -1,5 +1,6 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+import functools
 from typing import Dict, List, NoReturn, Optional, Tuple
 
 from pylint.exceptions import InvalidMessageError, UnknownMessageError
@@ -101,6 +102,7 @@ class MessageIdStore:
         )
         raise InvalidMessageError(error_message)
 
+    @functools.lru_cache()
     def get_active_msgids(self, msgid_or_symbol: str) -> List[str]:
         """Return msgids but the input can be a symbol."""
         # Only msgid can have a digit as second letter


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This add caching to bottlenecks in the MessageStore. Next step would be to generate the code of an immutable data structure from the checkers instead of creating and checking it at runtime and then using this structure directly, but I think caching is fine for now. (Especially as we can't do everything this way: For plugin there are still unexpected message id and symbol.)

``get_active_msgids`` was calling .lower() / is_digit on every message id we gave it every time caching it save a lot of call.
There's some function we can't cache because of the way PyLinter is designed.

Tested by linting django (03cadb912c78b769d6bf4a943a2a35fc1d952960) with ``python3 -m cProfile -m pylint .pylint_primer_tests/django|grep message``

### Before:
```
  1494493    0.257    0.000    0.257    0.000 <frozen importlib._bootstrap>:222(_verbose_message)
        3    0.000    0.000    0.000    0.000 _enchant.py:120(find_message)
    67884    0.064    0.000    2.472    0.000 base_checker.py:112(add_message)
      678    0.001    0.000    0.003    0.000 base_checker.py:147(create_message_definition_from_tuple)
       86    0.000    0.000    0.004    0.000 base_checker.py:171(messages)
        1    0.000    0.000    0.000    0.000 base_reporter.py:69(display_messages)
    41158    0.014    0.000    0.014    0.000 file_state.py:132(handle_ignored_message)
     2722    0.007    0.000    0.008    0.000 file_state.py:148(iter_spurious_suppression_messages)
    26728    0.021    0.000    0.032    0.000 linterstats.py:288(increase_single_message_count)
    26728    0.020    0.000    0.020    0.000 linterstats.py:292(increase_single_module_message_count)
        1    0.000    0.000    0.000    0.000 linterstats.py:298(reset_message_count)
        1    0.000    0.000    0.000    0.000 message.py:34(Message)
        1    0.000    0.000    0.001    0.001 message.py:5(<module>)
    26728    0.056    0.000    0.080    0.000 message.py:60(__new__)
        1    0.000    0.000    0.000    0.000 message_definition.py:17(MessageDefinition)
      678    0.000    0.000    0.001    0.000 message_definition.py:18(__init__)
        1    0.000    0.000    0.000    0.000 message_definition.py:4(<module>)
      718    0.000    0.000    0.000    0.000 message_definition.py:47(check_msgid)
      339    0.000    0.000    0.000    0.000 message_definition.py:60(may_be_emitted)
    67886    0.083    0.000    0.083    0.000 message_definition.py:94(check_message_definition)
        1    0.000    0.000    0.000    0.000 message_definition_store.py:15(MessageDefinitionStore)
        1    0.000    0.000    0.000    0.000 message_definition_store.py:21(__init__)
        1    0.000    0.000    0.000    0.000 message_definition_store.py:30(messages)
       43    0.000    0.000    0.005    0.000 message_definition_store.py:35(register_messages_from_checker)
        1    0.000    0.000    0.000    0.000 message_definition_store.py:4(<module>)
      339    0.000    0.000    0.001    0.000 message_definition_store.py:41(register_message)
   833883    0.836    0.000    2.848    0.000 message_definition_store.py:49(get_message_definitions)
   833882    0.353    0.000    0.353    0.000 message_definition_store.py:51(<listcomp>)
   833883    1.231    0.000    1.658    0.000 message_id_store.py:104(get_active_msgids)
        1    0.000    0.000    0.000    0.000 message_id_store.py:12(__init__)
        1    0.000    0.000    0.000    0.000 message_id_store.py:3(<module>)
      339    0.000    0.000    0.000    0.000 message_id_store.py:41(register_message_definition)
      339    0.000    0.000    0.000    0.000 message_id_store.py:50(add_msgid_and_symbol)
       20    0.000    0.000    0.000    0.000 message_id_store.py:58(add_legacy_msgid_and_symbol)
      359    0.000    0.000    0.000    0.000 message_id_store.py:71(check_msgid_and_symbol)
        1    0.000    0.000    0.000    0.000 message_id_store.py:8(MessageIdStore)
    41158    0.047    0.000    0.047    0.000 pylinter.py:1373(_get_message_state_scope)
   765813    0.800    0.000    0.942    0.000 pylinter.py:1391(_is_one_message_enabled)
   765805    1.766    0.000    6.404    0.000 pylinter.py:1423(is_message_enabled)
    67886    0.461    0.000    2.050    0.000 pylinter.py:1447(_add_one_message)
    67886    0.111    0.000    2.408    0.000 pylinter.py:1535(add_message)
      162    0.000    0.000    0.001    0.000 pylinter.py:1596(_message_symbol)
    32/12    0.000    0.000    0.000    0.000 pylinter.py:1621(_get_messages_to_set)
        1    0.000    0.000    0.000    0.000 pylinter.py:768(enable_fail_on_messages)
    38928    0.047    0.000    0.065    0.000 redefined_variable_type.py:65(_check_and_add_messages)
    27697    0.039    0.000    0.043    0.000 refactoring_checker.py:1091(_emit_nested_blocks_message_if_needed)
    26728    0.076    0.000    0.301    0.000 text.py:213(write_message)
    26728    0.050    0.000    0.359    0.000 text.py:221(handle_message)
      153    0.000    0.000    0.000    0.000 utils.py:488(check_messages)
      153    0.000    0.000    0.000    0.000 utils.py:491(store_messages)
        1    0.000    0.000    0.000    0.000 utils.py:63(get_fatal_error_message)
```

### After

```
  1494493    0.310    0.000    0.310    0.000 <frozen importlib._bootstrap>:222(_verbose_message)
        3    0.000    0.000    0.000    0.000 _enchant.py:120(find_message)
    67884    0.062    0.000    1.959    0.000 base_checker.py:112(add_message)
      678    0.001    0.000    0.003    0.000 base_checker.py:147(create_message_definition_from_tuple)
       86    0.000    0.000    0.004    0.000 base_checker.py:171(messages)
        1    0.000    0.000    0.000    0.000 base_reporter.py:69(display_messages)
    41158    0.017    0.000    0.017    0.000 file_state.py:132(handle_ignored_message)
     2722    0.006    0.000    0.007    0.000 file_state.py:148(iter_spurious_suppression_messages)
    26728    0.021    0.000    0.032    0.000 linterstats.py:288(increase_single_message_count)
    26728    0.021    0.000    0.021    0.000 linterstats.py:292(increase_single_module_message_count)
        1    0.000    0.000    0.000    0.000 linterstats.py:298(reset_message_count)
        1    0.000    0.000    0.000    0.000 message.py:34(Message)
        1    0.000    0.000    0.001    0.001 message.py:5(<module>)
    26728    0.054    0.000    0.078    0.000 message.py:60(__new__)
        1    0.000    0.000    0.000    0.000 message_definition.py:17(MessageDefinition)
      678    0.000    0.000    0.001    0.000 message_definition.py:18(__init__)
        1    0.000    0.000    0.000    0.000 message_definition.py:4(<module>)
      718    0.001    0.000    0.001    0.000 message_definition.py:47(check_msgid)
      339    0.000    0.000    0.000    0.000 message_definition.py:60(may_be_emitted)
    67886    0.096    0.000    0.096    0.000 message_definition.py:94(check_message_definition)
        1    0.000    0.000    0.000    0.000 message_definition_store.py:16(MessageDefinitionStore)
        1    0.000    0.000    0.000    0.000 message_definition_store.py:22(__init__)
        1    0.000    0.000    0.000    0.000 message_definition_store.py:31(messages)
       43    0.000    0.000    0.005    0.000 message_definition_store.py:36(register_messages_from_checker)
        1    0.000    0.000    0.000    0.000 message_definition_store.py:4(<module>)
      339    0.000    0.000    0.001    0.000 message_definition_store.py:42(register_message)
      175    0.000    0.000    0.001    0.000 message_definition_store.py:50(get_message_definitions)
      175    0.000    0.000    0.000    0.000 message_definition_store.py:53(<listcomp>)
      772    0.001    0.000    0.002    0.000 message_id_store.py:105(get_active_msgids)
        1    0.000    0.000    0.000    0.000 message_id_store.py:13(__init__)
        1    0.000    0.000    0.000    0.000 message_id_store.py:3(<module>)
      339    0.000    0.000    0.000    0.000 message_id_store.py:42(register_message_definition)
      339    0.000    0.000    0.000    0.000 message_id_store.py:51(add_msgid_and_symbol)
       20    0.000    0.000    0.000    0.000 message_id_store.py:59(add_legacy_msgid_and_symbol)
      359    0.000    0.000    0.000    0.000 message_id_store.py:72(check_msgid_and_symbol)
        1    0.000    0.000    0.000    0.000 message_id_store.py:9(MessageIdStore)
    41158    0.046    0.000    0.046    0.000 pylinter.py:1373(_get_message_state_scope)
   765813    0.817    0.000    0.996    0.000 pylinter.py:1391(_is_one_message_enabled)
   765805    1.480    0.000    3.386    0.000 pylinter.py:1426(is_message_enabled)
    67886    0.460    0.000    1.768    0.000 pylinter.py:1454(_add_one_message)
    67886    0.128    0.000    1.897    0.000 pylinter.py:1542(add_message)
      162    0.000    0.000    0.000    0.000 pylinter.py:1603(_message_symbol)
    32/12    0.000    0.000    0.000    0.000 pylinter.py:1628(_get_messages_to_set)
        1    0.000    0.000    0.000    0.000 pylinter.py:768(enable_fail_on_messages)
    38928    0.045    0.000    0.062    0.000 redefined_variable_type.py:65(_check_and_add_messages)
    27697    0.028    0.000    0.032    0.000 refactoring_checker.py:1091(_emit_nested_blocks_message_if_needed)
    26728    0.069    0.000    0.281    0.000 text.py:213(write_message)
    26728    0.046    0.000    0.334    0.000 text.py:221(handle_message)
      153    0.000    0.000    0.000    0.000 utils.py:488(check_messages)
      153    0.000    0.000    0.000    0.000 utils.py:491(store_messages)
        1    0.000    0.000    0.000    0.000 utils.py:63(get_fatal_error_message)
```

Follow up to #4814 
