### PR TITLE
tests_functional rc file not found overpasses default disables hotfix

### DIFF
--- a/doc/development_guide/testing.rst
+++ b/doc/development_guide/testing.rst
@@ -14,9 +14,13 @@ Pylint is very well tested and has a high code coverage. New contributions are n
 unless they include tests.
 
 Before you start testing your code, you need to install your source-code package locally.
-The best way to do so is running this terminal command:
+There are 2 ways we recommend to do so and you can do it in either way:
 
- python setup.py develop
+1. inside your forked repository run:
+      python setup.py develop
+
+2. outside your forked repository run:
+      pip install -e <forked_repo_dir_name>
 
 This ensures your testing environment is similar to Pylint's testing environment on GitHub.
 

--- a/doc/development_guide/testing.rst
+++ b/doc/development_guide/testing.rst
@@ -14,12 +14,8 @@ Pylint is very well tested and has a high code coverage. New contributions are n
 unless they include tests.
 
 Before you start testing your code, you need to install your source-code package locally.
-There are 2 ways we recommend to do so and you can do it in either way:
+To set up your environment for testing, open a terminal outside of your forked repository and run:
 
-1. inside your forked repository run:
-      python setup.py develop
-
-2. outside your forked repository run:
       pip install -e <forked_repo_dir_name>
 
 This ensures your testing environment is similar to Pylint's testing environment on GitHub.

--- a/doc/development_guide/testing.rst
+++ b/doc/development_guide/testing.rst
@@ -12,6 +12,14 @@ Test your code!
 
 Pylint is very well tested and has a high code coverage. New contributions are not accepted
 unless they include tests.
+
+Before you start testing your code, you need to install your source-code package locally.
+The best way to do so is running this terminal command:
+
+ python setup.py develop
+
+This ensures your testing environment is similar to Pylint's testing environment on GitHub.
+
 Pylint uses two types of tests: unittests and functional tests.
 
   - The unittests can be found in the ``/pylint/test`` directory and they can

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -47,12 +47,11 @@ class LintModuleTest:
         rc_file: Union[Path, str] = PYLINTRC
         try:
             rc_file = test_file.option_file
-        except NoFileError:
-            pass
-        finally:
             self._linter.disable("suppressed-message")
             self._linter.disable("locally-disabled")
             self._linter.disable("useless-suppression")
+        except NoFileError:
+            pass
 
         try:
             args = [test_file.source]

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -47,11 +47,12 @@ class LintModuleTest:
         rc_file: Union[Path, str] = PYLINTRC
         try:
             rc_file = test_file.option_file
+        except NoFileError:
+            pass
+        finally:
             self._linter.disable("suppressed-message")
             self._linter.disable("locally-disabled")
             self._linter.disable("useless-suppression")
-        except NoFileError:
-            pass
 
         try:
             args = [test_file.source]


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|  | :sparkles: New feature |
|  | :hammer: Refactoring   |
| ✓ | :scroll: Docs          |

## Description
When running `tests_functional` and there is no `.rc` file, the 3 default messages disables do not apply [`suppressed-message`, `locally-disabled`, `useless-suppression`].

Problematic code block of `pylint/testutils/lint_module_test.py`:

```
rc_file: Union[Path, str] = PYLINTRC
        try:
            rc_file = test_file.option_file
            self._linter.disable("suppressed-message")
            self._linter.disable("locally-disabled")
            self._linter.disable("useless-suppression")
        except NoFileError:
            pass
```

Suggested fix after discussion in [this comment](https://github.com/PyCQA/pylint/pull/5628#discussion_r785347490)

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #XXX