### PR TITLE
Add typing to `ScopeConsumer`

### DIFF
--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -63,7 +63,18 @@ import re
 import sys
 from enum import Enum
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, DefaultDict, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    DefaultDict,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import astroid
 from astroid import nodes
@@ -536,9 +547,13 @@ MSGS = {
 }
 
 
-ScopeConsumer = collections.namedtuple(
-    "ScopeConsumer", "to_consume consumed consumed_uncertain scope_type"
-)
+class ScopeConsumer(NamedTuple):
+    """Store nodes and their consumption states."""
+
+    to_consume: Dict[str, List[nodes.NodeNG]]
+    consumed: Dict[str, List[nodes.NodeNG]]
+    consumed_uncertain: DefaultDict[str, List[nodes.NodeNG]]
+    scope_type: str
 
 
 class NamesConsumer:


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

A downloaded a new extension for VS Code which pointed me to:
https://github.com/PyCQA/pylint/blob/4a6b6bf33053c5887274da14e00dd22a7dcb4284/pylint/checkers/variables.py#L1229

In an attempt to fix this we'll need to do some additional typing to other methods and classes in the `variables` checker. This would be a good start.

@jacobtylerwalls Tagging you as you're clearly the expert here, but I can't request a review from you.