### PR TITLE
Fix #5326: Fix false positive for `unused-variable` for a comprehension variable matching a type annotation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -83,7 +83,7 @@ Release date: TBA
 * Fix false positive for ``unused-variable`` for a comprehension variable matching
   an outer scope type annotation.
 
-  Refs #5326
+  Closes #5326
 
 * Some files in ``pylint.testutils`` were deprecated. In the future imports should be done from the
   ``pylint.testutils.functional`` namespace directly.

--- a/ChangeLog
+++ b/ChangeLog
@@ -80,7 +80,7 @@ Release date: TBA
 
   Closes #5461
 
-* Fix false positive for `unused-variable` for a comprehension variable matching
+* Fix false positive for ``unused-variable`` for a comprehension variable matching
   an outer scope type annotation.
 
   Refs #5326

--- a/ChangeLog
+++ b/ChangeLog
@@ -80,6 +80,11 @@ Release date: TBA
 
   Closes #5461
 
+* Fix false positive for `unused-variable` for a comprehension variable matching
+  an outer scope type annotation.
+
+  Refs #5326
+
 * Some files in ``pylint.testutils`` were deprecated. In the future imports should be done from the
   ``pylint.testutils.functional`` namespace directly.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -116,7 +116,7 @@ Other Changes
 
   Closes #5461
 
-* Fix false positive for `unused-variable` for a comprehension variable matching
+* Fix false positive for ``unused-variable`` for a comprehension variable matching
   an outer scope type annotation.
 
   Refs #5326

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -116,6 +116,11 @@ Other Changes
 
   Closes #5461
 
+* Fix false positive for `unused-variable` for a comprehension variable matching
+  an outer scope type annotation.
+
+  Refs #5326
+
 * Require Python ``3.6.2`` to run pylint.
 
   Closes #5065

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -119,7 +119,7 @@ Other Changes
 * Fix false positive for ``unused-variable`` for a comprehension variable matching
   an outer scope type annotation.
 
-  Refs #5326
+  Closes #5326
 
 * Require Python ``3.6.2`` to run pylint.
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1803,7 +1803,7 @@ class VariablesChecker(BaseChecker):
                 # Local refs are ordered, so we break.
                 #     print(var)
                 #     var = 1  # <- irrelevant
-                if defstmt_frame == node_frame and not ref_node.lineno < node.lineno:
+                if defstmt_frame == node_frame and ref_node.lineno > node.lineno:
                     break
 
                 # If the parent of the local reference is anything but an AnnAssign

--- a/tests/functional/u/undefined/undefined_variable_py38.py
+++ b/tests/functional/u/undefined/undefined_variable_py38.py
@@ -11,10 +11,10 @@ def typing_and_assignment_expression():
         print(var)
 
 
-def typing_and_self_referncing_assignment_expression():
+def typing_and_self_referencing_assignment_expression():
     """The variable gets assigned in an assignment expression that references itself"""
     var: int
-    if (var := var ** 2): # [undefined-variable]
+    if (var := var ** 2):  # false negative--walrus operator!
         print(var)
 
 
@@ -108,3 +108,20 @@ sorted_things = sorted(
     if (x_0 := thing.this_value) < (x_1 := thing.that_value)
     else x_1,
 )
+
+
+# Tests for type annotation reused in comprehension
+
+def type_annotation_used_after_comprehension():
+    """https://github.com/PyCQA/pylint/issues/5326#issuecomment-982635371"""
+    my_int: int
+    ints = [my_int + 1 for my_int in range(5)]
+
+    for my_int in ints:
+        print(my_int)
+
+
+def type_annotation_unused_after_comprehension():
+    """https://github.com/PyCQA/pylint/issues/5326"""
+    my_int: int
+    _ = [print(kwarg1=my_int, kwarg2=my_int) for my_int in range(10)]

--- a/tests/functional/u/undefined/undefined_variable_py38.txt
+++ b/tests/functional/u/undefined/undefined_variable_py38.txt
@@ -1,4 +1,3 @@
-undefined-variable:17:15:17:18:typing_and_self_referncing_assignment_expression:Undefined variable 'var':UNDEFINED
 undefined-variable:42:6:42:16::Undefined variable 'no_default':UNDEFINED
 undefined-variable:50:6:50:22::Undefined variable 'again_no_default':UNDEFINED
 undefined-variable:76:6:76:19::Undefined variable 'else_assign_1':UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fixes the regression described in #5326 where `undefined-variable` is emitted when a comprehension variable matches a type annotation.

One test result is edited to show that after these changes we will need better detection of walrus operators.

Fixes #5326
