### PR TITLE
Create a ``TypeVar`` style for ``invalid-name``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -450,8 +450,8 @@ Release date: TBA
   Insert your changelog randomly, it will reduce merge conflicts
   (Ie. not necessarily at the end)
 
-* ``invalid-name`` check now also checks ``TypeVar`` for a pattern set with the new option
-  ``--typevar-rgx`` option or a default ``PascalCase`` based style.
+* Improve ``invalid-name`` check for ``TypeVar`` names.
+  The accepted pattern can be customized with ``--typevar-rgx``.
 
   Closes #3401
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -450,6 +450,11 @@ Release date: TBA
   Insert your changelog randomly, it will reduce merge conflicts
   (Ie. not necessarily at the end)
 
+* ``invalid-name`` check now also checks ``TypeVar`` for a pattern set with the new option
+  ``--typevar-rgx`` option or a default ``PascalCase`` based style.
+
+  Closes #3401
+
 * Added new checker ``typevar-name-missing-variance``. Emitted when a covariant
   or contravariant ``TypeVar`` does not end with  ``_co`` or ``_contra`` respectively or
   when a ``TypeVar`` is not either but has a suffix.

--- a/doc/user_guide/options.rst
+++ b/doc/user_guide/options.rst
@@ -39,6 +39,8 @@ name is found in, and not the type of object assigned.
 +--------------------+---------------------------------------------------------------------------------------------------+
 | ``inlinevar``      | Loop variables in list comprehensions and generator expressions.                                  |
 +--------------------+---------------------------------------------------------------------------------------------------+
+| ``typevar``        | Type variable declared with ``TypeVar``.                                                          |
++--------------------+---------------------------------------------------------------------------------------------------+
 
 Default behavior
 ~~~~~~~~~~~~~~~~
@@ -117,6 +119,8 @@ expression will lead to an instance of ``invalid-name``.
 .. option:: --class-const-rgx=<regex>
 
 .. option:: --inlinevar-rgx=<regex>
+
+.. option:: --typevar-rgx=<regex>
 
 Multiple naming styles for custom regular expressions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/user_guide/options.rst
+++ b/doc/user_guide/options.rst
@@ -95,7 +95,7 @@ The following type of names are checked with a predefined pattern:
 +--------------------+---------------------------------------------------+------------------------------------------------------------+
 | Name type          | Good names                                        | Bad names                                                  |
 +====================+===================================================+============================================================+
-| ``TypeVar``        |`T`, `_CallableT`, `_T_co`, `AnyStr`, `DeviceTypeT`| `DICT_T`, `CALLABLE_T`, `ENUM_T`, `DeviceType`, `_StrType` |
+| ``typevar``        |`T`, `_CallableT`, `_T_co`, `AnyStr`, `DeviceTypeT`| `DICT_T`, `CALLABLE_T`, `ENUM_T`, `DeviceType`, `_StrType` |
 +--------------------+---------------------------------------------------+------------------------------------------------------------+
 
 Custom regular expressions

--- a/doc/user_guide/options.rst
+++ b/doc/user_guide/options.rst
@@ -84,6 +84,15 @@ Following options are exposed:
 
 .. option:: --inlinevar-naming-style=<style>
 
+Predefined Naming Patterns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Pylint provides predefined naming patterns for some names. These patterns are often
+based on a Naming Style but there is no option to choose one of the styles mentioned above.
+The pattern can be overwritten with the options discussed below.
+
+The following type of names are checked with a predefined pattern:
+
+- TypeVars. Accepted names include: `T`, `TypeVar`, `_CallableT`, `_T_co`.
 
 Custom regular expressions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/user_guide/options.rst
+++ b/doc/user_guide/options.rst
@@ -92,7 +92,11 @@ The pattern can be overwritten with the options discussed below.
 
 The following type of names are checked with a predefined pattern:
 
-- TypeVars. Accepted names include: `T`, `TypeVar`, `_CallableT`, `_T_co`.
++--------------------+---------------------------------------------------+------------------------------------------------------------+
+| Name type          | Good names                                        | Bad names                                                  |
++====================+===================================================+============================================================+
+| ``TypeVar``        |`T`, `_CallableT`, `_T_co`, `AnyStr`, `DeviceTypeT`| `DICT_T`, `CALLABLE_T`, `ENUM_T`, `DeviceType`, `_StrType` |
++--------------------+---------------------------------------------------+------------------------------------------------------------+
 
 Custom regular expressions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -334,6 +334,11 @@ Other Changes
 
   Closes #5360, #3877
 
+* ``invalid-name`` check now also checks ``TypeVar`` for a pattern set with the new option
+  ``--typevar-rgx`` option or a default ``PascalCase`` based style.
+
+  Closes #3401
+
 * Fixed a false positive (affecting unreleased development) for
   ``used-before-assignment`` involving homonyms between filtered comprehensions
   and assignments in except blocks.

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -334,8 +334,8 @@ Other Changes
 
   Closes #5360, #3877
 
-* ``invalid-name`` check now also checks ``TypeVar`` for a pattern set with the new option
-  ``--typevar-rgx`` option or a default ``PascalCase`` based style.
+* Improve ``invalid-name`` check for ``TypeVar`` names.
+  The accepted pattern can be customized with ``--typevar-rgx``.
 
   Closes #3401
 

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1708,11 +1708,13 @@ def _create_naming_options():
     for name_type in sorted(KNOWN_NAME_TYPES):
         human_readable_name = constants.HUMAN_READABLE_TYPES[name_type]
         name_type_hyphened = name_type.replace("_", "-")
-        help_msg = f"Regular expression matching correct {human_readable_name} names."
+        help_msg = f"Regular expression matching correct {human_readable_name} names. "
+        if name_type in KNOWN_NAME_TYPES_WITH_STYLE:
+            help_msg += f"Overrides {name_type_hyphened}-naming-style. "
+        help_msg += f"If left empty, {human_readable_name} will be checked with the set naming style."
 
         if name_type in KNOWN_NAME_TYPES_WITH_STYLE:
             default_style = DEFAULT_NAMING_STYLES[name_type]
-            help_msg += f" Overrides {name_type_hyphened}-naming-style."
             name_options.append(
                 (
                     f"{name_type_hyphened}-naming-style",
@@ -1726,9 +1728,6 @@ def _create_naming_options():
                 )
             )
 
-        help_msg += (
-            " If left empty, type variables will be checked with the set naming style."
-        )
         name_options.append(
             (
                 f"{name_type_hyphened}-rgx",

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1708,11 +1708,13 @@ def _create_naming_options():
     for name_type in sorted(KNOWN_NAME_TYPES):
         human_readable_name = constants.HUMAN_READABLE_TYPES[name_type]
         name_type_hyphened = name_type.replace("_", "-")
+
         help_msg = f"Regular expression matching correct {human_readable_name} names. "
         if name_type in KNOWN_NAME_TYPES_WITH_STYLE:
             help_msg += f"Overrides {name_type_hyphened}-naming-style. "
         help_msg += f"If left empty, {human_readable_name} will be checked with the set naming style."
 
+        # Add style option for names that support it
         if name_type in KNOWN_NAME_TYPES_WITH_STYLE:
             default_style = DEFAULT_NAMING_STYLES[name_type]
             name_options.append(
@@ -1889,14 +1891,13 @@ class NameChecker(_BasicChecker):
 
         for name_type in KNOWN_NAME_TYPES:
             if name_type in KNOWN_NAME_TYPES_WITH_STYLE:
-                naming_style_option_name = f"{name_type}_naming_style"
-                naming_style_name = getattr(self.config, naming_style_option_name)
+                naming_style_name = getattr(self.config, f"{name_type}_naming_style")
                 regexps[name_type] = NAMING_STYLES[naming_style_name].get_regex(
                     name_type
                 )
             else:
-                regexps[name_type] = DEFAULT_PATTERNS[name_type]
                 naming_style_name = "predefined"
+                regexps[name_type] = DEFAULT_PATTERNS[name_type]
 
             custom_regex_setting_name = f"{name_type}_rgx"
             custom_regex = getattr(self.config, custom_regex_setting_name, None)

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1682,7 +1682,7 @@ KNOWN_NAME_TYPES_WITH_STYLE = {
     "inlinevar",
 }
 
-# Name types that only have a 'rgx' option
+# Name types that have a 'rgx' option
 KNOWN_NAME_TYPES = {
     *KNOWN_NAME_TYPES_WITH_STYLE,
     "typevar",

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1897,6 +1897,7 @@ class NameChecker(_BasicChecker):
                 )
             else:
                 regexps[name_type] = DEFAULT_PATTERNS[name_type]
+                naming_style_name = "predefined"
 
             custom_regex_setting_name = f"{name_type}_rgx"
             custom_regex = getattr(self.config, custom_regex_setting_name, None)
@@ -1906,7 +1907,6 @@ class NameChecker(_BasicChecker):
             if custom_regex is not None:
                 hints[name_type] = f"{custom_regex.pattern!r} pattern"
             else:
-                assert naming_style_name
                 hints[name_type] = f"{naming_style_name} naming style"
 
         return regexps, hints

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1712,7 +1712,7 @@ def _create_naming_options():
         help_msg = f"Regular expression matching correct {human_readable_name} names. "
         if name_type in KNOWN_NAME_TYPES_WITH_STYLE:
             help_msg += f"Overrides {name_type_hyphened}-naming-style. "
-        help_msg += f"If left empty, {human_readable_name} will be checked with the set naming style."
+        help_msg += f"If left empty, {human_readable_name} names will be checked with the set naming style."
 
         # Add style option for names that support it
         if name_type in KNOWN_NAME_TYPES_WITH_STYLE:

--- a/pylint/checkers/base.py
+++ b/pylint/checkers/base.py
@@ -1667,7 +1667,7 @@ class BasicChecker(_BasicChecker):
         self._check_redeclared_assign_name([node.target])
 
 
-# Name types that hae a style option
+# Name types that have a style option
 KNOWN_NAME_TYPES_WITH_STYLE = {
     "module",
     "const",
@@ -1708,9 +1708,11 @@ def _create_naming_options():
     for name_type in sorted(KNOWN_NAME_TYPES):
         human_readable_name = constants.HUMAN_READABLE_TYPES[name_type]
         name_type_hyphened = name_type.replace("_", "-")
+        help_msg = f"Regular expression matching correct {human_readable_name} names."
 
         if name_type in KNOWN_NAME_TYPES_WITH_STYLE:
             default_style = DEFAULT_NAMING_STYLES[name_type]
+            help_msg += f" Overrides {name_type_hyphened}-naming-style."
             name_options.append(
                 (
                     f"{name_type_hyphened}-naming-style",
@@ -1724,6 +1726,9 @@ def _create_naming_options():
                 )
             )
 
+        help_msg += (
+            " If left empty, type variables will be checked with the set naming style."
+        )
         name_options.append(
             (
                 f"{name_type_hyphened}-rgx",
@@ -1731,7 +1736,7 @@ def _create_naming_options():
                     "default": None,
                     "type": "regexp",
                     "metavar": "<regexp>",
-                    "help": f"Regular expression matching correct {human_readable_name} names. Overrides {name_type_hyphened}-naming-style.",
+                    "help": help_msg,
                 },
             )
         )

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -71,6 +71,7 @@ HUMAN_READABLE_TYPES = {
     "class_attribute": "class attribute",
     "class_const": "class constant",
     "inlinevar": "inline iteration",
+    "typevar": "type variable",
 }
 
 

--- a/pylint/utils/linterstats.py
+++ b/pylint/utils/linterstats.py
@@ -26,6 +26,7 @@ class BadNames(TypedDict):
     method: int
     module: int
     variable: int
+    typevar: int
 
 
 class CodeTypeCount(TypedDict):
@@ -102,6 +103,7 @@ class LinterStats:
             method=0,
             module=0,
             variable=0,
+            typevar=0,
         )
         self.by_module: Dict[str, ModuleStats] = by_module or {}
         self.by_msg: Dict[str, int] = by_msg or {}
@@ -171,6 +173,7 @@ class LinterStats:
             "method",
             "module",
             "variable",
+            "typevar",
         ],
     ) -> int:
         """Get a bad names node count."""
@@ -192,6 +195,7 @@ class LinterStats:
             "method",
             "module",
             "variable",
+            "typevar",
         }:
             raise ValueError("Node type not part of the bad_names stat")
 
@@ -208,6 +212,7 @@ class LinterStats:
                 "method",
                 "module",
                 "variable",
+                "typevar",
             ],
             node_name,
         )
@@ -230,6 +235,7 @@ class LinterStats:
             method=0,
             module=0,
             variable=0,
+            typevar=0,
         )
 
     def get_code_count(
@@ -317,6 +323,7 @@ def merge_stats(stats: List[LinterStats]):
         merged.bad_names["method"] += stat.bad_names["method"]
         merged.bad_names["module"] += stat.bad_names["module"]
         merged.bad_names["variable"] += stat.bad_names["variable"]
+        merged.bad_names["typevar"] += stat.bad_names["typevar"]
 
         for mod_key, mod_value in stat.by_module.items():
             merged.by_module[mod_key] = mod_value

--- a/pylintrc
+++ b/pylintrc
@@ -354,8 +354,7 @@ method-rgx=[a-z_][a-z0-9_]{2,}$
 method-name-hint=[a-z_][a-z0-9_]{2,}$
 
 # Regular expression which can overwrite the naming style set by typevar-naming-style.
-# If left empty, type variables will be checked with the set naming style.
-typevar-rgx=
+#typevar-rgx=
 
 # Regular expression which should only match function or class names that do
 # not require a docstring. Use ^(?!__init__$)_ to also check __init__.

--- a/pylintrc
+++ b/pylintrc
@@ -353,6 +353,10 @@ method-rgx=[a-z_][a-z0-9_]{2,}$
 # Naming hint for method names
 method-name-hint=[a-z_][a-z0-9_]{2,}$
 
+# Regular expression which can overwrite the naming style set by typevar-naming-style.
+# If left empty, type variables will be checked with the set naming style.
+typevar-rgx=
+
 # Regular expression which should only match function or class names that do
 # not require a docstring. Use ^(?!__init__$)_ to also check __init__.
 no-docstring-rgx=__.*__

--- a/tests/checkers/unittest_base.py
+++ b/tests/checkers/unittest_base.py
@@ -210,23 +210,17 @@ class TestNamePresets(unittest.TestCase):
         SNAKE_CASE_NAMES | CAMEL_CASE_NAMES | UPPER_CASE_NAMES | PASCAL_CASE_NAMES
     )
 
-    def _test_name_is_correct_for_all_name_types_except_typevar(
+    def _test_name_is_correct_for_all_name_types(
         self, naming_style: Type[base.NamingStyle], name: str
     ) -> None:
-        for name_type in base.KNOWN_NAME_TYPES:
-            # pylint: disable-next=fixme
-            # TODO: See if there is a better way to tests these styles
-            if name_type != "typevar":
-                self._test_is_correct(naming_style, name, name_type)
+        for name_type in base.KNOWN_NAME_TYPES_WITH_STYLE:
+            self._test_is_correct(naming_style, name, name_type)
 
-    def _test_name_is_incorrect_for_all_name_types_except_type_var(
+    def _test_name_is_incorrect_for_all_name_types(
         self, naming_style: Type[base.NamingStyle], name: str
     ) -> None:
-        for name_type in base.KNOWN_NAME_TYPES:
-            # pylint: disable-next=fixme
-            # TODO: See if there is a better way to tests these styles
-            if name_type != "typevar":
-                self._test_is_incorrect(naming_style, name, name_type)
+        for name_type in base.KNOWN_NAME_TYPES_WITH_STYLE:
+            self._test_is_incorrect(naming_style, name, name_type)
 
     def _test_should_always_pass(self, naming_style: Type[base.NamingStyle]) -> None:
         always_pass_data = [
@@ -258,13 +252,9 @@ class TestNamePresets(unittest.TestCase):
         naming_style = base.SnakeCaseStyle
 
         for name in self.SNAKE_CASE_NAMES:
-            self._test_name_is_correct_for_all_name_types_except_typevar(
-                naming_style, name
-            )
+            self._test_name_is_correct_for_all_name_types(naming_style, name)
         for name in self.ALL_NAMES - self.SNAKE_CASE_NAMES:
-            self._test_name_is_incorrect_for_all_name_types_except_type_var(
-                naming_style, name
-            )
+            self._test_name_is_incorrect_for_all_name_types(naming_style, name)
 
         self._test_should_always_pass(naming_style)
 
@@ -272,13 +262,9 @@ class TestNamePresets(unittest.TestCase):
         naming_style = base.CamelCaseStyle
 
         for name in self.CAMEL_CASE_NAMES:
-            self._test_name_is_correct_for_all_name_types_except_typevar(
-                naming_style, name
-            )
+            self._test_name_is_correct_for_all_name_types(naming_style, name)
         for name in self.ALL_NAMES - self.CAMEL_CASE_NAMES:
-            self._test_name_is_incorrect_for_all_name_types_except_type_var(
-                naming_style, name
-            )
+            self._test_name_is_incorrect_for_all_name_types(naming_style, name)
 
         self._test_should_always_pass(naming_style)
 
@@ -286,16 +272,10 @@ class TestNamePresets(unittest.TestCase):
         naming_style = base.UpperCaseStyle
 
         for name in self.UPPER_CASE_NAMES:
-            self._test_name_is_correct_for_all_name_types_except_typevar(
-                naming_style, name
-            )
+            self._test_name_is_correct_for_all_name_types(naming_style, name)
         for name in self.ALL_NAMES - self.UPPER_CASE_NAMES:
-            self._test_name_is_incorrect_for_all_name_types_except_type_var(
-                naming_style, name
-            )
-        self._test_name_is_incorrect_for_all_name_types_except_type_var(
-            naming_style, "UPPERcase"
-        )
+            self._test_name_is_incorrect_for_all_name_types(naming_style, name)
+        self._test_name_is_incorrect_for_all_name_types(naming_style, "UPPERcase")
 
         self._test_should_always_pass(naming_style)
 
@@ -303,13 +283,9 @@ class TestNamePresets(unittest.TestCase):
         naming_style = base.PascalCaseStyle
 
         for name in self.PASCAL_CASE_NAMES:
-            self._test_name_is_correct_for_all_name_types_except_typevar(
-                naming_style, name
-            )
+            self._test_name_is_correct_for_all_name_types(naming_style, name)
         for name in self.ALL_NAMES - self.PASCAL_CASE_NAMES:
-            self._test_name_is_incorrect_for_all_name_types_except_type_var(
-                naming_style, name
-            )
+            self._test_name_is_incorrect_for_all_name_types(naming_style, name)
 
         self._test_should_always_pass(naming_style)
 

--- a/tests/checkers/unittest_base.py
+++ b/tests/checkers/unittest_base.py
@@ -210,17 +210,23 @@ class TestNamePresets(unittest.TestCase):
         SNAKE_CASE_NAMES | CAMEL_CASE_NAMES | UPPER_CASE_NAMES | PASCAL_CASE_NAMES
     )
 
-    def _test_name_is_correct_for_all_name_types(
+    def _test_name_is_correct_for_all_name_types_except_typevar(
         self, naming_style: Type[base.NamingStyle], name: str
     ) -> None:
         for name_type in base.KNOWN_NAME_TYPES:
-            self._test_is_correct(naming_style, name, name_type)
+            # pylint: disable-next=fixme
+            # TODO: See if there is a better way to tests these styles
+            if name_type != "typevar":
+                self._test_is_correct(naming_style, name, name_type)
 
-    def _test_name_is_incorrect_for_all_name_types(
+    def _test_name_is_incorrect_for_all_name_types_except_type_var(
         self, naming_style: Type[base.NamingStyle], name: str
     ) -> None:
         for name_type in base.KNOWN_NAME_TYPES:
-            self._test_is_incorrect(naming_style, name, name_type)
+            # pylint: disable-next=fixme
+            # TODO: See if there is a better way to tests these styles
+            if name_type != "typevar":
+                self._test_is_incorrect(naming_style, name, name_type)
 
     def _test_should_always_pass(self, naming_style: Type[base.NamingStyle]) -> None:
         always_pass_data = [
@@ -252,9 +258,13 @@ class TestNamePresets(unittest.TestCase):
         naming_style = base.SnakeCaseStyle
 
         for name in self.SNAKE_CASE_NAMES:
-            self._test_name_is_correct_for_all_name_types(naming_style, name)
+            self._test_name_is_correct_for_all_name_types_except_typevar(
+                naming_style, name
+            )
         for name in self.ALL_NAMES - self.SNAKE_CASE_NAMES:
-            self._test_name_is_incorrect_for_all_name_types(naming_style, name)
+            self._test_name_is_incorrect_for_all_name_types_except_type_var(
+                naming_style, name
+            )
 
         self._test_should_always_pass(naming_style)
 
@@ -262,9 +272,13 @@ class TestNamePresets(unittest.TestCase):
         naming_style = base.CamelCaseStyle
 
         for name in self.CAMEL_CASE_NAMES:
-            self._test_name_is_correct_for_all_name_types(naming_style, name)
+            self._test_name_is_correct_for_all_name_types_except_typevar(
+                naming_style, name
+            )
         for name in self.ALL_NAMES - self.CAMEL_CASE_NAMES:
-            self._test_name_is_incorrect_for_all_name_types(naming_style, name)
+            self._test_name_is_incorrect_for_all_name_types_except_type_var(
+                naming_style, name
+            )
 
         self._test_should_always_pass(naming_style)
 
@@ -272,10 +286,16 @@ class TestNamePresets(unittest.TestCase):
         naming_style = base.UpperCaseStyle
 
         for name in self.UPPER_CASE_NAMES:
-            self._test_name_is_correct_for_all_name_types(naming_style, name)
+            self._test_name_is_correct_for_all_name_types_except_typevar(
+                naming_style, name
+            )
         for name in self.ALL_NAMES - self.UPPER_CASE_NAMES:
-            self._test_name_is_incorrect_for_all_name_types(naming_style, name)
-        self._test_name_is_incorrect_for_all_name_types(naming_style, "UPPERcase")
+            self._test_name_is_incorrect_for_all_name_types_except_type_var(
+                naming_style, name
+            )
+        self._test_name_is_incorrect_for_all_name_types_except_type_var(
+            naming_style, "UPPERcase"
+        )
 
         self._test_should_always_pass(naming_style)
 
@@ -283,9 +303,13 @@ class TestNamePresets(unittest.TestCase):
         naming_style = base.PascalCaseStyle
 
         for name in self.PASCAL_CASE_NAMES:
-            self._test_name_is_correct_for_all_name_types(naming_style, name)
+            self._test_name_is_correct_for_all_name_types_except_typevar(
+                naming_style, name
+            )
         for name in self.ALL_NAMES - self.PASCAL_CASE_NAMES:
-            self._test_name_is_incorrect_for_all_name_types(naming_style, name)
+            self._test_name_is_incorrect_for_all_name_types_except_type_var(
+                naming_style, name
+            )
 
         self._test_should_always_pass(naming_style)
 

--- a/tests/functional/t/typevar_naming_style_default.py
+++ b/tests/functional/t/typevar_naming_style_default.py
@@ -14,23 +14,6 @@ GoodNameWithoutContra = TypeVar(  # [typevar-name-incorrect-variance]
 GoodNameT_co = TypeVar("GoodNameT_co", covariant=True)
 GoodNameT_contra = TypeVar("GoodNameT_contra", contravariant=True)
 GoodBoundNameT = TypeVar("GoodBoundNameT", bound=int)
-GoodBoundNameT_co = TypeVar(  # [typevar-name-incorrect-variance]
-    "GoodBoundNameT_co", bound=int
-)
-GoodBoundNameT_contra = TypeVar(  # [typevar-name-incorrect-variance]
-    "GoodBoundNameT_contra", bound=int
-)
-GoodBoundNameT_co = TypeVar("GoodBoundNameT_co", bound=int, covariant=True)
-GoodBoundNameT_contra = TypeVar("GoodBoundNameT_contra", bound=int, contravariant=True)
-
-GoodBoundNameT_co = TypeVar("GoodBoundNameT_co", int, str, covariant=True)
-GoodBoundNameT_co = TypeVar(  # [typevar-name-incorrect-variance]
-    "GoodBoundNameT_co", int, str, contravariant=True
-)
-GoodBoundNameT_contra = TypeVar("GoodBoundNameT_contra", int, str, contravariant=True)
-GoodBoundNameT_contra = TypeVar(  # [typevar-name-incorrect-variance]
-    "GoodBoundNameT_contra", int, str, covariant=True
-)
 
 # Some of these will create a RunTime error but serve as a regression test
 T = TypeVar(  # [typevar-name-incorrect-variance]

--- a/tests/functional/t/typevar_naming_style_default.py
+++ b/tests/functional/t/typevar_naming_style_default.py
@@ -1,0 +1,72 @@
+"""Test case for typevar-name-incorrect-variance with default settings"""
+# pylint: disable=too-few-public-methods
+
+from typing import TypeVar
+
+# PascalCase names with prefix
+GoodNameT = TypeVar("GoodNameT")
+_T = TypeVar("_T")
+_GoodNameT = TypeVar("_GoodNameT")
+__GoodNameT = TypeVar("__GoodNameT")
+GoodNameWithoutContra = TypeVar(  # [typevar-name-incorrect-variance]
+    "GoodNameWithoutContra", contravariant=True
+)
+GoodNameT_co = TypeVar("GoodNameT_co", covariant=True)
+GoodNameT_contra = TypeVar("GoodNameT_contra", contravariant=True)
+GoodBoundNameT = TypeVar("GoodBoundNameT", bound=int)
+GoodBoundNameT_co = TypeVar(  # [typevar-name-incorrect-variance]
+    "GoodBoundNameT_co", bound=int
+)
+GoodBoundNameT_contra = TypeVar(  # [typevar-name-incorrect-variance]
+    "GoodBoundNameT_contra", bound=int
+)
+GoodBoundNameT_co = TypeVar("GoodBoundNameT_co", bound=int, covariant=True)
+GoodBoundNameT_contra = TypeVar("GoodBoundNameT_contra", bound=int, contravariant=True)
+
+GoodBoundNameT_co = TypeVar("GoodBoundNameT_co", int, str, covariant=True)
+GoodBoundNameT_co = TypeVar(  # [typevar-name-incorrect-variance]
+    "GoodBoundNameT_co", int, str, contravariant=True
+)
+GoodBoundNameT_contra = TypeVar("GoodBoundNameT_contra", int, str, contravariant=True)
+GoodBoundNameT_contra = TypeVar(  # [typevar-name-incorrect-variance]
+    "GoodBoundNameT_contra", int, str, covariant=True
+)
+
+# Some of these will create a RunTime error but serve as a regression test
+T = TypeVar(  # [typevar-name-incorrect-variance]
+    "T", covariant=True, contravariant=True
+)
+T = TypeVar("T", covariant=False, contravariant=False)
+T_co = TypeVar("T_co", covariant=True, contravariant=True)
+T_contra = TypeVar(  # [typevar-name-incorrect-variance]
+    "T_contra", covariant=True, contravariant=True
+)
+T_co = TypeVar("T_co", covariant=True, contravariant=False)
+T_contra = TypeVar("T_contra", covariant=False, contravariant=True)
+
+# PascalCase names without prefix
+AnyStr = TypeVar("AnyStr")
+DeviceTypeT = TypeVar("DeviceTypeT")
+CALLABLE_T = TypeVar("CALLABLE_T")  # [invalid-name]
+DeviceType = TypeVar("DeviceType")  # [invalid-name]
+GoodNameWithoutContra = TypeVar(  # [typevar-name-incorrect-variance]
+    "GoodNameWithoutContra", contravariant=True
+)
+
+# camelCase names with prefix
+badName = TypeVar("badName")  # [invalid-name]
+badNameWithoutContra = TypeVar(  # [invalid-name, typevar-name-incorrect-variance]]
+    "badNameWithoutContra", contravariant=True
+)
+badName_co = TypeVar("badName_co", covariant=True)  # [invalid-name]
+badName_contra = TypeVar("badName_contra", contravariant=True)  # [invalid-name]
+
+# PascalCase names with lower letter prefix in tuple assignment
+(
+    a_BadName,  # [invalid-name]
+    a_BadNameWithoutContra,  # [invalid-name, typevar-name-incorrect-variance]
+) = TypeVar("a_BadName"), TypeVar("a_BadNameWithoutContra", contravariant=True)
+GoodName_co, a_BadName_contra = TypeVar(  # [invalid-name]
+    "GoodName_co", covariant=True
+), TypeVar("a_BadName_contra", contravariant=True)
+GoodName_co, VAR = TypeVar("GoodName_co", covariant=True), "a string"

--- a/tests/functional/t/typevar_naming_style_default.py
+++ b/tests/functional/t/typevar_naming_style_default.py
@@ -49,15 +49,9 @@ AnyStr = TypeVar("AnyStr")
 DeviceTypeT = TypeVar("DeviceTypeT")
 CALLABLE_T = TypeVar("CALLABLE_T")  # [invalid-name]
 DeviceType = TypeVar("DeviceType")  # [invalid-name]
-GoodNameWithoutContra = TypeVar(  # [typevar-name-incorrect-variance]
-    "GoodNameWithoutContra", contravariant=True
-)
 
 # camelCase names with prefix
 badName = TypeVar("badName")  # [invalid-name]
-badNameWithoutContra = TypeVar(  # [invalid-name, typevar-name-incorrect-variance]]
-    "badNameWithoutContra", contravariant=True
-)
 badName_co = TypeVar("badName_co", covariant=True)  # [invalid-name]
 badName_contra = TypeVar("badName_contra", contravariant=True)  # [invalid-name]
 

--- a/tests/functional/t/typevar_naming_style_default.txt
+++ b/tests/functional/t/typevar_naming_style_default.txt
@@ -1,19 +1,12 @@
 typevar-name-incorrect-variance:11:0:11:21::"Type variable ""GoodNameWithoutContra"" is contravariant, use ""GoodNameWithoutContra_contra"" instead":INFERENCE
-typevar-name-incorrect-variance:17:0:17:17::"Type variable ""GoodBoundNameT_co"" is invariant, use ""GoodBoundNameT"" instead":INFERENCE
-typevar-name-incorrect-variance:20:0:20:21::"Type variable ""GoodBoundNameT_contra"" is invariant, use ""GoodBoundNameT"" instead":INFERENCE
-typevar-name-incorrect-variance:27:0:27:17::"Type variable ""GoodBoundNameT_co"" is contravariant, use ""GoodBoundNameT_contra"" instead":INFERENCE
-typevar-name-incorrect-variance:31:0:31:21::"Type variable ""GoodBoundNameT_contra"" is covariant, use ""GoodBoundNameT_co"" instead":INFERENCE
-typevar-name-incorrect-variance:36:0:36:1::"Type variable ""T"" is covariant, use ""T_co"" instead":INFERENCE
-typevar-name-incorrect-variance:41:0:41:8::"Type variable ""T_contra"" is covariant, use ""T_co"" instead":INFERENCE
-invalid-name:50:0:50:10::"Type variable name ""CALLABLE_T"" doesn't conform to predefined naming style":HIGH
-invalid-name:51:0:51:10::"Type variable name ""DeviceType"" doesn't conform to predefined naming style":HIGH
-typevar-name-incorrect-variance:52:0:52:21::"Type variable ""GoodNameWithoutContra"" is contravariant, use ""GoodNameWithoutContra_contra"" instead":INFERENCE
-invalid-name:57:0:57:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
-invalid-name:58:0:58:20::"Type variable name ""badNameWithoutContra"" doesn't conform to predefined naming style":HIGH
-typevar-name-incorrect-variance:58:0:58:20::"Type variable ""badNameWithoutContra"" is contravariant, use ""badNameWithoutContra_contra"" instead":INFERENCE
-invalid-name:61:0:61:10::"Type variable name ""badName_co"" doesn't conform to predefined naming style":HIGH
-invalid-name:62:0:62:14::"Type variable name ""badName_contra"" doesn't conform to predefined naming style":HIGH
-invalid-name:66:4:66:13::"Type variable name ""a_BadName"" doesn't conform to predefined naming style":HIGH
-invalid-name:67:4:67:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to predefined naming style":HIGH
-typevar-name-incorrect-variance:67:4:67:26::"Type variable ""a_BadNameWithoutContra"" is contravariant, use ""a_BadNameWithoutContra_contra"" instead":INFERENCE
-invalid-name:69:13:69:29::"Type variable name ""a_BadName_contra"" doesn't conform to predefined naming style":HIGH
+typevar-name-incorrect-variance:19:0:19:1::"Type variable ""T"" is covariant, use ""T_co"" instead":INFERENCE
+typevar-name-incorrect-variance:24:0:24:8::"Type variable ""T_contra"" is covariant, use ""T_co"" instead":INFERENCE
+invalid-name:33:0:33:10::"Type variable name ""CALLABLE_T"" doesn't conform to predefined naming style":HIGH
+invalid-name:34:0:34:10::"Type variable name ""DeviceType"" doesn't conform to predefined naming style":HIGH
+invalid-name:37:0:37:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
+invalid-name:38:0:38:10::"Type variable name ""badName_co"" doesn't conform to predefined naming style":HIGH
+invalid-name:39:0:39:14::"Type variable name ""badName_contra"" doesn't conform to predefined naming style":HIGH
+invalid-name:43:4:43:13::"Type variable name ""a_BadName"" doesn't conform to predefined naming style":HIGH
+invalid-name:44:4:44:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to predefined naming style":HIGH
+typevar-name-incorrect-variance:44:4:44:26::"Type variable ""a_BadNameWithoutContra"" is contravariant, use ""a_BadNameWithoutContra_contra"" instead":INFERENCE
+invalid-name:46:13:46:29::"Type variable name ""a_BadName_contra"" doesn't conform to predefined naming style":HIGH

--- a/tests/functional/t/typevar_naming_style_default.txt
+++ b/tests/functional/t/typevar_naming_style_default.txt
@@ -1,0 +1,19 @@
+typevar-name-incorrect-variance:11:0:11:21::"Type variable ""GoodNameWithoutContra"" is contravariant, use ""GoodNameWithoutContra_contra"" instead":INFERENCE
+typevar-name-incorrect-variance:17:0:17:17::"Type variable ""GoodBoundNameT_co"" is invariant, use ""GoodBoundNameT"" instead":INFERENCE
+typevar-name-incorrect-variance:20:0:20:21::"Type variable ""GoodBoundNameT_contra"" is invariant, use ""GoodBoundNameT"" instead":INFERENCE
+typevar-name-incorrect-variance:27:0:27:17::"Type variable ""GoodBoundNameT_co"" is contravariant, use ""GoodBoundNameT_contra"" instead":INFERENCE
+typevar-name-incorrect-variance:31:0:31:21::"Type variable ""GoodBoundNameT_contra"" is covariant, use ""GoodBoundNameT_co"" instead":INFERENCE
+typevar-name-incorrect-variance:36:0:36:1::"Type variable ""T"" is covariant, use ""T_co"" instead":INFERENCE
+typevar-name-incorrect-variance:41:0:41:8::"Type variable ""T_contra"" is covariant, use ""T_co"" instead":INFERENCE
+invalid-name:50:0:50:10::"Type variable name ""CALLABLE_T"" doesn't conform to snake_case naming style":HIGH
+invalid-name:51:0:51:10::"Type variable name ""DeviceType"" doesn't conform to snake_case naming style":HIGH
+typevar-name-incorrect-variance:52:0:52:21::"Type variable ""GoodNameWithoutContra"" is contravariant, use ""GoodNameWithoutContra_contra"" instead":INFERENCE
+invalid-name:57:0:57:7::"Type variable name ""badName"" doesn't conform to snake_case naming style":HIGH
+invalid-name:58:0:58:20::"Type variable name ""badNameWithoutContra"" doesn't conform to snake_case naming style":HIGH
+typevar-name-incorrect-variance:58:0:58:20::"Type variable ""badNameWithoutContra"" is contravariant, use ""badNameWithoutContra_contra"" instead":INFERENCE
+invalid-name:61:0:61:10::"Type variable name ""badName_co"" doesn't conform to snake_case naming style":HIGH
+invalid-name:62:0:62:14::"Type variable name ""badName_contra"" doesn't conform to snake_case naming style":HIGH
+invalid-name:66:4:66:13::"Type variable name ""a_BadName"" doesn't conform to snake_case naming style":HIGH
+invalid-name:67:4:67:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to snake_case naming style":HIGH
+typevar-name-incorrect-variance:67:4:67:26::"Type variable ""a_BadNameWithoutContra"" is contravariant, use ""a_BadNameWithoutContra_contra"" instead":INFERENCE
+invalid-name:69:13:69:29::"Type variable name ""a_BadName_contra"" doesn't conform to snake_case naming style":HIGH

--- a/tests/functional/t/typevar_naming_style_default.txt
+++ b/tests/functional/t/typevar_naming_style_default.txt
@@ -5,15 +5,15 @@ typevar-name-incorrect-variance:27:0:27:17::"Type variable ""GoodBoundNameT_co""
 typevar-name-incorrect-variance:31:0:31:21::"Type variable ""GoodBoundNameT_contra"" is covariant, use ""GoodBoundNameT_co"" instead":INFERENCE
 typevar-name-incorrect-variance:36:0:36:1::"Type variable ""T"" is covariant, use ""T_co"" instead":INFERENCE
 typevar-name-incorrect-variance:41:0:41:8::"Type variable ""T_contra"" is covariant, use ""T_co"" instead":INFERENCE
-invalid-name:50:0:50:10::"Type variable name ""CALLABLE_T"" doesn't conform to snake_case naming style":HIGH
-invalid-name:51:0:51:10::"Type variable name ""DeviceType"" doesn't conform to snake_case naming style":HIGH
+invalid-name:50:0:50:10::"Type variable name ""CALLABLE_T"" doesn't conform to predefined naming style":HIGH
+invalid-name:51:0:51:10::"Type variable name ""DeviceType"" doesn't conform to predefined naming style":HIGH
 typevar-name-incorrect-variance:52:0:52:21::"Type variable ""GoodNameWithoutContra"" is contravariant, use ""GoodNameWithoutContra_contra"" instead":INFERENCE
-invalid-name:57:0:57:7::"Type variable name ""badName"" doesn't conform to snake_case naming style":HIGH
-invalid-name:58:0:58:20::"Type variable name ""badNameWithoutContra"" doesn't conform to snake_case naming style":HIGH
+invalid-name:57:0:57:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
+invalid-name:58:0:58:20::"Type variable name ""badNameWithoutContra"" doesn't conform to predefined naming style":HIGH
 typevar-name-incorrect-variance:58:0:58:20::"Type variable ""badNameWithoutContra"" is contravariant, use ""badNameWithoutContra_contra"" instead":INFERENCE
-invalid-name:61:0:61:10::"Type variable name ""badName_co"" doesn't conform to snake_case naming style":HIGH
-invalid-name:62:0:62:14::"Type variable name ""badName_contra"" doesn't conform to snake_case naming style":HIGH
-invalid-name:66:4:66:13::"Type variable name ""a_BadName"" doesn't conform to snake_case naming style":HIGH
-invalid-name:67:4:67:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to snake_case naming style":HIGH
+invalid-name:61:0:61:10::"Type variable name ""badName_co"" doesn't conform to predefined naming style":HIGH
+invalid-name:62:0:62:14::"Type variable name ""badName_contra"" doesn't conform to predefined naming style":HIGH
+invalid-name:66:4:66:13::"Type variable name ""a_BadName"" doesn't conform to predefined naming style":HIGH
+invalid-name:67:4:67:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to predefined naming style":HIGH
 typevar-name-incorrect-variance:67:4:67:26::"Type variable ""a_BadNameWithoutContra"" is contravariant, use ""a_BadNameWithoutContra_contra"" instead":INFERENCE
-invalid-name:69:13:69:29::"Type variable name ""a_BadName_contra"" doesn't conform to snake_case naming style":HIGH
+invalid-name:69:13:69:29::"Type variable name ""a_BadName_contra"" doesn't conform to predefined naming style":HIGH

--- a/tests/functional/t/typevar_naming_style_rgx.py
+++ b/tests/functional/t/typevar_naming_style_rgx.py
@@ -1,0 +1,15 @@
+"""Test case for typevar-name-missing-variance with non-default settings"""
+
+from typing import TypeVar
+
+# Name set by regex pattern
+TypeVarsShouldBeLikeThis = TypeVar("TypeVarsShouldBeLikeThis")
+TypeVarsShouldBeLikeThis_contra = TypeVar(
+    "TypeVarsShouldBeLikeThis_contra", contravariant=True
+)
+TypeVarsShouldBeLikeThis_co = TypeVar("TypeVarsShouldBeLikeThis_co", covariant=True)
+
+# Name using the standard style
+GoodNameT = TypeVar("GoodNameT")  # [invalid-name]
+GoodNameT_co = TypeVar("GoodNameT_co", covariant=True)  # [invalid-name]
+GoodNameT_contra = TypeVar("GoodNameT_contra", contravariant=True)  # [invalid-name]

--- a/tests/functional/t/typevar_naming_style_rgx.rc
+++ b/tests/functional/t/typevar_naming_style_rgx.rc
@@ -1,0 +1,2 @@
+[BASIC]
+typevar-rgx=TypeVarsShouldBeLikeThis(_co(ntra)?)?$

--- a/tests/functional/t/typevar_naming_style_rgx.txt
+++ b/tests/functional/t/typevar_naming_style_rgx.txt
@@ -1,0 +1,3 @@
+invalid-name:13:0:13:9::"Type variable name ""GoodNameT"" doesn't conform to 'TypeVarsShouldBeLikeThis(_co(ntra)?)?$' pattern":HIGH
+invalid-name:14:0:14:12::"Type variable name ""GoodNameT_co"" doesn't conform to 'TypeVarsShouldBeLikeThis(_co(ntra)?)?$' pattern":HIGH
+invalid-name:15:0:15:16::"Type variable name ""GoodNameT_contra"" doesn't conform to 'TypeVarsShouldBeLikeThis(_co(ntra)?)?$' pattern":HIGH


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

Not sure if we want to do this, but:
After merging https://github.com/PyCQA/pylint/pull/5825, we can merge this. It only adds the necessary boilerplate for `typevar` name checking, but uses the pattern as set for classes.
This makes the diff of https://github.com/PyCQA/pylint/pull/5221 even smaller and should help getting that merged asap after #5825 has been merged.

Closes #3401.