### PR TITLE
Allow passing arguments if ``epylint`` entry point is used as function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -90,7 +90,7 @@ Release date: TBA
 
   Closes #5504
 
-* When invoking ``pylint``, ``symilar`` or ``pyreverse`` by importing them in a python file
+* When invoking ``pylint``, ``epylint``, ``symilar`` or ``pyreverse`` by importing them in a python file
   you can now pass an ``arguments`` keyword besides patching ``sys.argv``.
 
   Closes #5320

--- a/ChangeLog
+++ b/ChangeLog
@@ -90,6 +90,11 @@ Release date: TBA
 
   Closes #5504
 
+* When invoking ``pylint``, ``symilar`` or ``pyreverse`` by importing them in a python file
+  you can now pass an ``arguments`` keyword besides patching ``sys.argv``.
+
+  Closes #5320
+
 * The ``PyLinter`` class will now be initialized with a ``TextReporter``
   as its reporter if none is provided.
 

--- a/doc/user_guide/run.rst
+++ b/doc/user_guide/run.rst
@@ -45,6 +45,20 @@ thanks to the ``Run()`` function in the ``pylint.lint`` module
   pylint_opts = ['--disable=line-too-long', 'myfile.py']
   pylint.lint.Run(pylint_opts)
 
+Another option would be to use the ``run_pylint`` function, which is the same function
+called by the command line. You can either patch ``sys.argv`` or supply arguments yourself:
+
+.. sourcecode:: python
+
+  import pylint
+
+  sys.argv = ["pylint", "your_file"]
+  pylint.run_pylint()
+
+  # Or:
+
+  pylint.run_pylint(arguments=["your_file"])
+
 To silently run Pylint on a ``module_name.py`` module,
 and get its standard output and error:
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -121,6 +121,11 @@ Other Changes
 
   Closes #5557
 
+* When invoking ``pylint``, ``symilar`` or ``pyreverse`` by importing them in a python file
+  you can now pass an ``arguments`` keyword besides patching ``sys.argv``.
+
+  Closes #5320
+
 * The ``PyLinter`` class will now be initialized with a ``TextReporter``
   as its reporter if none is provided.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -121,7 +121,7 @@ Other Changes
 
   Closes #5557
 
-* When invoking ``pylint``, ``symilar`` or ``pyreverse`` by importing them in a python file
+* When invoking ``pylint``, ``epylint``, ``symilar`` or ``pyreverse`` by importing them in a python file
   you can now pass an ``arguments`` keyword besides patching ``sys.argv``.
 
   Closes #5320

--- a/pylint/__init__.py
+++ b/pylint/__init__.py
@@ -31,10 +31,14 @@ def run_pylint(*, arguments: Optional[List[str]] = None):
         sys.exit(1)
 
 
-def run_epylint():
+def run_epylint(*, arguments: Optional[List[str]] = None):
+    """Run epylint
+
+    Arguments can be a list of strings normally supplied as arguments on the command line
+    """
     from pylint.epylint import Run as EpylintRun
 
-    EpylintRun()
+    EpylintRun(arguments=arguments)
 
 
 def run_pyreverse(*, arguments: Optional[List[str]] = None):

--- a/pylint/__init__.py
+++ b/pylint/__init__.py
@@ -11,17 +11,22 @@
 
 import os
 import sys
+from typing import List, Optional
 
 from pylint.__pkginfo__ import __version__
 
 # pylint: disable=import-outside-toplevel
 
 
-def run_pylint():
+def run_pylint(*, arguments: Optional[List[str]] = None):
+    """Run pylint
+
+    Arguments can be a list of strings normally supplied as arguments on the command line
+    """
     from pylint.lint import Run as PylintRun
 
     try:
-        PylintRun(sys.argv[1:])
+        PylintRun(arguments or sys.argv[1:])
     except KeyboardInterrupt:
         sys.exit(1)
 
@@ -32,18 +37,24 @@ def run_epylint():
     EpylintRun()
 
 
-def run_pyreverse():
-    """run pyreverse"""
+def run_pyreverse(*, arguments: Optional[List[str]] = None):
+    """Run pyreverse
+
+    Arguments can be a list of strings normally supplied as arguments on the command line
+    """
     from pylint.pyreverse.main import Run as PyreverseRun
 
-    PyreverseRun(sys.argv[1:])
+    PyreverseRun(arguments or sys.argv[1:])
 
 
-def run_symilar():
-    """run symilar"""
+def run_symilar(*, arguments: Optional[List[str]] = None):
+    """Run symilar
+
+    Arguments can be a list of strings normally supplied as arguments on the command line
+    """
     from pylint.checkers.similar import Run as SimilarRun
 
-    SimilarRun(sys.argv[1:])
+    SimilarRun(arguments or sys.argv[1:])
 
 
 def modify_sys_path() -> None:

--- a/pylint/__init__.py
+++ b/pylint/__init__.py
@@ -38,7 +38,7 @@ def run_epylint(argv: Optional[Sequence[str]] = None):
     """
     from pylint.epylint import Run as EpylintRun
 
-    EpylintRun(argv=argv)
+    EpylintRun(argv)
 
 
 def run_pyreverse(argv: Optional[Sequence[str]] = None):

--- a/pylint/__init__.py
+++ b/pylint/__init__.py
@@ -11,7 +11,7 @@
 
 import os
 import sys
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 from pylint.__pkginfo__ import __version__
 
@@ -31,14 +31,14 @@ def run_pylint(*, arguments: Optional[List[str]] = None):
         sys.exit(1)
 
 
-def run_epylint(*, arguments: Optional[List[str]] = None):
+def run_epylint(argv: Optional[Sequence[str]] = None):
     """Run epylint
 
     Arguments can be a list of strings normally supplied as arguments on the command line
     """
     from pylint.epylint import Run as EpylintRun
 
-    EpylintRun(arguments=arguments)
+    EpylintRun(argv=argv)
 
 
 def run_pyreverse(*, arguments: Optional[List[str]] = None):

--- a/pylint/epylint.py
+++ b/pylint/epylint.py
@@ -64,6 +64,7 @@ import shlex
 import sys
 from io import StringIO
 from subprocess import PIPE, Popen
+from typing import List, Optional
 
 
 def _get_env():
@@ -185,15 +186,17 @@ def py_run(command_options="", return_std=False, stdout=None, stderr=None):
         return None
 
 
-def Run():
-    if len(sys.argv) == 1:
+def Run(*, arguments: Optional[List[str]] = None):
+    if not arguments and len(sys.argv) == 1:
         print(f"Usage: {sys.argv[0]} <filename> [options]")
         sys.exit(1)
-    elif not os.path.exists(sys.argv[1]):
-        print(f"{sys.argv[1]} does not exist")
+
+    args = arguments or sys.argv[1:]
+    if not os.path.exists(args[0]):
+        print(f"{args[0]} does not exist")
         sys.exit(1)
     else:
-        sys.exit(lint(sys.argv[1], sys.argv[2:]))
+        sys.exit(lint(args[0], args[1:]))
 
 
 if __name__ == "__main__":

--- a/pylint/epylint.py
+++ b/pylint/epylint.py
@@ -64,7 +64,7 @@ import shlex
 import sys
 from io import StringIO
 from subprocess import PIPE, Popen
-from typing import List, Optional
+from typing import Optional, Sequence
 
 
 def _get_env():
@@ -186,17 +186,17 @@ def py_run(command_options="", return_std=False, stdout=None, stderr=None):
         return None
 
 
-def Run(*, arguments: Optional[List[str]] = None):
-    if not arguments and len(sys.argv) == 1:
+def Run(argv: Optional[Sequence[str]] = None):
+    if not argv and len(sys.argv) == 1:
         print(f"Usage: {sys.argv[0]} <filename> [options]")
         sys.exit(1)
 
-    args = arguments or sys.argv[1:]
-    if not os.path.exists(args[0]):
-        print(f"{args[0]} does not exist")
+    argv = argv or sys.argv[1:]
+    if not os.path.exists(argv[0]):
+        print(f"{argv[0]} does not exist")
         sys.exit(1)
     else:
-        sys.exit(lint(args[0], args[1:]))
+        sys.exit(lint(argv[0], argv[1:]))
 
 
 if __name__ == "__main__":

--- a/tests/test_pylint_runners.py
+++ b/tests/test_pylint_runners.py
@@ -23,7 +23,9 @@ def test_runner(runner: Callable, tmpdir: LocalPath) -> None:
             assert err.value.code == 0
 
 
-@pytest.mark.parametrize("runner", [run_pylint, run_pyreverse, run_symilar])
+@pytest.mark.parametrize(
+    "runner", [run_epylint, run_pylint, run_pyreverse, run_symilar]
+)
 def test_runner_with_arguments(runner: Callable, tmpdir: LocalPath) -> None:
     """Check the runners with arguments as parameter instead of sys.argv"""
     filepath = os.path.abspath(__file__)

--- a/tests/test_pylint_runners.py
+++ b/tests/test_pylint_runners.py
@@ -21,3 +21,14 @@ def test_runner(runner: Callable, tmpdir: LocalPath) -> None:
             with pytest.raises(SystemExit) as err:
                 runner()
             assert err.value.code == 0
+
+
+@pytest.mark.parametrize("runner", [run_pylint, run_pyreverse, run_symilar])
+def test_runner_with_arguments(runner: Callable, tmpdir: LocalPath) -> None:
+    """Check the runners with arguments as parameter instead of sys.argv"""
+    filepath = os.path.abspath(__file__)
+    testargs = [filepath]
+    with tmpdir.as_cwd():
+        with pytest.raises(SystemExit) as err:
+            runner(arguments=testargs)
+        assert err.value.code == 0

--- a/tests/test_pylint_runners.py
+++ b/tests/test_pylint_runners.py
@@ -32,5 +32,5 @@ def test_runner_with_arguments(runner: Callable, tmpdir: LocalPath) -> None:
     testargs = [filepath]
     with tmpdir.as_cwd():
         with pytest.raises(SystemExit) as err:
-            runner(arguments=testargs)
+            runner(argv=testargs)
         assert err.value.code == 0


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

Follow up to #5613. No `epylint` works as well 😄 