### PR TITLE
Use pytest-timeout for tests

### DIFF
--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -4,3 +4,4 @@ astroid==2.11.0  # Pinned to a specific version for tests
 typing-extensions~=4.1
 pytest~=7.0
 pytest-benchmark~=3.4
+pytest-timeout~=2.1

--- a/tests/checkers/unittest_refactoring.py
+++ b/tests/checkers/unittest_refactoring.py
@@ -2,8 +2,6 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 
 import os
-import signal
-from contextlib import contextmanager
 
 import pytest
 
@@ -14,36 +12,22 @@ PARENT_DIR = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 REGR_DATA = os.path.join(PARENT_DIR, "regrtest_data")
 
 
-@contextmanager
-def timeout(timeout_s: float):
-    def _handle(_signum, _frame):
-        pytest.fail("Test took too long")
-
-    signal.signal(signal.SIGALRM, _handle)
-    signal.setitimer(signal.ITIMER_REAL, timeout_s)
-    yield
-    signal.setitimer(signal.ITIMER_REAL, 0)
-    signal.signal(signal.SIGALRM, signal.SIG_DFL)
-
-
-@pytest.mark.skipif(not hasattr(signal, "setitimer"), reason="Assumes POSIX signals")
+@pytest.mark.timeout(8)
 def test_process_tokens() -> None:
-    with timeout(8.0):
-        with pytest.raises(SystemExit) as cm:
-            Run([os.path.join(REGR_DATA, "very_long_line.py")], reporter=TextReporter())
-        assert cm.value.code == 0
+    with pytest.raises(SystemExit) as cm:
+        Run([os.path.join(REGR_DATA, "very_long_line.py")], reporter=TextReporter())
+    assert cm.value.code == 0
 
 
-@pytest.mark.skipif(not hasattr(signal, "setitimer"), reason="Assumes POSIX signals")
+@pytest.mark.timeout(25)
 def test_issue_5724() -> None:
     """Regression test for parsing of pylint disable pragma's."""
-    with timeout(25.0):
-        with pytest.raises(SystemExit) as cm:
-            Run(
-                [
-                    os.path.join(REGR_DATA, "issue_5724.py"),
-                    "--enable=missing-final-newline",
-                ],
-                reporter=TextReporter(),
-            )
-        assert cm.value.code == 0
+    with pytest.raises(SystemExit) as cm:
+        Run(
+            [
+                os.path.join(REGR_DATA, "issue_5724.py"),
+                "--enable=missing-final-newline",
+            ],
+            reporter=TextReporter(),
+        )
+    assert cm.value.code == 0


### PR DESCRIPTION
- [x] Add yourself to ``CONTRIBUTORS.txt`` if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Use pytest-timeout plugin instead of custom context managers to handle timeouts in tests.  Amend #5925.