### PR TITLE
Add documentation for access-member-before-definition

### DIFF
--- a/doc/data/messages/a/access-member-before-definition/bad.py
+++ b/doc/data/messages/a/access-member-before-definition/bad.py
@@ -1,0 +1,5 @@
+class Foo:
+    def __init__(self, param):
+        if self.param:  # [access-member-before-definition]
+            pass
+        self.param = param

--- a/doc/data/messages/a/access-member-before-definition/good.py
+++ b/doc/data/messages/a/access-member-before-definition/good.py
@@ -1,0 +1,5 @@
+class Foo:
+    def __init__(self, param):
+        self.param = param
+        if self.param:
+            pass

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -830,7 +830,11 @@ a metaclass class method.",
                     node=node,
                 )
 
-    @check_messages("unused-private-member", "attribute-defined-outside-init")
+    @check_messages(
+        "unused-private-member",
+        "attribute-defined-outside-init",
+        "access-member-before-definition",
+    )
     def leave_classdef(self, node: nodes.ClassDef) -> None:
         """Checker for Class nodes.
 


### PR DESCRIPTION
- [x] Add yourself to ``CONTRIBUTORS.txt`` if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Code examples based on [pylint-errors](https://github.com/vald-phoenix/pylint-errors) and my own work.

Ref. #5953.