### PR TITLE
Get the msgids directly from the MessageIdStore

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1435,8 +1435,7 @@ class PyLinter(
             if confidence.name not in self.config.confidence:
                 return False
         try:
-            message_definitions = self.msgs_store.get_message_definitions(msg_descr)
-            msgids = [md.msgid for md in message_definitions]
+            msgids = self.msgs_store.message_id_store.get_active_msgids(msg_descr)
         except exceptions.UnknownMessageError:
             # The linter checks for messages that are not registered
             # due to version mismatch, just treat them as message IDs


### PR DESCRIPTION


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

We don't need to create message definitions to get their msgids.

The level of indirection may suggest we need to refactor a
little here. Maybe we actually need message definition only
when we want to display the messages.

Follow-up to #5605 
