### PR TITLE
Fix #5399: Fix false negatives for further variable messages for invalid type annotations or default arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -87,6 +87,12 @@ Release date: TBA
 
   Closes #5568
 
+* Fix false negative for ``undefined-variable`` and related variable messages
+  when the same undefined variable is used as a type annotation and is
+  accessed multiple times, or is used as a default argument to a function.
+
+  Closes #5399
+
 * Pyreverse - add output in mermaidjs format
 
 * Emit ``used-before-assignment`` instead of ``undefined-variable`` when attempting

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -124,6 +124,12 @@ Other Changes
   Closes #4798
   Closes #5081
 
+* Fix false negative for ``undefined-variable`` and related variable messages
+  when the same undefined variable is used as a type annotation and is
+  accessed multiple times, or is used as a default argument to a function.
+
+  Closes #5399
+
 * Emit ``used-before-assignment`` instead of ``undefined-variable`` when attempting
   to access unused type annotations.
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1532,6 +1532,8 @@ class VariablesChecker(BaseChecker):
                         )
                         and node.name in node.root().locals
                     ):
+                        if defined_by_stmt:
+                            current_consumer.mark_as_consumed(node.name, [node])
                         return (VariableVisitConsumerAction.CONTINUE, None)
 
             elif base_scope_type != "lambda":

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -170,7 +170,7 @@ TYPING_NAMES = frozenset(
 
 
 class VariableVisitConsumerAction(Enum):
-    """Used after _visit_consumer to determine the action to be taken
+    """Used after _check_consumer to determine the action to be taken
 
     Continue -> continue loop to next consumer
     Return -> return and thereby break the loop
@@ -180,6 +180,18 @@ class VariableVisitConsumerAction(Enum):
     CONTINUE = 0
     RETURN = 1
     CONSUME = 2
+
+
+VariableVisitConsumerActionAndOptionalNodesType = Union[
+    Tuple[
+        Union[
+            Literal[VariableVisitConsumerAction.CONTINUE],
+            Literal[VariableVisitConsumerAction.RETURN],
+        ],
+        None,
+    ],
+    Tuple[Literal[VariableVisitConsumerAction.CONSUME], List[nodes.NodeNG]],
+]
 
 
 def _is_from_future_import(stmt, name):
@@ -1371,16 +1383,7 @@ class VariablesChecker(BaseChecker):
         current_consumer: NamesConsumer,
         consumer_level: int,
         base_scope_type: Any,
-    ) -> Union[
-        Tuple[
-            Union[
-                Literal[VariableVisitConsumerAction.CONTINUE],
-                Literal[VariableVisitConsumerAction.RETURN],
-            ],
-            None,
-        ],
-        Tuple[Literal[VariableVisitConsumerAction.CONSUME], List[nodes.NodeNG]],
-    ]:
+    ) -> VariableVisitConsumerActionAndOptionalNodesType:
         """Checks a consumer for conditions that should trigger messages"""
         # If the name has already been consumed, only check it's not a loop
         # variable used outside the loop.
@@ -1580,11 +1583,7 @@ class VariablesChecker(BaseChecker):
             return (VariableVisitConsumerAction.CONSUME, found_nodes)
 
         elif isinstance(defstmt, nodes.ClassDef):
-            is_first_level_ref = self._is_first_level_self_reference(node, defstmt)
-            if is_first_level_ref == 2:
-                return (VariableVisitConsumerAction.CONTINUE, None)
-            if is_first_level_ref:
-                return (VariableVisitConsumerAction.RETURN, None)
+            return self._is_first_level_self_reference(node, defstmt, found_nodes)
 
         elif isinstance(defnode, nodes.NamedExpr):
             if isinstance(defnode.parent, nodes.IfExp):
@@ -1977,15 +1976,10 @@ class VariablesChecker(BaseChecker):
 
     @staticmethod
     def _is_first_level_self_reference(
-        node: nodes.Name, defstmt: nodes.ClassDef
-    ) -> Literal[0, 1, 2]:
+        node: nodes.Name, defstmt: nodes.ClassDef, found_nodes: List[nodes.NodeNG]
+    ) -> VariableVisitConsumerActionAndOptionalNodesType:
         """Check if a first level method's annotation or default values
-        refers to its own class.
-
-        Return values correspond to:
-            0 = Continue and consume names
-            1 = Break
-            2 = Continue without consuming names
+        refers to its own class, and return a consumer action
         """
         if node.frame(future=True).parent == defstmt and node.statement(
             future=True
@@ -1994,14 +1988,14 @@ class VariablesChecker(BaseChecker):
             # Break if postponed evaluation is enabled
             if utils.is_node_in_type_annotation_context(node):
                 if not utils.is_postponed_evaluation_enabled(node):
-                    return 2
-                return 1
+                    return (VariableVisitConsumerAction.CONTINUE, None)
+                return (VariableVisitConsumerAction.RETURN, None)
             # Check if used as default value by calling the class
             if isinstance(node.parent, nodes.Call) and isinstance(
                 node.parent.parent, nodes.Arguments
             ):
-                return 2
-        return 0
+                return (VariableVisitConsumerAction.CONTINUE, None)
+        return (VariableVisitConsumerAction.CONSUME, found_nodes)
 
     @staticmethod
     def _is_never_evaluated(

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -170,7 +170,8 @@ TYPING_NAMES = frozenset(
 
 
 class VariableVisitConsumerAction(Enum):
-    """Used after _check_consumer to determine the action to be taken
+    """Reported by _check_consumer() and its sub-methods to determine the
+    subsequent action to take in _undefined_and_used_before_checker().
 
     Continue -> continue loop to next consumer
     Return -> return and thereby break the loop

--- a/tests/functional/u/undefined/undefined_variable.py
+++ b/tests/functional/u/undefined/undefined_variable.py
@@ -28,8 +28,8 @@ def bad_default(var, default=unknown2):  # [undefined-variable]
     """function with default arg's value set to an nonexistent name"""
     print(var, default)
     print(xxxx)  # [undefined-variable]
-    augvar += 1  # [undefined-variable]
-    del vardel  # [undefined-variable]
+    augvar += 1  # [undefined-variable, unused-variable]
+    del vardel  # [undefined-variable, unused-variable]
 
 LMBD = lambda x, y=doesnotexist: x+y  # [undefined-variable]
 LMBD2 = lambda x, y: x+z  # [undefined-variable]
@@ -133,7 +133,7 @@ class Ancestor1(object):
     """ No op """
 
 NANA = BAT # [undefined-variable]
-del BAT
+del BAT  # [undefined-variable]
 
 
 class KeywordArgument(object):
@@ -356,3 +356,12 @@ GLOBAL_VAR_TWO = 2
 
 GLOBAL_VAR: int
 GLOBAL_VAR_TWO: int
+
+
+class RepeatedReturnAnnotations:
+    def x(self, o: RepeatedReturnAnnotations) -> bool:  # [undefined-variable]
+        pass
+    def y(self) -> RepeatedReturnAnnotations:  # [undefined-variable]
+        pass
+    def z(self) -> RepeatedReturnAnnotations:  # [undefined-variable]
+        pass

--- a/tests/functional/u/undefined/undefined_variable.py
+++ b/tests/functional/u/undefined/undefined_variable.py
@@ -28,8 +28,8 @@ def bad_default(var, default=unknown2):  # [undefined-variable]
     """function with default arg's value set to an nonexistent name"""
     print(var, default)
     print(xxxx)  # [undefined-variable]
-    augvar += 1  # [undefined-variable, unused-variable]
-    del vardel  # [undefined-variable, unused-variable]
+    augvar += 1  # [undefined-variable]
+    del vardel  # [undefined-variable]
 
 LMBD = lambda x, y=doesnotexist: x+y  # [undefined-variable]
 LMBD2 = lambda x, y: x+z  # [undefined-variable]

--- a/tests/functional/u/undefined/undefined_variable.txt
+++ b/tests/functional/u/undefined/undefined_variable.txt
@@ -5,7 +5,9 @@ undefined-variable:23:8:23:20::Undefined variable '__revision__':UNDEFINED
 undefined-variable:27:29:27:37:bad_default:Undefined variable 'unknown2':UNDEFINED
 undefined-variable:30:10:30:14:bad_default:Undefined variable 'xxxx':UNDEFINED
 undefined-variable:31:4:31:10:bad_default:Undefined variable 'augvar':UNDEFINED
+unused-variable:31:4:31:10:bad_default:Unused variable 'augvar':UNDEFINED
 undefined-variable:32:8:32:14:bad_default:Undefined variable 'vardel':UNDEFINED
+unused-variable:32:8:32:14:bad_default:Unused variable 'vardel':UNDEFINED
 undefined-variable:34:19:34:31:<lambda>:Undefined variable 'doesnotexist':UNDEFINED
 undefined-variable:35:23:35:24:<lambda>:Undefined variable 'z':UNDEFINED
 used-before-assignment:38:4:38:9::Using variable 'POUET' before assignment:CONTROL_FLOW
@@ -19,6 +21,7 @@ used-before-assignment:98:26:98:35:TestClass.MissingAncestor:Using variable 'Anc
 used-before-assignment:105:36:105:41:TestClass.test1.UsingBeforeDefinition:Using variable 'Empty' before assignment:HIGH
 undefined-variable:119:10:119:14:Self:Undefined variable 'Self':UNDEFINED
 undefined-variable:135:7:135:10::Undefined variable 'BAT':UNDEFINED
+undefined-variable:136:4:136:7::Undefined variable 'BAT':UNDEFINED
 used-before-assignment:146:31:146:38:KeywordArgument.test1:Using variable 'enabled' before assignment:HIGH
 undefined-variable:149:32:149:40:KeywordArgument.test2:Undefined variable 'disabled':UNDEFINED
 undefined-variable:154:22:154:25:KeywordArgument.<lambda>:Undefined variable 'arg':UNDEFINED
@@ -33,3 +36,6 @@ used-before-assignment:294:7:294:8:undefined_annotation:Using variable 'x' befor
 undefined-variable:324:11:324:12:decorated3:Undefined variable 'x':UNDEFINED
 undefined-variable:329:19:329:20:decorated4:Undefined variable 'y':UNDEFINED
 undefined-variable:350:10:350:20:global_var_mixed_assignment:Undefined variable 'GLOBAL_VAR':HIGH
+undefined-variable:362:19:362:44:RepeatedReturnAnnotations.x:Undefined variable 'RepeatedReturnAnnotations':UNDEFINED
+undefined-variable:364:19:364:44:RepeatedReturnAnnotations.y:Undefined variable 'RepeatedReturnAnnotations':UNDEFINED
+undefined-variable:366:19:366:44:RepeatedReturnAnnotations.z:Undefined variable 'RepeatedReturnAnnotations':UNDEFINED

--- a/tests/functional/u/undefined/undefined_variable.txt
+++ b/tests/functional/u/undefined/undefined_variable.txt
@@ -5,9 +5,7 @@ undefined-variable:23:8:23:20::Undefined variable '__revision__':UNDEFINED
 undefined-variable:27:29:27:37:bad_default:Undefined variable 'unknown2':UNDEFINED
 undefined-variable:30:10:30:14:bad_default:Undefined variable 'xxxx':UNDEFINED
 undefined-variable:31:4:31:10:bad_default:Undefined variable 'augvar':UNDEFINED
-unused-variable:31:4:31:10:bad_default:Unused variable 'augvar':UNDEFINED
 undefined-variable:32:8:32:14:bad_default:Undefined variable 'vardel':UNDEFINED
-unused-variable:32:8:32:14:bad_default:Unused variable 'vardel':UNDEFINED
 undefined-variable:34:19:34:31:<lambda>:Undefined variable 'doesnotexist':UNDEFINED
 undefined-variable:35:23:35:24:<lambda>:Undefined variable 'z':UNDEFINED
 used-before-assignment:38:4:38:9::Using variable 'POUET' before assignment:CONTROL_FLOW

--- a/tests/functional/u/use/used_before_assignment_py37.py
+++ b/tests/functional/u/use/used_before_assignment_py37.py
@@ -14,7 +14,7 @@ class MyClass:
         return self == other[0]
 
     def incorrect_default_method(
-        self, other=MyClass() # [used-before-assignment]
+        self, other=MyClass() # [undefined-variable]
     ) -> bool:
         return self == other
 

--- a/tests/functional/u/use/used_before_assignment_py37.txt
+++ b/tests/functional/u/use/used_before_assignment_py37.txt
@@ -1,1 +1,1 @@
-used-before-assignment:17:20:17:27:MyClass.incorrect_default_method:Using variable 'MyClass' before assignment:HIGH
+undefined-variable:17:20:17:27:MyClass.incorrect_default_method:Undefined variable 'MyClass':UNDEFINED

--- a/tests/functional/u/use/used_before_assignment_typing.py
+++ b/tests/functional/u/use/used_before_assignment_typing.py
@@ -9,17 +9,17 @@ class MyClass:
     """Type annotation or default values for first level methods can't refer to their own class"""
 
     def incorrect_typing_method(
-        self, other: MyClass  # [used-before-assignment]
+        self, other: MyClass  # [undefined-variable]
     ) -> bool:
         return self == other
 
     def incorrect_nested_typing_method(
-        self, other: List[MyClass]  # [used-before-assignment]
+        self, other: List[MyClass]  # [undefined-variable]
     ) -> bool:
         return self == other[0]
 
     def incorrect_default_method(
-        self, other=MyClass()  # [used-before-assignment]
+        self, other=MyClass()  # [undefined-variable]
     ) -> bool:
         return self == other
 

--- a/tests/functional/u/use/used_before_assignment_typing.txt
+++ b/tests/functional/u/use/used_before_assignment_typing.txt
@@ -1,3 +1,3 @@
-used-before-assignment:12:21:12:28:MyClass.incorrect_typing_method:Using variable 'MyClass' before assignment:HIGH
-used-before-assignment:17:26:17:33:MyClass.incorrect_nested_typing_method:Using variable 'MyClass' before assignment:HIGH
-used-before-assignment:22:20:22:27:MyClass.incorrect_default_method:Using variable 'MyClass' before assignment:HIGH
+undefined-variable:12:21:12:28:MyClass.incorrect_typing_method:Undefined variable 'MyClass':UNDEFINED
+undefined-variable:17:26:17:33:MyClass.incorrect_nested_typing_method:Undefined variable 'MyClass':UNDEFINED
+undefined-variable:22:20:22:27:MyClass.incorrect_default_method:Undefined variable 'MyClass':UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
There were two _short-circuit-and-consume-names_ paths in the variables checker preventing reporting further errors:
 - undefined variable as default function argument
 - undefined variable as type annotation

Removing some of these "special early consume" messages has the benefit that going through the regular path raises the correct flavor of `used-before-assignment` versus `undefined-variable`.

Closes #5399

***

Will need a rebase after #5709. (edit: done!)