### PR TITLE
Add missing __magic__ methods to `_SPECIAL_METHODS_PARAMS`

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -356,3 +356,4 @@ contributors:
 - Téo Bouvard
 - Konrad Weihmann
 - Sergey B Kirpichev
+- Joseph Young (jpy-git)

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,8 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.13.rst'
 
+* Add missing dunder methods to ``unexpected-special-method-signature`` check.
+
 * No longer emit ``no-member`` in for loops that reference ``self`` if the binary operation that
   started the for loop uses a ``self`` that is encapsulated in tuples or lists.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -110,6 +110,8 @@ Extensions
 Other Changes
 =============
 
+* Add missing dunder methods to ``unexpected-special-method-signature`` check.
+
 * No longer emit ``no-member`` in for loops that reference ``self`` if the binary operation that
   started the for loop uses a ``self`` that is encapsulated in tuples or lists.
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -160,6 +160,8 @@ _SPECIAL_METHODS_PARAMS = {
         "__aiter__",
         "__anext__",
         "__fspath__",
+        "__subclasses__",
+        "__init_subclass__",
     ),
     1: (
         "__format__",

--- a/tests/functional/u/unexpected_special_method_signature.py
+++ b/tests/functional/u/unexpected_special_method_signature.py
@@ -30,6 +30,12 @@ class Invalid(object):
     def __getattr__(self, nanana): # [unexpected-special-method-signature]
         pass
 
+    def __subclasses__(self, blabla):  # [unexpected-special-method-signature]
+        pass
+
+    @classmethod
+    def __init_subclass__(cls, blabla):  # [unexpected-special-method-signature]
+        pass
 
 class FirstBadContextManager(object):
     def __enter__(self):

--- a/tests/functional/u/unexpected_special_method_signature.txt
+++ b/tests/functional/u/unexpected_special_method_signature.txt
@@ -6,11 +6,13 @@ unexpected-special-method-signature:20:4:20:17:Invalid.__round__:The special met
 unexpected-special-method-signature:23:4:23:20:Invalid.__deepcopy__:The special method '__deepcopy__' expects 1 param(s), 2 were given:UNDEFINED
 no-method-argument:26:4:26:16:Invalid.__iter__:Method has no argument:UNDEFINED
 unexpected-special-method-signature:30:4:30:19:Invalid.__getattr__:The special method '__getattr__' expects 1 param(s), 2 were given:UNDEFINED
-unexpected-special-method-signature:37:4:37:16:FirstBadContextManager.__exit__:The special method '__exit__' expects 3 param(s), 1 was given:UNDEFINED
-unexpected-special-method-signature:43:4:43:16:SecondBadContextManager.__exit__:The special method '__exit__' expects 3 param(s), 4 were given:UNDEFINED
-unexpected-special-method-signature:51:4:51:16:ThirdBadContextManager.__exit__:The special method '__exit__' expects 3 param(s), 4 were given:UNDEFINED
-unexpected-special-method-signature:57:4:57:17:Async.__aiter__:The special method '__aiter__' expects 0 param(s), 1 was given:UNDEFINED
-unexpected-special-method-signature:59:4:59:17:Async.__anext__:The special method '__anext__' expects 0 param(s), 2 were given:UNDEFINED
-unexpected-special-method-signature:61:4:61:17:Async.__await__:The special method '__await__' expects 0 param(s), 1 was given:UNDEFINED
-unexpected-special-method-signature:63:4:63:18:Async.__aenter__:The special method '__aenter__' expects 0 param(s), 1 was given:UNDEFINED
-unexpected-special-method-signature:65:4:65:17:Async.__aexit__:The special method '__aexit__' expects 3 param(s), 0 was given:UNDEFINED
+unexpected-special-method-signature:33:4:33:22:Invalid.__subclasses__:The special method '__subclasses__' expects 0 param(s), 1 was given:UNDEFINED
+unexpected-special-method-signature:37:4:37:25:Invalid.__init_subclass__:The special method '__init_subclass__' expects 0 param(s), 1 was given:UNDEFINED
+unexpected-special-method-signature:43:4:43:16:FirstBadContextManager.__exit__:The special method '__exit__' expects 3 param(s), 1 was given:UNDEFINED
+unexpected-special-method-signature:49:4:49:16:SecondBadContextManager.__exit__:The special method '__exit__' expects 3 param(s), 4 were given:UNDEFINED
+unexpected-special-method-signature:57:4:57:16:ThirdBadContextManager.__exit__:The special method '__exit__' expects 3 param(s), 4 were given:UNDEFINED
+unexpected-special-method-signature:63:4:63:17:Async.__aiter__:The special method '__aiter__' expects 0 param(s), 1 was given:UNDEFINED
+unexpected-special-method-signature:65:4:65:17:Async.__anext__:The special method '__anext__' expects 0 param(s), 2 were given:UNDEFINED
+unexpected-special-method-signature:67:4:67:17:Async.__await__:The special method '__await__' expects 0 param(s), 1 was given:UNDEFINED
+unexpected-special-method-signature:69:4:69:18:Async.__aenter__:The special method '__aenter__' expects 0 param(s), 1 was given:UNDEFINED
+unexpected-special-method-signature:71:4:71:17:Async.__aexit__:The special method '__aexit__' expects 3 param(s), 0 was given:UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [X] Add yourself to ``CONTRIBUTORS.txt`` if you are a new contributor.
- [X] Add a ChangeLog entry describing what your PR does.
- [X] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [X] Write a good description on what the PR does.
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Noticed this whilst working on #5938.

These magic methods were missing from the `_SPECIAL_METHODS_PARAMS` variable used for several checks so I've added them in:
- [`__subclasses__`](https://docs.python.org/3/library/stdtypes.html?highlight=__subclasses#class.__subclasses__)
- [`__init_subclass__`](https://docs.python.org/3/library/stdtypes.html?highlight=__subclasses#class.__subclasses__)

This variable gets used in these checkers:
- variables.py
- class_checker.py
- special_methods_checker.py
