### PR TITLE
Add broken Callable check

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -406,6 +406,10 @@ Release date: TBA
     if ``py-version`` is set to Python ``3.7.1`` or below.
     https://bugs.python.org/issue34921
 
+  * Added new check ``broken-collections-callable`` to detect broken uses of ``collections.abc.Callable``
+    if ``py-version`` is set to Python ``3.9.1`` or below.
+    https://bugs.python.org/issue42965
+
 * The ``testutils`` for unittests now accept ``end_lineno`` and ``end_column``. Tests
   without these will trigger a ``DeprecationWarning``.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -81,6 +81,10 @@ Extensions
     if ``py-version`` is set to Python ``3.7.1`` or below.
     https://bugs.python.org/issue34921
 
+  * Added new check ``broken-collections-callable`` to detect broken uses of ``collections.abc.Callable``
+    if ``py-version`` is set to Python ``3.9.1`` or below.
+    https://bugs.python.org/issue42965
+
 * ``DocstringParameterChecker``
 
   * Fixed incorrect classification of Numpy-style docstring as Google-style docstring for

--- a/tests/functional/ext/typing/typing_broken_callable.py
+++ b/tests/functional/ext/typing/typing_broken_callable.py
@@ -1,0 +1,27 @@
+"""
+'collections.abc.Callable' is broken inside Optional and Union types for Python 3.9.0
+https://bugs.python.org/issue42965
+
+Use 'typing.Callable' instead.
+"""
+# pylint: disable=missing-docstring,unsubscriptable-object
+import collections.abc
+from collections.abc import Callable
+from typing import Optional, Union
+
+Alias1 = Optional[Callable[[int], None]]  # [broken-collections-callable]
+Alias2 = Union[Callable[[int], None], None]  # [broken-collections-callable]
+
+Alias3 = Optional[Callable[..., None]]
+Alias4 = Union[Callable[..., None], None]
+Alias5 = list[Callable[..., None]]
+
+
+def func1() -> Optional[Callable[[int], None]]:  # [broken-collections-callable]
+    ...
+
+def func2() -> Optional["Callable[[int], None]"]:
+    ...
+
+def func3() -> Union[collections.abc.Callable[[int], None], None]:  # [broken-collections-callable]
+    ...

--- a/tests/functional/ext/typing/typing_broken_callable.py
+++ b/tests/functional/ext/typing/typing_broken_callable.py
@@ -15,6 +15,7 @@ Alias2 = Union[Callable[[int], None], None]  # [broken-collections-callable]
 Alias3 = Optional[Callable[..., None]]
 Alias4 = Union[Callable[..., None], None]
 Alias5 = list[Callable[..., None]]
+Alias6 = Callable[[int], None]
 
 
 def func1() -> Optional[Callable[[int], None]]:  # [broken-collections-callable]

--- a/tests/functional/ext/typing/typing_broken_callable.rc
+++ b/tests/functional/ext/typing/typing_broken_callable.rc
@@ -1,0 +1,6 @@
+[master]
+py-version=3.9
+load-plugins=pylint.extensions.typing
+
+[testoptions]
+min_pyver=3.7

--- a/tests/functional/ext/typing/typing_broken_callable.txt
+++ b/tests/functional/ext/typing/typing_broken_callable.txt
@@ -1,0 +1,4 @@
+broken-collections-callable:12:18:12:26::'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE
+broken-collections-callable:13:15:13:23::'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE
+broken-collections-callable:20:24:20:32:func1:'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE
+broken-collections-callable:26:21:26:45:func3:'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE

--- a/tests/functional/ext/typing/typing_broken_callable.txt
+++ b/tests/functional/ext/typing/typing_broken_callable.txt
@@ -1,4 +1,4 @@
 broken-collections-callable:12:18:12:26::'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE
 broken-collections-callable:13:15:13:23::'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE
-broken-collections-callable:20:24:20:32:func1:'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE
-broken-collections-callable:26:21:26:45:func3:'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE
+broken-collections-callable:21:24:21:32:func1:'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE
+broken-collections-callable:27:21:27:45:func3:'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE

--- a/tests/functional/ext/typing/typing_broken_callable_deprecated_alias.py
+++ b/tests/functional/ext/typing/typing_broken_callable_deprecated_alias.py
@@ -1,0 +1,25 @@
+"""
+'collections.abc.Callable' is broken inside Optional and Union types for Python 3.9.0
+https://bugs.python.org/issue42965
+
+Use 'typing.Callable' instead.
+
+Don't emit 'deprecated-typing-alias' for 'Callable' if at least one replacement
+would create broken instances.
+"""
+# pylint: disable=missing-docstring,unsubscriptable-object
+from typing import Callable, Optional, Union
+
+Alias1 = Optional[Callable[[int], None]]
+Alias2 = Union[Callable[[int], None], None]
+
+Alias3 = Optional[Callable[..., None]]
+Alias4 = Union[Callable[..., None], None]
+Alias5 = list[Callable[[int], None]]
+
+
+def func1() -> Optional[Callable[[int], None]]:
+    ...
+
+def func2() -> Optional["Callable[[int], None]"]:
+    ...

--- a/tests/functional/ext/typing/typing_broken_callable_deprecated_alias.py
+++ b/tests/functional/ext/typing/typing_broken_callable_deprecated_alias.py
@@ -16,6 +16,7 @@ Alias2 = Union[Callable[[int], None], None]
 Alias3 = Optional[Callable[..., None]]
 Alias4 = Union[Callable[..., None], None]
 Alias5 = list[Callable[[int], None]]
+Alias6 = Callable[[int], None]
 
 
 def func1() -> Optional[Callable[[int], None]]:

--- a/tests/functional/ext/typing/typing_broken_callable_deprecated_alias.rc
+++ b/tests/functional/ext/typing/typing_broken_callable_deprecated_alias.rc
@@ -1,0 +1,6 @@
+[master]
+py-version=3.9
+load-plugins=pylint.extensions.typing
+
+[testoptions]
+min_pyver=3.7

--- a/tests/functional/ext/typing/typing_broken_callable_future_import.py
+++ b/tests/functional/ext/typing/typing_broken_callable_future_import.py
@@ -1,0 +1,29 @@
+"""
+'collections.abc.Callable' is broken inside Optional and Union types for Python 3.9.0
+https://bugs.python.org/issue42965
+
+Use 'typing.Callable' instead.
+"""
+# pylint: disable=missing-docstring,unsubscriptable-object
+from __future__ import annotations
+
+import collections.abc
+from collections.abc import Callable
+from typing import Optional, Union
+
+Alias1 = Optional[Callable[[int], None]]  # [broken-collections-callable]
+Alias2 = Union[Callable[[int], None], None]  # [broken-collections-callable]
+
+Alias3 = Optional[Callable[..., None]]
+Alias4 = Union[Callable[..., None], None]
+Alias5 = list[Callable[[int], None]]
+
+
+def func1() -> Optional[Callable[[int], None]]:
+    ...
+
+def func2() -> Optional["Callable[[int], None]"]:
+    ...
+
+def func3() -> Union[collections.abc.Callable[[int], None], None]:
+    ...

--- a/tests/functional/ext/typing/typing_broken_callable_future_import.py
+++ b/tests/functional/ext/typing/typing_broken_callable_future_import.py
@@ -17,6 +17,7 @@ Alias2 = Union[Callable[[int], None], None]  # [broken-collections-callable]
 Alias3 = Optional[Callable[..., None]]
 Alias4 = Union[Callable[..., None], None]
 Alias5 = list[Callable[[int], None]]
+Alias6 = Callable[[int], None]
 
 
 def func1() -> Optional[Callable[[int], None]]:

--- a/tests/functional/ext/typing/typing_broken_callable_future_import.rc
+++ b/tests/functional/ext/typing/typing_broken_callable_future_import.rc
@@ -1,0 +1,6 @@
+[master]
+py-version=3.9
+load-plugins=pylint.extensions.typing
+
+[testoptions]
+min_pyver=3.7

--- a/tests/functional/ext/typing/typing_broken_callable_future_import.txt
+++ b/tests/functional/ext/typing/typing_broken_callable_future_import.txt
@@ -1,0 +1,2 @@
+broken-collections-callable:14:18:14:26::'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE
+broken-collections-callable:15:15:15:23::'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description
Similar to the broken NoReturn check - #5304, however this time for `Callable`.
Using `collections.abc.Callable` inside `Optional` and `Union` is broken in Python 3.9.0 and 3.9.1.

This one is a bit more difficult as we currently currently suggest replacing the deprecated `typing.Callable` with `collections.abc.Callable`. Doing that can result in unexpected errors. The PR will change that behavior and **not** emit `deprecated-typing-alias` for `typing.Callable` if `py-version < (3, 9, 2)`. In addition it adds a new check to warn about potential errors.

**Example broken code**
```py
from collections.abc import Callable
from typing import Optional, Union

Alias1 = Optional[Callable[[int], None]
Alias2 = Union[Callable[[int], None], None]
```

**When exactly is it broken?**
* Python 3.9.0 or 3.9.1
* And `collections.abc.Callable` as part of `Optional` or `Union`
* And argument list for `Callable`, e.g. `[int]`.

https://bugs.python.org/issue42965