### PR TITLE
Fix crash in `use-maxsplit-arg` checker where `sep` given by keyword

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -238,6 +238,11 @@ Release date: TBA
 
   Closes #5461
 
+* Fixed crash in ``use-maxsplit-arg`` checker when providing the ``sep`` argument
+  to ``str.split()`` by keyword.
+
+  Closes #5737
+
 * Fix false positive for ``unused-variable`` for a comprehension variable matching
   an outer scope type annotation.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -275,6 +275,11 @@ Other Changes
 
   Closes #5461
 
+* Fixed crash in ``use-maxsplit-arg`` checker when providing the ``sep`` argument
+  to ``str.split()`` by keyword.
+
+  Closes #5737
+
 * Fix false positive for ``unused-variable`` for a comprehension variable matching
   an outer scope type annotation.
 

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -113,7 +113,7 @@ class RecommendationChecker(checkers.BaseChecker):
             return
 
         try:
-            utils.get_argument_from_call(node, 0, "sep")
+            sep = utils.get_argument_from_call(node, 0, "sep")
         except utils.NoSuchArgumentError:
             return
 
@@ -154,7 +154,7 @@ class RecommendationChecker(checkers.BaseChecker):
                 new_name = (
                     node.func.as_string().rsplit(fn_name, maxsplit=1)[0]
                     + new_fn
-                    + f"({node.args[0].as_string()}, maxsplit=1)[{subscript_value}]"
+                    + f"({sep.as_string()}, maxsplit=1)[{subscript_value}]"
                 )
                 self.add_message("use-maxsplit-arg", node=node, args=(new_name,))
 

--- a/tests/functional/u/use/use_maxsplit_arg.py
+++ b/tests/functional/u/use/use_maxsplit_arg.py
@@ -90,3 +90,7 @@ i = 0
 for j in range(5):
     print(source.split('.')[i])
     i = i + 1
+
+# Test for crash when sep is given by keyword
+# https://github.com/PyCQA/pylint/issues/5737
+get_last = SEQ.split(sep=None)[-1]  # [use-maxsplit-arg]

--- a/tests/functional/u/use/use_maxsplit_arg.txt
+++ b/tests/functional/u/use/use_maxsplit_arg.txt
@@ -19,3 +19,4 @@ use-maxsplit-arg:79:6:79:27::Use Bar.split.rsplit(',', maxsplit=1)[-1] instead:U
 use-maxsplit-arg:82:4:82:23::Use '1,2,3'.split('\n', maxsplit=1)[0] instead:UNDEFINED
 use-maxsplit-arg:83:4:83:26::Use '1,2,3'.rsplit('split', maxsplit=1)[-1] instead:UNDEFINED
 use-maxsplit-arg:84:4:84:28::Use '1,2,3'.split('rsplit', maxsplit=1)[0] instead:UNDEFINED
+use-maxsplit-arg:96:11:96:30::Use SEQ.rsplit(None, maxsplit=1)[-1] instead:UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Fix crash in `use-maxsplit-arg` checker if `sep` is provided by keyword to `str.split()`.

Closes #5737
