### PR TITLE
Fix #5370: Emit `redefined-outer-name` when a nested except handler shadows an outer one

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -117,6 +117,7 @@ Release date: TBA
 
 * Emit ``redefined-outer-name`` when a nested except handler shadows an outer one.
 
+  Closes #4434 
   Closes #5370
 
 * Fatal errors now emit a score of 0.0 regardless of whether the linted module

--- a/ChangeLog
+++ b/ChangeLog
@@ -115,6 +115,10 @@ Release date: TBA
 
   Partially closes #1730
 
+* Emit ``redefined-outer-name`` when a nested except handler shadows an outer one.
+
+  Closes #5370
+
 * Fatal errors now emit a score of 0.0 regardless of whether the linted module
   contained any statements
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -117,7 +117,7 @@ Release date: TBA
 
 * Emit ``redefined-outer-name`` when a nested except handler shadows an outer one.
 
-  Closes #4434 
+  Closes #4434
   Closes #5370
 
 * Fatal errors now emit a score of 0.0 regardless of whether the linted module

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -120,6 +120,7 @@ Other Changes
 
 * Emit ``redefined-outer-name`` when a nested except handler shadows an outer one.
 
+  Closes #4434 
   Closes #5370
 
 * Fatal errors now emit a score of 0.0 regardless of whether the linted module

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -120,7 +120,7 @@ Other Changes
 
 * Emit ``redefined-outer-name`` when a nested except handler shadows an outer one.
 
-  Closes #4434 
+  Closes #4434
   Closes #5370
 
 * Fatal errors now emit a score of 0.0 regardless of whether the linted module

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -118,6 +118,10 @@ Other Changes
 
 * Fixed crash on uninferable decorators on Python 3.6 and 3.7
 
+* Emit ``redefined-outer-name`` when a nested except handler shadows an outer one.
+
+  Closes #5370
+
 * Fatal errors now emit a score of 0.0 regardless of whether the linted module
   contained any statements
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -846,6 +846,7 @@ class VariablesChecker(BaseChecker):
         self._checking_mod_attr = None
         self._loop_variables = []
         self._type_annotation_names = []
+        self._except_handler_names = []
         self._postponed_evaluation_enabled = False
 
     def open(self) -> None:
@@ -1129,6 +1130,28 @@ class VariablesChecker(BaseChecker):
         self._undefined_and_used_before_checker(node, stmt)
         if self._is_undefined_loop_variable_enabled:
             self._loopvar_name(node)
+
+    @utils.check_messages("redefined-outer-name")
+    def visit_excepthandler(self, node: nodes.ExceptHandler) -> None:
+        if not node.name or not isinstance(node.name, nodes.AssignName):
+            return
+
+        for outer_except, outer_except_assign_name in self._except_handler_names:
+            if node.name.name == outer_except_assign_name.name:
+                self.add_message(
+                    "redefined-outer-name",
+                    args=(outer_except_assign_name.name, outer_except.fromlineno),
+                    node=node,
+                )
+                break
+
+        self._except_handler_names.append((node, node.name))
+
+    @utils.check_messages("redefined-outer-name")
+    def leave_excepthandler(self, node: nodes.ExceptHandler) -> None:
+        if not node.name or not isinstance(node.name, nodes.AssignName):
+            return
+        self._except_handler_names.pop()
 
     def _undefined_and_used_before_checker(
         self, node: nodes.Name, stmt: nodes.NodeNG

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -847,6 +847,7 @@ class VariablesChecker(BaseChecker):
         self._loop_variables = []
         self._type_annotation_names = []
         self._except_handler_names = []
+        """This is a queue, last in first out"""
         self._postponed_evaluation_enabled = False
 
     def open(self) -> None:

--- a/tests/functional/r/redefined_except_handler.py
+++ b/tests/functional/r/redefined_except_handler.py
@@ -1,4 +1,7 @@
-"""https://github.com/PyCQA/pylint/issues/5370"""
+"""Tests for except handlers that shadow outer except handlers or exceptions.
+
+See: https://github.com/PyCQA/pylint/issues/5370
+"""
 
 try:
     pass

--- a/tests/functional/r/redefined_except_handler.py
+++ b/tests/functional/r/redefined_except_handler.py
@@ -1,0 +1,56 @@
+"""https://github.com/PyCQA/pylint/issues/5370"""
+
+try:
+    pass
+except ImportError as err:
+    try:
+        pass
+    except ImportError as err:  # [redefined-outer-name]
+        pass
+    print(err)
+
+try:
+    pass
+except ImportError as err:
+    try:
+        pass
+    except ImportError as err2:
+        pass
+    print(err)
+
+try:
+    try:
+        pass
+    except ImportError as err:
+        pass
+except ImportError:
+    try:
+        pass
+    except ImportError as err:
+        pass
+    print(err)
+
+
+try:
+    try:
+        pass
+    except ImportError as err:
+        pass
+except ImportError as err:
+    try:
+        pass
+    except ImportError:
+        pass
+    print(err)
+
+try:
+    pass
+except ImportError as err:
+    try:
+        pass
+    except ImportError as err2:
+        try:
+            pass
+        except ImportError as err:  # [redefined-outer-name]
+            pass
+    print(err)

--- a/tests/functional/r/redefined_except_handler.py
+++ b/tests/functional/r/redefined_except_handler.py
@@ -54,3 +54,16 @@ except ImportError as err:
         except ImportError as err:  # [redefined-outer-name]
             pass
     print(err)
+
+
+class CustomException(Exception):
+    """https://github.com/PyCQA/pylint/issues/4434"""
+
+
+def func():
+    """Override CustomException by except .. as .."""
+    try:
+        raise CustomException('Test')  # [used-before-assignment]
+    # pylint:disable-next=invalid-name, unused-variable
+    except IOError as CustomException:  # [redefined-outer-name]
+        pass

--- a/tests/functional/r/redefined_except_handler.txt
+++ b/tests/functional/r/redefined_except_handler.txt
@@ -1,2 +1,4 @@
 redefined-outer-name:8:4:9:12::Redefining name 'err' from outer scope (line 5):UNDEFINED
 redefined-outer-name:54:8:55:16::Redefining name 'err' from outer scope (line 48):UNDEFINED
+used-before-assignment:66:14:66:29:func:Using variable 'CustomException' before assignment:UNDEFINED
+redefined-outer-name:68:4:69:12:func:Redefining name 'CustomException' from outer scope (line 59):UNDEFINED

--- a/tests/functional/r/redefined_except_handler.txt
+++ b/tests/functional/r/redefined_except_handler.txt
@@ -1,4 +1,4 @@
-redefined-outer-name:8:4:9:12::Redefining name 'err' from outer scope (line 5):UNDEFINED
-redefined-outer-name:54:8:55:16::Redefining name 'err' from outer scope (line 48):UNDEFINED
-used-before-assignment:66:14:66:29:func:Using variable 'CustomException' before assignment:UNDEFINED
-redefined-outer-name:68:4:69:12:func:Redefining name 'CustomException' from outer scope (line 59):UNDEFINED
+redefined-outer-name:11:4:12:12::Redefining name 'err' from outer scope (line 8):UNDEFINED
+redefined-outer-name:57:8:58:16::Redefining name 'err' from outer scope (line 51):UNDEFINED
+used-before-assignment:69:14:69:29:func:Using variable 'CustomException' before assignment:UNDEFINED
+redefined-outer-name:71:4:72:12:func:Redefining name 'CustomException' from outer scope (line 62):UNDEFINED

--- a/tests/functional/r/redefined_except_handler.txt
+++ b/tests/functional/r/redefined_except_handler.txt
@@ -1,0 +1,2 @@
+redefined-outer-name:8:4:9:12::Redefining name 'err' from outer scope (line 5):UNDEFINED
+redefined-outer-name:54:8:55:16::Redefining name 'err' from outer scope (line 48):UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Description

Emit `redefined-outer-name` when a nested except handler shadows (overwrites) the name used in an outer except handler.

Implementation borrows from the `redefined-outer-name` implementation for if branches.

Closes #5370, Closes #4434
