### PR TITLE
Add parameter typing to ``PyLinter``

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -545,11 +545,11 @@ class PyLinter(
 
     def __init__(
         self,
-        options=(),
+        options: Tuple[Tuple[str, OptionDict], ...] = (),
         reporter: Union[reporters.BaseReporter, reporters.MultiReporter, None] = None,
-        option_groups=(),
-        pylintrc=None,
-    ):
+        option_groups: Tuple[Tuple[str, str], ...] = (),
+        pylintrc: Optional[str] = None,
+    ) -> None:
         """Some stuff has to be done before ancestors initialization...
         messages store / checkers / reporter / astroid manager
         """
@@ -581,9 +581,7 @@ class PyLinter(
         self.stats = LinterStats()
 
         # Attributes related to (command-line) options and their parsing
-        # pylint: disable-next=fixme
-        # TODO: Make these implicitly typing when typing for __init__ parameter is added
-        self._external_opts: Tuple[Tuple[str, OptionDict], ...] = options
+        self._external_opts = options
         self.options: Tuple[Tuple[str, OptionDict], ...] = (
             options + PyLinter.make_options()
         )


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Finally 🎉 

This means that the ``__init__`` and all attributes of `PyLinter` are now fully typed. This will be the last typing PR (from my end) to be proposed for `2.13`. This is just a side-project I have been wanting to finish for a long time!