### PR TITLE
Improve CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -441,10 +441,10 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            ${{ runner.os }}-${{ matrix.python-version }}-${{
             steps.generate-python-key.outputs.key }}
           restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ env.CACHE_VERSION }}-
+            ${{ runner.os }}-${{ matrix.python-version }}-venv-${{ env.CACHE_VERSION }}-
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -476,7 +476,7 @@ jobs:
         with:
           path: venv
           key:
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            ${{ runner.os }}-${{ matrix.python-version }}-${{
             needs.prepare-tests-pypy.outputs.python-key }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -280,7 +280,7 @@ jobs:
     name: tests / run benchmark / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: prepare-tests-linux
+    needs: ["prepare-tests-linux", "pytest-linux"]
     strategy:
       fail-fast: false
       matrix:
@@ -332,6 +332,7 @@ jobs:
     name: tests / prepare / ${{ matrix.python-version }} / Windows
     runs-on: windows-latest
     timeout-minutes: 10
+    needs: pytest-linux
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
   prepare-base:
     name: Prepare base dependencies
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
       pre-commit-key: ${{ steps.generate-pre-commit-key.outputs.key }}
@@ -77,7 +77,7 @@ jobs:
   formatting:
     name: checks / pre-commit
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: prepare-base
     steps:
       - name: Check out code from GitHub
@@ -151,7 +151,7 @@ jobs:
   prepare-tests-linux:
     name: tests / prepare / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
@@ -194,7 +194,7 @@ jobs:
   pytest-linux:
     name: tests / run / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: prepare-tests-linux
     strategy:
       fail-fast: false
@@ -279,7 +279,7 @@ jobs:
   benchmark-linux:
     name: tests / run benchmark / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: prepare-tests-linux
     strategy:
       fail-fast: false
@@ -331,7 +331,7 @@ jobs:
   prepare-tests-windows:
     name: tests / prepare / ${{ matrix.python-version }} / Windows
     runs-on: windows-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
@@ -374,7 +374,7 @@ jobs:
   pytest-windows:
     name: tests / run / ${{ matrix.python-version }} / Windows
     runs-on: windows-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: prepare-tests-windows
     strategy:
       fail-fast: false
@@ -413,7 +413,7 @@ jobs:
   prepare-tests-pypy:
     name: tests / prepare / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: ["pypy-3.6"]
@@ -456,7 +456,7 @@ jobs:
   pytest-pypy:
     name: tests / run / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: prepare-tests-pypy
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description
CI improvements similar to those already applied to astroid.
* Update timeouts
* Stage different jobs (`windows` + `benchmark` are only run after `pytest-linux` is done)
* Fix pypy cache key. See discussion here: https://github.com/PyCQA/pylint/pull/5853#discussion_r816835038

/CC: @Pierre-Sassoulas @DanielNoord 