### PR TITLE
Add `distutils` to deprecated modules

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -399,6 +399,8 @@ Release date: TBA
 
   Closes #5862
 
+* Importing the deprecated stdlib module ``distutils`` now emits ``deprecated_module``.
+
 * ``missing-raises-doc`` will now check the class hierarchy of the raised exceptions
 
   .. code-block:: python

--- a/ChangeLog
+++ b/ChangeLog
@@ -399,7 +399,7 @@ Release date: TBA
 
   Closes #5862
 
-* Importing the deprecated stdlib module ``distutils`` now emits ``deprecated_module``.
+* Importing the deprecated stdlib module ``distutils`` now emits ``deprecated_module`` on Python 3.10+.
 
 * ``missing-raises-doc`` will now check the class hierarchy of the raised exceptions
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -386,7 +386,7 @@ Other Changes
 
   Closes #5862
 
-* Importing the deprecated stdlib module ``distutils`` now emits ``deprecated_module``.
+* Importing the deprecated stdlib module ``distutils`` now emits ``deprecated_module`` on Python 3.10+.
 
 * Fixed false positive ``unexpected-keyword-arg`` for decorators.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -386,6 +386,8 @@ Other Changes
 
   Closes #5862
 
+* Importing the deprecated stdlib module ``distutils`` now emits ``deprecated_module``.
+
 * Fixed false positive ``unexpected-keyword-arg`` for decorators.
 
   Closes #258

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -51,7 +51,7 @@ import collections
 import copy
 import os
 import sys
-from distutils import sysconfig
+import sysconfig
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 
 import astroid
@@ -449,14 +449,13 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             return os.path.normcase(os.path.abspath(path))
 
         paths = set()
-        real_prefix = getattr(sys, "real_prefix", None)
-        for prefix in filter(None, (real_prefix, sys.prefix)):
-            path = sysconfig.get_python_lib(prefix=prefix)
-            path = _normalized_path(path)
-            paths.add(path)
+        path = sysconfig.get_path("purelib")
+        path = _normalized_path(path)
+        paths.add(path)
 
         # Handle Debian's derivatives /usr/local.
         if os.path.isfile("/etc/debian_version"):
+            real_prefix = getattr(sys, "real_prefix", None)
             for prefix in filter(None, (real_prefix, sys.prefix)):
                 libpython = os.path.join(
                     prefix,

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -51,7 +51,7 @@ import collections
 import copy
 import os
 import sys
-from distutils import sysconfig  # pylint: disable=deprecated-module
+from distutils import sysconfig
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 
 import astroid

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -79,6 +79,7 @@ DEPRECATED_MODULES = {
     (3, 6, 0): {"asynchat", "asyncore"},
     (3, 7, 0): {"macpath"},
     (3, 9, 0): {"lib2to3", "parser", "symbol", "binhex"},
+    (3, 10, 0): {"distutils"},
 }
 
 DEPRECATED_ARGUMENTS = {
@@ -126,6 +127,7 @@ DEPRECATED_DECORATORS = {
         "abc.abstractstaticmethod",
         "abc.abstractproperty",
     },
+    (3, 4, 0): {"importlib.util.module_for_loader"},
 }
 
 
@@ -205,6 +207,10 @@ DEPRECATED_METHODS: Dict = {
         },
         (3, 4, 0): {
             "importlib.find_loader",
+            "importlib.abc.Loader.load_module",
+            "importlib.abc.Loader.module_repr",
+            "importlib.abc.PathEntryFinder.find_loader",
+            "importlib.abc.PathEntryFinder.find_module",
             "plistlib.readPlist",
             "plistlib.writePlist",
             "plistlib.readPlistFromBytes",
@@ -253,6 +259,7 @@ DEPRECATED_METHODS: Dict = {
         },
         (3, 10, 0): {
             "_sqlite3.enable_shared_cache",
+            "importlib.abc.Finder.find_module",
             "pathlib.Path.link_to",
             "zipimport.zipimporter.load_module",
             "zipimport.zipimporter.find_module",

--- a/tests/functional/d/deprecated/deprecated_module_py310.py
+++ b/tests/functional/d/deprecated/deprecated_module_py310.py
@@ -1,0 +1,4 @@
+"""Test deprecated modules from Python 3.10."""
+# pylint: disable=unused-import
+
+import distutils  # [deprecated-module]

--- a/tests/functional/d/deprecated/deprecated_module_py310.rc
+++ b/tests/functional/d/deprecated/deprecated_module_py310.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver = 3.10

--- a/tests/functional/d/deprecated/deprecated_module_py310.txt
+++ b/tests/functional/d/deprecated/deprecated_module_py310.txt
@@ -1,0 +1,1 @@
+deprecated-module:4:0:4:16::Uses of a deprecated module 'distutils':UNDEFINED

--- a/tests/functional/r/regression_02/regression_distutil_import_error_73.py
+++ b/tests/functional/r/regression_02/regression_distutil_import_error_73.py
@@ -7,7 +7,7 @@ https://github.com/PyCQA/pylint/issues/2955
 https://github.com/PyCQA/astroid/pull/1321
 """
 
-# pylint: disable=unused-import
+# pylint: disable=unused-import, deprecated-module
 
 import distutils.version
 from distutils.util import strtobool


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

`distutils` was deprecated in Python 3.10. Adding it (and some other tiny methods and decorators that were missed) to the list of deprecations.