### PR TITLE
Allow dev version of next minor ``astroid`` version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,10 @@ packages = find:
 install_requires =
     dill>=0.2
     platformdirs>=2.2.0
-    astroid>=2.9.2,<2.10 # (You should also upgrade requirements_test_min.txt)
+    # Also upgrade requirements_test_min.txt if you are bumping astroid.
+    # Pinned to dev of next minor update to allow editable installs,
+    # see https://github.com/PyCQA/astroid/issues/1341
+    astroid>=2.9.2,<=2.10.0-dev0
     isort>=4.2.5,<6
     mccabe>=0.6,<0.7
     toml>=0.9.2


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description

Closes https://github.com/PyCQA/astroid/issues/1341.

See discussion there as well. This allows installing an editable local installation of `astroid` without `pylint` throwing errors about unmatched versions.