### PR TITLE
Fix test conflicts

### DIFF
--- a/tests/functional/u/undefined/undefined_variable_py38.py
+++ b/tests/functional/u/undefined/undefined_variable_py38.py
@@ -132,11 +132,11 @@ def type_annotation_used_improperly_after_comprehension():
     """https://github.com/PyCQA/pylint/issues/5654"""
     my_int: int
     _ = [print(sep=my_int, end=my_int) for my_int in range(10)]
-    print(my_int)  # [undefined-variable]
+    print(my_int)  # [used-before-assignment]
 
 
 def type_annotation_used_improperly_after_comprehension_2():
     """Same case as above but with positional arguments"""
     my_int: int
     _ = [print(my_int, my_int) for my_int in range(10)]
-    print(my_int)  # [undefined-variable]
+    print(my_int)  # [used-before-assignment]

--- a/tests/functional/u/undefined/undefined_variable_py38.txt
+++ b/tests/functional/u/undefined/undefined_variable_py38.txt
@@ -3,5 +3,5 @@ undefined-variable:50:6:50:22::Undefined variable 'again_no_default':UNDEFINED
 undefined-variable:76:6:76:19::Undefined variable 'else_assign_1':UNDEFINED
 undefined-variable:99:6:99:19::Undefined variable 'else_assign_2':UNDEFINED
 unused-variable:126:4:126:10:type_annotation_unused_after_comprehension:Unused variable 'my_int':UNDEFINED
-undefined-variable:135:10:135:16:type_annotation_used_improperly_after_comprehension:Undefined variable 'my_int':UNDEFINED
-undefined-variable:142:10:142:16:type_annotation_used_improperly_after_comprehension_2:Undefined variable 'my_int':UNDEFINED
+used-before-assignment:135:10:135:16:type_annotation_used_improperly_after_comprehension:Using variable 'my_int' before assignment:HIGH
+used-before-assignment:142:10:142:16:type_annotation_used_improperly_after_comprehension_2:Using variable 'my_int' before assignment:HIGH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

After f85fb8d975d17f411e5f91ed2d5f21ba999e121e, certain unused type annotations raise `used-before-assignment` rather than `undefined-variable`. The subsequent commit 0fb6a120c6f0fbc94e305542fe29e790274be096 was drafted before the prior change was made, and it addressed a related false negative, so this commit just applies the intended change of message type.

Sorry for not pointing this out during review; I was figuring I would have a short interval to fix this when one of them got merged!