### PR TITLE
Remove ``lru_cache`` from ``get_message_definitions``

### DIFF
--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -2,7 +2,6 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import collections
-import functools
 from typing import TYPE_CHECKING, Dict, List, Tuple, ValuesView
 
 from pylint.exceptions import UnknownMessageError
@@ -47,14 +46,8 @@ class MessageDefinitionStore:
         self._messages_definitions[message.msgid] = message
         self._msgs_by_category[message.msgid[0]].append(message.msgid)
 
-    @functools.lru_cache()
     def get_message_definitions(self, msgid_or_symbol: str) -> List[MessageDefinition]:
-        """Returns the Message definition for either a numeric or symbolic id.
-
-        The cache has no limit as its size will likely stay minimal. For each message we store
-        about 1000 characters, so even if we would have 1000 messages the cache would only
-        take up ~= 1 Mb.
-        """
+        """Returns the Message definition for either a numeric or symbolic id."""
         return [
             self._messages_definitions[m]
             for m in self.message_id_store.get_active_msgids(msgid_or_symbol)


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Ref #5670, #5605 

This cache isn't actually that necessary. As long as `message_id_store.get_active_msgids` is reasonably fast (or cached) this function is also quite fast.

I tested using a similar pattern as in #5672 but actually setting values to a `dict` instance attribute and retrieving them takes longer than just doing the list comprehension for the return values of `get_active_msgids`. I think this is because if `get_active_msgids` returns just one `msgid` it's just one dict lookup whereas with a primitive cache it would be one dict lookup but also one dict assignment.
Anyway, a cache seems over engineered looking at the changes in these run times as long as `get_active_msgids` is cached.


Tested on `pylint` over `pylint`. 
With lru_cache:
```console
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
105    0.000    0.000    0.001    0.000 message_definition_store.py:50(get_message_definitions)
```

With new cache:
```console
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
5069    0.008    0.000    0.011    0.000 message_definition_store.py:51(get_message_definitions)
```

Without new cache:
```console
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
5069    0.005    0.000    0.008    0.000 message_definition_store.py:49(get_message_definitions)
```

Problem introduced in https://github.com/PyCQA/pylint/pull/5605