### PR TITLE
Fix crash on properties & inherited methods in ``implicit-booleaness``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,11 @@ Release date: TBA
 
   Closes #5483
 
+* Fixed crash on properties and inherited class methods when comparing them for
+  equality against an empty dict.
+
+  Closes #5646
+
 * Fixed a false positive for ``assigning-non-slot`` when the slotted class
   defined ``__setattr__``.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -40,6 +40,11 @@ Other Changes
 * When run in parallel mode ``pylint`` now pickles the data passed to subprocesses with
   the ``dill`` package. The ``dill`` package has therefore been added as a dependency.
 
+* Fixed crash on properties and inherited class methods when comparing them for
+  equality against an empty dict.
+
+  Closes #5646
+
 * By default, pylint does no longer take files starting with ``.#`` into account. Those are
   considered `emacs file locks`_. This behavior can be reverted by redefining the
   ``ignore-patterns`` option.

--- a/pylint/checkers/refactoring/implicit_booleaness_checker.py
+++ b/pylint/checkers/refactoring/implicit_booleaness_checker.py
@@ -107,7 +107,7 @@ class ImplicitBooleanessChecker(checkers.BaseChecker):
         except astroid.InferenceError:
             # Probably undefined-variable, abort check
             return
-        mother_classes = self.base_names_of_base_node(instance)
+        mother_classes = self.base_names_of_instance(instance)
         affected_by_pep8 = any(
             t in mother_classes for t in ("str", "tuple", "list", "set")
         )
@@ -165,7 +165,7 @@ class ImplicitBooleanessChecker(checkers.BaseChecker):
                 target_instance = utils.safe_infer(target_node)
                 if target_instance is None:
                     continue
-                mother_classes = self.base_names_of_base_node(target_instance)
+                mother_classes = self.base_names_of_instance(target_instance)
                 is_base_comprehension_type = any(
                     t in mother_classes for t in ("tuple", "list", "dict", "set")
                 )
@@ -209,17 +209,13 @@ class ImplicitBooleanessChecker(checkers.BaseChecker):
                     )
 
     @staticmethod
-    def base_names_of_base_node(
-        node: Union[bases.UnboundMethod, bases.Instance]
+    def base_names_of_instance(
+        node: Union[bases.Uninferable, bases.Instance]
     ) -> List[str]:
         """Return all names inherited by a class instance or those returned by a function.
 
         The inherited names include 'object'.
         """
-        if isinstance(node, bases.UnboundMethod):
-            return [i.name for i in node.infer_call_result(node)]
         if isinstance(node, bases.Instance):
             return [node.name] + [x.name for x in node.ancestors()]
-
-        # For example for astroid.nodes.Uninferable
         return []

--- a/pylint/checkers/refactoring/implicit_booleaness_checker.py
+++ b/pylint/checkers/refactoring/implicit_booleaness_checker.py
@@ -107,7 +107,7 @@ class ImplicitBooleanessChecker(checkers.BaseChecker):
         except astroid.InferenceError:
             # Probably undefined-variable, abort check
             return
-        mother_classes = self.base_classes_and_return_names(instance)
+        mother_classes = self.base_names_of_base_node(instance)
         affected_by_pep8 = any(
             t in mother_classes for t in ("str", "tuple", "list", "set")
         )
@@ -165,7 +165,7 @@ class ImplicitBooleanessChecker(checkers.BaseChecker):
                 target_instance = utils.safe_infer(target_node)
                 if target_instance is None:
                     continue
-                mother_classes = self.base_classes_and_return_names(target_instance)
+                mother_classes = self.base_names_of_base_node(target_instance)
                 is_base_comprehension_type = any(
                     t in mother_classes for t in ("tuple", "list", "dict", "set")
                 )
@@ -209,7 +209,7 @@ class ImplicitBooleanessChecker(checkers.BaseChecker):
                     )
 
     @staticmethod
-    def base_classes_and_return_names(
+    def base_names_of_base_node(
         node: Union[bases.UnboundMethod, bases.Instance]
     ) -> List[str]:
         """Return all names inherited by a class instance or those returned by a function.

--- a/tests/checkers/unittest_refactoring.py
+++ b/tests/checkers/unittest_refactoring.py
@@ -5,10 +5,8 @@ import os
 import signal
 from contextlib import contextmanager
 
-import astroid
 import pytest
 
-from pylint.checkers.refactoring import ImplicitBooleanessChecker
 from pylint.lint import Run
 from pylint.reporters.text import TextReporter
 
@@ -26,52 +24,6 @@ def timeout(timeout_s: float):
     yield
     signal.setitimer(signal.ITIMER_REAL, 0)
     signal.signal(signal.SIGALRM, signal.SIG_DFL)
-
-
-def test_class_tree_detection() -> None:
-    module = astroid.parse(
-        """
-class ClassWithBool(list):
-    def __bool__(self):
-        return True
-
-class ClassWithoutBool(dict):
-    pass
-
-class ChildClassWithBool(ClassWithBool):
-    pass
-
-class ChildClassWithoutBool(ClassWithoutBool):
-    pass
-"""
-    )
-    with_bool, without_bool, child_with_bool, child_without_bool = module.body
-    assert ImplicitBooleanessChecker().base_classes_and_return_names(with_bool) == [
-        "ClassWithBool",
-        "list",
-        "object",
-    ]
-    assert ImplicitBooleanessChecker().base_classes_and_return_names(without_bool) == [
-        "ClassWithoutBool",
-        "dict",
-        "object",
-    ]
-    assert ImplicitBooleanessChecker().base_classes_and_return_names(
-        child_with_bool
-    ) == [
-        "ChildClassWithBool",
-        "ClassWithBool",
-        "list",
-        "object",
-    ]
-    assert ImplicitBooleanessChecker().base_classes_and_return_names(
-        child_without_bool
-    ) == [
-        "ChildClassWithoutBool",
-        "ClassWithoutBool",
-        "dict",
-        "object",
-    ]
 
 
 @pytest.mark.skipif(not hasattr(signal, "setitimer"), reason="Assumes POSIX signals")

--- a/tests/checkers/unittest_refactoring.py
+++ b/tests/checkers/unittest_refactoring.py
@@ -46,23 +46,27 @@ class ChildClassWithoutBool(ClassWithoutBool):
 """
     )
     with_bool, without_bool, child_with_bool, child_without_bool = module.body
-    assert ImplicitBooleanessChecker().base_classes_of_node(with_bool) == [
+    assert ImplicitBooleanessChecker().base_classes_and_return_names(with_bool) == [
         "ClassWithBool",
         "list",
         "object",
     ]
-    assert ImplicitBooleanessChecker().base_classes_of_node(without_bool) == [
+    assert ImplicitBooleanessChecker().base_classes_and_return_names(without_bool) == [
         "ClassWithoutBool",
         "dict",
         "object",
     ]
-    assert ImplicitBooleanessChecker().base_classes_of_node(child_with_bool) == [
+    assert ImplicitBooleanessChecker().base_classes_and_return_names(
+        child_with_bool
+    ) == [
         "ChildClassWithBool",
         "ClassWithBool",
         "list",
         "object",
     ]
-    assert ImplicitBooleanessChecker().base_classes_of_node(child_without_bool) == [
+    assert ImplicitBooleanessChecker().base_classes_and_return_names(
+        child_without_bool
+    ) == [
         "ChildClassWithoutBool",
         "ClassWithoutBool",
         "dict",

--- a/tests/functional/u/use/use_implicit_booleaness_not_comparison.py
+++ b/tests/functional/u/use/use_implicit_booleaness_not_comparison.py
@@ -194,3 +194,46 @@ if data or not data:
 long_test = {}
 if long_test == {        }: # [use-implicit-booleaness-not-comparison]
     pass
+
+
+# Check for properties and uninferable class methods
+# See https://github.com/PyCQA/pylint/issues/5646
+from xyz import AnotherClassWithProperty
+
+
+class ParentWithProperty:
+
+    @classmethod
+    @property
+    def parent_function(cls):
+        return {}
+
+
+class MyClassWithProxy(ParentWithProperty):
+
+    attribute = True
+
+    @property
+    @classmethod
+    def my_property(cls):
+        return {}
+
+    @property
+    @classmethod
+    def my_difficult_property(cls):
+        if cls.attribute:
+            return {}
+        return MyClassWithProxy()
+
+
+
+def test_func():
+    """Some assertions against empty dicts."""
+    my_class = MyClassWithProxy()
+    assert my_class.parent_function == {}  # [use-implicit-booleaness-not-comparison]
+    assert my_class.my_property == {}  # [use-implicit-booleaness-not-comparison]
+
+    # If the return value is not always implicit boolean, don't raise
+    assert my_class.my_difficult_property == {}
+    # Uninferable does not raise
+    assert AnotherClassWithProperty().my_property == {}

--- a/tests/functional/u/use/use_implicit_booleaness_not_comparison.txt
+++ b/tests/functional/u/use/use_implicit_booleaness_not_comparison.txt
@@ -28,3 +28,5 @@ use-implicit-booleaness-not-comparison:160:3:160:20::'numpy_array >= ()' can be 
 use-implicit-booleaness-not-comparison:185:3:185:13::'data == {}' can be simplified to 'not data' as an empty sequence is falsey:UNDEFINED
 use-implicit-booleaness-not-comparison:187:3:187:13::'data != {}' can be simplified to 'data' as an empty sequence is falsey:UNDEFINED
 use-implicit-booleaness-not-comparison:195:3:195:26::'long_test == {}' can be simplified to 'not long_test' as an empty sequence is falsey:UNDEFINED
+use-implicit-booleaness-not-comparison:233:11:233:41:test_func:'my_class.parent_function == {}' can be simplified to 'not my_class.parent_function' as an empty sequence is falsey:UNDEFINED
+use-implicit-booleaness-not-comparison:234:11:234:37:test_func:'my_class.my_property == {}' can be simplified to 'not my_class.my_property' as an empty sequence is falsey:UNDEFINED


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #5646 and supersedes #5647.

The typing on this function was incorrect and never actually received classes. Instead it received `bases.Instance` which was also deductible from the parameter name. I've completely rewritten the function as I felt this was the best way to go.