### PR TITLE
Don't assume test runners have more than 2 cores available

### DIFF
--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -413,15 +413,9 @@ class TestCheckParallel:
             (3, 1, 1),
             (3, 1, 2),
             (3, 1, 3),
-            (3, 5, 1),
-            (3, 5, 2),
-            (3, 5, 3),
             (10, 2, 1),
             (10, 2, 2),
             (10, 2, 3),
-            (2, 10, 1),
-            (2, 10, 2),
-            (2, 10, 3),
         ],
     )
     def test_compare_workers_to_single_proc(self, num_files, num_jobs, num_checkers):
@@ -513,15 +507,9 @@ class TestCheckParallel:
             (3, 1, 1),
             (3, 1, 2),
             (3, 1, 3),
-            (3, 5, 1),
-            (3, 5, 2),
-            (3, 5, 3),
             (10, 2, 1),
             (10, 2, 2),
             (10, 2, 3),
-            (2, 10, 1),
-            (2, 10, 2),
-            (2, 10, 3),
         ],
     )
     def test_map_reduce(self, num_files, num_jobs, num_checkers):


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This fixes the CI issues we were seeing in #5778 and #5805.
The second argument of these tuples is used to determine the number of jobs. However, the Linux runner only has two cores available. I'm not sure why this is different on Linux and Windows, but I think because we were trying to use more processes than available cores the test became either very slow or completely locked up.
You can see that we these changes both #5778 and #5805 pass the tests in expected times on all environments.