### PR TITLE
Add missing messages to docs

### DIFF
--- a/doc/messages/messages_list.rst
+++ b/doc/messages/messages_list.rst
@@ -59,6 +59,8 @@ All messages in the error category:
    error/bad-string-format-type.rst
    error/bad-super-call.rst
    error/bidirectional-unicode.rst
+   error/broken-collections-callable.rst
+   error/broken-noreturn.rst
    error/catching-non-exception.rst
    error/class-variable-slots-conflict.rst
    error/continue-in-finally.rst
@@ -218,6 +220,7 @@ All messages in the warning category:
    warning/duplicate-except.rst
    warning/duplicate-key.rst
    warning/duplicate-string-formatting-argument.rst
+   warning/eq-without-hash.rst
    warning/eval-used.rst
    warning/exec-used.rst
    warning/expression-not-assigned.rst
@@ -360,6 +363,7 @@ All messages in the convention category:
    convention/docstring-first-line-empty.rst
    convention/empty-docstring.rst
    convention/import-outside-toplevel.rst
+   convention/import-private-name.rst
    convention/invalid-characters-in-docstring.rst
    convention/invalid-name.rst
    convention/line-too-long.rst
@@ -379,6 +383,7 @@ All messages in the convention category:
    convention/too-many-lines.rst
    convention/trailing-newlines.rst
    convention/trailing-whitespace.rst
+   convention/typevar-name-incorrect-variance.rst
    convention/unexpected-line-ending-format.rst
    convention/ungrouped-imports.rst
    convention/unidiomatic-typecheck.rst


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [X] Add yourself to ``CONTRIBUTORS.txt`` if you are a new contributor.
- [X] Add a ChangeLog entry describing what your PR does.
- [X] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [X] Write a good description on what the PR does.
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Another quick PR. Noticed that when I ran `tox -e docs` it generated some missing messages to the docs. These are all from recent PRs so would be good to get them added to the docs before the next release.
