### PR TITLE
Fix false negative for `used-before-assignment` when some except handlers don't define a name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -210,6 +210,12 @@ Release date: TBA
 
   Closes #5500
 
+* Fixed a false negative for ``used-before-assignment`` when some but not all
+  except handlers defined a name relied upon after an except block when the
+  corresponding try block contained a return statement.
+
+  Partially closes #5524
+
 * When evaluating statements in the ``else`` clause of a loop, ``used-before-assignment``
   assumes that assignments in the except blocks took place if the
   except handlers constituted the only ways for the loop to finish without

--- a/ChangeLog
+++ b/ChangeLog
@@ -214,7 +214,7 @@ Release date: TBA
   except handlers defined a name relied upon after an except block when the
   corresponding try block contained a return statement.
 
-  Partially closes #5524
+  Closes #5524
 
 * When evaluating statements in the ``else`` clause of a loop, ``used-before-assignment``
   assumes that assignments in the except blocks took place if the

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -251,6 +251,12 @@ Other Changes
 
   Closes #5500
 
+* Fixed a false negative for ``used-before-assignment`` when some but not all
+  except handlers defined a name relied upon after an except block when the
+  corresponding try block contained a return statement.
+
+  Partially closes #5524
+
 * When evaluating statements in the ``else`` clause of a loop, ``used-before-assignment``
   assumes that assignments in the except blocks took place if the
   except handlers constituted the only ways for the loop to finish without

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -255,7 +255,7 @@ Other Changes
   except handlers defined a name relied upon after an except block when the
   corresponding try block contained a return statement.
 
-  Partially closes #5524
+  Closes #5524
 
 * When evaluating statements in the ``else`` clause of a loop, ``used-before-assignment``
   assumes that assignments in the except blocks took place if the

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -703,17 +703,18 @@ scope_type : {self._atomic.scope_type}
         for other_node in found_nodes:
             other_node_statement = other_node.statement(future=True)
             # Only testing for statements in the except block of TryExcept
-            if not (
-                isinstance(other_node_statement.parent, nodes.ExceptHandler)
-                and isinstance(other_node_statement.parent.parent, nodes.TryExcept)
-            ):
+            closest_except_handler = utils.get_node_first_ancestor_of_type(
+                other_node_statement, nodes.ExceptHandler
+            )
+            if not closest_except_handler:
                 continue
+            closest_try_except: nodes.TryExcept = closest_except_handler.parent
             # If the other node is in the same scope as this node, assume it executes
-            if other_node_statement.parent.parent_of(node):
+            if closest_except_handler.parent_of(node):
                 continue
             try_block_returns = any(
                 isinstance(try_statement, nodes.Return)
-                for try_statement in other_node_statement.parent.parent.body
+                for try_statement in closest_try_except.body
             )
             # If the try block returns, assume the except blocks execute.
             if try_block_returns:
@@ -722,24 +723,18 @@ scope_type : {self._atomic.scope_type}
                 if (
                     isinstance(node_statement.parent, nodes.TryFinally)
                     and node_statement in node_statement.parent.finalbody
-                    # We have already tested that other_node_statement has two parents
-                    # and it was TryExcept, so getting one more parent is safe.
-                    and other_node_statement.parent.parent.parent.parent_of(
-                        node_statement
-                    )
+                    and closest_try_except.parent.parent_of(node_statement)
                 ):
                     uncertain_nodes.append(other_node)
                 # Assume the except blocks execute, so long as each handler
                 # defines the name, raises, or returns.
                 elif all(
                     NamesConsumer._defines_name_raises_or_returns(node.name, handler)
-                    for handler in other_node_statement.parent.parent.handlers
+                    for handler in closest_try_except.handlers
                 ):
                     continue
 
-            if NamesConsumer._check_loop_finishes_via_except(
-                node, other_node_statement.parent.parent
-            ):
+            if NamesConsumer._check_loop_finishes_via_except(node, closest_try_except):
                 continue
 
             # Passed all tests for uncertain execution

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -751,7 +751,14 @@ scope_type : {self._atomic.scope_type}
         for stmt in handler.get_children():
             if isinstance(stmt, (nodes.Raise, nodes.Return)):
                 return True
-            if isinstance(stmt, nodes.Assign) and stmt.targets[0].as_string() == name:
+            if isinstance(stmt, nodes.Assign):
+                 for target in stmt.targets:
+                     if isinstance(target, nodes.AssignName) and target.name == name:
+                         return True
+                     if isinstance(target, (nodes.Tuple, nodes.List)):
+                         for elt in utils.get_all_elements(target):
+                             if isinstance(elt, nodes.Const) and elt.value == name:
+                                 return True
                 return True
             if isinstance(stmt, nodes.If):
                 if (

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -749,7 +749,7 @@ scope_type : {self._atomic.scope_type}
         raises, or returns.
         """
 
-        def _define_raise_or_return(stmt) -> bool:
+        def _define_raise_or_return(stmt: nodes.NodeNG) -> bool:
             if isinstance(stmt, (nodes.Raise, nodes.Return)):
                 return True
             if isinstance(stmt, nodes.Assign):
@@ -758,6 +758,7 @@ scope_type : {self._atomic.scope_type}
                         if isinstance(elt, nodes.AssignName) and elt.name == name:
                             return True
             if isinstance(stmt, nodes.If):
+                # Check for assignments inside the test
                 if (
                     isinstance(stmt.test, nodes.NamedExpr)
                     and stmt.test.target.name == name

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -756,10 +756,11 @@ scope_type : {self._atomic.scope_type}
                     if isinstance(target, nodes.AssignName) and target.name == name:
                         return True
                     if isinstance(target, (nodes.Tuple, nodes.List)):
-                        for elt in utils.get_all_elements(target):
-                            if isinstance(elt, nodes.Const) and elt.value == name:
-                                return True
-                return True
+                        if any(
+                            isinstance(elt, nodes.Const) and elt.value == name
+                            for elt in utils.get_all_elements(target)
+                        ):
+                            return True
             if isinstance(stmt, nodes.If):
                 if (
                     isinstance(stmt.test, nodes.NamedExpr)

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -767,7 +767,9 @@ scope_type : {self._atomic.scope_type}
                 ):
                     return True
                 if isinstance(stmt.test, nodes.Call):
-                    for arg_or_kwarg in stmt.test.args + stmt.test.keywords:
+                    for arg_or_kwarg in stmt.test.args + [
+                        kw.value for kw in stmt.test.keywords
+                    ]:
                         if (
                             isinstance(arg_or_kwarg, nodes.NamedExpr)
                             and arg_or_kwarg.target.name == name

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -752,13 +752,13 @@ scope_type : {self._atomic.scope_type}
             if isinstance(stmt, (nodes.Raise, nodes.Return)):
                 return True
             if isinstance(stmt, nodes.Assign):
-                 for target in stmt.targets:
-                     if isinstance(target, nodes.AssignName) and target.name == name:
+                for target in stmt.targets:
+                    if isinstance(target, nodes.AssignName) and target.name == name:
                          return True
-                     if isinstance(target, (nodes.Tuple, nodes.List)):
-                         for elt in utils.get_all_elements(target):
-                             if isinstance(elt, nodes.Const) and elt.value == name:
-                                 return True
+                    if isinstance(target, (nodes.Tuple, nodes.List)):
+                        for elt in utils.get_all_elements(target):
+                            if isinstance(elt, nodes.Const) and elt.value == name:
+                                return True
                 return True
             if isinstance(stmt, nodes.If):
                 if (

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -753,13 +753,8 @@ scope_type : {self._atomic.scope_type}
                 return True
             if isinstance(stmt, nodes.Assign):
                 for target in stmt.targets:
-                    if isinstance(target, nodes.AssignName) and target.name == name:
-                        return True
-                    if isinstance(target, (nodes.Tuple, nodes.List)):
-                        if any(
-                            isinstance(elt, nodes.Const) and elt.value == name
-                            for elt in utils.get_all_elements(target)
-                        ):
+                    for elt in utils.get_all_elements(target):
+                        if isinstance(elt, nodes.AssignName) and elt.name == name:
                             return True
             if isinstance(stmt, nodes.If):
                 if (

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -708,10 +708,10 @@ scope_type : {self._atomic.scope_type}
             )
             if not closest_except_handler:
                 continue
-            closest_try_except: nodes.TryExcept = closest_except_handler.parent
             # If the other node is in the same scope as this node, assume it executes
             if closest_except_handler.parent_of(node):
                 continue
+            closest_try_except: nodes.TryExcept = closest_except_handler.parent
             try_block_returns = any(
                 isinstance(try_statement, nodes.Return)
                 for try_statement in closest_try_except.body

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -764,12 +764,13 @@ scope_type : {self._atomic.scope_type}
                     and stmt.test.target.name == name
                 ):
                     return True
-                for arg_or_kwarg in stmt.test.args + stmt.test.keywords:
-                    if (
-                        isinstance(arg_or_kwarg, nodes.NamedExpr)
-                        and arg_or_kwarg.target.name == name
-                    ):
-                        return True
+                if isinstance(stmt.test, nodes.Call):
+                    for arg_or_kwarg in stmt.test.args + stmt.test.keywords:
+                        if (
+                            isinstance(arg_or_kwarg, nodes.NamedExpr)
+                            and arg_or_kwarg.target.name == name
+                        ):
+                            return True
         return False
 
     @staticmethod

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -711,8 +711,7 @@ scope_type : {self._atomic.scope_type}
             # If the other node is in the same scope as this node, assume it executes
             if closest_except_handler.parent_of(node):
                 continue
-            closest_try_except = closest_except_handler.parent
-            assert isinstance(closest_try_except, nodes.TryExcept)
+            closest_try_except: nodes.TryExcept = closest_except_handler.parent
             try_block_returns = any(
                 isinstance(try_statement, nodes.Return)
                 for try_statement in closest_try_except.body

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -759,10 +759,16 @@ scope_type : {self._atomic.scope_type}
             if isinstance(stmt, nodes.Assign) and stmt.targets[0].as_string() == name:
                 return True
             if isinstance(stmt, nodes.If):
-                if isinstance(stmt.test, nodes.NamedExpr) and stmt.test.target.name == name:
+                if (
+                    isinstance(stmt.test, nodes.NamedExpr)
+                    and stmt.test.target.name == name
+                ):
                     return True
                 for arg_or_kwarg in stmt.test.args + stmt.test.keywords:
-                    if isinstance(arg_or_kwarg, nodes.NamedExpr) and arg_or_kwarg.target.name == name:
+                    if (
+                        isinstance(arg_or_kwarg, nodes.NamedExpr)
+                        and arg_or_kwarg.target.name == name
+                    ):
                         return True
         return False
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -754,7 +754,7 @@ scope_type : {self._atomic.scope_type}
             if isinstance(stmt, nodes.Assign):
                 for target in stmt.targets:
                     if isinstance(target, nodes.AssignName) and target.name == name:
-                         return True
+                        return True
                     if isinstance(target, (nodes.Tuple, nodes.List)):
                         for elt in utils.get_all_elements(target):
                             if isinstance(elt, nodes.Const) and elt.value == name:

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -711,7 +711,8 @@ scope_type : {self._atomic.scope_type}
             # If the other node is in the same scope as this node, assume it executes
             if closest_except_handler.parent_of(node):
                 continue
-            closest_try_except: nodes.TryExcept = closest_except_handler.parent
+            closest_try_except = closest_except_handler.parent
+            assert isinstance(closest_try_except, nodes.TryExcept)
             try_block_returns = any(
                 isinstance(try_statement, nodes.Return)
                 for try_statement in closest_try_except.body

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
@@ -51,32 +51,6 @@ def func_ok3(var):
     print(msg)
 
 
-def func_ok4(var):
-    """'msg' is defined in one handler with a named expression under an if."""
-    try:
-        return 1 / var.some_other_func()
-    except AttributeError:
-        if (msg := var.get_msg()):
-            pass
-    except ZeroDivisionError:
-        msg = "Division by 0"
-    print(msg)
-
-
-def func_ok5(var):
-    """'msg' is defined in one handler with a named expression occurring
-    in a call used in an if test.
-    """
-    try:
-        return 1 / var.some_other_func()
-    except AttributeError:
-        if print(msg := var.get_msg()):
-            pass
-    except ZeroDivisionError:
-        msg = "Division by 0"
-    print(msg)
-
-
 def func_invalid1(var):
     """'msg' is not defined in one handler."""
     try:

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
@@ -49,3 +49,51 @@ def func_ok3(var):
     except ZeroDivisionError:
         msg = "Division by 0"
     print(msg)
+
+
+def func_ok4(var):
+    """'msg' is defined in one handler with a named expression under an if."""
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        if (msg := var.get_msg()):
+            pass
+    except ZeroDivisionError:
+        msg = "Division by 0"
+    print(msg)
+
+
+def func_ok5(var):
+    """'msg' is defined in one handler with a named expression occurring
+    in a call used in an if test.
+    """
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        if print(msg := var.get_msg()):
+            pass
+    except ZeroDivisionError:
+        msg = "Division by 0"
+    print(msg)
+
+
+def func_invalid1(var):
+    """'msg' is not defined in one handler."""
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        pass
+    except ZeroDivisionError:
+        msg = "Division by 0"
+    print(msg)  # [used-before-assignment]
+
+
+def func_invalid2(var):
+    """'msg' is not defined in one handler."""
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        msg: str
+    except ZeroDivisionError:
+        msg = "Division by 0"
+    print(msg)  # [used-before-assignment]

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
@@ -71,3 +71,20 @@ def func_invalid2(var):
     except ZeroDivisionError:
         msg = "Division by 0"
     print(msg)  # [used-before-assignment]
+
+
+def func_invalid3(var):
+    """'msg' is not defined in one handler, but is defined in another
+    nested under an if.
+    """
+    err_message = False
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        msg: str
+    except ZeroDivisionError:
+        if err_message:
+            msg = "Division by 0"
+        else:
+            msg = None
+    print(msg)  # [used-before-assignment]

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
@@ -99,13 +99,15 @@ def func_invalid2(var):
 
 def func_invalid3(var):
     """'msg' is not defined in one handler, but is defined in another
-    nested under an if.
+    nested under an if. Nesting under an if tests that the implementation
+    does not assume direct parentage between `msg=` and `except`, and
+    the prior except is necessary to raise the message.
     """
     err_message = False
     try:
         return 1 / var.some_other_func()
     except AttributeError:
-        msg: str
+        pass
     except ZeroDivisionError:
         if err_message:
             msg = "Division by 0"

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
@@ -151,3 +151,27 @@ def func_invalid4(var):
             msg = "Division by 0"
             my_file.write("****")
     print(msg)  # [used-before-assignment]
+
+
+def func_invalid5(var):
+    """Define 'msg' in one handler only via chained assignment."""
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        pass
+    except ZeroDivisionError:
+        msg2 = msg = "Division by 0"
+        print(msg2)
+    print(msg)  # [used-before-assignment]
+
+
+def func_invalid6(var):
+    """Define 'msg' in one handler only via unpacked iterable."""
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        pass
+    except ZeroDivisionError:
+        msg, msg2 = ["Division by 0"] * 2
+        print(msg2)
+    print(msg)  # [used-before-assignment]

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
@@ -75,6 +75,30 @@ def func_ok5(var):
     print(msg)
 
 
+def func_ok6(var):
+    """Define 'msg' in one handler nested under if block."""
+    err_message = False
+    try:
+        return 1 / var.some_other_func()
+    except ZeroDivisionError:
+        if err_message:
+            msg = "Division by 0"
+        else:
+            msg = None
+    print(msg)
+
+
+def func_ok7(var):
+    """Define 'msg' in one handler nested under with statement."""
+    try:
+        return 1 / var.some_other_func()
+    except ZeroDivisionError:
+        with open(__file__, encoding='utf-8') as my_file:
+            msg = "Division by 0"
+            my_file.write(msg)
+    print(msg)
+
+
 def func_invalid1(var):
     """'msg' is not defined in one handler."""
     try:

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
@@ -138,3 +138,16 @@ def func_invalid3(var):
         else:
             msg = None
     print(msg)  # [used-before-assignment]
+
+
+def func_invalid4(var):
+    """Define 'msg' in one handler nested under with statement."""
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        pass
+    except ZeroDivisionError:
+        with open(__file__, encoding='utf-8') as my_file:
+            msg = "Division by 0"
+            my_file.write("****")
+    print(msg)  # [used-before-assignment]

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.py
@@ -51,6 +51,30 @@ def func_ok3(var):
     print(msg)
 
 
+def func_ok4(var):
+    """Define "msg" with a chained assignment."""
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        msg2 = msg = "Division by 0"
+        print(msg2)
+    except ZeroDivisionError:
+        msg = "Division by 0"
+    print(msg)
+
+
+def func_ok5(var):
+    """Define 'msg' via unpacked iterable."""
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        msg, msg2 = ["Division by 0", "Division by 0"]
+        print(msg2)
+    except ZeroDivisionError:
+        msg = "Division by 0"
+    print(msg)
+
+
 def func_invalid1(var):
     """'msg' is not defined in one handler."""
     try:

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
@@ -1,3 +1,4 @@
 used-before-assignment:16:14:16:29:function:Using variable 'failure_message' before assignment:CONTROL_FLOW
 used-before-assignment:62:10:62:13:func_invalid1:Using variable 'msg' before assignment:CONTROL_FLOW
 used-before-assignment:73:10:73:13:func_invalid2:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:90:10:90:13:func_invalid3:Using variable 'msg' before assignment:CONTROL_FLOW

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
@@ -1,4 +1,4 @@
 used-before-assignment:16:14:16:29:function:Using variable 'failure_message' before assignment:CONTROL_FLOW
-used-before-assignment:86:10:86:13:func_invalid1:Using variable 'msg' before assignment:CONTROL_FLOW
-used-before-assignment:97:10:97:13:func_invalid2:Using variable 'msg' before assignment:CONTROL_FLOW
-used-before-assignment:116:10:116:13:func_invalid3:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:110:10:110:13:func_invalid1:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:121:10:121:13:func_invalid2:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:140:10:140:13:func_invalid3:Using variable 'msg' before assignment:CONTROL_FLOW

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
@@ -1,4 +1,4 @@
 used-before-assignment:16:14:16:29:function:Using variable 'failure_message' before assignment:CONTROL_FLOW
 used-before-assignment:86:10:86:13:func_invalid1:Using variable 'msg' before assignment:CONTROL_FLOW
 used-before-assignment:97:10:97:13:func_invalid2:Using variable 'msg' before assignment:CONTROL_FLOW
-used-before-assignment:114:10:114:13:func_invalid3:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:116:10:116:13:func_invalid3:Using variable 'msg' before assignment:CONTROL_FLOW

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
@@ -3,3 +3,5 @@ used-before-assignment:110:10:110:13:func_invalid1:Using variable 'msg' before a
 used-before-assignment:121:10:121:13:func_invalid2:Using variable 'msg' before assignment:CONTROL_FLOW
 used-before-assignment:140:10:140:13:func_invalid3:Using variable 'msg' before assignment:CONTROL_FLOW
 used-before-assignment:153:10:153:13:func_invalid4:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:165:10:165:13:func_invalid5:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:177:10:177:13:func_invalid6:Using variable 'msg' before assignment:CONTROL_FLOW

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
@@ -1,4 +1,4 @@
 used-before-assignment:16:14:16:29:function:Using variable 'failure_message' before assignment:CONTROL_FLOW
-used-before-assignment:62:10:62:13:func_invalid1:Using variable 'msg' before assignment:CONTROL_FLOW
-used-before-assignment:73:10:73:13:func_invalid2:Using variable 'msg' before assignment:CONTROL_FLOW
-used-before-assignment:90:10:90:13:func_invalid3:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:86:10:86:13:func_invalid1:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:97:10:97:13:func_invalid2:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:114:10:114:13:func_invalid3:Using variable 'msg' before assignment:CONTROL_FLOW

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
@@ -1,3 +1,3 @@
 used-before-assignment:16:14:16:29:function:Using variable 'failure_message' before assignment:CONTROL_FLOW
-used-before-assignment:88:10:88:13:func_invalid1:Using variable 'msg' before assignment:CONTROL_FLOW
-used-before-assignment:99:10:99:13:func_invalid2:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:62:10:62:13:func_invalid1:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:73:10:73:13:func_invalid2:Using variable 'msg' before assignment:CONTROL_FLOW

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
@@ -1,1 +1,3 @@
 used-before-assignment:16:14:16:29:function:Using variable 'failure_message' before assignment:CONTROL_FLOW
+used-before-assignment:88:10:88:13:func_invalid1:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:99:10:99:13:func_invalid2:Using variable 'msg' before assignment:CONTROL_FLOW

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return.txt
@@ -2,3 +2,4 @@ used-before-assignment:16:14:16:29:function:Using variable 'failure_message' bef
 used-before-assignment:110:10:110:13:func_invalid1:Using variable 'msg' before assignment:CONTROL_FLOW
 used-before-assignment:121:10:121:13:func_invalid2:Using variable 'msg' before assignment:CONTROL_FLOW
 used-before-assignment:140:10:140:13:func_invalid3:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:153:10:153:13:func_invalid4:Using variable 'msg' before assignment:CONTROL_FLOW

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return_py38.py
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return_py38.py
@@ -30,3 +30,17 @@ def func_ok_namedexpr_2(var):
     except ZeroDivisionError:
         msg = "Division by 0"
     print(msg)
+
+
+def func_ok_namedexpr_3(var):
+    """'msg' is defined in one handler with a named expression occurring
+    as a keyword in a call used in an if test.
+    """
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        if print("zero!", "here", sep=(msg := var.get_sep())):
+            pass
+    except ZeroDivisionError:
+        msg = "Division by 0"
+    print(msg)

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return_py38.py
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return_py38.py
@@ -1,0 +1,32 @@
+"""Tests for used-before-assignment with assignments in except handlers after
+try blocks with return statements.
+See: https://github.com/PyCQA/pylint/issues/5500.
+"""
+# pylint: disable=inconsistent-return-statements
+
+
+# Intended to follow func_ok1 ... 3 in neighboring file
+def func_ok4(var):
+    """'msg' is defined in one handler with a named expression under an if."""
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        if (msg := var.get_msg()):
+            pass
+    except ZeroDivisionError:
+        msg = "Division by 0"
+    print(msg)
+
+
+def func_ok5(var):
+    """'msg' is defined in one handler with a named expression occurring
+    in a call used in an if test.
+    """
+    try:
+        return 1 / var.some_other_func()
+    except AttributeError:
+        if print(msg := var.get_msg()):
+            pass
+    except ZeroDivisionError:
+        msg = "Division by 0"
+    print(msg)

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return_py38.py
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return_py38.py
@@ -5,8 +5,8 @@ See: https://github.com/PyCQA/pylint/issues/5500.
 # pylint: disable=inconsistent-return-statements
 
 
-# Intended to follow func_ok1 ... 3 in neighboring file
-def func_ok4(var):
+# Named expressions
+def func_ok_namedexpr_1(var):
     """'msg' is defined in one handler with a named expression under an if."""
     try:
         return 1 / var.some_other_func()
@@ -18,7 +18,7 @@ def func_ok4(var):
     print(msg)
 
 
-def func_ok5(var):
+def func_ok_namedexpr_2(var):
     """'msg' is defined in one handler with a named expression occurring
     in a call used in an if test.
     """

--- a/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return_py38.rc
+++ b/tests/functional/u/use/used_before_assignment_except_handler_for_try_with_return_py38.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.8


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fixes #5524.

<s>In discussion I suggested closing #2835 as a duplicate, but if folks like we could "unlink" the two and reopen the older ticket.

The older ticket is just suggesting "always assume try statements fail", and @cdce8p suggested a new message for that (`possibly-unbound`). Probably a 2.14 or later thing. By contrast this PR is just fixing a quick false negative. Sorry for not seeing that we were more likely to tackle these separately!</s> Edit: done!