### PR TITLE
Fix `used-before-assignment` false positive for class definition in function scope

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -374,6 +374,11 @@ Release date: TBA
 
   Closes #5679
 
+* Fix false positive for ``used-before-assignment`` from a class definition
+  nested under a function subclassing a class defined outside the function.
+
+  Closes #4590
+
 * Fix ``unnecessary_dict_index_lookup`` false positive when deleting a dictionary's entry.
 
   Closes #4716

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -265,6 +265,11 @@ Other Changes
 
   Closes #5724
 
+* Fix false positive for ``used-before-assignment`` from a class definition
+  nested under a function subclassing a class defined outside the function.
+
+  Closes #4590
+
 * Fix ``unnecessary_dict_index_lookup`` false positive when deleting a dictionary's entry.
 
   Closes #4716

--- a/tests/functional/u/used/used_before_assignment_class_nested_under_function.py
+++ b/tests/functional/u/used/used_before_assignment_class_nested_under_function.py
@@ -1,0 +1,13 @@
+"""https://github.com/PyCQA/pylint/issues/4590"""
+# pylint: disable=too-few-public-methods
+
+
+def conditional_class_factory():
+    """Define a nested class"""
+    class ConditionalClass(ModuleClass):
+        """Subclasses a name from the module scope"""
+    return ConditionalClass
+
+
+class ModuleClass:
+    """Module-level class"""


### PR DESCRIPTION
## Type of Changes


|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fix false `used-before-assignment` for a class definition nested under a function subclassing a class defined outside the function. Because the class is guarded by a function, the parent class should be available at runtime.

Closes #4590
