### PR TITLE
``unused-variable`` when `nonlocal` name in a multiple-assignment

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -48,7 +48,7 @@ Release date: TBA
 
 * Fixed false positive for ``unused-variable`` when a ``nonlocal`` name is assigned as part of a multi-name assignment.
 
-  Cloases #3781
+  Closes #3781
 
 * Added ``lru-cache-decorating-method`` checker with checks for the use of ``functools.lru_cache``
   on class methods. This is unrecommended as it creates memory leaks by never letting the instance

--- a/ChangeLog
+++ b/ChangeLog
@@ -46,6 +46,10 @@ Release date: TBA
 
   Closes #3088
 
+* Fixed false positive for ``unused-variable`` when a `nonlocal` name is assigned as part of a multi-name assignment.
+
+  Cloases #3781
+
 * Added ``lru-cache-decorating-method`` checker with checks for the use of ``functools.lru_cache``
   on class methods. This is unrecommended as it creates memory leaks by never letting the instance
   getting garbage collected.

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -275,6 +275,10 @@ Other Changes
 
   Closes #4955
 
+* Fixed false positive for ``unused-variable`` when a `nonlocal` name is assigned as part of a multi-name assignment.
+
+  Closes #3781
+
 * Fixed false positive for ``global-variable-not-assigned`` when the ``del`` statement is used
 
   Closes #5333

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2136,7 +2136,9 @@ class VariablesChecker(BaseChecker):
         if name in argnames:
             self._check_unused_arguments(name, node, stmt, argnames)
         else:
-            if stmt.parent and isinstance(stmt.parent, (nodes.Assign, nodes.AnnAssign)):
+            if stmt.parent and isinstance(
+                stmt.parent, (nodes.Assign, nodes.AnnAssign, nodes.Tuple)
+            ):
                 if name in nonlocal_names:
                     return
 

--- a/tests/functional/n/nonlocal_without_binding.py
+++ b/tests/functional/n/nonlocal_without_binding.py
@@ -44,13 +44,13 @@ def func2():
 
 def function():
     """Test for `unused-variable` when multiple-assignment contains a `nonlocal`"""
-    a, b = 0, []
+    myint, mylist = 0, []
 
-    print(b)
+    print(mylist)
 
     def inner():
-        nonlocal a
-        b.append(a)
-        a += 1
+        nonlocal myint
+        mylist.append(myint)
+        myint += 1
 
     return inner()

--- a/tests/functional/n/nonlocal_without_binding.py
+++ b/tests/functional/n/nonlocal_without_binding.py
@@ -40,3 +40,17 @@ def func2():
         local = 1
 
     return local + nonlocal_
+
+
+def function():
+    """Test for `unused-variable` when multiple-assignment contains a `nonlocal`"""
+    a, b = 0, []
+
+    print(b)
+
+    def inner():
+        nonlocal a
+        b.append(a)
+        a += 1
+
+    return inner()

--- a/tests/functional/u/undefined/undefined_variable.py
+++ b/tests/functional/u/undefined/undefined_variable.py
@@ -440,3 +440,16 @@ def nested_class_as_return_annotation():
             pass
 
     print(MyObject)
+
+
+def function():
+    a, b = 0, []
+
+    print(b)
+
+    def inner():
+        nonlocal a
+        b.append(a)
+        a += 1
+
+    return inner()

--- a/tests/functional/u/undefined/undefined_variable.py
+++ b/tests/functional/u/undefined/undefined_variable.py
@@ -440,16 +440,3 @@ def nested_class_as_return_annotation():
             pass
 
     print(MyObject)
-
-
-def function():
-    a, b = 0, []
-
-    print(b)
-
-    def inner():
-        nonlocal a
-        b.append(a)
-        a += 1
-
-    return inner()


### PR DESCRIPTION
The `nodes.Tuple` type is currently not considered in the logic to determine if the name is a member of the nonlocal set;
With this merge-request, if the parent of the name which is assigned is of type `nodes.Tuple` (as is the case with tuple-unpacking) then a `return` is reached which prevents emitting the warning message.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #3781
