### PR TITLE
Add stdlib `xml.etree.cElementTree` to deprecated modules

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -395,6 +395,10 @@ Release date: TBA
 
   Closes #258
 
+* Importing the deprecated stdlib module ``xml.etree.cElementTree`` now emits ``deprecated_module``.
+
+  Closes #5862
+
 * ``missing-raises-doc`` will now check the class hierarchy of the raised exceptions
 
   .. code-block:: python

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -382,6 +382,10 @@ Other Changes
 * The ``testutils`` for unittests now accept ``end_lineno`` and ``end_column``. Tests
   without these will trigger a ``DeprecationWarning``.
 
+* Importing the deprecated stdlib module ``xml.etree.cElementTree`` now emits ``deprecated_module``.
+
+  Closes #5862
+
 * Fixed false positive ``unexpected-keyword-arg`` for decorators.
 
   Closes #258

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -73,6 +73,7 @@ NON_INSTANCE_METHODS = {"builtins.staticmethod", "builtins.classmethod"}
 DEPRECATED_MODULES = {
     (0, 0, 0): {"tkinter.tix", "fpectl"},
     (3, 2, 0): {"optparse"},
+    (3, 3, 0): {"xml.etree.cElementTree"},
     (3, 4, 0): {"imp"},
     (3, 5, 0): {"formatter"},
     (3, 6, 0): {"asynchat", "asyncore"},

--- a/tests/functional/d/deprecated/deprecated_module_py33.py
+++ b/tests/functional/d/deprecated/deprecated_module_py33.py
@@ -1,0 +1,4 @@
+"""Test deprecated modules from Python 3.3."""
+# pylint: disable=unused-import
+
+import xml.etree.cElementTree  # [deprecated-module]

--- a/tests/functional/d/deprecated/deprecated_module_py33.txt
+++ b/tests/functional/d/deprecated/deprecated_module_py33.txt
@@ -1,0 +1,1 @@
+deprecated-module:4:0:4:29::Uses of a deprecated module 'xml.etree.cElementTree':UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Description

Closes #5862, see full write-up there. 

`cElementTree` has been deprecated since Python 3.3, but does not raise `DeprecationWarning` to avoid pestering folks using really old idioms, from before the C-accelerator was on by default.

`pylint` can (and should!) be a bit more aggressive than that, and it was even floated on the python issue that this is a job for a linter.