### PR TITLE
Fix #5568: Allow nested classes as return annotations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -74,6 +74,11 @@ Release date: TBA
 
   Closes #5569
 
+* Fix false positive for ``undefined-variable`` when ``namedtuple`` class
+  attributes are used as return annotations.
+
+  Closes #5568
+
 * Pyreverse - add output in mermaidjs format
 
 * ``used-before-assignment`` now considers that assignments in a try block

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -139,6 +139,11 @@ Other Changes
 
   Closes #5323
 
+* Fix false positive for ``undefined-variable`` when ``namedtuple`` class
+  attributes are used as return annotations.
+
+  Closes #5568
+
 * ``used-before-assignment`` now considers that assignments in a try block
   may not have occurred when the except or finally blocks are executed.
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1781,20 +1781,18 @@ class VariablesChecker(BaseChecker):
             frame, nodes.FunctionDef
         ):
             # Special rule for function return annotations,
-            # which uses the same name as the class where
-            # the function lives.
+            # using a name defined earlier in the class containing the function.
             if node is frame.returns and defframe.parent_of(frame.returns):
-                maybe_before_assign = annotation_return = True
-
-            if (
-                maybe_before_assign
-                and defframe.name in defframe.locals
-                and defframe.locals[node.name][0].lineno < frame.lineno
-            ):
-                # Detect class assignments with the same
-                # name as the class. In this case, no warning
-                # should be raised.
-                maybe_before_assign = False
+                annotation_return = True
+                if (
+                    frame.returns.name in defframe.locals
+                    and defframe.locals[node.name][0].lineno < frame.lineno
+                ):
+                    # Detect class assignments with a name defined earlier in the
+                    # class. In this case, no warning should be raised.
+                    maybe_before_assign = False
+                else:
+                    maybe_before_assign = True
             if isinstance(node.parent, nodes.Arguments):
                 maybe_before_assign = stmt.fromlineno <= defstmt.fromlineno
         elif is_recursive_klass:

--- a/tests/functional/u/undefined/undefined_variable.py
+++ b/tests/functional/u/undefined/undefined_variable.py
@@ -429,7 +429,7 @@ def typing_and_value_assignment_with_tuple_assignment():
 
 def nested_class_as_return_annotation():
     """A namedtuple as a class attribute is used as a return annotation
-    
+
     Taken from https://github.com/PyCQA/pylint/issues/5568"""
     from collections import namedtuple
 

--- a/tests/functional/u/undefined/undefined_variable.py
+++ b/tests/functional/u/undefined/undefined_variable.py
@@ -428,7 +428,9 @@ def typing_and_value_assignment_with_tuple_assignment():
 
 
 def nested_class_as_return_annotation():
-    """A namedtuple as a class attribute is used as a return annotation"""
+    """A namedtuple as a class attribute is used as a return annotation
+    
+    Taken from https://github.com/PyCQA/pylint/issues/5568"""
     from collections import namedtuple
 
     class MyObject:

--- a/tests/functional/u/undefined/undefined_variable.py
+++ b/tests/functional/u/undefined/undefined_variable.py
@@ -425,3 +425,16 @@ def typing_and_value_assignment_with_tuple_assignment():
     var_one, var_two = 1, 1
     print(var_one)
     print(var_two)
+
+
+def nested_class_as_return_annotation():
+    """A namedtuple as a class attribute is used as a return annotation"""
+    from collections import namedtuple
+
+    class MyObject:
+        Coords = namedtuple('Point', ['x', 'y'])
+
+        def my_method(self) -> Coords:
+            pass
+
+    print(MyObject)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The `undefined-variable` checker had a special case for return annotations matching the name of the containing class, but this missed other nested classes like a `namedtuple` used as a class attribute.

Closes #5568
