### PR TITLE
Remove completed TODO

### DIFF
--- a/tests/functional/u/undefined/undefined_variable_py38.py
+++ b/tests/functional/u/undefined/undefined_variable_py38.py
@@ -14,7 +14,7 @@ def typing_and_assignment_expression():
 def typing_and_self_referencing_assignment_expression():
     """The variable gets assigned in an assignment expression that references itself"""
     var: int
-    if (var := var ** 2):  # false negative--walrus operator!
+    if (var := var ** 2):  # false negative: https://github.com/PyCQA/pylint/issues/5653
         print(var)
 
 
@@ -128,7 +128,6 @@ def type_annotation_unused_after_comprehension():
 
 
 def type_annotation_used_improperly_after_comprehension():
-    # TO-DO follow up in https://github.com/PyCQA/pylint/issues/5713
     """https://github.com/PyCQA/pylint/issues/5654"""
     my_int: int
     _ = [print(sep=my_int, end=my_int) for my_int in range(10)]

--- a/tests/functional/u/undefined/undefined_variable_py38.txt
+++ b/tests/functional/u/undefined/undefined_variable_py38.txt
@@ -3,5 +3,5 @@ undefined-variable:50:6:50:22::Undefined variable 'again_no_default':UNDEFINED
 undefined-variable:76:6:76:19::Undefined variable 'else_assign_1':INFERENCE
 undefined-variable:99:6:99:19::Undefined variable 'else_assign_2':INFERENCE
 unused-variable:126:4:126:10:type_annotation_unused_after_comprehension:Unused variable 'my_int':UNDEFINED
-used-before-assignment:135:10:135:16:type_annotation_used_improperly_after_comprehension:Using variable 'my_int' before assignment:HIGH
-used-before-assignment:142:10:142:16:type_annotation_used_improperly_after_comprehension_2:Using variable 'my_int' before assignment:HIGH
+used-before-assignment:134:10:134:16:type_annotation_used_improperly_after_comprehension:Using variable 'my_int' before assignment:HIGH
+used-before-assignment:141:10:141:16:type_annotation_used_improperly_after_comprehension_2:Using variable 'my_int' before assignment:HIGH


### PR DESCRIPTION
## Type of Changes


|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description
Removing a completed TODO.

Changing the message type occurred in 0fb6a120c6f0fbc94e305542fe29e790274be096 and updating this unit test to match took place in fa2b6ceca796311a918e28770d101b53a43f84f3. Didn't notice I could remove this TODO when fixing the conflicts (just wanted to get `main` unblocked!)