### PR TITLE
Fix #5586: False positive for `used-before-assignment` with homonyms in filtered comprehensions and except blocks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -96,6 +96,12 @@ Release date: TBA
 
   Closes #5360, #3877
 
+* Fixed a false positive (affecting unreleased development) for
+  ``used-before-assignment`` involving homonyms between filtered comprehensions
+  and assignments in except blocks.
+
+  Closes #5586
+
 * Fixed crash with slots assignments and annotated assignments.
 
   Closes #5479
@@ -236,12 +242,6 @@ Release date: 2021-11-25
   typed variables in the body of class methods that reference the same class
 
   Closes #5342
-
-* Fixed a false positive (affecting unreleased development) for
-  ``used-before-assignment`` involving homonyms between filtered comprehensions
-  and assignments in except blocks.
-
-  Closes #5586
 
 * Specified that the ``ignore-paths`` option considers "\" to represent a
   windows directory delimiter instead of a regular expression escape

--- a/ChangeLog
+++ b/ChangeLog
@@ -237,6 +237,12 @@ Release date: 2021-11-25
 
   Closes #5342
 
+* Fixed a false positive (affecting unreleased development) for
+  ``used-before-assignment`` involving homonyms between filtered comprehensions
+  and assignments in except blocks.
+
+  Closes #5586
+
 * Specified that the ``ignore-paths`` option considers "\" to represent a
   windows directory delimiter instead of a regular expression escape
   character.

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -139,6 +139,12 @@ Other Changes
 
   Closes #5360, #3877
 
+* Fixed a false positive (affecting unreleased development) for
+  ``used-before-assignment`` involving homonyms between filtered comprehensions
+  and assignments in except blocks.
+
+  Closes #5586
+
 * Fixed crash on list comprehensions that used ``type`` as inner variable name.
 
   Closes #5461

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1316,6 +1316,9 @@ class VariablesChecker(BaseChecker):
             if utils.is_func_decorator(current_consumer.node) or not (
                 current_consumer.scope_type == "comprehension"
                 and self._has_homonym_in_upper_function_scope(node, consumer_level)
+                # But don't catch homonyms against the filter of a comprehension,
+                # "if x" in [x for x in expr() if x]
+                # https://github.com/PyCQA/pylint/issues/5586
                 and not (
                     isinstance(node.parent.parent, nodes.Comprehension)
                     and node.parent in node.parent.parent.ifs

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1317,7 +1317,7 @@ class VariablesChecker(BaseChecker):
                 current_consumer.scope_type == "comprehension"
                 and self._has_homonym_in_upper_function_scope(node, consumer_level)
                 # But don't catch homonyms against the filter of a comprehension,
-                # "if x" in [x for x in expr() if x]
+                # (like "if x" in "[x for x in expr() if x]")
                 # https://github.com/PyCQA/pylint/issues/5586
                 and not (
                     isinstance(node.parent.parent, nodes.Comprehension)

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1316,6 +1316,10 @@ class VariablesChecker(BaseChecker):
             if utils.is_func_decorator(current_consumer.node) or not (
                 current_consumer.scope_type == "comprehension"
                 and self._has_homonym_in_upper_function_scope(node, consumer_level)
+                and not (
+                    isinstance(node.parent.parent, nodes.Comprehension)
+                    and node.parent in node.parent.parent.ifs
+                )
             ):
                 self._check_late_binding_closure(node)
                 self._loopvar_name(node)

--- a/tests/functional/u/use/used_before_assignment_filtered_comprehension.py
+++ b/tests/functional/u/use/used_before_assignment_filtered_comprehension.py
@@ -1,0 +1,9 @@
+"""Homonym between filtered comprehension and assignment in except block."""
+
+def func():
+    """https://github.com/PyCQA/pylint/issues/5586"""
+    try:
+        print(value for value in range(1 / 0) if isinstance(value, int))
+    except ZeroDivisionError:
+        value = 1
+        print(value)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #5586

With a small adjustment, @DanielNoord's suggestion in https://github.com/PyCQA/pylint/issues/5586#issuecomment-1010155471 passes the suite, so I just opened a PR. I'm not certain this is the best way to do this, but I tried an alternative diff in `get_next_to_consume()`, and it turned out to be more questionable.
