### PR TITLE
Update `pandas-dev` testing primer package branch to `main`

### DIFF
--- a/tests/primer/packages_to_lint_batch_two.json
+++ b/tests/primer/packages_to_lint_batch_two.json
@@ -1,6 +1,6 @@
 {
   "pandas": {
-    "branch": "master",
+    "branch": "main",
     "directories": ["pandas"],
     "pylint_additional_args": ["--ignore-patterns=\"test_"],
     "url": "https://github.com/pandas-dev/pandas.git"


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`pandas-dev` just renamed their main branch from `master` to `main` as seen [here](https://github.com/pandas-dev/pandas/pull/45336). This is one of our primer repositories so we need to update accordingly or else batch two tests fail.
