### PR TITLE
Handle when the 'ancestors' attribute is not present in an object

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -595,3 +595,6 @@ contributors:
 * Eero Vuojolahti: contributor
 
 * Kian-Meng, Ang: contributor
+
+* Julia Eskew (doctoryes): contributor
+  - Fixed issue 5646, handle when the 'ancestors' attribute is not present in an object

--- a/ChangeLog
+++ b/ChangeLog
@@ -191,6 +191,15 @@ Release date: TBA
   (Ie. not necessarily at the end)
 
 
+What's New in Pylint 2.12.3?
+============================
+Release date:
+
+* Fixed handling of missing 'ancestors' object attribute.
+
+  Closes #5646
+
+
 What's New in Pylint 2.12.2?
 ============================
 Release date: 2021-11-25

--- a/doc/whatsnew/2.12.rst
+++ b/doc/whatsnew/2.12.rst
@@ -255,3 +255,8 @@ Other Changes
   or ``not in`` checks
 
   Closes #5323
+
+* Fixed handling of missing 'ancestors' object attribute.
+
+  Closes #5646
+

--- a/doc/whatsnew/2.12.rst
+++ b/doc/whatsnew/2.12.rst
@@ -259,4 +259,3 @@ Other Changes
 * Fixed handling of missing 'ancestors' object attribute.
 
   Closes #5646
-

--- a/pylint/checkers/refactoring/implicit_booleaness_checker.py
+++ b/pylint/checkers/refactoring/implicit_booleaness_checker.py
@@ -213,5 +213,5 @@ class ImplicitBooleanessChecker(checkers.BaseChecker):
         """Return all the classes names that a ClassDef inherit from including 'object'."""
         try:
             return [instance.name] + [x.name for x in instance.ancestors()]
-        except TypeError:
+        except (TypeError, AttributeError):
             return [instance.name]


### PR DESCRIPTION
Fix for issue described here: #5646 

Handle when the 'ancestors' attribute is not present in an object.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #5646
