### PR TITLE
Use ``dill`` to pickle when run in parallel mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,9 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.13.rst'
 
+* When run in parallel mode ``pylint`` now pickles the data passed to subprocesses with
+  the ``dill`` package. The ``dill`` package has therefore been added as a dependency.
+
 * ``used-before-assignment`` now considers that assignments in a try block
   may not have occurred when the except or finally blocks are executed.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -32,6 +32,9 @@ Extensions
 Other Changes
 =============
 
+* When run in parallel mode ``pylint`` now pickles the data passed to subprocesses with
+  the ``dill`` package. The ``dill`` package has therefore been added as a dependency.
+
 * By default, pylint does no longer take files starting with ``.#`` into account. Those are
   considered `emacs file locks`_. This behavior can be reverted by redefining the
   ``ignore-patterns`` option.

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -3,7 +3,18 @@
 
 import collections
 import functools
-from typing import Any, DefaultDict, Iterable, List, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    DefaultDict,
+    Iterable,
+    List,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+import dill
 
 from pylint import reporters
 from pylint.lint.utils import _patch_sys_path
@@ -15,6 +26,9 @@ try:
     import multiprocessing
 except ImportError:
     multiprocessing = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:
+    from pylint.lint import PyLinter
 
 # PyLinter object used by worker processes when checking files using multiprocessing
 # should only be used by the worker processes
@@ -33,9 +47,16 @@ def _get_new_args(message):
     return (message.msg_id, message.symbol, location, message.msg, message.confidence)
 
 
-def _worker_initialize(linter, arguments=None):
+def _worker_initialize(
+    linter: bytes, arguments: Union[None, str, Sequence[str]] = None
+) -> None:
+    """Function called to initialize a worker for a Process within a multiprocessing Pool
+
+    :param linter: A linter-class (PyLinter) instance pickled with dill
+    :param arguments: File or module name(s) to lint and to be added to sys.path
+    """
     global _worker_linter  # pylint: disable=global-statement
-    _worker_linter = linter
+    _worker_linter = dill.loads(linter)
 
     # On the worker process side the messages are just collected and passed back to
     # parent process as _worker_check_file function's return value
@@ -97,26 +118,24 @@ def _merge_mapreduce_data(linter, all_mapreduce_data):
             checker.reduce_map_data(linter, collated_map_reduce_data[checker.name])
 
 
-def check_parallel(linter, jobs, files: Iterable[FileItem], arguments=None):
+def check_parallel(
+    linter: "PyLinter",
+    jobs: int,
+    files: Iterable[FileItem],
+    arguments: Union[None, str, Sequence[str]] = None,
+) -> None:
     """Use the given linter to lint the files with given amount of workers (jobs)
     This splits the work filestream-by-filestream. If you need to do work across
     multiple files, as in the similarity-checker, then inherit from MapReduceMixin and
-    implement the map/reduce mixin functionality"""
-    # The reporter does not need to be passed to worker processes, i.e. the reporter does
-    original_reporter = linter.reporter
-    linter.reporter = None
-
+    implement the map/reduce mixin functionality.
+    """
     # The linter is inherited by all the pool's workers, i.e. the linter
     # is identical to the linter object here. This is required so that
     # a custom PyLinter object can be used.
     initializer = functools.partial(_worker_initialize, arguments=arguments)
     pool = multiprocessing.Pool(  # pylint: disable=consider-using-with
-        jobs, initializer=initializer, initargs=[linter]
+        jobs, initializer=initializer, initargs=[dill.dumps(linter)]
     )
-    # ...and now when the workers have inherited the linter, the actual reporter
-    # can be set back here on the parent process so that results get stored into
-    # correct reporter
-    linter.set_reporter(original_reporter)
     linter.open()
     try:
         all_stats = []
@@ -141,7 +160,7 @@ def check_parallel(linter, jobs, files: Iterable[FileItem], arguments=None):
                 msg = Message(
                     msg[0], msg[1], MessageLocationTuple(*msg[2]), msg[3], msg[4]
                 )
-                linter.reporter.handle_message(msg)  # type: ignore[attr-defined]  # linter.set_reporter() call above makes linter have a reporter attr
+                linter.reporter.handle_message(msg)
             all_stats.append(stats)
             all_mapreduce_data[worker_idx].append(mapreduce_data)
             linter.msg_status |= msg_status

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    dill>=0.3.4
+    dill>=0.2
     platformdirs>=2.2.0
     astroid>=2.9.0,<2.10 # (You should also upgrade requirements_test_min.txt)
     isort>=4.2.5,<6

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
+    dill>=0.3.4
     platformdirs>=2.2.0
     astroid>=2.9.0,<2.10 # (You should also upgrade requirements_test_min.txt)
     isort>=4.2.5,<6
@@ -122,4 +123,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-git.*]
+ignore_missing_imports = True
+
+[mypy-dill]
 ignore_missing_imports = True


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

For reference see my earlier comment here:
https://github.com/PyCQA/pylint/pull/5584#issuecomment-1002470174

`multiprocessing.Pool` pickles the arguments passed in `initargs`. This was noted in the original commit that added this: https://github.com/PyCQA/pylint/commit/8babeffde54a696e7ba84d69f8fc1f871e432950
One of the effects of this was that it was decided to set `reporter` to `None` as then the reporter doesn't need to be pickled. We're running into a similar issue with the migration to `argparse` since `argparse.ArgumentsParser` isn't pickle-able by `stdlib`.

To overcome this I looked at the solution proposed on StackOverflow here:
https://stackoverflow.com/questions/8804830/python-multiprocessing-picklingerror-cant-pickle-type-function

The `dill` package is able to pickle objects such as `Argumentsparser`. Therefore, by pickling the `linter` object with `dill` before passing to `multiprocessing.Pool` we can avoid the error ran into with the `stdlib`.
As @Pierre-Sassoulas said in https://github.com/PyCQA/pylint/issues/5584#issuecomment-1002476948_:

> Look like ``dill`` do not have any dependencies of its own and its 3-clause BSD license seems compatible with pylint. We would more than double their download per day by adding them as a dependencies but it's already used a lot. 


@cdce8p Is the way I added `dill` to the `mypy` config correct?
