### PR TITLE
Prevent `useless-suppression` on disables for stdlib deprecation checker

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -402,6 +402,10 @@ Release date: TBA
 
   Closes #5862
 
+* Disables for ``deprecated-module`` and similar warnings for stdlib features deprecated
+  in newer versions of Python no longer raise ``useless-suppression`` when linting with
+  older Python interpreters where those features are not yet deprecated.
+
 * ``missing-raises-doc`` will now check the class hierarchy of the raised exceptions
 
   .. code-block:: python

--- a/ChangeLog
+++ b/ChangeLog
@@ -395,6 +395,9 @@ Release date: TBA
 
   Closes #258
 
+* Emit warnings for deprecated names according to the ``py-version`` setting
+  instead of the Python interpreter version.
+
 * Importing the deprecated stdlib module ``xml.etree.cElementTree`` now emits ``deprecated_module``.
 
   Closes #5862

--- a/ChangeLog
+++ b/ChangeLog
@@ -401,9 +401,6 @@ Release date: TBA
 
   Closes #258
 
-* Emit warnings for deprecated names according to the ``py-version`` setting
-  instead of the Python interpreter version.
-
 * Importing the deprecated stdlib module ``xml.etree.cElementTree`` now emits ``deprecated_module``.
 
   Closes #5862

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -382,6 +382,9 @@ Other Changes
 * The ``testutils`` for unittests now accept ``end_lineno`` and ``end_column``. Tests
   without these will trigger a ``DeprecationWarning``.
 
+* Emit warnings for deprecated names according to the ``py-version`` setting
+  instead of the Python interpreter version.
+
 * Importing the deprecated stdlib module ``xml.etree.cElementTree`` now emits ``deprecated_module``.
 
   Closes #5862

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -382,8 +382,9 @@ Other Changes
 * The ``testutils`` for unittests now accept ``end_lineno`` and ``end_column``. Tests
   without these will trigger a ``DeprecationWarning``.
 
-* Emit warnings for deprecated names according to the ``py-version`` setting
-  instead of the Python interpreter version.
+* Disables for ``deprecated-module`` and similar warnings for stdlib features deprecated
+  in newer versions of Python no longer raise ``useless-suppression`` when linting with
+  older Python interpreters where those features are not yet deprecated.
 
 * Importing the deprecated stdlib module ``xml.etree.cElementTree`` now emits ``deprecated_module``.
 

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -36,7 +36,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 """Checkers for various standard library functions."""
-
+import sys
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
@@ -46,7 +46,6 @@ from astroid import nodes
 from pylint import interfaces
 from pylint.checkers import BaseChecker, DeprecatedMixin, utils
 from pylint.interfaces import IAstroidChecker
-from pylint.utils import get_global_option
 
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
@@ -474,25 +473,20 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
         self._deprecated_modules: Set[str] = set()
         self._deprecated_decorators: Set[str] = set()
 
-    def open(self):
-        # In all versions
-        self._deprecated_methods.update(DEPRECATED_METHODS[0])
-        # Pad (X, Y) -> (X, Y, 0) since the constants are 3-tuples
-        py_version = (*get_global_option(self, "py-version"), 0)
-        for since_vers, func_list in DEPRECATED_METHODS[py_version[0]].items():
-            if since_vers <= py_version:
+        for since_vers, func_list in DEPRECATED_METHODS[sys.version_info[0]].items():
+            if since_vers <= sys.version_info:
                 self._deprecated_methods.update(func_list)
         for since_vers, func_list in DEPRECATED_ARGUMENTS.items():
-            if since_vers <= py_version:
+            if since_vers <= sys.version_info:
                 self._deprecated_arguments.update(func_list)
         for since_vers, class_list in DEPRECATED_CLASSES.items():
-            if since_vers <= py_version:
+            if since_vers <= sys.version_info:
                 self._deprecated_classes.update(class_list)
         for since_vers, mod_list in DEPRECATED_MODULES.items():
-            if since_vers <= py_version:
+            if since_vers <= sys.version_info:
                 self._deprecated_modules.update(mod_list)
         for since_vers, decorator_list in DEPRECATED_DECORATORS.items():
-            if since_vers <= py_version:
+            if since_vers <= sys.version_info:
                 self._deprecated_decorators.update(decorator_list)
 
     def _check_bad_thread_instantiation(self, node):

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -466,11 +466,11 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
 
     def __init__(self, linter: Optional["PyLinter"] = None) -> None:
         BaseChecker.__init__(self, linter)
-        self._deprecated_methods: Set[Any] = set()
-        self._deprecated_attributes: Dict = {}
-        self._deprecated_classes: Dict = {}
-        self._deprecated_modules: Set[Any] = set()
-        self._deprecated_decorators: Set[Any] = set()
+        self._deprecated_methods: Set[str] = set()
+        self._deprecated_attributes: Dict[str, Tuple[Tuple[Optional[int], str], ...]] = {}
+        self._deprecated_classes: Dict[str, Set[str]] = {}
+        self._deprecated_modules: Set[str] = set()
+        self._deprecated_decorators: Set[str] = set()
 
     def open(self):
         # In all versions

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -467,7 +467,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
     def __init__(self, linter: Optional["PyLinter"] = None) -> None:
         BaseChecker.__init__(self, linter)
         self._deprecated_methods: Set[str] = set()
-        self._deprecated_attributes: Dict[
+        self._deprecated_arguments: Dict[
             str, Tuple[Tuple[Optional[int], str], ...]
         ] = {}
         self._deprecated_classes: Dict[str, Set[str]] = {}
@@ -484,7 +484,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                 self._deprecated_methods.update(func_list)
         for since_vers, func_list in DEPRECATED_ARGUMENTS.items():
             if since_vers <= py_version:
-                self._deprecated_attributes.update(func_list)
+                self._deprecated_arguments.update(func_list)
         for since_vers, class_list in DEPRECATED_CLASSES.items():
             if since_vers <= py_version:
                 self._deprecated_classes.update(class_list)
@@ -788,7 +788,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
         return self._deprecated_methods
 
     def deprecated_arguments(self, method: str):
-        return self._deprecated_attributes.get(method, ())
+        return self._deprecated_arguments.get(method, ())
 
     def deprecated_classes(self, module: str):
         return self._deprecated_classes.get(module, ())

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -466,19 +466,16 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
 
     def __init__(self, linter: Optional["PyLinter"] = None) -> None:
         BaseChecker.__init__(self, linter)
-        self._deprecated_names_populated = False
         self._deprecated_methods: Set[Any] = set()
         self._deprecated_attributes: Dict = {}
         self._deprecated_classes: Dict = {}
         self._deprecated_modules: Set[Any] = set()
         self._deprecated_decorators: Set[Any] = set()
 
-    def _ensure_deprecated_names_populated(self):
-        if self._deprecated_names_populated:
-            return
+    def open(self):
         # In all versions
         self._deprecated_methods.update(DEPRECATED_METHODS[0])
-        # Pad (X.Y) -> (X.Y.0), since the constants are 3-tuples
+        # Pad (X, Y) -> (X, Y, 0) since the constants are 3-tuples
         py_version = (*get_global_option(self, "py-version"), 0)
         for since_vers, func_list in DEPRECATED_METHODS[py_version[0]].items():
             if since_vers <= py_version:
@@ -495,7 +492,6 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
         for since_vers, decorator_list in DEPRECATED_DECORATORS.items():
             if since_vers <= py_version:
                 self._deprecated_decorators.update(decorator_list)
-        self._deprecated_names_populated = True
 
     def _check_bad_thread_instantiation(self, node):
         if not node.kwargs and not node.keywords and len(node.args) <= 1:
@@ -784,23 +780,18 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
 
     def deprecated_modules(self):
         """Callback returning the deprecated modules."""
-        self._ensure_deprecated_names_populated()
         return self._deprecated_modules
 
     def deprecated_methods(self):
-        self._ensure_deprecated_names_populated()
         return self._deprecated_methods
 
     def deprecated_arguments(self, method: str):
-        self._ensure_deprecated_names_populated()
         return self._deprecated_attributes.get(method, ())
 
     def deprecated_classes(self, module: str):
-        self._ensure_deprecated_names_populated()
         return self._deprecated_classes.get(module, ())
 
     def deprecated_decorators(self) -> Iterable:
-        self._ensure_deprecated_names_populated()
         return self._deprecated_decorators
 
 

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -38,7 +38,7 @@
 """Checkers for various standard library functions."""
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 import astroid
 from astroid import nodes
@@ -467,7 +467,9 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
     def __init__(self, linter: Optional["PyLinter"] = None) -> None:
         BaseChecker.__init__(self, linter)
         self._deprecated_methods: Set[str] = set()
-        self._deprecated_attributes: Dict[str, Tuple[Tuple[Optional[int], str], ...]] = {}
+        self._deprecated_attributes: Dict[
+            str, Tuple[Tuple[Optional[int], str], ...]
+        ] = {}
         self._deprecated_classes: Dict[str, Set[str]] = {}
         self._deprecated_modules: Set[str] = set()
         self._deprecated_decorators: Set[str] = set()

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -36,6 +36,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 """Checkers for various standard library functions."""
+
 import sys
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -38,7 +38,7 @@
 """Checkers for various standard library functions."""
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
 import astroid
 from astroid import nodes

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -176,3 +176,13 @@ DELETED_MESSAGES = [
     # https://github.com/PyCQA/pylint/pull/3571
     DeletedMessage("C0330", "bad-continuation"),
 ]
+
+
+INCOMPATIBLE_WITH_USELESS_SUPPRESSION = [
+    "R0401",  # cyclic-import
+    "W0402",  # deprecated-module
+    "W1505",  # deprecated-method
+    "W1511",  # deprecated-argument
+    "W1512",  # deprecated-class
+    "W1513",  # deprecated-decorator
+]

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -175,11 +175,18 @@ DELETED_MESSAGES = [
 ]
 
 
-INCOMPATIBLE_WITH_USELESS_SUPPRESSION = [
-    "R0401",  # cyclic-import
-    "W0402",  # deprecated-module
-    "W1505",  # deprecated-method
-    "W1511",  # deprecated-argument
-    "W1512",  # deprecated-class
-    "W1513",  # deprecated-decorator
-]
+# ignore some messages when emitting useless-suppression:
+# - cyclic-import: can show false positives due to incomplete context
+# - deprecated-{module, argument, class, method, decorator}:
+#   can cause false positives for multi-interpreter projects
+#   when linting with an interpreter on a lower python version
+INCOMPATIBLE_WITH_USELESS_SUPPRESSION = frozenset(
+    [
+        "R0401",  # cyclic-import
+        "W0402",  # deprecated-module
+        "W1505",  # deprecated-method
+        "W1511",  # deprecated-argument
+        "W1512",  # deprecated-class
+        "W1513",  # deprecated-decorator
+    ]
+)

--- a/pylint/utils/file_state.py
+++ b/pylint/utils/file_state.py
@@ -163,16 +163,14 @@ class FileState:
     ]:
         for warning, lines in self._raw_module_msgs_state.items():
             for line, enable in lines.items():
-                if not enable and (warning, line) not in self._ignored_msgs:
-                    # ignore cyclic-import check which can show false positives
-                    # here due to incomplete context
-                    # and deprecated-{module, argument, class, method, decorator}
-                    # which can cause false positives for multi-interpreter projects
-                    # when linting with an interpreter on a lower python version
-                    if warning not in INCOMPATIBLE_WITH_USELESS_SUPPRESSION:
-                        yield "useless-suppression", line, (
-                            msgs_store.get_msg_display_string(warning),
-                        )
+                if (
+                    not enable
+                    and (warning, line) not in self._ignored_msgs
+                    and warning not in INCOMPATIBLE_WITH_USELESS_SUPPRESSION
+                ):
+                    yield "useless-suppression", line, (
+                        msgs_store.get_msg_display_string(warning),
+                    )
         # don't use iteritems here, _ignored_msgs may be modified by add_message
         for (warning, from_), ignored_lines in list(self._ignored_msgs.items()):
             for line in ignored_lines:

--- a/pylint/utils/file_state.py
+++ b/pylint/utils/file_state.py
@@ -16,7 +16,11 @@ from typing import (
 
 from astroid import nodes
 
-from pylint.constants import MSG_STATE_SCOPE_MODULE, WarningScope
+from pylint.constants import (
+    INCOMPATIBLE_WITH_USELESS_SUPPRESSION,
+    MSG_STATE_SCOPE_MODULE,
+    WarningScope,
+)
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -162,7 +166,10 @@ class FileState:
                 if not enable and (warning, line) not in self._ignored_msgs:
                     # ignore cyclic-import check which can show false positives
                     # here due to incomplete context
-                    if warning != "R0401":
+                    # and deprecated-{module, argument, class, method, decorator}
+                    # which can cause false positives for multi-interpreter projects
+                    # when linting with an interpreter on a lower python version
+                    if warning not in INCOMPATIBLE_WITH_USELESS_SUPPRESSION:
                         yield "useless-suppression", line, (
                             msgs_store.get_msg_display_string(warning),
                         )

--- a/tests/functional/d/deprecated/deprecated_method_suppression.py
+++ b/tests/functional/d/deprecated/deprecated_method_suppression.py
@@ -5,4 +5,4 @@ This test can be run on all Python versions, but it will lack value when
 Pylint drops support for 3.9."""
 # pylint: disable=import-error, unused-import
 
-import _sqlite3.enable_shared_cache  # pylint: disable=deprecated-method
+import threading.current_thread  # pylint: disable=deprecated-method

--- a/tests/functional/d/deprecated/deprecated_method_suppression.py
+++ b/tests/functional/d/deprecated/deprecated_method_suppression.py
@@ -1,0 +1,8 @@
+"""Test that versions below Py3.10 will not emit useless-suppression for
+disabling deprecated-method (on a method deprecated in Py3.10.
+
+This test can be run on all Python versions, but it will lack value when
+Pylint drops support for 3.9"""
+# pylint: disable=import-error, unused-import
+
+import pathlib.Path.link_to  # pylint: disable=deprecated-method

--- a/tests/functional/d/deprecated/deprecated_method_suppression.py
+++ b/tests/functional/d/deprecated/deprecated_method_suppression.py
@@ -2,7 +2,7 @@
 disabling deprecated-method (on a method deprecated in Py3.10.
 
 This test can be run on all Python versions, but it will lack value when
-Pylint drops support for 3.9"""
+Pylint drops support for 3.9."""
 # pylint: disable=import-error, unused-import
 
-import pathlib.Path.link_to  # pylint: disable=deprecated-method
+import _sqlite3.enable_shared_cache  # pylint: disable=deprecated-method

--- a/tests/functional/d/deprecated/deprecated_methods_py39.py
+++ b/tests/functional/d/deprecated/deprecated_methods_py39.py
@@ -1,0 +1,4 @@
+"""Test deprecated methods from Python 3.9."""
+
+import binascii
+binascii.b2a_hqx() # [deprecated-method]

--- a/tests/functional/d/deprecated/deprecated_methods_py39.rc
+++ b/tests/functional/d/deprecated/deprecated_methods_py39.rc
@@ -1,2 +1,2 @@
-[master]
-py-version=3.9
+[testoptions]
+min_pyver=3.9

--- a/tests/functional/d/deprecated/deprecated_methods_py39.rc
+++ b/tests/functional/d/deprecated/deprecated_methods_py39.rc
@@ -1,0 +1,2 @@
+[master]
+py-version=3.9

--- a/tests/functional/d/deprecated/deprecated_methods_py39.txt
+++ b/tests/functional/d/deprecated/deprecated_methods_py39.txt
@@ -1,0 +1,1 @@
+deprecated-method:4:0:4:18::Using deprecated method b2a_hqx():UNDEFINED

--- a/tests/functional/d/deprecated/deprecated_module_py3.rc
+++ b/tests/functional/d/deprecated/deprecated_module_py3.rc
@@ -1,2 +1,2 @@
-[master]
-py-version=3.6
+[testoptions]
+max_pyver=3.6

--- a/tests/functional/d/deprecated/deprecated_module_py3.rc
+++ b/tests/functional/d/deprecated/deprecated_module_py3.rc
@@ -1,2 +1,2 @@
-[testoptions]
-max_pyver=3.6
+[master]
+py-version=3.6

--- a/tests/functional/d/deprecated/deprecated_module_py3.txt
+++ b/tests/functional/d/deprecated/deprecated_module_py3.txt
@@ -1,1 +1,1 @@
-deprecated-module:4:::Uses of a deprecated module 'optparse'
+deprecated-module:4:0:4:15::Uses of a deprecated module 'optparse':UNDEFINED

--- a/tests/functional/d/deprecated/deprecated_module_py39.py
+++ b/tests/functional/d/deprecated/deprecated_module_py39.py
@@ -1,0 +1,4 @@
+"""Test deprecated modules from Python 3.9."""
+# pylint: disable=unused-import
+
+import binhex  # [deprecated-module]

--- a/tests/functional/d/deprecated/deprecated_module_py39.rc
+++ b/tests/functional/d/deprecated/deprecated_module_py39.rc
@@ -1,5 +1,2 @@
 [testoptions]
 min_pyver=3.9
-
-[Messages Control]
-enable=deprecated-module

--- a/tests/functional/d/deprecated/deprecated_module_py39.rc
+++ b/tests/functional/d/deprecated/deprecated_module_py39.rc
@@ -1,5 +1,5 @@
-[master]
-py-version=3.9
+[testoptions]
+min_pyver=3.9
 
 [Messages Control]
 enable=deprecated-module

--- a/tests/functional/d/deprecated/deprecated_module_py39.rc
+++ b/tests/functional/d/deprecated/deprecated_module_py39.rc
@@ -1,0 +1,5 @@
+[master]
+py-version=3.9
+
+[Messages Control]
+enable=deprecated-module

--- a/tests/functional/d/deprecated/deprecated_module_py39.txt
+++ b/tests/functional/d/deprecated/deprecated_module_py39.txt
@@ -1,0 +1,1 @@
+deprecated-module:4:0:4:13::Uses of a deprecated module 'binhex':UNDEFINED

--- a/tests/functional/d/deprecated/deprecated_module_py39_earlier_pyversion.py
+++ b/tests/functional/d/deprecated/deprecated_module_py39_earlier_pyversion.py
@@ -1,0 +1,6 @@
+"""Test deprecated modules from Python 3.9,
+but use an earlier --py-version and ensure no warning emitted.
+"""
+# pylint: disable=unused-import
+
+import binhex

--- a/tests/functional/d/deprecated/deprecated_module_py39_earlier_pyversion.py
+++ b/tests/functional/d/deprecated/deprecated_module_py39_earlier_pyversion.py
@@ -1,6 +1,6 @@
 """Test deprecated modules from Python 3.9,
-but use an earlier --py-version and ensure no warning emitted.
+but use an earlier --py-version and ensure a warning is still emitted.
 """
 # pylint: disable=unused-import
 
-import binhex
+import binhex  # [deprecated-module]

--- a/tests/functional/d/deprecated/deprecated_module_py39_earlier_pyversion.rc
+++ b/tests/functional/d/deprecated/deprecated_module_py39_earlier_pyversion.rc
@@ -1,2 +1,5 @@
 [master]
 py-version=3.8
+
+[testoptions]
+min_pyver=3.9

--- a/tests/functional/d/deprecated/deprecated_module_py39_earlier_pyversion.rc
+++ b/tests/functional/d/deprecated/deprecated_module_py39_earlier_pyversion.rc
@@ -1,0 +1,2 @@
+[master]
+py-version=3.8

--- a/tests/functional/d/deprecated/deprecated_module_py39_earlier_pyversion.txt
+++ b/tests/functional/d/deprecated/deprecated_module_py39_earlier_pyversion.txt
@@ -1,0 +1,1 @@
+deprecated-module:6:0:6:13::Uses of a deprecated module 'binhex':UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description
**Before**
<s>The deprecated names checker ignored the `py_version` setting, raising warnings (or not) depending on the python interpreter version.</s>
`useless-suppression` is raised on disables of `deprecated-module` and sim. on lower versions where the module is not yet deprecated. This can make it challenging to get a project to pass pylint on multiple versions with a disable for a deprecated module.

**Now**
<s>Deprecated name warnings are emitted according to `py_version` (which falls back to the interpreter version).

Discussed at https://github.com/PyCQA/pylint/pull/5874#issuecomment-1061261766. </s>
`useless-suppression` is treated as incompatible with the stdlib deprecation checks--it is not emitted.

**Tangent**
As a follow up, we could consider adding ~`--py-version=3.8` to the pre-commit config to match CI?~ After 2.13, I suppose it should be `--py-version=3.7`.