### PR TITLE
Fix typing of ``safe_infer``

### DIFF
--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1231,7 +1231,7 @@ def supports_delitem(value: nodes.NodeNG, _: nodes.NodeNG) -> bool:
     return _supports_protocol(value, _supports_delitem_protocol)
 
 
-def _get_python_type_of_node(node):
+def _get_python_type_of_node(node: nodes.NodeNG) -> Optional[str]:
     pytype = getattr(node, "pytype", None)
     if callable(pytype):
         return pytype()
@@ -1239,13 +1239,15 @@ def _get_python_type_of_node(node):
 
 
 @lru_cache(maxsize=1024)
-def safe_infer(node: nodes.NodeNG, context=None) -> Optional[nodes.NodeNG]:
+def safe_infer(
+    node: nodes.NodeNG, context: Optional[InferenceContext] = None
+) -> Union[nodes.NodeNG, Type[astroid.Uninferable], None]:
     """Return the inferred value for the given node.
 
     Return None if inference failed or if there is some ambiguity (more than
     one node has been inferred of different types).
     """
-    inferred_types = set()
+    inferred_types: Set[Optional[str]] = set()
     try:
         infer_gen = node.infer(context=context)
         value = next(infer_gen)


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

While looking at #5901 I noticed that the typing on `safe_infer` is incorrect. `Uninferable` doesn't subclass `NodeNG` and thus the return annotation is incorrect. I also added typing to related functions.

Change was introduced in https://github.com/PyCQA/pylint/pull/2338/. I haven't fully investigated but I think this was just a mistake (or `Uninferable` was added in between these 4 years).