### PR TITLE
Fix pre-commit configuration hook URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
       - id: black
         args: [--safe, --quiet]
         exclude: *fixtures
-  - repo: https://github.com/Pierre-Sassoulas/black-disable-checker/
+  - repo: https://github.com/Pierre-Sassoulas/black-disable-checker
     rev: 1.0.1
     hooks:
       - id: black-disable-checker

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -603,3 +603,5 @@ contributors:
   - Improve non-ascii-name checker
 
 * Daniel Brookman: contributor
+
+* Téo Bouvard: contributor


### PR DESCRIPTION
Removing the final slash in the `repo` url prevents git from not being
able to clone the repository.

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does. -> Not applicable since this is an internal implementation detail ?
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`. -> Not applicable since this is an internal implementation detail ?
- [x] Write a good description on what the PR does.


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Running `pre-commit run` on a fresh repository fails during the initalization of the `black-disable-checker` hook, because of a malformed `git` URL. The error log from `~/.cache/pre-commit/pre-commit.log` is given below.

### version information

```
pre-commit version: 2.17.0
git --version: git version 2.35.1
sys.version:
    3.10.2 (main, Jan 15 2022, 19:56:27) [GCC 11.1.0]
sys.executable: /usr/bin/python
os.name: posix
sys.platform: linux
```

### error information

```
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    ERROR: Repository not found.
    fatal: Could not read from remote repository.
    
    Please make sure you have the correct access rights
    and the repository exists.
    
```

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/pre_commit/store.py", line 183, in clone_strategy
    self._shallow_clone(ref, _git_cmd)
  File "/usr/lib/python3.10/site-packages/pre_commit/store.py", line 165, in _shallow_clone
    git_cmd('-c', git_config, 'fetch', 'origin', ref, '--depth=1')
  File "/usr/lib/python3.10/site-packages/pre_commit/store.py", line 180, in _git_cmd
    cmd_output_b('git', *args, cwd=directory, env=env)
  File "/usr/lib/python3.10/site-packages/pre_commit/util.py", line 154, in cmd_output_b
    raise CalledProcessError(returncode, cmd, retcode, stdout_b, stderr_b)
pre_commit.util.CalledProcessError: command: ('/usr/bin/git', '-c', 'protocol.version=2', 'fetch', 'origin', '1.0.1', '--depth=1')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    ERROR: Repository not found.
    fatal: Could not read from remote repository.
    
    Please make sure you have the correct access rights
    and the repository exists.
    

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/pre_commit/error_handler.py", line 70, in error_handler
    yield
  File "/usr/lib/python3.10/site-packages/pre_commit/main.py", line 396, in main
    return run(args.config, store, args)
  File "/usr/lib/python3.10/site-packages/pre_commit/commands/run.py", line 403, in run
    for hook in all_hooks(config, store)
  File "/usr/lib/python3.10/site-packages/pre_commit/repository.py", line 228, in all_hooks
    return tuple(
  File "/usr/lib/python3.10/site-packages/pre_commit/repository.py", line 231, in <genexpr>
    for hook in _repository_hooks(repo, store, root_config)
  File "/usr/lib/python3.10/site-packages/pre_commit/repository.py", line 206, in _repository_hooks
    return _cloned_repository_hooks(repo_config, store, root_config)
  File "/usr/lib/python3.10/site-packages/pre_commit/repository.py", line 172, in _cloned_repository_hooks
    manifest_path = os.path.join(store.clone(repo, rev), C.MANIFEST_FILE)
  File "/usr/lib/python3.10/site-packages/pre_commit/store.py", line 187, in clone
    return self._new_repo(repo, ref, deps, clone_strategy)
  File "/usr/lib/python3.10/site-packages/pre_commit/store.py", line 144, in _new_repo
    make_strategy(directory)
  File "/usr/lib/python3.10/site-packages/pre_commit/store.py", line 185, in clone_strategy
    self._complete_clone(ref, _git_cmd)
  File "/usr/lib/python3.10/site-packages/pre_commit/store.py", line 157, in _complete_clone
    git_cmd('fetch', 'origin', '--tags')
  File "/usr/lib/python3.10/site-packages/pre_commit/store.py", line 180, in _git_cmd
    cmd_output_b('git', *args, cwd=directory, env=env)
  File "/usr/lib/python3.10/site-packages/pre_commit/util.py", line 154, in cmd_output_b
    raise CalledProcessError(returncode, cmd, retcode, stdout_b, stderr_b)
pre_commit.util.CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    ERROR: Repository not found.
    fatal: Could not read from remote repository.
    
    Please make sure you have the correct access rights
    and the repository exists.
```

Removing the last slash of the URL fixes the issue.

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->
