### PR TITLE
Upgrade flake8-typing-import to 1.12.0 [pre-commit]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-typing-imports==1.10.1]
+        additional_dependencies: [flake8-typing-imports==1.12.0]
         exclude: *fixtures
   - repo: local
     hooks:


### PR DESCRIPTION
## Description
Upgrade `flake8-typing-import` to `1.12.0`. It was changed in `requirements_test_pre_commit.txt` in #5562 but never updated in in `pre-commit-config.yaml`.
https://github.com/asottile/flake8-typing-imports/compare/v1.10.1...v1.12.0