### PR TITLE
Avoid using get on a defaultdict

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1659,7 +1659,7 @@ class PyLinter(
         else:
             category_id_formatted = category_id
         if category_id_formatted is not None:
-            for _msgid in self.msgs_store._msgs_by_category.get(category_id_formatted):
+            for _msgid in self.msgs_store._msgs_by_category[category_id_formatted]:
                 message_definitions.extend(
                     self._get_messages_to_set(_msgid, enable, ignore_unknown)
                 )


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

I was poking around Pylint internals, trying to add new issue categories to the codebase, and stumbled upon this bug.
Since `MessageDefinitionStore._msgs_by_category` is a `defaultdict(list)`, using `.get()` here can break the code on bad input, because it will return `None`, which is not iterable.

