### PR TITLE
Fix #5638: Allow for encoding to be supplied as a positional argument

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -120,6 +120,11 @@ Release date: TBA
   Closes #4434
   Closes #5370
 
+* ``encoding`` can now be supplied as a positional argument to calls that open
+  files without triggering ``unspecified-encoding``.
+
+  Closes #5638
+
 * Fatal errors now emit a score of 0.0 regardless of whether the linted module
   contained any statements
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -123,6 +123,11 @@ Other Changes
   Closes #4434
   Closes #5370
 
+* ``encoding`` can now be supplied as a positional argument to calls that open
+  files without triggering ``unspecified-encoding``.
+
+  Closes #5638
+
 * Fatal errors now emit a score of 0.0 regardless of whether the linted module
   contained any statements
 

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -640,9 +640,17 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                     encoding_arg = utils.get_argument_from_call(
                         node, position=0, keyword="encoding"
                     )
+                elif open_module == "pathlib" and node.func.attrname == "write_text":
+                    encoding_arg = utils.get_argument_from_call(
+                        node, position=1, keyword="encoding"
+                    )
+                elif open_module == "pathlib":
+                    encoding_arg = utils.get_argument_from_call(
+                        node, position=2, keyword="encoding"
+                    )
                 else:
                     encoding_arg = utils.get_argument_from_call(
-                        node, position=None, keyword="encoding"
+                        node, position=3, keyword="encoding"
                     )
             except utils.NoSuchArgumentError:
                 self.add_message("unspecified-encoding", node=node)

--- a/tests/functional/u/unspecified_encoding_py38.py
+++ b/tests/functional/u/unspecified_encoding_py38.py
@@ -143,3 +143,16 @@ args_good_one = IOArgs(encoding=None, mode="wb")
 
 # Test for crash reported in https://github.com/PyCQA/pylint/issues/5321
 open(FILENAME, args_good_one.mode, encoding=args_good_one.encoding)
+
+# Positional arguments
+open(FILENAME, "w", -1, "utf-8")
+open(FILENAME, "w", -1)  # [unspecified-encoding]
+
+Path(FILENAME).open("w", -1, "utf-8")
+Path(FILENAME).open("w", -1)  # [unspecified-encoding]
+
+Path(FILENAME).read_text("utf-8")
+Path(FILENAME).read_text()  # [unspecified-encoding]
+
+Path(FILENAME).write_text("string", "utf-8")
+Path(FILENAME).write_text("string")  # [unspecified-encoding]

--- a/tests/functional/u/unspecified_encoding_py38.txt
+++ b/tests/functional/u/unspecified_encoding_py38.txt
@@ -23,3 +23,7 @@ unspecified-encoding:81:0:81:21::Using open without explicitly specifying an enc
 unspecified-encoding:82:0:82:25::Using open without explicitly specifying an encoding:UNDEFINED
 unspecified-encoding:83:0:83:25::Using open without explicitly specifying an encoding:UNDEFINED
 unspecified-encoding:84:0:84:39::Using open without explicitly specifying an encoding:UNDEFINED
+unspecified-encoding:149:0:149:23::Using open without explicitly specifying an encoding:UNDEFINED
+unspecified-encoding:152:0:152:28::Using open without explicitly specifying an encoding:UNDEFINED
+unspecified-encoding:155:0:155:26::Using open without explicitly specifying an encoding:UNDEFINED
+unspecified-encoding:158:0:158:35::Using open without explicitly specifying an encoding:UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Allows `encoding` to be supplied as a positional argument to calls opening files without triggering `unspecified-encoding`. The positional argument was identified correctly only for `read_text()` (see line 63 of test file).

Closes #5638
