### PR TITLE
Fixes to tests due to (possible) new ``tolineno`` behaviour

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,9 @@ Release date: TBA
 
   Closes #5729
 
+* The line numbering for messages related to function arguments is now more accurate. This can
+  require some message disables to be relocated to updated positions.
+
 * Add ``--recursive`` option to allow recursive discovery of all modules and packages in subtree. Running pylint with
   ``--recursive=y`` option will check all discovered ``.py`` files and packages found inside subtree of directory provided
   as parameter to pylint.

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -110,6 +110,9 @@ Other Changes
 
   Closes #5840
 
+* The line numbering for messages related to function arguments is now more accurate. This can
+  require some message disables to be relocated to updated positions.
+
 * ``using-f-string-in-unsupported-version`` and ``using-final-decorator-in-unsupported-version`` msgids
     were renamed from ``W1601`` and ``W1602`` to ``W2601`` and ``W2602``. Disables using these msgids will break.
     This is done in order to restore consistency with the already existing msgids for ``apply-builtin`` and

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 -e .[testutil]
 # astroid dependency is also defined in setup.cfg
-astroid==2.9.3  # Pinned to a specific version for tests
+astroid==2.11.0  # Pinned to a specific version for tests
 typing-extensions~=4.0
 pytest~=7.0
 pytest-benchmark~=3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     # Also upgrade requirements_test_min.txt if you are bumping astroid.
     # Pinned to dev of next minor update to allow editable installs,
     # see https://github.com/PyCQA/astroid/issues/1341
-    astroid>=2.9.2,<=2.10.0-dev0
+    astroid>=2.11.0,<=2.12.0-dev0
     isort>=4.2.5,<6
     mccabe>=0.6,<0.8
     tomli>=1.1.0;python_version<"3.11"

--- a/tests/checkers/unittest_stdlib.py
+++ b/tests/checkers/unittest_stdlib.py
@@ -49,10 +49,8 @@ class TestStdlibChecker(CheckerTestCase):
         """
 
         def infer_func(
-            node: Name, context: Optional[Any] = None
-        ) -> Iterator[
-            Union[Iterator, Iterator[AssignAttr]]
-        ]:  # pylint: disable=unused-argument
+            node: Name, context: Optional[Any] = None  # pylint: disable=unused-argument
+        ) -> Iterator[Union[Iterator, Iterator[AssignAttr]]]:
             new_node = nodes.AssignAttr(attrname="alpha", parent=node)
             yield new_node
 

--- a/tests/checkers/unittest_unicode/unittest_bad_chars.py
+++ b/tests/checkers/unittest_unicode/unittest_bad_chars.py
@@ -130,6 +130,7 @@ class TestBadCharsChecker(pylint.testutils.CheckerTestCase):
             # string
             module = astroid.MANAGER.ast_from_string(file)
         except AstroidBuildingError:
+            # pylint: disable-next=redefined-variable-type
             module = cast(nodes.Module, FakeNode(file.read_bytes()))
 
         expected = [

--- a/tests/functional/ext/broad_try_clause/broad_try_clause_extension.txt
+++ b/tests/functional/ext/broad_try_clause/broad_try_clause_extension.txt
@@ -1,4 +1,4 @@
 too-many-try-statements:5:0:10:8::try clause contains 3 statements, expected at most 1:UNDEFINED
 too-many-try-statements:12:0:17:8::try clause contains 3 statements, expected at most 1:UNDEFINED
-too-many-try-statements:19:0:27:8::try clause contains 4 statements, expected at most 1:UNDEFINED
+too-many-try-statements:19:0:25:8::try clause contains 4 statements, expected at most 1:UNDEFINED
 too-many-try-statements:29:0:44:8::try clause contains 7 statements, expected at most 1:UNDEFINED

--- a/tests/functional/i/invalid/invalid_name.py
+++ b/tests/functional/i/invalid/invalid_name.py
@@ -58,13 +58,8 @@ def dummy_decorator(aaabc, bbbcd):
     return real_decorator
 
 
-@dummy_decorator(1, [
-    0  # Fixing #119 should make this go away
-# C0103 always points here - line 61  # [invalid-name]
-
-
-])
-def a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad():  # Should be line 65
+@dummy_decorator(1, [0])
+def a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad():  # [invalid-name]
     """Docstring"""
     print('LOL')
 

--- a/tests/functional/i/invalid/invalid_name.txt
+++ b/tests/functional/i/invalid/invalid_name.txt
@@ -2,7 +2,7 @@ invalid-name:12:0:12:3::"Constant name ""aaa"" doesn't conform to UPPER_CASE nam
 invalid-name:16:4:16:8::"Constant name ""time"" doesn't conform to UPPER_CASE naming style":HIGH
 invalid-name:32:0:33:12:a:"Function name ""a"" doesn't conform to snake_case naming style":HIGH
 invalid-name:46:4:46:13::"Constant name ""Foocapfor"" doesn't conform to UPPER_CASE naming style":HIGH
-invalid-name:63:0:69:16:a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad:"Function name ""a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad"" doesn't conform to snake_case naming style":HIGH
-invalid-name:75:23:75:29:FooBar.__init__:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
-invalid-name:81:8:81:14:FooBar.func1:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
-invalid-name:101:8:101:15:FooBar.test_disable_mixed:"Argument name ""fooBar2"" doesn't conform to snake_case naming style":HIGH
+invalid-name:62:0:64:16:a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad:"Function name ""a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad"" doesn't conform to snake_case naming style":HIGH
+invalid-name:70:23:70:29:FooBar.__init__:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
+invalid-name:76:8:76:14:FooBar.func1:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
+invalid-name:96:8:96:15:FooBar.test_disable_mixed:"Argument name ""fooBar2"" doesn't conform to snake_case naming style":HIGH

--- a/tests/functional/r/regression/regression_2913.py
+++ b/tests/functional/r/regression/regression_2913.py
@@ -14,6 +14,6 @@ class BaseCorrect:  # pylint: disable=too-few-public-methods
     """My base class."""
 
 
-class BaseInner:  # [too-few-public-methods]
+class BaseInner:
     # pylint: disable=too-few-public-methods
     """My base class."""

--- a/tests/functional/r/regression/regression_2913.txt
+++ b/tests/functional/r/regression/regression_2913.txt
@@ -1,1 +1,0 @@
-too-few-public-methods:17:0:19:24:BaseInner:Too few public methods (0/2):UNDEFINED


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

These are the changes necessary for the tests to allow https://github.com/PyCQA/astroid/pull/1351 to pass the `pylint` test suite.

I'll annotate the changes to explain why something changed and why I think this is not a bad thing.

Obviously, this is all dependent on https://github.com/PyCQA/astroid/pull/1351 actually landing, which will need to be discussed in the `astroid` repository.

_Expect a push to https://github.com/PyCQA/astroid/pull/1351 in a couple of minutes to undraft that PR._