### PR TITLE
Make sure to split non-separated csv ``OuputLine's``

### DIFF
--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -117,49 +117,50 @@ class OutputLine(NamedTuple):
         """Create an OutputLine from a comma separated list (the functional tests expected
         output .txt files).
         """
+        if isinstance(row, str):
+            row = row.split(",")
         try:
-            if isinstance(row, Sequence):
-                column = cls._get_column(row[2])
-                if len(row) == 5:
-                    warnings.warn(
-                        "In pylint 3.0 functional tests expected output should always include the "
-                        "expected confidence level, expected end_line and expected end_column. "
-                        "An OutputLine should thus have a length of 8.",
-                        DeprecationWarning,
-                    )
-                    return cls(
-                        row[0],
-                        int(row[1]),
-                        column,
-                        None,
-                        None,
-                        row[3],
-                        row[4],
-                        UNDEFINED.name,
-                    )
-                if len(row) == 6:
-                    warnings.warn(
-                        "In pylint 3.0 functional tests expected output should always include the "
-                        "expected end_line and expected end_column. An OutputLine should thus have "
-                        "a length of 8.",
-                        DeprecationWarning,
-                    )
-                    return cls(
-                        row[0], int(row[1]), column, None, None, row[3], row[4], row[5]
-                    )
-                if len(row) == 8:
-                    end_line = cls._get_py38_none_value(row[3], check_endline)
-                    end_column = cls._get_py38_none_value(row[4], check_endline)
-                    return cls(
-                        row[0],
-                        int(row[1]),
-                        column,
-                        cls._value_to_optional_int(end_line),
-                        cls._value_to_optional_int(end_column),
-                        row[5],
-                        row[6],
-                        row[7],
-                    )
+            column = cls._get_column(row[2])
+            if len(row) == 5:
+                warnings.warn(
+                    "In pylint 3.0 functional tests expected output should always include the "
+                    "expected confidence level, expected end_line and expected end_column. "
+                    "An OutputLine should thus have a length of 8.",
+                    DeprecationWarning,
+                )
+                return cls(
+                    row[0],
+                    int(row[1]),
+                    column,
+                    None,
+                    None,
+                    row[3],
+                    row[4],
+                    UNDEFINED.name,
+                )
+            if len(row) == 6:
+                warnings.warn(
+                    "In pylint 3.0 functional tests expected output should always include the "
+                    "expected end_line and expected end_column. An OutputLine should thus have "
+                    "a length of 8.",
+                    DeprecationWarning,
+                )
+                return cls(
+                    row[0], int(row[1]), column, None, None, row[3], row[4], row[5]
+                )
+            if len(row) == 8:
+                end_line = cls._get_py38_none_value(row[3], check_endline)
+                end_column = cls._get_py38_none_value(row[4], check_endline)
+                return cls(
+                    row[0],
+                    int(row[1]),
+                    column,
+                    cls._value_to_optional_int(end_line),
+                    cls._value_to_optional_int(end_column),
+                    row[5],
+                    row[6],
+                    row[7],
+                )
             raise IndexError
         except Exception as e:
             raise MalformedOutputLineException(row, e) from e

--- a/tests/testutils/test_output_line.py
+++ b/tests/testutils/test_output_line.py
@@ -123,16 +123,27 @@ def test_output_line_to_csv(confidence: Confidence, message: Callable) -> None:
 
 def test_output_line_from_csv_error() -> None:
     """Test that errors are correctly raised for incorrect OutputLine's."""
+    # Test a csv-string which does not have a number for line and column
     with pytest.raises(
         MalformedOutputLineException,
         match="msg-symbolic-name:42:27:MyClass.my_function:The message",
     ):
         OutputLine.from_csv("'missing-docstring', 'line', 'column', 'obj', 'msg'", True)
+    # Test a tuple which does not have a number for line and column
     with pytest.raises(
         MalformedOutputLineException, match="symbol='missing-docstring' ?"
     ):
         csv = ("missing-docstring", "line", "column", "obj", "msg")
         OutputLine.from_csv(csv, True)
+    # Test a csv-string that is too long
+    with pytest.raises(
+        MalformedOutputLineException,
+        match="msg-symbolic-name:42:27:MyClass.my_function:The message",
+    ):
+        OutputLine.from_csv(
+            "'missing-docstring', 1, 2, 'obj', 'msg', 'func', 'message', 'conf', 'too_long'",
+            True,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

https://github.com/PyCQA/pylint/blob/2631583577a3b2228af66214a364e4e284ba55dd/tests/testutils/test_output_line.py#L126-L130

This example was not actually handled correctly. For some reason `issubclass(str, Sequence)` equals `True`, so the `isinstance` check didn't make any sense. This meant that the above line had a `len` of `51`. This changes it so that a string will first be separated on the comma's and then parsed.
The diff is quite large as the indentation could then be removed. 

I also hope this removes some `DeprecationWarnings` that were showing up in the test suite on `3.7` and `3.8`.