### PR TITLE
Fix unsafe `utils.safe_infer`

### DIFF
--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1263,6 +1263,7 @@ def safe_infer(node: nodes.NodeNG, context=None) -> Optional[nodes.NodeNG]:
             if (
                 isinstance(inferred, nodes.FunctionDef)
                 and inferred.args.args is not None
+                and isinstance(value, nodes.FunctionDef)
                 and value.args.args is not None
                 and len(inferred.args.args) != len(value.args.args)
             ):


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Came across an error while testing Home Assistant. `safe_infer` here assumes that `value` is a `FunctionDef` to be able to access `value.args.args`. The assumption is never fully checked however. `value` could also be an `<Instance of builtins.function ...>` which would cause an `AttributeError`.

I wasn't able to write a dedicated regression test unfortunately. Home Assistant only managed to break it with some combination of patching a builtin function and custom plugins which import parts of the checked files itself.

The condition was originally added in #5409
