### PR TITLE
Add check against initializing and then mutating a dictionary

### DIFF
--- a/pylint/extensions/bad_builtin.py
+++ b/pylint/extensions/bad_builtin.py
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
 
 BAD_FUNCTIONS = ["map", "filter"]
 # Some hints regarding the use of bad builtins.
-BUILTIN_HINTS = {"map": "Using a list comprehension can be clearer."}
-BUILTIN_HINTS["filter"] = BUILTIN_HINTS["map"]
+list_comp_msg = "Using a list comprehension can be clearer."
+BUILTIN_HINTS = {"map": list_comp_msg, "filter": list_comp_msg}
 
 
 class BadBuiltinChecker(BaseChecker):

--- a/pylint/extensions/dict_init_mutate.py
+++ b/pylint/extensions/dict_init_mutate.py
@@ -1,0 +1,64 @@
+"""Check for use of dictionary mutation after intialization."""
+
+from astroid import nodes
+
+from pylint.checkers import BaseChecker
+from pylint.checkers.utils import check_messages
+from pylint.interfaces import IAstroidChecker
+
+
+class DictInitMutateChecker(BaseChecker):
+
+    __implements__ = (IAstroidChecker,)
+    name = "dict-init-mutate"
+    msgs = {
+        "W0170": (
+            "Dictionary mutated immediately after initialization",
+            "dict-init-mutate",
+            "Dictionaries can be initialized with a single statement"
+            "using dictionary literal syntax.",
+        )
+    }
+
+    @check_messages("dict-init-mutate")
+    def visit_assign(self, node: nodes.Assign) -> None:
+        # For now, we're just looking for the simple case in which the
+        # dictionary is assigned to a name and that name is
+        # subscripted and then mutated. Looking at nested instances
+        # would be cool, but it's more # complicated.
+
+        if not isinstance(node.value, nodes.Dict):
+            return
+
+        if len(node.targets) != 1:
+            return
+
+        if not isinstance((dict_name := node.targets[0]), nodes.AssignName):
+            return
+
+        if (sibling := node.next_sibling()) is None:
+            return
+
+        if not isinstance(sibling, nodes.Assign):
+            return
+
+        if len(sibling.targets) != 1:
+            return
+
+        if not isinstance((sibling_target := sibling.targets[0]), nodes.Subscript):
+            return
+
+        if not isinstance((sibling_name := sibling_target.value), nodes.Name):
+            return
+
+        if sibling_name.name == dict_name.name:
+            self.add_message("dict-init-mutate", node=node)
+
+
+def register(linter):
+    """Required method to auto register this checker.
+
+    :param linter: Main interface object for Pylint plugins
+    :type linter: Pylint object
+    """
+    linter.register_checker(DictInitMutateChecker(linter))

--- a/pylintrc
+++ b/pylintrc
@@ -34,6 +34,7 @@ load-plugins=
     pylint.extensions.typing,
     pylint.extensions.redefined_variable_type,
     pylint.extensions.comparison_placement,
+    pylint.extensions.dict_init_mutate,
 
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use.

--- a/tests/functional/ext/dict_init_mutate.py
+++ b/tests/functional/ext/dict_init_mutate.py
@@ -1,0 +1,12 @@
+config = {}  # [dict-init-mutate]
+config['dir'] = 'bin'
+config['user'] = 'me'
+config['workers'] = 5
+
+config = {}  # [dict-init-mutate]
+config['dir'] = 'bin'
+config['user'] = 'me'
+config['workers'] = 5
+config['options'] = {}  # We're skipping this one for now.
+config['options']['debug'] = False
+config['options']['verbose'] = True

--- a/tests/functional/ext/dict_init_mutate.rc
+++ b/tests/functional/ext/dict_init_mutate.rc
@@ -1,0 +1,7 @@
+[MASTER]
+load-plugins=pylint.extensions.dict_init_mutate,
+
+[MESSAGES CONTROL]
+disable=
+  invalid-name,
+  missing-module-docstring,

--- a/tests/functional/ext/dict_init_mutate.txt
+++ b/tests/functional/ext/dict_init_mutate.txt
@@ -1,0 +1,2 @@
+dict-init-mutate:1:0::Dictionary mutated immediately after initialization
+dict-init-mutate:6:0::Dictionary mutated immediately after initialization


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Add a new optional check against initializing a dictionary and then immediately mutating it.

Closes #2876