### PR TITLE
Handle ``ComprehensionScope`` and their behaviour better

### DIFF
--- a/pylint/checkers/classes/special_methods_checker.py
+++ b/pylint/checkers/classes/special_methods_checker.py
@@ -289,6 +289,7 @@ class SpecialMethodsChecker(BaseChecker):
         if isinstance(node, astroid.bases.Generator):
             # Generators can be iterated.
             return True
+        # TODO: Should be covered by https://github.com/PyCQA/astroid/pull/1475
         if isinstance(node, nodes.ComprehensionScope):
             # Comprehensions can be iterated.
             return True

--- a/pylint/checkers/classes/special_methods_checker.py
+++ b/pylint/checkers/classes/special_methods_checker.py
@@ -289,6 +289,7 @@ class SpecialMethodsChecker(BaseChecker):
         if isinstance(node, astroid.bases.Generator):
             # Generators can be iterated.
             return True
+        # pylint: disable-next=fixme
         # TODO: Should be covered by https://github.com/PyCQA/astroid/pull/1475
         if isinstance(node, nodes.ComprehensionScope):
             # Comprehensions can be iterated.

--- a/pylint/checkers/classes/special_methods_checker.py
+++ b/pylint/checkers/classes/special_methods_checker.py
@@ -289,6 +289,9 @@ class SpecialMethodsChecker(BaseChecker):
         if isinstance(node, astroid.bases.Generator):
             # Generators can be iterated.
             return True
+        if isinstance(node, nodes.ComprehensionScope):
+            # Comprehensions can be iterated.
+            return True
 
         if isinstance(node, astroid.Instance):
             try:

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -273,11 +273,11 @@ def _missing_member_hint(owner, attrname, distance_threshold, max_choices):
 
     names = [repr(name) for name in names]
     if len(names) == 1:
-        names = ", ".join(names)
+        names_hint = ", ".join(names)
     else:
-        names = f"one of {', '.join(names[:-1])} or {names[-1]}"
+        names_hint = f"one of {', '.join(names[:-1])} or {names[-1]}"
 
-    return f"; maybe {names}?"
+    return f"; maybe {names_hint}?"
 
 
 MSGS = {
@@ -2047,10 +2047,10 @@ class IterableChecker(BaseChecker):
         return False
 
     def _check_iterable(self, node, check_async=False):
-        if is_inside_abstract_class(node) or is_comprehension(node):
+        if is_inside_abstract_class(node):
             return
         inferred = safe_infer(node)
-        if not inferred:
+        if not inferred or is_comprehension(inferred):
             return
         if not is_iterable(inferred, check_async=check_async):
             self.add_message("not-an-iterable", args=node.as_string(), node=node)

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1189,6 +1189,9 @@ def _supports_protocol(
         if protocol_callback(value):
             return True
 
+    if isinstance(value, nodes.ComprehensionScope):
+        return True
+
     if (
         isinstance(value, astroid.bases.Proxy)
         and isinstance(value._proxied, astroid.BaseInstance)

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1189,6 +1189,7 @@ def _supports_protocol(
         if protocol_callback(value):
             return True
 
+    # TODO: Should be covered by https://github.com/PyCQA/astroid/pull/1475
     if isinstance(value, nodes.ComprehensionScope):
         return True
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1189,6 +1189,7 @@ def _supports_protocol(
         if protocol_callback(value):
             return True
 
+    # pylint: disable-next=fixme
     # TODO: Should be covered by https://github.com/PyCQA/astroid/pull/1475
     if isinstance(value, nodes.ComprehensionScope):
         return True


### PR DESCRIPTION
- [x] Add yourself to ``CONTRIBUTORS.txt`` if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Description

Refactoring necessary for https://github.com/PyCQA/astroid/pull/1475 to be "acceptable" for `pylint`.

Note that the change to `names_hint = ", ".join(names)` might be unrelated, but I couldn't get `pre-commit` to pass without it and I wanted to show that if you clone https://github.com/PyCQA/astroid/pull/1475 and these changes then both test suites should pass.