### PR TITLE
Removed unused detection of site-packages directory

### DIFF
--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -443,7 +443,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
 
     @staticmethod
     def _compute_site_packages() -> Set[str]:
-        def _normalized_path(path):
+        def _normalized_path(path: str) -> str:
             return os.path.normcase(os.path.abspath(path))
 
         return {_normalized_path(path) for path in astroid.modutils.STD_LIB_DIRS}

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -442,7 +442,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
         self._site_packages = self._compute_site_packages()
 
     @staticmethod
-    def _compute_site_packages():
+    def _compute_site_packages() -> Set[str]:
         def _normalized_path(path):
             return os.path.normcase(os.path.abspath(path))
 

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -50,8 +50,6 @@
 import collections
 import copy
 import os
-import sys
-from distutils import sysconfig
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 
 import astroid
@@ -448,25 +446,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
         def _normalized_path(path):
             return os.path.normcase(os.path.abspath(path))
 
-        paths = set()
-        real_prefix = getattr(sys, "real_prefix", None)
-        for prefix in filter(None, (real_prefix, sys.prefix)):
-            path = sysconfig.get_python_lib(prefix=prefix)
-            path = _normalized_path(path)
-            paths.add(path)
-
-        # Handle Debian's derivatives /usr/local.
-        if os.path.isfile("/etc/debian_version"):
-            for prefix in filter(None, (real_prefix, sys.prefix)):
-                libpython = os.path.join(
-                    prefix,
-                    "local",
-                    "lib",
-                    "python" + sysconfig.get_python_version(),
-                    "dist-packages",
-                )
-                paths.add(libpython)
-        return paths
+        return {_normalized_path(path) for path in astroid.modutils.STD_LIB_DIRS}
 
     def open(self):
         """Called before visiting project (i.e set of modules)."""

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -439,15 +439,6 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             ("RP0402", "Modules dependencies graph", self._report_dependencies_graph),
         )
 
-        self._site_packages = self._compute_site_packages()
-
-    @staticmethod
-    def _compute_site_packages() -> Set[str]:
-        def _normalized_path(path: str) -> str:
-            return os.path.normcase(os.path.abspath(path))
-
-        return {_normalized_path(path) for path in astroid.modutils.STD_LIB_DIRS}
-
     def open(self):
         """Called before visiting project (i.e set of modules)."""
         self.linter.stats.dependencies = {}


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

<s>Remove use of deprecated module `distutils` by relying on astroid's determination of the location of site packages. It seems error-prone to have two places for this logic.</s>

EDIT: remove unused functionality for determining the location of site-packages (unused since 9812c5a49ae430945e9ad5dde7ec523904498805).
