### PR TITLE
Fix #5683: False positive ``used-before-assignment`` in loop `else` where the only non-break exit is through `except`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -157,6 +157,13 @@ Release date: TBA
 
   Closes #5500
 
+* When evaluating statements in the ``else`` clause of a loop, ``used-before-assignment``
+  assumes that assignments in the except blocks took place if the
+  except handlers constituted the only ways for the loop to finish without
+  breaking early.
+
+  Closes #5683
+
 * ``used-before-assignment`` now checks names in try blocks.
 
 * Fixed false positive with ``used-before-assignment`` for assignment expressions

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -205,6 +205,13 @@ Other Changes
 
   Closes #5500
 
+* When evaluating statements in the ``else`` clause of a loop, ``used-before-assignment``
+  assumes that assignments in the except blocks took place if the
+  except handlers constituted the only ways for the loop to finish without
+  breaking early.
+
+  Closes #5683
+
 * ``used-before-assignment`` now checks names in try blocks.
 
 * Fixed false positive with ``used-before-assignment`` for assignment expressions

--- a/tests/functional/u/use/used_before_assignment_issue4761.py
+++ b/tests/functional/u/use/used_before_assignment_issue4761.py
@@ -10,3 +10,169 @@ def function():
         return 1
 
     return some_message
+
+
+# Cases related to a specific control flow where
+# the `else` of a loop can depend on a name only defined
+# in a single except handler because that except handler is the
+# only non-break exit branch.
+
+def valid_only_non_break_exit_from_loop_is_except_handler():
+    """https://github.com/PyCQA/pylint/issues/5683"""
+    for _ in range(3):
+        try:
+            function()  # not an exit branch because of `else` below
+        except ValueError as verr:
+            error = verr  # < exit branch where error is defined
+        else:
+            break  # < exit condition where error is *not* defined
+            # will skip else: raise error
+        print("retrying...")
+    else:
+        # This usage is valid because there is only one exit branch
+        raise error
+
+
+def invalid_no_outer_else():
+    """The reliance on the name is not guarded by else."""
+    for _ in range(3):
+        try:
+            function()
+        except ValueError as verr:
+            error = verr
+        else:
+            break
+        print("retrying...")
+    raise error  # [used-before-assignment]
+
+
+def invalid_no_outer_else_2():
+    """Same, but the raise is inside a loop."""
+    for _ in range(3):
+        try:
+            function()
+        except ValueError as verr:
+            error = verr
+        else:
+            break
+        raise error  # [used-before-assignment]
+
+
+def invalid_no_inner_else():
+    """No inner else statement."""
+    for _ in range(3):
+        try:
+            function()
+        except ValueError as verr:
+            error = verr
+        print("retrying...")
+        if function():
+            break
+    else:
+        raise error  # [used-before-assignment]
+
+
+def invalid_wrong_break_location():
+    """The break is in the wrong location."""
+    for _ in range(3):
+        try:
+            function()
+            break
+        except ValueError as verr:
+            error = verr
+            print("I give up")
+    else:
+        raise error  # [used-before-assignment]
+
+
+def invalid_no_break():
+    """No break."""
+    for _ in range(3):
+        try:
+            function()
+        except ValueError as verr:
+            error = verr
+        else:
+            pass
+    else:  # pylint: disable=useless-else-on-loop
+        raise error  # [used-before-assignment]
+
+
+def invalid_other_non_break_exit_from_loop_besides_except_handler():
+    """The continue creates another exit branch."""
+    while function():
+        if function():
+            continue
+        try:
+            pass
+        except ValueError as verr:
+            error = verr
+        else:
+            break
+    else:
+        raise error  # [used-before-assignment]
+
+
+def valid_continue_does_not_matter():
+    """This continue doesn't matter: still just one exit branch."""
+    while function():
+        try:
+            for _ in range(3):
+                if function():
+                    continue
+                print(1 / 0)
+        except ZeroDivisionError as zde:
+            error = zde
+        else:
+            break
+    else:
+        raise error
+
+
+def invalid_conditional_continue_after_break():
+    """The continue is another exit branch"""
+    while function():
+        try:
+            if function():
+                break
+            if not function():
+                continue
+        except ValueError as verr:
+            error = verr
+        else:
+            break
+    else:
+        raise error  # [used-before-assignment]
+
+
+def invalid_unrelated_loops():
+    """The loop else in question is not related to the try/except/else."""
+    for _ in range(3):
+        try:
+            function()
+        except ValueError as verr:
+            error = verr
+        else:
+            break
+    while function():
+        print('The time is:')
+        break
+    else:
+        raise error  # [used-before-assignment]
+
+
+def valid_nested_loops():
+    """The name `error` is still available in a nested else."""
+    for _ in range(3):
+        try:
+            function()
+        except ValueError as verr:
+            error = verr
+        else:
+            break
+    else:
+        while function():
+            print('The time is:')
+            break
+        else:
+            raise error

--- a/tests/functional/u/use/used_before_assignment_issue4761.txt
+++ b/tests/functional/u/use/used_before_assignment_issue4761.txt
@@ -1,1 +1,9 @@
 used-before-assignment:9:11:9:23:function:Using variable 'some_message' before assignment:CONTROL_FLOW
+used-before-assignment:46:10:46:15:invalid_no_outer_else:Using variable 'error' before assignment:CONTROL_FLOW
+used-before-assignment:58:14:58:19:invalid_no_outer_else_2:Using variable 'error' before assignment:CONTROL_FLOW
+used-before-assignment:72:14:72:19:invalid_no_inner_else:Using variable 'error' before assignment:CONTROL_FLOW
+used-before-assignment:85:14:85:19:invalid_wrong_break_location:Using variable 'error' before assignment:CONTROL_FLOW
+used-before-assignment:98:14:98:19:invalid_no_break:Using variable 'error' before assignment:CONTROL_FLOW
+used-before-assignment:113:14:113:19:invalid_other_non_break_exit_from_loop_besides_except_handler:Using variable 'error' before assignment:CONTROL_FLOW
+used-before-assignment:145:14:145:19:invalid_conditional_continue_after_break:Using variable 'error' before assignment:CONTROL_FLOW
+used-before-assignment:161:14:161:19:invalid_unrelated_loops:Using variable 'error' before assignment:CONTROL_FLOW


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description


Closes #5683
