### PR TITLE
Improved `bad-open-mode` message when providing `None` to the `mode` argument of an `open()` call

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -60,6 +60,11 @@ Release date: TBA
 
   Closes #5731
 
+* Improved ``bad-open-mode`` message when providing ``None`` to the ``mode``
+  argument of an ``open()`` call.
+
+  Closes #5733
+
 * Added ``lru-cache-decorating-method`` checker with checks for the use of ``functools.lru_cache``
   on class methods. This is unrecommended as it creates memory leaks by never letting the instance
   getting garbage collected.

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -166,6 +166,11 @@ Other Changes
 
   Closes #5731
 
+* Improved ``bad-open-mode`` message when providing ``None`` to the ``mode``
+  argument of an ``open()`` call.
+
+  Closes #5733
+
 * Fix false negative for ``consider-iterating-dictionary`` during membership checks encapsulated in iterables
   or ``not in`` checks
 

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -648,7 +648,11 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
             if isinstance(mode_arg, nodes.Const) and not _check_mode_str(
                 mode_arg.value
             ):
-                self.add_message("bad-open-mode", node=node, args=mode_arg.value)
+                self.add_message(
+                    "bad-open-mode",
+                    node=node,
+                    args=mode_arg.value or str(mode_arg.value),
+                )
 
     def _check_open_encoded(self, node: nodes.Call, open_module: str) -> None:
         """Check that the encoded argument of an open call is valid."""

--- a/tests/functional/u/unspecified_encoding_py38.txt
+++ b/tests/functional/u/unspecified_encoding_py38.txt
@@ -27,5 +27,5 @@ unspecified-encoding:149:0:149:23::Using open without explicitly specifying an e
 unspecified-encoding:152:0:152:28::Using open without explicitly specifying an encoding:UNDEFINED
 unspecified-encoding:155:0:155:26::Using open without explicitly specifying an encoding:UNDEFINED
 unspecified-encoding:158:0:158:35::Using open without explicitly specifying an encoding:UNDEFINED
-bad-open-mode:161:0:161:25::"""%s"" is not a valid mode for open.":UNDEFINED
+bad-open-mode:161:0:161:25::"""None"" is not a valid mode for open.":UNDEFINED
 unspecified-encoding:161:0:161:25::Using open without explicitly specifying an encoding:UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description


Closes #5733
