### PR TITLE
Add timeouts for CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
   prepare-base:
     name: Prepare base dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
       pre-commit-key: ${{ steps.generate-pre-commit-key.outputs.key }}
@@ -76,6 +77,7 @@ jobs:
   formatting:
     name: checks / pre-commit
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: prepare-base
     steps:
       - name: Check out code from GitHub
@@ -118,6 +120,7 @@ jobs:
   spelling:
     name: checks / spelling
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: prepare-base
     steps:
       - name: Check out code from GitHub
@@ -148,6 +151,7 @@ jobs:
   prepare-tests-linux:
     name: tests / prepare / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
@@ -190,6 +194,7 @@ jobs:
   pytest-linux:
     name: tests / run / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: prepare-tests-linux
     strategy:
       fail-fast: false
@@ -229,6 +234,7 @@ jobs:
   coverage:
     name: tests / process / coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: ["prepare-tests-linux", "pytest-linux"]
     strategy:
       matrix:
@@ -273,6 +279,7 @@ jobs:
   benchmark-linux:
     name: tests / run benchmark / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: prepare-tests-linux
     strategy:
       fail-fast: false
@@ -324,6 +331,7 @@ jobs:
   prepare-tests-windows:
     name: tests / prepare / ${{ matrix.python-version }} / Windows
     runs-on: windows-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
@@ -366,6 +374,7 @@ jobs:
   pytest-windows:
     name: tests / run / ${{ matrix.python-version }} / Windows
     runs-on: windows-latest
+    timeout-minutes: 10
     needs: prepare-tests-windows
     strategy:
       fail-fast: false
@@ -404,6 +413,7 @@ jobs:
   prepare-tests-pypy:
     name: tests / prepare / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         python-version: ["pypy3"]
@@ -446,6 +456,7 @@ jobs:
   pytest-pypy:
     name: tests / run / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: prepare-tests-pypy
     strategy:
       fail-fast: false

--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -24,6 +24,7 @@ jobs:
   prepare-tests-linux:
     name: prepare / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         python-version: [3.8, 3.9, "3.10"]
@@ -66,6 +67,7 @@ jobs:
   pytest-primer-stdlib:
     name: run on stdlib / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: prepare-tests-linux
     strategy:
       matrix:
@@ -100,6 +102,7 @@ jobs:
   pytest-primer-external-batch-one:
     name: run on batch one / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: prepare-tests-linux
     strategy:
       matrix:
@@ -134,6 +137,7 @@ jobs:
   pytest-primer-external-batch-two:
     name: run on batch two / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: prepare-tests-linux
     strategy:
       matrix:


### PR DESCRIPTION
## Description

I recently had a job run for 6h just to fail. Usually they all complete in <10min (CI) / <30min (Primer). So anything that is taking longer than that is probably going to fail anyway.

This PR adds `timeout-minutes` to the individual jobs to abort them after a reasonable amount of time. Usually 2x what they actually need. https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

/CC: @DanielNoord Is 60min enough for Primer jobs? From what I've seen an individual one usually takes 20min.