### PR TITLE
Fix false positive `used-before-assignment` for named expressions in ternary operators

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -102,6 +102,12 @@ Release date: TBA
 
   Closes #5569
 
+* Fix false positives for ``used-before-assignment`` from using named
+  expressions in a ternary operator test and using that expression as
+  a call argument.
+
+  Closes #5177, #5212
+
 * Fix false positive for ``undefined-variable`` when ``namedtuple`` class
   attributes are used as return annotations.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -154,6 +154,12 @@ Other Changes
 
   Closes #4941
 
+* Fix false positives for ``used-before-assignment`` from using named
+  expressions in a ternary operator test and using that expression as
+  a call argument.
+
+  Closes #5177, #5212
+
 * Fix ``unnecessary_dict_index_lookup`` false positive when deleting a dictionary's entry.
 
   Closes #4716

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1965,8 +1965,23 @@ class VariablesChecker(BaseChecker):
                     )
                     and (
                         isinstance(defstmt.value, nodes.IfExp)
-                        or isinstance(defstmt.value, nodes.Lambda)
-                        and isinstance(defstmt.value.body, nodes.IfExp)
+                        or (
+                            isinstance(defstmt.value, nodes.Lambda)
+                            and isinstance(defstmt.value.body, nodes.IfExp)
+                        )
+                        or (
+                            isinstance(defstmt.value, nodes.Call)
+                            and (
+                                any(
+                                    isinstance(kwarg.value, nodes.IfExp)
+                                    for kwarg in defstmt.value.keywords
+                                )
+                                or any(
+                                    isinstance(arg, nodes.IfExp)
+                                    for arg in defstmt.value.args
+                                )
+                            )
+                        )
                     )
                     and frame is defframe
                     and defframe.parent_of(node)

--- a/tests/functional/u/undefined/undefined_variable_py38.py
+++ b/tests/functional/u/undefined/undefined_variable_py38.py
@@ -140,3 +140,19 @@ def type_annotation_used_improperly_after_comprehension_2():
     my_int: int
     _ = [print(my_int, my_int) for my_int in range(10)]
     print(my_int)  # [used-before-assignment]
+
+
+# Tests for named expressions (walrus operator)
+
+# Expression in ternary operator: positional argument
+print(sep=colon if (colon := ":") else None)
+
+
+class Dummy:
+    """Expression in ternary operator: keyword argument"""
+    # pylint: disable=too-few-public-methods
+    def __init__(self, value):
+        self.value = value
+
+
+dummy = Dummy(value=val if (val := 'something') else 'anything')


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Extend an existing special case in the variables checker ("Single statement if, with assignment expression on same line as assignment") to include assignment expressions inside ternary operator tests used in calls (keyword or positional arguments).

Closes #5177 
Closes #5212
