### PR TITLE
Fix parsing of long lines when ``missing-final-newline`` is enabled

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -129,6 +129,10 @@ Release date: TBA
 
   Closes #5569
 
+* Fix parsing of long lines when ``missing-final-newline`` is enabled.
+
+  Closes #5724
+
 * Fix false positives for ``used-before-assignment`` from using named
   expressions in a ternary operator test and using that expression as
   a call argument.

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -180,6 +180,10 @@ Other Changes
 
   Closes #5177, #5212
 
+* Fix parsing of long lines when ``missing-final-newline`` is enabled.
+
+  Closes #5724
+
 * Fix ``unnecessary_dict_index_lookup`` false positive when deleting a dictionary's entry.
 
   Closes #4716

--- a/pylint/utils/pragma_parser.py
+++ b/pylint/utils/pragma_parser.py
@@ -9,10 +9,7 @@ from typing import Generator, List, Optional
 # so that an option can be continued with the reasons
 # why it is active or disabled.
 OPTION_RGX = r"""
-    \s*                # Any number of whitespace
-    \#?                # One or zero hash
-    .*                 # Anything (as much as possible)
-    (\s*               # Beginning of first matched group and any number of whitespaces
+    (                  # Beginning of first matched group and any number of whitespaces
     \#                 # Beginning of comment
     .*?                # Anything (as little as possible)
     \bpylint:          # pylint word and column

--- a/pylint/utils/pragma_parser.py
+++ b/pylint/utils/pragma_parser.py
@@ -11,7 +11,7 @@ from typing import Generator, List, Optional
 OPTION_RGX = r"""
     (                  # Beginning of first matched group and any number of whitespaces
     \#                 # Beginning of comment
-    .*?                # Anything (as little as possible)
+    \s*?               # Any whitespaces (as little as possible)
     \bpylint:          # pylint word and column
     \s*                # Any number of whitespaces
     ([^;#\n]+))        # Anything except semicolon or hash or newline (it is the second matched group)


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #5724.

The stuff at the beginning of this regex pattern isn't actually needed for us to extract our disable comments. This massively speeds up the parsing and unstucks us from the code in the issue.
I haven't added a test case as it is a bit difficult to test "don't look for things we don't need"...