### PR TITLE
Fix #5112: Prevent `used-before-assignment` if named expression found first in container

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -205,6 +205,11 @@ Release date: TBA
 
   Closes #367
 
+* Fixed a false positive for ``used-before-assignment`` when a named expression
+  appears as the first value in a container.
+
+  Closes #5112
+
 * ``used-before-assignment`` now assumes that assignments in except blocks
   may not have occurred and warns accordingly.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -241,6 +241,11 @@ Other Changes
 
   Closes #3793
 
+* Fixed a false positive for ``used-before-assignment`` when a named expression
+  appears as the first value in a container.
+
+  Closes #5112
+
 * Fixed false positive for ``used-before-assignment`` with self-referential type
   annotation in conditional statements within class methods.
 

--- a/tests/functional/u/undefined/undefined_variable_py38.py
+++ b/tests/functional/u/undefined/undefined_variable_py38.py
@@ -155,3 +155,12 @@ class Dummy:
 
 
 dummy = Dummy(value=val if (val := 'something') else 'anything')
+
+def expression_in_ternary_operator_inside_container():
+    """Named expression in ternary operator: inside container"""
+    return [val2 if (val2 := 'something') else 'anything']
+
+
+def expression_in_ternary_operator_inside_container_wrong_position():
+    """Same case, but named expression comes too late"""
+    return [val3, val3 if (val3 := 'something') else 'anything']  # [used-before-assignment]

--- a/tests/functional/u/undefined/undefined_variable_py38.txt
+++ b/tests/functional/u/undefined/undefined_variable_py38.txt
@@ -5,3 +5,4 @@ undefined-variable:99:6:99:19::Undefined variable 'else_assign_2':INFERENCE
 unused-variable:126:4:126:10:type_annotation_unused_after_comprehension:Unused variable 'my_int':UNDEFINED
 used-before-assignment:134:10:134:16:type_annotation_used_improperly_after_comprehension:Using variable 'my_int' before assignment:HIGH
 used-before-assignment:141:10:141:16:type_annotation_used_improperly_after_comprehension_2:Using variable 'my_int' before assignment:HIGH
+used-before-assignment:166:12:166:16:expression_in_ternary_operator_inside_container_wrong_position:Using variable 'val3' before assignment:HIGH


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Prevent a false positive for `used-before-assignment` when a named expression (walrus operator) is found first in a container.

For instance, this passed:

```python
assert x := True
```
But this didn't (it's a tuple):
```python
assert x := True, x
```
Notice this should not pass:
```python
assert x, x := True
```
Closes #5112

Of course, this can wait for 2.14, no problem.