### PR TITLE
Enum: Add support for self-defined members

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -439,6 +439,7 @@ contributors:
 - Jacques Kvam <jwkvam@gmail.com>
 - Jace Browning <jacebrowning@gmail.com>: updated default report format with clickable paths
 - JT Olds <jtolds@xnet5.com>
+- Huw Jones <huw@huwcbjones.co.uk> (huwcbjones)
 - Hayden Richards <62866982+SupImDos@users.noreply.github.com> (SupImDos)
   * Fixed "no-self-use" for async methods
   * Fixed "docparams" extension for async functions and methods

--- a/ChangeLog
+++ b/ChangeLog
@@ -249,6 +249,10 @@ Release date: TBA
 
   Closes #5219
 
+* Fixed false positive ``no-member`` for Enums with self-defined members.
+
+  Closes #5138
+
 * Fix false negative for ``no-member`` when attempting to assign an instance
   attribute to itself without any prior assignment.
 

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -260,6 +260,10 @@ Other Changes
 
   Closes #5219
 
+* Fixed false positive ``no-member`` for Enums with self-defined members.
+
+  Closes #5138
+
 * Fix false negative for ``no-member`` when attempting to assign an instance
   attribute to itself without any prior assignment.
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -543,7 +543,15 @@ def _get_all_attribute_assignments(
 def _enum_has_attribute(
     owner: Union[astroid.Instance, nodes.ClassDef], node: nodes.Attribute
 ) -> bool:
-    enum_def = owner
+    if isinstance(owner, astroid.Instance):
+        enum_def = next(
+            (b.parent for b in owner.bases if isinstance(b.parent, nodes.ClassDef)),
+            None,
+        )
+        if enum_def is None:
+            return False
+    else:
+        enum_def = owner
     # Traverse the AST to find the Enum ClassDef
     while not isinstance(enum_def, astroid.ClassDef):
         enum_def = enum_def.parent

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -556,6 +556,15 @@ def _enum_has_attribute(
             (b.parent for b in owner.bases if isinstance(b.parent, nodes.ClassDef)),
             None,
         )
+
+        if enum_def is None:
+            # We don't inherit from anything, so try to find the parent
+            # class definition and roll with that
+            enum_def = node
+            while enum_def is not None and not isinstance(enum_def, nodes.ClassDef):
+                enum_def = enum_def.parent
+
+        # If this blows, something is clearly wrong
         assert enum_def is not None, "enum_def unexpectedly None"
     else:
         enum_def = owner

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -529,8 +529,13 @@ def _get_all_attribute_assignments(
     node: astroid.FunctionDef, name: str | None = None
 ) -> set[str]:
     attributes = set()
-    for child in node.nodes_of_class(astroid.Assign):
-        for assign_target in child.targets:
+    for child in node.nodes_of_class((astroid.Assign, astroid.AnnAssign)):
+        targets = []
+        if isinstance(child, astroid.Assign):
+            targets = child.targets
+        elif isinstance(child, astroid.AnnAssign):
+            targets = [child.target]
+        for assign_target in targets:
             if not isinstance(assign_target, astroid.AssignAttr):
                 continue
             if not isinstance(assign_target.expr, astroid.Name):
@@ -541,7 +546,7 @@ def _get_all_attribute_assignments(
 
 
 def _enum_has_attribute(
-    owner: Union[astroid.Instance, nodes.ClassDef], node: nodes.Attribute
+    owner: astroid.Instance | nodes.ClassDef, node: nodes.Attribute
 ) -> bool:
     if isinstance(owner, astroid.Instance):
         enum_def = next(

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -450,9 +450,9 @@ def _emit_no_member(
             except astroid.MroError:
                 return False
             if metaclass:
-                # Renamed in Python 3.10 to `EnumType`
                 if _enum_has_attribute(owner, node):
                     return False
+                # Renamed in Python 3.10 to `EnumType`
                 return metaclass.qname() in {"enum.EnumMeta", "enum.EnumType"}
             return False
         if not has_known_bases(owner):
@@ -525,7 +525,9 @@ def _emit_no_member(
     return True
 
 
-def _enum_has_attribute(owner, node) -> bool:
+def _enum_has_attribute(
+    owner: Union[astroid.Instance, nodes.ClassDef], node: nodes.Attribute
+) -> bool:
     enum_def = owner
     # Traverse the AST to find the Enum ClassDef
     while not isinstance(enum_def, astroid.ClassDef):

--- a/tests/functional/e/enum_self_defined_member_5138.py
+++ b/tests/functional/e/enum_self_defined_member_5138.py
@@ -1,0 +1,22 @@
+# [missing-module-docstring]
+from enum import IntEnum
+
+
+class Day(IntEnum):  # [missing-class-docstring]
+    MONDAY = (1, "Mon")
+    TUESDAY = (2, "Tue")
+    WEDNESDAY = (3, "Wed")
+    THURSDAY = (4, "Thu")
+    FRIDAY = (5, "Fri")
+    SATURDAY = (6, "Sat")
+    SUNDAY = (7, "Sun")
+
+    def __new__(cls, value, abbr):
+        obj = int.__new__(cls, value)
+        obj._value_ = value
+        obj.abbr = abbr
+        return obj
+
+
+print(Day.FRIDAY.abbr)
+print(Day.FRIDAY.foo)  # [no-member]

--- a/tests/functional/e/enum_self_defined_member_5138.py
+++ b/tests/functional/e/enum_self_defined_member_5138.py
@@ -20,6 +20,9 @@ class Day(IntEnum):
             obj.abbr = ""
         return obj
 
+    def __repr__(self):
+        return f"{self._value_}: {self.foo}"  # [no-member]
+
 
 print(Day.FRIDAY.abbr)
 print(Day.FRIDAY.foo)  # [no-member]

--- a/tests/functional/e/enum_self_defined_member_5138.py
+++ b/tests/functional/e/enum_self_defined_member_5138.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-docstring
-from enum import IntEnum
+from enum import IntEnum, Enum
 
 
 class Day(IntEnum):
@@ -11,12 +11,32 @@ class Day(IntEnum):
     SATURDAY = (6, "Sat")
     SUNDAY = (7, "Sun")
 
-    def __new__(cls, value, abbr):
+    def __new__(cls, value, abbr=None):
         obj = int.__new__(cls, value)
         obj._value_ = value
-        obj.abbr = abbr
+        if abbr:
+            obj.abbr = abbr
+        else:
+            obj.abbr = ""
         return obj
 
 
 print(Day.FRIDAY.abbr)
 print(Day.FRIDAY.foo)  # [no-member]
+
+
+class Length(Enum):
+    METRE = "metre", "m"
+    MILE = "mile", "m", True
+
+    def __init__(self, text: str, unit: str,  is_imperial: bool = False):
+        self.text = text
+        self.unit = unit
+        if is_imperial:
+            self.suffix = " (imp)"
+        else:
+            self.suffix = ""
+
+
+print(f"100 {Length.METRE.unit}{Length.METRE.suffix}")
+print(Length.MILE.foo)  # [no-member]

--- a/tests/functional/e/enum_self_defined_member_5138.py
+++ b/tests/functional/e/enum_self_defined_member_5138.py
@@ -1,3 +1,4 @@
+"""Tests for self-defined Enum members (https://github.com/PyCQA/pylint/issues/5138)"""
 # pylint: disable=missing-docstring
 from enum import IntEnum, Enum
 
@@ -43,3 +44,20 @@ class Length(Enum):
 
 print(f"100 {Length.METRE.unit}{Length.METRE.suffix}")
 print(Length.MILE.foo)  # [no-member]
+
+
+class Binary(int, Enum):
+    ZERO = 0
+    ONE = 1
+
+    def __init__(self, value: int) -> None:
+        super().__init__()
+        self.str, self.inverse = str(value), abs(value - 1)
+
+        def no_op(_value):
+            pass
+        value_squared = value ** 2
+        no_op(value_squared)
+
+
+print(f"1={Binary.ONE.value} (Inverted: {Binary.ONE.inverse}")

--- a/tests/functional/e/enum_self_defined_member_5138.py
+++ b/tests/functional/e/enum_self_defined_member_5138.py
@@ -1,8 +1,8 @@
-# [missing-module-docstring]
+# pylint: disable=missing-docstring
 from enum import IntEnum
 
 
-class Day(IntEnum):  # [missing-class-docstring]
+class Day(IntEnum):
     MONDAY = (1, "Mon")
     TUESDAY = (2, "Tue")
     WEDNESDAY = (3, "Wed")

--- a/tests/functional/e/enum_self_defined_member_5138.py
+++ b/tests/functional/e/enum_self_defined_member_5138.py
@@ -33,8 +33,8 @@ class Length(Enum):
     MILE = "mile", "m", True
 
     def __init__(self, text: str, unit: str,  is_imperial: bool = False):
-        self.text = text
-        self.unit = unit
+        self.text: str = text
+        self.unit: str = unit
         if is_imperial:
             self.suffix = " (imp)"
         else:

--- a/tests/functional/e/enum_self_defined_member_5138.txt
+++ b/tests/functional/e/enum_self_defined_member_5138.txt
@@ -1,2 +1,3 @@
-no-member:25:6:25:20::Instance of 'FRIDAY' has no 'foo' member:INFERENCE
-no-member:42:6:42:21::Instance of 'MILE' has no 'foo' member:INFERENCE
+no-member:24:34:24:42:Day.__repr__:Instance of 'Day' has no 'foo' member:INFERENCE
+no-member:28:6:28:20::Instance of 'FRIDAY' has no 'foo' member:INFERENCE
+no-member:45:6:45:21::Instance of 'MILE' has no 'foo' member:INFERENCE

--- a/tests/functional/e/enum_self_defined_member_5138.txt
+++ b/tests/functional/e/enum_self_defined_member_5138.txt
@@ -1,1 +1,2 @@
-no-member:22:6:22:20::Instance of 'FRIDAY' has no 'foo' member:INFERENCE
+no-member:25:6:25:20::Instance of 'FRIDAY' has no 'foo' member:INFERENCE
+no-member:42:6:42:21::Instance of 'MILE' has no 'foo' member:INFERENCE

--- a/tests/functional/e/enum_self_defined_member_5138.txt
+++ b/tests/functional/e/enum_self_defined_member_5138.txt
@@ -1,3 +1,1 @@
-missing-module-docstring:1:0:None:None::Missing module docstring:HIGH
-missing-class-docstring:5:0:18:18:Day:Missing class docstring:HIGH
 no-member:22:6:22:20::Instance of 'FRIDAY' has no 'foo' member:INFERENCE

--- a/tests/functional/e/enum_self_defined_member_5138.txt
+++ b/tests/functional/e/enum_self_defined_member_5138.txt
@@ -1,3 +1,3 @@
-no-member:24:34:24:42:Day.__repr__:Instance of 'Day' has no 'foo' member:INFERENCE
-no-member:28:6:28:20::Instance of 'FRIDAY' has no 'foo' member:INFERENCE
-no-member:45:6:45:21::Instance of 'MILE' has no 'foo' member:INFERENCE
+no-member:25:34:25:42:Day.__repr__:Instance of 'Day' has no 'foo' member:INFERENCE
+no-member:29:6:29:20::Instance of 'FRIDAY' has no 'foo' member:INFERENCE
+no-member:46:6:46:21::Instance of 'MILE' has no 'foo' member:INFERENCE

--- a/tests/functional/e/enum_self_defined_member_5138.txt
+++ b/tests/functional/e/enum_self_defined_member_5138.txt
@@ -1,0 +1,3 @@
+missing-module-docstring:1:0:None:None::Missing module docstring:HIGH
+missing-class-docstring:5:0:18:18:Day:Missing class docstring:HIGH
+no-member:22:6:22:20::Instance of 'FRIDAY' has no 'foo' member:INFERENCE


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description
As per title, this PR adds an enhancement to the typechecker to find _simple_ self-defined members

This change **does not** support:
* conditionally defining members (it will assume all members are valid even if the validity is conditional)
* defining members via a function call in `__new__` or `__init__`

Closes #5138
