### PR TITLE
Fix pyreverse type hinting for class methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,8 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.13.rst'
 
+* Fix pyreverse diagrams type hinting for classmethods and staticmethods.
+
 * Fix matching ``--notes`` options that end in a non-word character.
 
   Closes #5840

--- a/pylint/pyreverse/printer.py
+++ b/pylint/pyreverse/printer.py
@@ -100,7 +100,7 @@ class Printer(ABC):
     @staticmethod
     def _get_method_arguments(method: nodes.FunctionDef) -> List[str]:
         if method.args.args:
-            first_arg = 0 if method.type in ("function", "staticmethod") else 1
+            first_arg = 0 if method.type in {"function", "staticmethod"} else 1
             arguments: List[nodes.AssignName] = method.args.args[first_arg:]
         else:
             first_arg = 0

--- a/pylint/pyreverse/printer.py
+++ b/pylint/pyreverse/printer.py
@@ -100,13 +100,13 @@ class Printer(ABC):
     @staticmethod
     def _get_method_arguments(method: nodes.FunctionDef) -> List[str]:
         if method.args.args:
-            arguments: List[nodes.AssignName] = [
-                arg for arg in method.args.args if arg.name != "self"
-            ]
+            first_arg = 0 if method.type in ("function", "staticmethod") else 1
+            arguments: List[nodes.AssignName] = method.args.args[first_arg:]
         else:
+            first_arg = 0
             arguments = []
 
-        annotations = dict(zip(arguments, method.args.annotations[1:]))
+        annotations = dict(zip(arguments, method.args.annotations[first_arg:]))
         for arg in arguments:
             annotation_label = ""
             ann = annotations.get(arg)

--- a/pylint/pyreverse/printer.py
+++ b/pylint/pyreverse/printer.py
@@ -99,12 +99,11 @@ class Printer(ABC):
 
     @staticmethod
     def _get_method_arguments(method: nodes.FunctionDef) -> List[str]:
-        if method.args.args:
-            first_arg = 0 if method.type in {"function", "staticmethod"} else 1
-            arguments: List[nodes.AssignName] = method.args.args[first_arg:]
-        else:
-            first_arg = 0
-            arguments = []
+        if method.args.args is None:
+            return []
+
+        first_arg = 0 if method.type in {"function", "staticmethod"} else 1
+        arguments: List[nodes.AssignName] = method.args.args[first_arg:]
 
         annotations = dict(zip(arguments, method.args.annotations[first_arg:]))
         for arg in arguments:

--- a/tests/data/clientmodule_test.py
+++ b/tests/data/clientmodule_test.py
@@ -28,3 +28,11 @@ class Specialization(Ancestor):
         self._id = _id
         self.relation = DoNothing()
         self.relation2 = relation2
+
+    @classmethod
+    def from_value(cls, value: int):
+        return cls(value, 0, DoNothing2())
+
+    @staticmethod
+    def transform_value(value: int) -> int:
+        return value * 2

--- a/tests/pyreverse/data/classes_No_Name.dot
+++ b/tests/pyreverse/data/classes_No_Name.dot
@@ -8,7 +8,7 @@ charset="utf-8"
 "data.suppliermodule_test.DoSomething" [color="black", fontcolor="black", label="{DoSomething|my_int : Optional[int]\lmy_int_2 : Optional[int]\lmy_string : str\l|do_it(new_int: int): int\l}", shape="record", style="solid"];
 "data.suppliermodule_test.Interface" [color="black", fontcolor="black", label="{Interface|\l|get_value()\lset_value(value)\l}", shape="record", style="solid"];
 "data.property_pattern.PropertyPatterns" [color="black", fontcolor="black", label="{PropertyPatterns|prop1\lprop2\l|}", shape="record", style="solid"];
-"data.clientmodule_test.Specialization" [color="black", fontcolor="black", label="{Specialization|TYPE : str\lrelation\lrelation2\ltop : str\l|}", shape="record", style="solid"];
+"data.clientmodule_test.Specialization" [color="black", fontcolor="black", label="{Specialization|TYPE : str\lrelation\lrelation2\ltop : str\l|from_value(value: int)\ltransform_value(value: int): int\l}", shape="record", style="solid"];
 "data.clientmodule_test.Specialization" -> "data.clientmodule_test.Ancestor" [arrowhead="empty", arrowtail="none"];
 "data.clientmodule_test.Ancestor" -> "data.suppliermodule_test.Interface" [arrowhead="empty", arrowtail="node", style="dashed"];
 "data.suppliermodule_test.DoNothing" -> "data.clientmodule_test.Ancestor" [arrowhead="diamond", arrowtail="none", fontcolor="green", label="cls_member", style="solid"];

--- a/tests/pyreverse/data/classes_No_Name.html
+++ b/tests/pyreverse/data/classes_No_Name.html
@@ -35,6 +35,8 @@
             relation
             relation2
             top : str
+            from_value(value: int)
+            transform_value(value: int) -> int
           }
           Specialization --|> Ancestor
           Ancestor ..|> Interface

--- a/tests/pyreverse/data/classes_No_Name.mmd
+++ b/tests/pyreverse/data/classes_No_Name.mmd
@@ -30,6 +30,8 @@ classDiagram
     relation
     relation2
     top : str
+    from_value(value: int)
+    transform_value(value: int) -> int
   }
   Specialization --|> Ancestor
   Ancestor ..|> Interface

--- a/tests/pyreverse/data/classes_No_Name.puml
+++ b/tests/pyreverse/data/classes_No_Name.puml
@@ -31,6 +31,8 @@ class "Specialization" as data.clientmodule_test.Specialization {
   relation
   relation2
   top : str
+  from_value(value: int)
+  transform_value(value: int) -> int
 }
 data.clientmodule_test.Specialization --|> data.clientmodule_test.Ancestor
 data.clientmodule_test.Ancestor ..|> data.suppliermodule_test.Interface

--- a/tests/pyreverse/data/classes_No_Name.vcg
+++ b/tests/pyreverse/data/classes_No_Name.vcg
@@ -25,7 +25,7 @@ graph:{
   node: {title:"data.property_pattern.PropertyPatterns"  label:"\fbPropertyPatterns\fn\n\f__________________\n\f08prop1\n\f08prop2\n\f__________________"
   shape:box
 }
-  node: {title:"data.clientmodule_test.Specialization"  label:"\fbSpecialization\fn\n\f________________\n\f08TYPE : str\n\f08relation\n\f08relation2\n\f08top : str\n\f________________"
+  node: {title:"data.clientmodule_test.Specialization"  label:"\fbSpecialization\fn\n\f_________________\n\f08TYPE : str\n\f08relation\n\f08relation2\n\f08top : str\n\f_________________\n\f10from_value()\n\f10transform_value()"
   shape:box
 }
   edge: {sourcename:"data.clientmodule_test.Specialization" targetname:"data.clientmodule_test.Ancestor"  arrowstyle:solid

--- a/tests/pyreverse/data/classes_colorized.dot
+++ b/tests/pyreverse/data/classes_colorized.dot
@@ -8,7 +8,7 @@ charset="utf-8"
 "data.suppliermodule_test.DoSomething" [color="aliceblue", fontcolor="black", label="{DoSomething|my_int : Optional[int]\lmy_int_2 : Optional[int]\lmy_string : str\l|do_it(new_int: int): int\l}", shape="record", style="filled"];
 "data.suppliermodule_test.Interface" [color="aliceblue", fontcolor="black", label="{Interface|\l|get_value()\lset_value(value)\l}", shape="record", style="filled"];
 "data.property_pattern.PropertyPatterns" [color="aliceblue", fontcolor="black", label="{PropertyPatterns|prop1\lprop2\l|}", shape="record", style="filled"];
-"data.clientmodule_test.Specialization" [color="aliceblue", fontcolor="black", label="{Specialization|TYPE : str\lrelation\lrelation2\ltop : str\l|}", shape="record", style="filled"];
+"data.clientmodule_test.Specialization" [color="aliceblue", fontcolor="black", label="{Specialization|TYPE : str\lrelation\lrelation2\ltop : str\l|from_value(value: int)\ltransform_value(value: int): int\l}", shape="record", style="filled"];
 "data.clientmodule_test.Specialization" -> "data.clientmodule_test.Ancestor" [arrowhead="empty", arrowtail="none"];
 "data.clientmodule_test.Ancestor" -> "data.suppliermodule_test.Interface" [arrowhead="empty", arrowtail="node", style="dashed"];
 "data.suppliermodule_test.DoNothing" -> "data.clientmodule_test.Ancestor" [arrowhead="diamond", arrowtail="none", fontcolor="green", label="cls_member", style="solid"];

--- a/tests/pyreverse/data/classes_colorized.puml
+++ b/tests/pyreverse/data/classes_colorized.puml
@@ -31,6 +31,8 @@ class "Specialization" as data.clientmodule_test.Specialization #aliceblue {
   relation
   relation2
   top : str
+  from_value(value: int)
+  transform_value(value: int) -> int
 }
 data.clientmodule_test.Specialization --|> data.clientmodule_test.Ancestor
 data.clientmodule_test.Ancestor ..|> data.suppliermodule_test.Interface

--- a/tests/pyreverse/test_printer.py
+++ b/tests/pyreverse/test_printer.py
@@ -8,6 +8,7 @@
 from typing import Type
 
 import pytest
+from astroid import nodes
 
 from pylint.pyreverse.dot_printer import DotPrinter
 from pylint.pyreverse.plantuml_printer import PlantUmlPrinter
@@ -44,6 +45,15 @@ def test_explicit_layout(
 def test_unsupported_layout(layout: Layout, printer_class: Type[Printer]):
     with pytest.raises(ValueError):
         printer_class(title="unittest", layout=layout)
+
+
+def test_method_arguments_none():
+    func = nodes.FunctionDef()
+    args = nodes.Arguments()
+    args.args = None
+    func.postinit(args, body=None)
+    parsed_args = Printer._get_method_arguments(func)
+    assert parsed_args == []
 
 
 class TestPlantUmlPrinter:


### PR DESCRIPTION
This commit fixes the alignment of arguments and their type annotations
in pyreverse printer output.

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
Not a feature, is it an important bug fix ?
- [x] Write a good description on what the PR does.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Until now, the following class

```python
class Example:
    def method(self, arg: int):
        pass
    
    @classmethod
    def class_method(cls, arg: int):
        pass
    
    @staticmethod
    def static_method(arg: int):
        pass
```

would generate the following PlantUML diagram when running `pyreverse -o puml example.py`

```puml
@startuml example
class Example {
  class_method(cls: int, arg)
  method(arg: int)
  static_method(arg)
}
@enduml
```

This output displays wrong type hints because the alignment of arguments and their type annotations is based on the first argument having name `self`. This is not the case for class methods, where the first argument is usually `cls` and static methods where the first argument is not related to the class.

This commit fixes the issue by performing the alignment using the method type rather than the parameters names. This generates the correct class diagram shown below.

```puml
@startuml example
class Example {
  class_method(arg: int)
  method(arg: int)
  static_method(arg: int)
}
@enduml
```
