### PR TITLE
Use value directly instead of index in ``enumerate`` contexts

### DIFF
--- a/pylint/checkers/__init__.py
+++ b/pylint/checkers/__init__.py
@@ -124,8 +124,8 @@ def table_lines_from_stats(
                 ("error", "NC"),
             ]
 
-    for index, _ in enumerate(new):
-        new_value = new[index][1]
+    for index, value in enumerate(new):
+        new_value = value[1]
         old_value = old[index][1]
         diff_str = (
             diff_string(old_value, new_value)
@@ -134,7 +134,7 @@ def table_lines_from_stats(
         )
         new_str = f"{new_value:.3f}" if isinstance(new_value, float) else str(new_value)
         old_str = f"{old_value:.3f}" if isinstance(old_value, float) else str(old_value)
-        lines.extend((new[index][0].replace("_", " "), new_str, old_str, diff_str))
+        lines.extend((value[0].replace("_", " "), new_str, old_str, diff_str))
     return lines
 
 

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -578,12 +578,12 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             token_string = token[1]
             if token_string == "elif":
                 # AST exists by the time process_tokens is called, so
-                # it's safe to assume tokens[index+1]
-                # exists. tokens[index+1][2] is the elif's position as
+                # it's safe to assume tokens[index+1] exists.
+                # tokens[index+1][2] is the elif's position as
                 # reported by CPython and PyPy,
-                # tokens[index][2] is the actual position and also is
+                # token[2] is the actual position and also is
                 # reported by IronPython.
-                self._elifs.extend([tokens[index][2], tokens[index + 1][2]])
+                self._elifs.extend([token[2], tokens[index + 1][2]])
             elif _is_trailing_comma(tokens, index):
                 if self.linter.is_message_enabled("trailing-comma-tuple"):
                     self.add_message("trailing-comma-tuple", line=token.start[0])


### PR DESCRIPTION
Refactoring to prevent warnings being issued on these lines from a new
checker.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

The new `unnecessary-list-lookup` checker being added in PR #5834 will cause regressions, refactoring to avoid this.
