### PR TITLE
Rename CI job names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -227,7 +227,7 @@ jobs:
           path: .coverage
 
   coverage:
-    name: tests / process coverage
+    name: tests / process / coverage
     runs-on: ubuntu-latest
     needs: ["prepare-tests-linux", "pytest-linux"]
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
           pre-commit install --install-hooks
 
   formatting:
-    name: Run pre-commit checks
+    name: checks / pre-commit
     runs-on: ubuntu-latest
     needs: prepare-base
     steps:
@@ -116,7 +116,7 @@ jobs:
           pre-commit run pylint --all-files
 
   spelling:
-    name: Run spelling checks
+    name: checks / spelling
     runs-on: ubuntu-latest
     needs: prepare-base
     steps:
@@ -146,7 +146,7 @@ jobs:
           pytest tests/ -k unittest_spelling
 
   prepare-tests-linux:
-    name: Prepare tests for Python ${{ matrix.python-version }} (Linux)
+    name: tests / prepare / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -188,7 +188,7 @@ jobs:
           pip install -U -r requirements_test.txt
 
   pytest-linux:
-    name: Run tests Python ${{ matrix.python-version }} (Linux)
+    name: tests / run / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     needs: prepare-tests-linux
     strategy:
@@ -227,7 +227,7 @@ jobs:
           path: .coverage
 
   coverage:
-    name: Process test coverage
+    name: tests / process coverage
     runs-on: ubuntu-latest
     needs: ["prepare-tests-linux", "pytest-linux"]
     strategy:
@@ -271,7 +271,7 @@ jobs:
           coveralls --rcfile=${{ env.COVERAGERC_FILE }} --service=github
 
   benchmark-linux:
-    name: Run benchmark tests Python ${{ matrix.python-version }} (Linux)
+    name: tests / run benchmark / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     needs: prepare-tests-linux
     strategy:
@@ -322,7 +322,7 @@ jobs:
           path: .benchmarks/
 
   prepare-tests-windows:
-    name: Prepare tests for Python ${{ matrix.python-version }} (Windows)
+    name: tests / prepare / ${{ matrix.python-version }} / Windows
     runs-on: windows-latest
     strategy:
       matrix:
@@ -364,7 +364,7 @@ jobs:
           pip install -U -r requirements_test_min.txt
 
   pytest-windows:
-    name: Run tests Python ${{ matrix.python-version }} (Windows)
+    name: tests / run / ${{ matrix.python-version }} / Windows
     runs-on: windows-latest
     needs: prepare-tests-windows
     strategy:
@@ -402,7 +402,7 @@ jobs:
           pytest --benchmark-disable tests/
 
   prepare-tests-pypy:
-    name: Prepare tests for Python ${{ matrix.python-version }}
+    name: tests / prepare / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -444,7 +444,7 @@ jobs:
           pip install -U -r requirements_test_min.txt
 
   pytest-pypy:
-    name: Run tests Python ${{ matrix.python-version }}
+    name: tests / run / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     needs: prepare-tests-pypy
     strategy:

--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -1,4 +1,4 @@
-name: Primer tests
+name: Primer
 
 on:
   push:
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   prepare-tests-linux:
-    name: Prepare tests for Python ${{ matrix.python-version }} (Linux)
+    name: prepare / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -64,7 +64,7 @@ jobs:
           pip install -U -r requirements_test.txt
 
   pytest-primer-stdlib:
-    name: Run primer tests on stdlib Python ${{ matrix.python-version }} (Linux)
+    name: run on stdlib / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     needs: prepare-tests-linux
     strategy:
@@ -98,9 +98,7 @@ jobs:
           pytest -m primer_stdlib --primer-stdlib -n auto
 
   pytest-primer-external-batch-one:
-    name:
-      Run primer tests batch one on external libs Python ${{ matrix.python-version }}
-      (Linux)
+    name: run on batch one / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     needs: prepare-tests-linux
     strategy:
@@ -134,9 +132,7 @@ jobs:
           pytest -m primer_external_batch_one --primer-external -n auto
 
   pytest-primer-external-batch-two:
-    name:
-      Run primer tests batch two on external libs Python ${{ matrix.python-version }}
-      (Linux)
+    name: run on batch two / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     needs: prepare-tests-linux
     strategy:


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Taking inspiration from `pip` as seen here https://github.com/pypa/pip/pull/10720 I really like their clean CI jobs names.
This is probably personal preference, but would we consider changing them? This is my suggestion based on their design.