### PR TITLE
pre-commit colorama error fix with mypy checker on Windows

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -127,3 +127,6 @@ ignore_missing_imports = True
 
 [mypy-dill]
 ignore_missing_imports = True
+
+[mypy-colorama]
+ignore_missing_imports = True


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|   | :sparkles: New feature |
|   | :hammer: Refactoring   |
|   | :scroll: Docs          |

## Description

Fixes `mypy` issue regarding `colorama` and `--ignore-missing-imports`:

```
Cannot find implementation or library stub for module named "colorama" (https://mypy.readthedocs.io/en/stable/ files)

http://pylint/reporters/text.py:323:%20note:%20See%20https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #5627
