### PR TITLE
Fix end position in unittests

### DIFF
--- a/pylint/testutils/checker_test_case.py
+++ b/pylint/testutils/checker_test_case.py
@@ -73,14 +73,14 @@ class CheckerTestCase:
                 # pylint: disable=fixme
                 # TODO: Require end_line and end_col_offset and remove the warning
                 if not expected_msg.end_line == gotten_msg.end_line:
-                    warnings.warn(
+                    warnings.warn(  # pragma: no cover
                         f"The end_line attribute of {gotten_msg} does not match "
                         f"the expected value in {expected_msg}. In pylint 3.0 correct end_line "
                         "attributes will be required for MessageTest.",
                         DeprecationWarning,
                     )
                 if not expected_msg.end_col_offset == gotten_msg.end_col_offset:
-                    warnings.warn(
+                    warnings.warn(  # pragma: no cover
                         f"The end_col_offset attribute of {gotten_msg} does not match "
                         f"the expected value in {expected_msg}. In pylint 3.0 correct end_col_offset "
                         "attributes will be required for MessageTest.",

--- a/tests/checkers/unittest_base.py
+++ b/tests/checkers/unittest_base.py
@@ -66,8 +66,8 @@ class TestMultiNamingStyle(CheckerTestCase):
             confidence=HIGH,
             line=2,
             col_offset=0,
-            end_line=3,
-            end_col_offset=8,
+            end_line=2,
+            end_col_offset=12,
         )
         with self.assertAddsMessages(message):
             cls = None
@@ -100,8 +100,8 @@ class TestMultiNamingStyle(CheckerTestCase):
                 confidence=HIGH,
                 line=2,
                 col_offset=0,
-                end_line=3,
-                end_col_offset=8,
+                end_line=2,
+                end_col_offset=13,
             ),
             MessageTest(
                 "invalid-name",
@@ -114,8 +114,8 @@ class TestMultiNamingStyle(CheckerTestCase):
                 confidence=HIGH,
                 line=6,
                 col_offset=0,
-                end_line=7,
-                end_col_offset=8,
+                end_line=6,
+                end_col_offset=12,
             ),
         ]
         with self.assertAddsMessages(*messages):
@@ -153,7 +153,7 @@ class TestMultiNamingStyle(CheckerTestCase):
             confidence=HIGH,
             line=6,
             col_offset=0,
-            end_line=7,
+            end_line=6,
             end_col_offset=8,
         )
         with self.assertAddsMessages(message):
@@ -190,8 +190,8 @@ class TestMultiNamingStyle(CheckerTestCase):
             confidence=HIGH,
             line=8,
             col_offset=0,
-            end_line=9,
-            end_col_offset=8,
+            end_line=8,
+            end_col_offset=9,
         )
         with self.assertAddsMessages(message):
             func = None


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Follow up to #5897. I did not update these tests in that PR as it was not necessary (we only raise a `DeprecationWarning` for unittests with incorrect end positions).