### PR TITLE
Fix #5569: Fix a crash in `unused-private-member` when `type(self)` used in bound methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,11 @@ Release date: TBA
   Closes #4798
   Closes #5081
 
+* Fix a crash in ``unused-private-member`` checker when analyzing code using
+  ``type(self)`` in bound methods.
+
+  Closes #5569
+
 * Pyreverse - add output in mermaidjs format
 
 * ``used-before-assignment`` now considers that assignments in a try block

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -74,6 +74,11 @@ Other Changes
 
   Closes #4716
 
+* Fix a crash in ``unused-private-member`` checker when analyzing code using
+  ``type(self)`` in bound methods.
+
+  Closes #5569
+
 * Fix crash in ``unnecessary-dict-index-lookup`` checker if the output of
   ``items()`` is assigned to a 1-tuple.
 

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1669,7 +1669,7 @@ a metaclass class method.",
             return False
         return frame_name and frame_name in PYMETHODS
 
-    def _is_type_self_call(self, expr):
+    def _is_type_self_call(self, expr: nodes.NodeNG) -> bool:
         return (
             isinstance(expr, nodes.Call)
             and isinstance(expr.func, nodes.Name)
@@ -2032,7 +2032,7 @@ a metaclass class method.",
         """
         return self._is_mandatory_method_param(node.expr)
 
-    def _is_mandatory_method_param(self, node):
+    def _is_mandatory_method_param(self, node: nodes.NodeNG) -> bool:
         """Check if nodes.Name corresponds to first attribute variable name
 
         Name is `self` for method, `cls` for classmethod and `mcs` for metaclass.

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -309,3 +309,13 @@ class Foo:
 
     def method(self):
         print(self.__class__.__ham)
+
+
+class TypeSelfCallInMethod:
+    """Regression test for issue 5569"""
+    @classmethod
+    def b(cls) -> None:
+        cls.__a = ''  # [unused-private-member]
+
+    def a(self):
+        return type(self).__a

--- a/tests/functional/u/unused/unused_private_member.txt
+++ b/tests/functional/u/unused/unused_private_member.txt
@@ -17,3 +17,4 @@ unused-private-member:243:12:243:50:FalsePositive4681.__init__:Unused private me
 unused-private-member:274:4:275:26:FalsePositive4849.__unused_private_method:Unused private member `FalsePositive4849.__unused_private_method()`:UNDEFINED
 unused-private-member:291:4:294:44:Pony.__init_defaults:Unused private member `Pony.__init_defaults(self)`:UNDEFINED
 unused-private-member:296:4:298:20:Pony.__get_fur_color:Unused private member `Pony.__get_fur_color(self)`:UNDEFINED
+unused-private-member:318:8:318:15:TypeSelfCallInMethod.b:Unused private member `TypeSelfCallInMethod.__a`:UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #5569
