### PR TITLE
Fix matching note tags with a non-word char last

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -601,3 +601,5 @@ contributors:
 * Carli Freudenberg (CarliJoy): contributor
   - Fixed issue 5281, added Unicode checker
   - Improve non-ascii-name checker
+
+* Daniel Brookman: contributor

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,10 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.13.rst'
 
+* Fix matching ``--notes`` options that end in a non-word character.
+
+  Closes #5840
+
 * ``using-f-string-in-unsupported-version`` and ``using-final-decorator-in-unsupported-version`` msgids
     were renamed from ``W1601`` and ``W1602`` to ``W2601`` and ``W2602``. Disabling using these msgids will break.
     This is done in order to restore consistency with the already existing msgids for ``apply-builtin`` and

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -92,6 +92,10 @@ Extensions
 Other Changes
 =============
 
+* Fix matching ``--notes`` options that end in a non-word character.
+
+  Closes #5840
+
 * ``using-f-string-in-unsupported-version`` and ``using-final-decorator-in-unsupported-version`` msgids
     were renamed from ``W1601`` and ``W1602`` to ``W2601`` and ``W2602``. Disables using these msgids will break.
     This is done in order to restore consistency with the already existing msgids for ``apply-builtin`` and

--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -121,9 +121,9 @@ class EncodingChecker(BaseChecker):
 
         notes = "|".join(re.escape(note) for note in self.config.notes)
         if self.config.notes_rgx:
-            regex_string = rf"#\s*({notes}|{self.config.notes_rgx})\b"
+            regex_string = rf"#\s*({notes}|{self.config.notes_rgx})(?=(:|\s|\Z))"
         else:
-            regex_string = rf"#\s*({notes})\b"
+            regex_string = rf"#\s*({notes})(?=(:|\s|\Z))"
 
         self._fixme_pattern = re.compile(regex_string, re.I)
 

--- a/tests/checkers/unittest_misc.py
+++ b/tests/checkers/unittest_misc.py
@@ -68,6 +68,16 @@ class TestFixme(CheckerTestCase):
         ):
             self.checker.process_tokens(_tokenize_str(code))
 
+    @set_config(notes=["???"])
+    def test_non_alphanumeric_codetag(self) -> None:
+        code = """a = 1
+                #???
+                """
+        with self.assertAddsMessages(
+            MessageTest(msg_id="fixme", line=2, args="???", col_offset=17)
+        ):
+            self.checker.process_tokens(_tokenize_str(code))
+
     @set_config(notes=[])
     def test_absent_codetag(self) -> None:
         code = """a = 1


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

Using `\b` at the end of the patterns for note tags will only match ones that end in an alphanumeric character, immediately followed by a non-alphanumeric character, or the end of the string. This is due to `\b` being defined as a boundary between a word character (`\w`) and a non-word character (`\W`), or the end of the string. This leads to deviations like `???` being ignored when specified.

Swapping `\b` for a positive lookahead that targets a whitespace, a colon, or the end of a string accounts for this.

Closes #5840.