### PR TITLE
Fix Markdown link in ReStructuredText README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -168,8 +168,7 @@ Use the badge in your project's README.rst (or any other rst file)::
 
 
 If you use GitHub Actions, and one of your CI workflows begins with "name: pylint", you
-can use GitHub's
-[workflow status badges](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name)
+can use GitHub's `workflow status badges <https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name>`_
 to show an up-to-date indication of whether pushes to your default branch pass pylint.
 For more detailed information, check the documentation.
 


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor. 
(already done in #5869)
- [ ] Add a ChangeLog entry describing what your PR does.
Not applicable since the `README` is only shown in GitHub ?
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
Not applicable since the `README` is only shown in GitHub ?
- [x] Write a good description on what the PR does.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

This commit updates a link formatted using Markdown syntax to use
ReStructuredText syntax, which is what the README file is written in.
This allows a prettier link visualization in GitHub, by not displaying
the full URL between parentheses.
