### PR TITLE
Fix the period added in docstring automatically by mistake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
         args: [--prose-wrap=always, --print-width=88]
         exclude: tests(/.*)*/data
   - repo: https://github.com/DanielNoord/pydocstringformatter
-    rev: v0.4.0
+    rev: a9f94bf13b08fe33f784ed7f0a0fc39e2a8549e2
     hooks:
       - id: pydocstringformatter
         exclude: *fixtures

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -471,7 +471,7 @@ class FormatChecker(BaseTokenChecker):
         return dispatch
 
     def process_tokens(self, tokens):
-        """Process tokens and search for :.
+        """Process tokens and search for :
 
         _ too long lines (i.e. longer than <max_chars>)
         _ optionally bad construct (if given, bad_construct must be a compiled

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -55,10 +55,7 @@ UNUSED_PARAM_SENTINEL = object()
 
 
 class Run:
-    """Helper class to use as main for pylint :
-
-    run(*sys.argv[1:])
-    """
+    """Helper class to use as main for pylint with 'run(*sys.argv[1:])'."""
 
     LinterClass = PyLinter
     option_groups = (

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -55,7 +55,7 @@ UNUSED_PARAM_SENTINEL = object()
 
 
 class Run:
-    """Helper class to use as main for pylint :.
+    """Helper class to use as main for pylint :
 
     run(*sys.argv[1:])
     """

--- a/pylint/pyreverse/diadefslib.py
+++ b/pylint/pyreverse/diadefslib.py
@@ -210,10 +210,7 @@ class ClassDiadefGenerator(DiaDefGenerator):
 
 
 class DiadefsHandler:
-    """Handle diagram definitions :
-
-    get it from user (i.e. xml files) or generate them
-    """
+    """Get diagram definitions from user (i.e. xml files) or generate them."""
 
     def __init__(self, config):
         self.config = config

--- a/pylint/pyreverse/diadefslib.py
+++ b/pylint/pyreverse/diadefslib.py
@@ -126,7 +126,7 @@ class DiaDefGenerator:
 
 
 class DefaultDiadefGenerator(LocalsVisitor, DiaDefGenerator):
-    """Generate minimum diagram definition for the project :.
+    """Generate minimum diagram definition for the project :
 
     * a package diagram including project's modules
     * a class diagram including project's classes
@@ -210,7 +210,7 @@ class ClassDiadefGenerator(DiaDefGenerator):
 
 
 class DiadefsHandler:
-    """Handle diagram definitions :.
+    """Handle diagram definitions :
 
     get it from user (i.e. xml files) or generate them
     """


### PR DESCRIPTION


<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description
Due to https://github.com/DanielNoord/pydocstringformatter/pull/52
