### PR TITLE
Fix #5654: Fix false negative for `undefined-variable` for unused type annotation after the same name appears multiple times in a comprehension

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -175,6 +175,11 @@ Release date: TBA
 
   Closes #5326
 
+* Fix false negative for ``undefined-variable`` for a variable used multiple times
+  in a comprehension matching an unused outer scope type annotation.
+
+  Closes #5654
+
 * Some files in ``pylint.testutils`` were deprecated. In the future imports should be done from the
   ``pylint.testutils.functional`` namespace directly.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -210,6 +210,11 @@ Other Changes
 
   Closes #5326
 
+* Fix false negative for ``undefined-variable`` for a variable used multiple times
+  in a comprehension matching an unused outer scope type annotation.
+
+  Closes #5654
+
 * Require Python ``3.6.2`` to run pylint.
 
   Closes #5065

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1393,7 +1393,7 @@ class VariablesChecker(BaseChecker):
                         and node.parent in node.parent.parent.ifs
                     )
                     # Or homonyms against values to keyword arguments
-                    # (like "var" in [func(arg=var) for var in expr()])
+                    # (like "var" in "[func(arg=var) for var in expr()]")
                     or (
                         isinstance(node.scope(), nodes.ComprehensionScope)
                         and isinstance(node.parent, (nodes.Call, nodes.Keyword))

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1388,8 +1388,16 @@ class VariablesChecker(BaseChecker):
                 # (like "if x" in "[x for x in expr() if x]")
                 # https://github.com/PyCQA/pylint/issues/5586
                 and not (
-                    isinstance(node.parent.parent, nodes.Comprehension)
-                    and node.parent in node.parent.parent.ifs
+                    (
+                        isinstance(node.parent.parent, nodes.Comprehension)
+                        and node.parent in node.parent.parent.ifs
+                    )
+                    # Or homonyms against values to keyword arguments
+                    # (like "var" in [func(arg=var) for var in expr()])
+                    or (
+                        isinstance(node.scope(), nodes.ComprehensionScope)
+                        and isinstance(node.parent, (nodes.Call, nodes.Keyword))
+                    )
                 )
             ):
                 self._check_late_binding_closure(node)

--- a/tests/functional/u/undefined/undefined_variable_py38.py
+++ b/tests/functional/u/undefined/undefined_variable_py38.py
@@ -128,6 +128,7 @@ def type_annotation_unused_after_comprehension():
 
 
 def type_annotation_used_improperly_after_comprehension():
+    # TO-DO follow up in https://github.com/PyCQA/pylint/issues/5713
     """https://github.com/PyCQA/pylint/issues/5654"""
     my_int: int
     _ = [print(sep=my_int, end=my_int) for my_int in range(10)]

--- a/tests/functional/u/undefined/undefined_variable_py38.py
+++ b/tests/functional/u/undefined/undefined_variable_py38.py
@@ -123,5 +123,19 @@ def type_annotation_used_after_comprehension():
 
 def type_annotation_unused_after_comprehension():
     """https://github.com/PyCQA/pylint/issues/5326"""
+    my_int: int  # [unused-variable]
+    _ = [print(sep=my_int, end=my_int) for my_int in range(10)]
+
+
+def type_annotation_used_improperly_after_comprehension():
+    """https://github.com/PyCQA/pylint/issues/5654"""
     my_int: int
-    _ = [print(kwarg1=my_int, kwarg2=my_int) for my_int in range(10)]
+    _ = [print(sep=my_int, end=my_int) for my_int in range(10)]
+    print(my_int)  # [undefined-variable]
+
+
+def type_annotation_used_improperly_after_comprehension_2():
+    """Same case as above but with positional arguments"""
+    my_int: int
+    _ = [print(my_int, my_int) for my_int in range(10)]
+    print(my_int)  # [undefined-variable]

--- a/tests/functional/u/undefined/undefined_variable_py38.txt
+++ b/tests/functional/u/undefined/undefined_variable_py38.txt
@@ -3,5 +3,5 @@ undefined-variable:50:6:50:22::Undefined variable 'again_no_default':UNDEFINED
 undefined-variable:76:6:76:19::Undefined variable 'else_assign_1':UNDEFINED
 undefined-variable:99:6:99:19::Undefined variable 'else_assign_2':UNDEFINED
 unused-variable:126:4:126:10:type_annotation_unused_after_comprehension:Unused variable 'my_int':UNDEFINED
-undefined-variable:134:10:134:16:type_annotation_used_improperly_after_comprehension:Undefined variable 'my_int':UNDEFINED
-undefined-variable:141:10:141:16:type_annotation_used_improperly_after_comprehension_2:Undefined variable 'my_int':UNDEFINED
+undefined-variable:135:10:135:16:type_annotation_used_improperly_after_comprehension:Undefined variable 'my_int':UNDEFINED
+undefined-variable:142:10:142:16:type_annotation_used_improperly_after_comprehension_2:Undefined variable 'my_int':UNDEFINED

--- a/tests/functional/u/undefined/undefined_variable_py38.txt
+++ b/tests/functional/u/undefined/undefined_variable_py38.txt
@@ -2,3 +2,6 @@ undefined-variable:42:6:42:16::Undefined variable 'no_default':UNDEFINED
 undefined-variable:50:6:50:22::Undefined variable 'again_no_default':UNDEFINED
 undefined-variable:76:6:76:19::Undefined variable 'else_assign_1':UNDEFINED
 undefined-variable:99:6:99:19::Undefined variable 'else_assign_2':UNDEFINED
+unused-variable:126:4:126:10:type_annotation_unused_after_comprehension:Unused variable 'my_int':UNDEFINED
+undefined-variable:134:10:134:16:type_annotation_used_improperly_after_comprehension:Undefined variable 'my_int':UNDEFINED
+undefined-variable:141:10:141:16:type_annotation_used_improperly_after_comprehension_2:Undefined variable 'my_int':UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Closes #5654

Added another exception to the "return early if a name already consumed is encountered again" logic, again having to do with comprehensions. This is getting special-case heavy, so comprehension handling might need to be factored differently going forward, but the challenge was not breaking the `unused-argument` warning raised here: https://github.com/PyCQA/pylint/blob/7611ec443509888b96087d1519be9d73cf3b4c79/tests/functional/u/unused/unused_argument.py#L43-L48
