### PR TITLE
Set up system of code examples and details for message documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: v1.4
     hooks:
       - id: autoflake
-        exclude: &fixtures tests/functional/|tests/input|tests/regrtest_data/|tests/data/
+        exclude: &fixtures tests/functional/|tests/input|tests/regrtest_data/|tests/data/|doc/data/messages
         args:
           - --in-place
           - --remove-all-unused-imports

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -73,7 +73,7 @@ release = __version__
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
+exclude_patterns = ["_build", "data/**"]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 # default_role = None

--- a/doc/data/messages/e/empty-docstring/bad.py
+++ b/doc/data/messages/e/empty-docstring/bad.py
@@ -1,0 +1,2 @@
+def foo():
+    pass  # [emtpy-docstring]

--- a/doc/data/messages/e/empty-docstring/good.py
+++ b/doc/data/messages/e/empty-docstring/good.py
@@ -1,0 +1,2 @@
+def foo():
+    """A dummy description."""

--- a/doc/data/messages/y/yield-inside-async-function/bad.py
+++ b/doc/data/messages/y/yield-inside-async-function/bad.py
@@ -1,0 +1,2 @@
+async def foo():
+    yield from [1, 2, 3]  # [yield-inside-async-function]

--- a/doc/data/messages/y/yield-inside-async-function/details.rst
+++ b/doc/data/messages/y/yield-inside-async-function/details.rst
@@ -1,1 +1,1 @@
-THe message can't be emitted when using Python < 3.5.
+The message can't be emitted when using Python < 3.5.

--- a/doc/data/messages/y/yield-inside-async-function/details.rst
+++ b/doc/data/messages/y/yield-inside-async-function/details.rst
@@ -1,0 +1,1 @@
+THe message can't be emitted when using Python < 3.5.

--- a/doc/data/messages/y/yield-inside-async-function/good.py
+++ b/doc/data/messages/y/yield-inside-async-function/good.py
@@ -1,0 +1,7 @@
+async def foo():
+    def _inner_foo():
+        yield from [1, 2, 3]
+
+
+async def foo():
+    yield 42

--- a/doc/data/messages/y/yield-inside-async-function/related.rst
+++ b/doc/data/messages/y/yield-inside-async-function/related.rst
@@ -1,0 +1,1 @@
+- `PEP 525 <https://peps.python.org/pep-0525/>`_

--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -24,7 +24,7 @@ PYLINT_MESSAGES_PATH = PYLINT_BASE_PATH / "doc" / "messages"
 """Path to the messages documentation folder."""
 
 PYLINT_MESSAGES_DATA_PATH = PYLINT_BASE_PATH / "doc" / "data" / "messages"
-"""Path to the messages documentation folder."""
+"""Path to the folder with data for the messages documentation."""
 
 MSG_TYPES_DOC = {k: v if v != "info" else "information" for k, v in MSG_TYPES.items()}
 

--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -53,7 +53,7 @@ def _register_all_checkers_and_extensions(linter: PyLinter) -> None:
     initialize_extensions(linter)
 
 
-def _get_message_data(data_path: Path) -> Tuple[str, str, str]:
+def _get_message_data(data_path: Path) -> Tuple[str, str, str, str]:
     """Get the message data from the specified path."""
     good_code, bad_code, details, related = "", "", "", ""
 
@@ -61,7 +61,7 @@ def _get_message_data(data_path: Path) -> Tuple[str, str, str]:
         return good_code, bad_code, details, related
 
     if (data_path / "good.py").exists():
-        with open(data_path / "good.py") as file:
+        with open(data_path / "good.py", encoding="utf-8") as file:
             file_content = file.readlines()
             indented_file_content = "".join("  " + i for i in file_content)
             good_code = f"""
@@ -72,7 +72,7 @@ def _get_message_data(data_path: Path) -> Tuple[str, str, str]:
 {indented_file_content}"""
 
     if (data_path / "bad.py").exists():
-        with open(data_path / "bad.py") as file:
+        with open(data_path / "bad.py", encoding="utf-8") as file:
             file_content = file.readlines()
             indented_file_content = "".join("  " + i for i in file_content)
             bad_code = f"""
@@ -83,20 +83,20 @@ def _get_message_data(data_path: Path) -> Tuple[str, str, str]:
 {indented_file_content}"""
 
     if (data_path / "details.rst").exists():
-        with open(data_path / "details.rst") as file:
-            file_content = file.read()
-            related = f"""
+        with open(data_path / "details.rst", encoding="utf-8") as file:
+            file_content_string = file.read()
+            details = f"""
 **Additional details:**
 
-{file_content}"""
+{file_content_string}"""
 
     if (data_path / "related.rst").exists():
-        with open(data_path / "related.rst") as file:
-            file_content = file.read()
+        with open(data_path / "related.rst", encoding="utf-8") as file:
+            file_content_string = file.read()
             related = f"""
 **Related links:**
 
-{file_content}"""
+{file_content_string}"""
 
     return good_code, bad_code, details, related
 


### PR DESCRIPTION
- [x] Add yourself to ``CONTRIBUTORS.txt`` if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :scroll: Docs          |

## Description

This closes #5527. I'd like to create a separate issue to track the progress of migrating the code examples of `pylint-errors`.

This allows for each message to have a `good.py`, `bad.py`, `related.rst` and `details.rst` section. I have added two examples which can be viewed [here](https://pylint--5934.org.readthedocs.build/en/5934/messages/error/yield-inside-async-function.html) and [here](https://pylint--5934.org.readthedocs.build/en/5934/messages/convention/empty-docstring.html). Based on [this](https://vald-phoenix.github.io/pylint-errors/plerr/errors/async/E1700) and [this](https://vald-phoenix.github.io/pylint-errors/plerr/errors/basic/C0112). Note that the original example is actually incorrect.
The `bad.py` is written in the same style as the functional test so that at one point we could test against them. For now, I have considered that out of scope. (I also want to find a way to not do that every PR as not to inflate test time).

I think the structure works but let me know what you think!