### PR TITLE
Improve error message arguments formatting [redefined-slots]

### DIFF
--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1397,7 +1397,7 @@ a metaclass class method.",
         if redefined_slots:
             self.add_message(
                 "redefined-slots-in-subclass",
-                args=", ".join(name for name in slots_names if name in redefined_slots),
+                args=([name for name in slots_names if name in redefined_slots],),
                 node=slots_node,
             )
 

--- a/tests/functional/r/redefined_slots.txt
+++ b/tests/functional/r/redefined_slots.txt
@@ -1,2 +1,2 @@
-redefined-slots-in-subclass:15:16:15:47:Subclass1:Redefined slots 'a, deque' in subclass:UNDEFINED
-redefined-slots-in-subclass:33:16:33:61:Subclass3:Redefined slots 'a, b, i, j, k' in subclass:UNDEFINED
+redefined-slots-in-subclass:15:16:15:47:Subclass1:Redefined slots ['a', 'deque'] in subclass:UNDEFINED
+redefined-slots-in-subclass:33:16:33:61:Subclass3:Redefined slots ['a', 'b', 'i', 'j', 'k'] in subclass:UNDEFINED


### PR DESCRIPTION
## Description

Change the error message for `redefiend-slots-in-subclass` to output slot names as list instead of string. Originally added in #5640.

Noticed that while fixing one error in Home-Assistant. I did find the comma-separated string slightly confusing to read.

/CC: @mbyrnepr2