### PR TITLE
Lint all files in a directory

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -516,7 +516,7 @@ class PyLinter(
                 },
             ),
             (
-                "discover-files",
+                "recursive",
                 {
                     "action": "store_true",
                     "help": ("Discover python files in file system subtree."),
@@ -1150,7 +1150,7 @@ class PyLinter(
 
     def _expand_files(self, modules) -> List[ModuleDescriptionDict]:
         """get modules and errors from a list of modules and handle errors"""
-        if self.config.discover_files:
+        if self.config.recursive:
             result, errors = discover_modules(
                 modules,
                 self.config.black_list,

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -39,7 +39,7 @@ from pylint.constants import (
     MSG_TYPES_LONG,
     MSG_TYPES_STATUS,
 )
-from pylint.lint.expand_modules import expand_modules
+from pylint.lint.expand_modules import discover_modules, expand_modules
 from pylint.lint.parallel import check_parallel
 from pylint.lint.report_functions import (
     report_messages_by_module_stats,
@@ -513,6 +513,13 @@ class PyLinter(
                         "Interpret the stdin as a python script, whose filename "
                         "needs to be passed as the module_or_package argument."
                     ),
+                },
+            ),
+            (
+                "discover-files",
+                {
+                    "action": "store_true",
+                    "help": ("Discover python files in file system subtree."),
                 },
             ),
             (
@@ -1143,12 +1150,20 @@ class PyLinter(
 
     def _expand_files(self, modules) -> List[ModuleDescriptionDict]:
         """get modules and errors from a list of modules and handle errors"""
-        result, errors = expand_modules(
-            modules,
-            self.config.black_list,
-            self.config.black_list_re,
-            self._ignore_paths,
-        )
+        if self.config.discover_files:
+            result, errors = discover_modules(
+                modules,
+                self.config.black_list,
+                self.config.black_list_re,
+                self._ignore_paths,
+            )
+        else:
+            result, errors = expand_modules(
+                modules,
+                self.config.black_list,
+                self.config.black_list_re,
+                self._ignore_paths,
+            )
         for error in errors:
             message = modname = error["mod"]
             key = error["key"]


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|     | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Description

This PR adds new parameter `--discover-files` which switches pylint into mode when it iterates over FS subtree and executes pylint on all `.py` files within this subtree regardless they are in package or not. But in the other hand this PR honours package name in the final output.

Example consider following subtree:
```
- test
     `+- a.py
      +- b.py
      +- c
          `+- __init__.py
           +- d.py 
```
The pylint output with no switch will be following:
```
$ pylint test
************* Module test
test/__init__.py:1:0: F0010: error while code parsing: Unable to load file test/__init__.py:
[Errno 2] No such file or directory: 'test/__init__.py' (parse-error)
```
The pylint output with switch will be following:
> Note: Each file contains single line simulating error `1 == 1`
```
$ pylint --discover-files test
************* Module a
test/a.py:1:0: W0104: Statement seems to have no effect (pointless-statement)
test/a.py:1:0: R0124: Redundant comparison - 1 == 1 (comparison-with-itself)
************* Module b
test/b.py:1:0: W0104: Statement seems to have no effect (pointless-statement)
test/b.py:1:0: R0124: Redundant comparison - 1 == 1 (comparison-with-itself)
************* Module c
test/c/__init__.py:1:0: W0104: Statement seems to have no effect (pointless-statement)
test/c/__init__.py:1:0: R0124: Redundant comparison - 1 == 1 (comparison-with-itself)
************* Module c.d
test/c/d.py:1:0: W0104: Statement seems to have no effect (pointless-statement)
test/c/d.py:1:0: R0124: Redundant comparison - 1 == 1 (comparison-with-itself)

------------------------------------------------------------------
Your code has been rated at 0.00/10 (previous run: 0.00/10, +0.00)
```
Closes #352
