### PR TITLE
Fix escaping of some strings in functional tests

### DIFF
--- a/tests/functional/e/.#emacs_file_lock_redefined_conf.txt
+++ b/tests/functional/e/.#emacs_file_lock_redefined_conf.txt
@@ -1,1 +1,1 @@
-invalid-name:1:0:None:None::Module name "#emacs_file_lock_redefined_conf" doesn't conform to snake_case naming style:HIGH
+invalid-name:1:0:None:None::"Module name ""#emacs_file_lock_redefined_conf"" doesn't conform to snake_case naming style":HIGH

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_required_exc_inheritance.txt
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_required_exc_inheritance.txt
@@ -1,1 +1,1 @@
-missing-raises-doc:12:0:18:25:test_find_missing_raise_for_parent:"""NameError""" not documented as being raised:UNDEFINED
+missing-raises-doc:12:0:18:25:test_find_missing_raise_for_parent:"""NameError"" not documented as being raised":UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #5650 
