### PR TITLE
Correct reference to `argv` in documentation for `run_pylint()`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -233,7 +233,7 @@ Release date: TBA
   Closes #5504
 
 * When invoking ``pylint``, ``epylint``, ``symilar`` or ``pyreverse`` by importing them in a python file
-  you can now pass an ``arguments`` keyword besides patching ``sys.argv``.
+  you can now pass an ``argv`` keyword besides patching ``sys.argv``.
 
   Closes #5320
 

--- a/doc/user_guide/run.rst
+++ b/doc/user_guide/run.rst
@@ -57,7 +57,7 @@ called by the command line. You can either patch ``sys.argv`` or supply argument
 
   # Or:
 
-  pylint.run_pylint(arguments=["your_file"])
+  pylint.run_pylint(argv=["your_file"])
 
 To silently run Pylint on a ``module_name.py`` module,
 and get its standard output and error:

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -282,7 +282,7 @@ Other Changes
   Closes #5557
 
 * When invoking ``pylint``, ``epylint``, ``symilar`` or ``pyreverse`` by importing them in a python file
-  you can now pass an ``arguments`` keyword besides patching ``sys.argv``.
+  you can now pass an ``argv`` keyword besides patching ``sys.argv``.
 
   Closes #5320
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

The argument `arguments` was renamed to `argv` in #5619 without updating the docs.
