### PR TITLE
Fix duplicate names of ``Pylint Messages`` in docs

### DIFF
--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -122,8 +122,9 @@ def _write_messages_list_page(
         stream.write(
             f""".. _messages-list:
 
-.. NOTE: This file is auto-generated. Make any changes to the associated
-.. docs extension in '{__name__}.py'.
+..
+  NOTE: This file is auto-generated. Make any changes to the associated
+  docs extension in '{__name__}.py'.
 
 {get_rst_title("Overview of all Pylint messages", "=")}
 Pylint can emit the following messages:

--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -121,8 +121,6 @@ def _write_messages_list_page(
         # Write header of file
         stream.write(
             f""".. _messages-list:
-
-..
   NOTE: This file is auto-generated. Make any changes to the associated
   docs extension in '{__name__}.py'.
 

--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -122,11 +122,11 @@ def _write_messages_list_page(
         stream.write(
             f""".. _messages-list:
 
+{get_rst_title("Overview of all Pylint messages", "=")}
 ..
   NOTE This file is auto-generated. Make any changes to the associated
   docs extension in 'pylint_messages.py'.
 
-{get_rst_title("Overview of all Pylint messages", "=")}
 Pylint can emit the following messages:
 
 """

--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -122,6 +122,9 @@ def _write_messages_list_page(
         stream.write(
             f""".. _messages-list:
 
+.. NOTE: This file is auto-generated. Make any changes to the associated
+.. docs extension in '{__name__}.py'.
+
 {get_rst_title("Overview of all Pylint messages", "=")}
 Pylint can emit the following messages:
 

--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -121,6 +121,8 @@ def _write_messages_list_page(
         # Write header of file
         stream.write(
             f""".. _messages-list:
+
+..
   NOTE: This file is auto-generated. Make any changes to the associated
   docs extension in '{__name__}.py'.
 

--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -122,7 +122,7 @@ def _write_messages_list_page(
         stream.write(
             f""".. _messages-list:
 
-{get_rst_title("Pylint Messages", "=")}
+{get_rst_title("Overview of all Pylint messages", "=")}
 Pylint can emit the following messages:
 
 """

--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -122,10 +122,6 @@ def _write_messages_list_page(
         stream.write(
             f""".. _messages-list:
 
-..
-  NOTE: This file is auto-generated. Make any changes to the associated
-  docs extension in '{__name__}.py'.
-
 {get_rst_title("Overview of all Pylint messages", "=")}
 Pylint can emit the following messages:
 

--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -122,6 +122,10 @@ def _write_messages_list_page(
         stream.write(
             f""".. _messages-list:
 
+..
+  NOTE This file is auto-generated. Make any changes to the associated
+  docs extension in 'pylint_messages.py'.
+
 {get_rst_title("Overview of all Pylint messages", "=")}
 Pylint can emit the following messages:
 

--- a/doc/messages/messages_introduction.rst
+++ b/doc/messages/messages_introduction.rst
@@ -1,7 +1,7 @@
 .. _messages-introduction:
 
-Pylint messages
-================
+Message categories
+=====================
 
 Pylint can emit various messages. These are categorized according to categories::
 

--- a/doc/messages/messages_list.rst
+++ b/doc/messages/messages_list.rst
@@ -1,6 +1,8 @@
 .. _messages-list:
+
+..
   NOTE: This file is auto-generated. Make any changes to the associated
-  docs extension in 'pylint_messages.py'.
+  docs extension in '{__name__}.py'.
 
 Overview of all Pylint messages
 ===============================

--- a/doc/messages/messages_list.rst
+++ b/doc/messages/messages_list.rst
@@ -1,10 +1,11 @@
 .. _messages-list:
 
-.. NOTE: This file is auto-generated. Make any changes to the associated
-.. docs extension in 'pylint_messages.py'.
+..
+  NOTE: This file is auto-generated. Make any changes to the associated
+  docs extension in 'pylint_messages.py'.
 
 Overview of all Pylint messages
-=================================
+===============================
 
 Pylint can emit the following messages:
 

--- a/doc/messages/messages_list.rst
+++ b/doc/messages/messages_list.rst
@@ -1,11 +1,11 @@
 .. _messages-list:
 
+Overview of all Pylint messages
+===============================
+
 ..
   NOTE This file is auto-generated. Make any changes to the associated
   docs extension in 'pylint_messages.py'.
-
-Overview of all Pylint messages
-===============================
 
 Pylint can emit the following messages:
 

--- a/doc/messages/messages_list.rst
+++ b/doc/messages/messages_list.rst
@@ -2,7 +2,7 @@
 
 ..
   NOTE: This file is auto-generated. Make any changes to the associated
-  docs extension in '{__name__}.py'.
+  docs extension in 'pylint_messages.py'.
 
 Overview of all Pylint messages
 ===============================
@@ -58,6 +58,7 @@ All messages in the error category:
    error/bad-str-strip-call.rst
    error/bad-string-format-type.rst
    error/bad-super-call.rst
+   error/bidirectional-unicode.rst
    error/catching-non-exception.rst
    error/class-variable-slots-conflict.rst
    error/continue-in-finally.rst
@@ -74,6 +75,12 @@ All messages in the error category:
    error/invalid-all-object.rst
    error/invalid-bool-returned.rst
    error/invalid-bytes-returned.rst
+   error/invalid-character-backspace.rst
+   error/invalid-character-carriage-return.rst
+   error/invalid-character-esc.rst
+   error/invalid-character-nul.rst
+   error/invalid-character-sub.rst
+   error/invalid-character-zero-width-space.rst
    error/invalid-class-object.rst
    error/invalid-envvar-value.rst
    error/invalid-format-returned.rst
@@ -92,6 +99,7 @@ All messages in the error category:
    error/invalid-star-assignment-target.rst
    error/invalid-str-returned.rst
    error/invalid-unary-operand-type.rst
+   error/invalid-unicode-codec.rst
    error/logging-format-truncated.rst
    error/logging-too-few-args.rst
    error/logging-too-many-args.rst
@@ -102,6 +110,8 @@ All messages in the error category:
    error/missing-format-string-key.rst
    error/missing-kwoa.rst
    error/mixed-format-string.rst
+   error/modified-iterating-dict.rst
+   error/modified-iterating-set.rst
    error/no-member.rst
    error/no-method-argument.rst
    error/no-name-in-module.rst
@@ -232,6 +242,7 @@ All messages in the warning category:
    warning/logging-fstring-interpolation.rst
    warning/logging-not-lazy.rst
    warning/lost-exception.rst
+   warning/lru-cache-decorating-method.rst
    warning/misplaced-future.rst
    warning/missing-any-param-doc.rst
    warning/missing-format-argument-key.rst
@@ -244,9 +255,11 @@ All messages in the warning category:
    warning/missing-type-doc.rst
    warning/missing-yield-doc.rst
    warning/missing-yield-type-doc.rst
+   warning/modified-iterating-list.rst
    warning/multiple-constructor-doc.rst
    warning/nan-comparison.rst
    warning/no-init.rst
+   warning/non-ascii-file-name.rst
    warning/non-parent-init-called.rst
    warning/non-str-assignment-to-dunder-name.rst
    warning/overlapping-except.rst
@@ -261,6 +274,7 @@ All messages in the warning category:
    warning/redeclared-assigned-name.rst
    warning/redefined-builtin.rst
    warning/redefined-outer-name.rst
+   warning/redefined-slots-in-subclass.rst
    warning/redundant-returns-doc.rst
    warning/redundant-u-string-prefix.rst
    warning/redundant-unittest-assert.rst
@@ -278,6 +292,7 @@ All messages in the warning category:
    warning/try-except-raise.rst
    warning/unbalanced-tuple-unpacking.rst
    warning/undefined-loop-variable.rst
+   warning/unnecessary-ellipsis.rst
    warning/unnecessary-lambda.rst
    warning/unnecessary-pass.rst
    warning/unnecessary-semicolon.rst
@@ -331,6 +346,7 @@ All messages in the convention category:
 
    convention/bad-classmethod-argument.rst
    convention/bad-docstring-quotes.rst
+   convention/bad-file-encoding.rst
    convention/bad-mcs-classmethod-argument.rst
    convention/bad-mcs-method-argument.rst
    convention/compare-to-empty-string.rst
@@ -355,6 +371,7 @@ All messages in the convention category:
    convention/mixed-line-endings.rst
    convention/multiple-imports.rst
    convention/multiple-statements.rst
+   convention/non-ascii-module-import.rst
    convention/non-ascii-name.rst
    convention/single-string-used-for-slots.rst
    convention/singleton-comparison.rst
@@ -386,6 +403,7 @@ All renamed messages in the convention category:
    convention/len-as-condition.rst
    convention/missing-docstring.rst
    convention/old-misplaced-comparison-constant.rst
+   convention/old-non-ascii-name.rst
 
 
 Refactor

--- a/doc/messages/messages_list.rst
+++ b/doc/messages/messages_list.rst
@@ -1,6 +1,4 @@
 .. _messages-list:
-
-..
   NOTE: This file is auto-generated. Make any changes to the associated
   docs extension in 'pylint_messages.py'.
 

--- a/doc/messages/messages_list.rst
+++ b/doc/messages/messages_list.rst
@@ -1,7 +1,7 @@
 .. _messages-list:
 
 ..
-  NOTE: This file is auto-generated. Make any changes to the associated
+  NOTE This file is auto-generated. Make any changes to the associated
   docs extension in 'pylint_messages.py'.
 
 Overview of all Pylint messages

--- a/doc/messages/messages_list.rst
+++ b/doc/messages/messages_list.rst
@@ -1,7 +1,7 @@
 .. _messages-list:
 
-Pylint Messages
-===============
+Overview of all Pylint messages
+=================================
 
 Pylint can emit the following messages:
 

--- a/doc/messages/messages_list.rst
+++ b/doc/messages/messages_list.rst
@@ -1,7 +1,7 @@
 .. _messages-list:
 
-# NOTE: Thie file is auto-generated. Make any changes to the assosciated
-# docs extenstion.
+.. NOTE: This file is auto-generated. Make any changes to the associated
+.. docs extension in 'pylint_messages.py'.
 
 Overview of all Pylint messages
 =================================

--- a/doc/messages/messages_list.rst
+++ b/doc/messages/messages_list.rst
@@ -1,5 +1,8 @@
 .. _messages-list:
 
+# NOTE: Thie file is auto-generated. Make any changes to the assosciated
+# docs extenstion.
+
 Overview of all Pylint messages
 =================================
 

--- a/doc/release.md
+++ b/doc/release.md
@@ -6,7 +6,7 @@ So, you want to release the `X.Y.Z` version of pylint ?
 
 1. Check if the dependencies of the package are correct, make sure that astroid is
    pinned to the latest version.
-2. Install the release dependencies `pip3 install pre-commit tbump`
+2. Install the release dependencies `pip3 install pre-commit tbump tox`
 3. Bump the version by using `tbump X.Y.Z --no-tag --no-push`
 4. Check the result (Do `git diff vX.Y.Z-1 ChangeLog doc/whatsnew/` in particular).
 5. Move back to a dev version for pylint with `tbump`:

--- a/tbump.toml
+++ b/tbump.toml
@@ -29,6 +29,10 @@ name = "Upgrade changelog"
 cmd = "python3 script/bump_changelog.py {new_version}"
 
 [[before_commit]]
+name = "Upgrade and check doc"
+cmd = "tox -e docs||echo 'Hack so this command does not fail'"
+
+[[before_commit]]
 name = "Upgrade copyrights"
 cmd = "pip3 install copyrite;copyrite --contribution-threshold 1 --change-threshold 3 --backend-type git --aliases=.copyrite_aliases . --jobs=8"
 


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description

Pretty stupid to have missed this. Should be merged asap to help SEO.

Closes #5740.