### PR TITLE
New checker `unnecessary-list-index-lookup` (#4525)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,10 @@ Release date: TBA
 
   Closes #578
 
+* Added new checker ``unnecessary-list-index-lookup`` for indexing into a list while
+  iterating over ``enumerate()``.
+
+  Closes #4525
 
 * Fix false negative for ``no-member`` when attempting to assign an instance
   attribute to itself without any prior assignment.

--- a/doc/data/messages/u/unnecessary-list-index-lookup/bad.py
+++ b/doc/data/messages/u/unnecessary-list-index-lookup/bad.py
@@ -1,0 +1,4 @@
+letters = ['a', 'b', 'c']
+
+for index, letter in enumerate(letters):
+    print(letters[index])  # [unnecessary-list-index-lookup]

--- a/doc/data/messages/u/unnecessary-list-index-lookup/good.py
+++ b/doc/data/messages/u/unnecessary-list-index-lookup/good.py
@@ -1,0 +1,4 @@
+letters = ['a', 'b', 'c']
+
+for index, letter in enumerate(letters):
+    print(letter)

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -18,6 +18,11 @@ New checkers
 
   Closes #578
 
+* Added new checker ``unnecessary-list-index-lookup`` for indexing into a list while
+  iterating over ``enumerate()``.
+
+  Closes #4525
+
 Removed checkers
 ================
 

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1990,10 +1990,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         ):
             return
 
-        if (
-            not isinstance(node.target, nodes.Tuple)
-            or len(node.target.elts) < 2
-        ):
+        if not isinstance(node.target, nodes.Tuple) or len(node.target.elts) < 2:
             # enumerate() result is being assigned without destructuring
             return
 

--- a/tests/functional/c/consider/consider_using_enumerate.py
+++ b/tests/functional/c/consider/consider_using_enumerate.py
@@ -1,6 +1,6 @@
 """Emit a message for iteration through range and len is encountered."""
 
-# pylint: disable=missing-docstring, import-error, useless-object-inheritance, unsubscriptable-object, too-few-public-methods
+# pylint: disable=missing-docstring, import-error, useless-object-inheritance, unsubscriptable-object, too-few-public-methods, unnecessary-list-index-lookup
 
 def bad():
     iterable = [1, 2, 3]

--- a/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
+++ b/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
@@ -1,0 +1,46 @@
+"""Tests for unnecessary-list-index-lookup."""
+
+# pylint: disable=missing-docstring, too-few-public-methods, expression-not-assigned, line-too-long, unused-variable
+
+my_list = ['a', 'b']
+
+for idx, val in enumerate(my_list):
+    print(my_list[idx]) # [unnecessary-list-index-lookup]
+
+for idx, _ in enumerate(my_list):
+    print(my_list[0])
+    if idx > 0:
+        print(my_list[idx - 1])
+
+for idx, val in enumerate(my_list):
+    del my_list[idx]
+
+for idx, val in enumerate(my_list):
+    my_list[idx] = 42
+
+for vals in enumerate(my_list):
+    # This could be refactored, but too complex to infer
+    print(my_list[vals[0]])
+
+def process_list(data):
+    for index, value in enumerate(data):
+        index = 1
+        print(data[index])
+
+def process_list_again(data):
+    for index, value in enumerate(data):
+        value = 1
+        print(data[index]) # Can't use value here, it's been redefined
+
+other_list = [1, 2]
+for idx, val in enumerate(my_list):
+    print(other_list[idx])
+
+OTHER_INDEX = 0
+for idx, val in enumerate(my_list):
+    print(my_list[OTHER_INDEX])
+
+result = [val for idx, val in enumerate(my_list) if my_list[idx] == 'a'] # [unnecessary-list-index-lookup]
+result = [val for idx, val in enumerate(my_list) if idx > 0 and my_list[idx - 1] == 'a']
+result = [val for idx, val in enumerate(my_list) if other_list[idx] == 'a']
+result = [my_list[idx] for idx, val in enumerate(my_list)] # [unnecessary-list-index-lookup]

--- a/tests/functional/u/unnecessary/unnecessary_list_index_lookup.txt
+++ b/tests/functional/u/unnecessary/unnecessary_list_index_lookup.txt
@@ -1,0 +1,3 @@
+unnecessary-list-index-lookup:8:10:8:22::Unnecessary list index lookup, use 'val' instead:HIGH
+unnecessary-list-index-lookup:43:52:43:64::Unnecessary list index lookup, use 'val' instead:HIGH
+unnecessary-list-index-lookup:46:10:46:22::Unnecessary list index lookup, use 'val' instead:HIGH

--- a/tests/functional/u/unnecessary/unnecessary_list_index_lookup_py38.py
+++ b/tests/functional/u/unnecessary/unnecessary_list_index_lookup_py38.py
@@ -1,0 +1,9 @@
+"""Tests for unnecessary-list-index-lookup with assignment expressions."""
+
+# pylint: disable=missing-docstring, too-few-public-methods, expression-not-assigned, line-too-long, unused-variable
+
+my_list = ['a', 'b']
+
+for idx, val in enumerate(my_list):
+    if (val := 42) and my_list[idx] == 'b':
+        print(1)

--- a/tests/functional/u/unnecessary/unnecessary_list_index_lookup_py38.rc
+++ b/tests/functional/u/unnecessary/unnecessary_list_index_lookup_py38.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.8


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

Added a new checker for catching the case of iterating over a list using `enumerate()`:

    for index, value in enumerate(mylist):
        print(mylist[index]) # Bad, should use value instead

This will now report

    Unnecessary list index lookup, use 'value' instead

Closes #4525
