### PR TITLE
Fix crashes for accesses to `node.parent.name` on `FunctionDef` nodes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,12 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.13.rst'
 
+
+* Fixed crash from ``arguments-differ`` and ``arguments-renamed`` when methods were
+  defined outside the top level of a class.
+
+  Closes #5648
+
 * Added several checkers to deal with unicode security issues
   (see `Trojan Sources <https://trojansource.codes/>`_ and
   `PEP 672 <https://www.python.org/dev/peps/pep-0672/>`_ for details) that also

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -71,6 +71,11 @@ Extensions
 Other Changes
 =============
 
+* Fixed crash from ``arguments-differ`` and ``arguments-renamed`` when methods were
+  defined outside the top level of a class.
+
+  Closes #5648
+
 * Fixed false positive ``consider-using-dict-comprehension`` when creating a dict
   using a list of tuples where key AND value vary depending on the same condition.
 

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1325,7 +1325,7 @@ a metaclass class method.",
         ) and self._py38_plus:
             self.add_message(
                 "overridden-final-method",
-                args=(function_node.name, parent_function_node.parent.name),
+                args=(function_node.name, parent_function_node.parent.frame().name),
                 node=function_node,
             )
 
@@ -1997,24 +1997,24 @@ a metaclass class method.",
                     error_type = "arguments-differ"
                     msg_args = (
                         msg
-                        + f"was {total_args_refmethod} in '{refmethod.parent.name}.{refmethod.name}' and "
+                        + f"was {total_args_refmethod} in '{refmethod.parent.frame().name}.{refmethod.name}' and "
                         f"is now {total_args_method1} in",
                         class_type,
-                        f"{method1.parent.name}.{method1.name}",
+                        f"{method1.parent.frame().name}.{method1.name}",
                     )
                 elif "renamed" in msg:
                     error_type = "arguments-renamed"
                     msg_args = (
                         msg,
                         class_type,
-                        f"{method1.parent.name}.{method1.name}",
+                        f"{method1.parent.frame().name}.{method1.name}",
                     )
                 else:
                     error_type = "arguments-differ"
                     msg_args = (
                         msg,
                         class_type,
-                        f"{method1.parent.name}.{method1.name}",
+                        f"{method1.parent.frame().name}.{method1.name}",
                     )
                 self.add_message(error_type, args=msg_args, node=method1)
         elif (

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1585,7 +1585,7 @@ accessed. Python regular expressions are accepted.",
             not isinstance(itemmethod, nodes.FunctionDef)
             or itemmethod.root().name != "builtins"
             or not itemmethod.parent
-            or itemmethod.parent.name not in SEQUENCE_TYPES
+            or itemmethod.parent.frame().name not in SEQUENCE_TYPES
         ):
             return None
 

--- a/tests/functional/a/arguments_renamed.py
+++ b/tests/functional/a/arguments_renamed.py
@@ -72,3 +72,29 @@ class ChildDefaults(ParentDefaults):
 
     def test3(self, dummy_param, arg2): # no error here
         print(f"arguments: {arg2}")
+
+# Check for crash on method definitions not at top level of class
+# https://github.com/PyCQA/pylint/issues/5648
+class FruitConditional:
+
+    define_eat = True
+
+    def brew(self, fruit_name: str):
+        print(f"Brewing a fruit named {fruit_name}")
+
+    if define_eat:
+        def eat_with_condiment(self, fruit_name:str, condiment: Condiment):
+            print(f"Eating a fruit named {fruit_name} with {condiment}")
+
+class FruitOverrideConditional(FruitConditional):
+
+    fruit = "orange"
+    override_condiment = True
+
+    if fruit == "orange":
+        def brew(self, orange_name: str): # [arguments-renamed]
+            print(f"Brewing an orange named {orange_name}")
+
+        if override_condiment:
+            def eat_with_condiment(self, fruit_name: str, condiment: Condiment, error: str): # [arguments-differ]
+                print(f"Eating a fruit named {fruit_name} with {condiment}")

--- a/tests/functional/a/arguments_renamed.txt
+++ b/tests/functional/a/arguments_renamed.txt
@@ -7,3 +7,5 @@ arguments-renamed:48:4:49:22:Child2.test:Parameter 'arg' has been renamed to 'va
 arguments-differ:51:4:52:58:Child2.kwargs_test:Number of parameters was 4 in 'Parent.kwargs_test' and is now 3 in overridden 'Child2.kwargs_test' method:UNDEFINED
 arguments-renamed:51:4:52:58:Child2.kwargs_test:Parameter 'var2' has been renamed to 'kw2' in overridden 'Child2.kwargs_test' method:UNDEFINED
 arguments-renamed:67:4:68:56:ChildDefaults.test1:Parameter 'barg' has been renamed to 'param2' in overridden 'ChildDefaults.test1' method:UNDEFINED
+arguments-renamed:95:8:96:59:FruitOverrideConditional.brew:Parameter 'fruit_name' has been renamed to 'orange_name' in overridden 'FruitOverrideConditional.brew' method:UNDEFINED
+arguments-differ:99:12:100:76:FruitOverrideConditional.eat_with_condiment:Number of parameters was 3 in 'FruitConditional.eat_with_condiment' and is now 4 in overridden 'FruitOverrideConditional.eat_with_condiment' method:UNDEFINED

--- a/tests/functional/o/overridden_final_method_py38.py
+++ b/tests/functional/o/overridden_final_method_py38.py
@@ -14,3 +14,18 @@ class Base:
 class Subclass(Base):
     def my_method(self): # [overridden-final-method]
         pass
+
+# Check for crash on method definitions not at top level of class
+# https://github.com/PyCQA/pylint/issues/5648
+class BaseConditional:
+
+    create_final_method = True
+    if create_final_method:
+        @final
+        def my_method(self):
+            pass
+
+class Subclass2(BaseConditional):
+
+    def my_method(self): # [overridden-final-method]
+        pass

--- a/tests/functional/o/overridden_final_method_py38.txt
+++ b/tests/functional/o/overridden_final_method_py38.txt
@@ -1,1 +1,2 @@
 overridden-final-method:15:4:16:12:Subclass.my_method:Method 'my_method' overrides a method decorated with typing.final which is defined in class 'Base':UNDEFINED
+overridden-final-method:30:4:31:12:Subclass2.my_method:Method 'my_method' overrides a method decorated with typing.final which is defined in class 'BaseConditional':UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Fixed the reported crash and other places where the same risky pattern (unprotected `node.parent.name`) appears, one of which was in a different checker.

Closes #5648 
