### PR TITLE
Bump astroid from 2.9.3 to 2.10.0

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -601,3 +601,5 @@ contributors:
 * Carli Freudenberg (CarliJoy): contributor
   - Fixed issue 5281, added Unicode checker
   - Improve non-ascii-name checker
+
+* Mathieu Parent (sathieu): contributor

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,5 +1,5 @@
 -e .[testutil]
 # astroid dependency is also defined in setup.cfg
-astroid==2.9.3  # Pinned to a specific version for tests
+astroid==2.10.0  # Pinned to a specific version for tests
 pytest~=7.0
 pytest-benchmark~=3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     # Also upgrade requirements_test_min.txt if you are bumping astroid.
     # Pinned to dev of next minor update to allow editable installs,
     # see https://github.com/PyCQA/astroid/issues/1341
-    astroid>=2.9.2,<=2.10.0-dev0
+    astroid>=2.9.2,<=2.11.0-dev0
     isort>=4.2.5,<6
     mccabe>=0.6,<0.7
     toml>=0.9.2


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Bumps [astroid](https://github.com/PyCQA/astroid) from 2.9.3 to 2.10.0.
- [Release notes](https://github.com/PyCQA/astroid/releases)
- [Changelog](https://github.com/PyCQA/astroid/blob/main/ChangeLog)
- [Commits](https://github.com/PyCQA/astroid/compare/v2.9.3...v2.10.0)
