### PR TITLE
Loosen TypeVar name pattern

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -46,6 +46,11 @@ Release date: TBA
 
   Closes #2793
 
+* Loosen TypeVar default name pattern a bit to allow names with multiple uppercase
+  characters. E.g. ``HVACModeT`` or ``IPAddressT``.
+
+  Closes #5981
+
 * Fixed false positive for ``unused-argument`` when a ``nonlocal`` name is used
   in a nested function that is returned without being called by its parent.
 

--- a/doc/user_guide/options.rst
+++ b/doc/user_guide/options.rst
@@ -95,7 +95,8 @@ The following type of names are checked with a predefined pattern:
 +--------------------+---------------------------------------------------+------------------------------------------------------------+
 | Name type          | Good names                                        | Bad names                                                  |
 +====================+===================================================+============================================================+
-| ``typevar``        |`T`, `_CallableT`, `_T_co`, `AnyStr`, `DeviceTypeT`| `DICT_T`, `CALLABLE_T`, `ENUM_T`, `DeviceType`, `_StrType` |
+| ``typevar``        | ``T``, ``_CallableT``, ``_T_co``, ``AnyStr``,     | ``DICT_T``, ``CALLABLE_T``, ``ENUM_T``, ``DeviceType``,    |
+|                    | ``DeviceTypeT``, ``IPAddressT``                   | ``_StrType``                                               |
 +--------------------+---------------------------------------------------+------------------------------------------------------------+
 
 Custom regular expressions

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -26,7 +26,7 @@ from pylint.checkers.utils import is_property_deleter, is_property_setter
 # Default patterns for name types that do not have styles
 DEFAULT_PATTERNS = {
     "typevar": re.compile(
-        r"^_{0,2}(?:[^\W\da-z_]+|(?:[^\W\da-z_][^\WA-Z_]+)+T?(?<!Type))(?:_co(?:ntra)?)?$"
+        r"^_{0,2}(?:[^\W\da-z_]+|(?:[^\W\da-z_]+[^\WA-Z_]+)+T?(?<!Type))(?:_co(?:ntra)?)?$"
     )
 }
 

--- a/tests/functional/t/typevar_naming_style_default.py
+++ b/tests/functional/t/typevar_naming_style_default.py
@@ -30,8 +30,11 @@ T_contra = TypeVar("T_contra", covariant=False, contravariant=True)
 # PascalCase names without prefix
 AnyStr = TypeVar("AnyStr")
 DeviceTypeT = TypeVar("DeviceTypeT")
+HVACModeT = TypeVar("HVACModeT")
+_IPAddress = TypeVar("_IPAddress")
 CALLABLE_T = TypeVar("CALLABLE_T")  # [invalid-name]
 DeviceType = TypeVar("DeviceType")  # [invalid-name]
+IPAddressU = TypeVar("IPAddressU")  # [invalid-name]
 
 # camelCase names with prefix
 badName = TypeVar("badName")  # [invalid-name]

--- a/tests/functional/t/typevar_naming_style_default.txt
+++ b/tests/functional/t/typevar_naming_style_default.txt
@@ -1,12 +1,13 @@
 typevar-name-incorrect-variance:11:0:11:21::"Type variable ""GoodNameWithoutContra"" is contravariant, use ""GoodNameWithoutContra_contra"" instead":INFERENCE
 typevar-name-incorrect-variance:19:0:19:1::"Type variable ""T"" is covariant, use ""T_co"" instead":INFERENCE
 typevar-name-incorrect-variance:24:0:24:8::"Type variable ""T_contra"" is covariant, use ""T_co"" instead":INFERENCE
-invalid-name:33:0:33:10::"Type variable name ""CALLABLE_T"" doesn't conform to predefined naming style":HIGH
-invalid-name:34:0:34:10::"Type variable name ""DeviceType"" doesn't conform to predefined naming style":HIGH
-invalid-name:37:0:37:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
-invalid-name:38:0:38:10::"Type variable name ""badName_co"" doesn't conform to predefined naming style":HIGH
-invalid-name:39:0:39:14::"Type variable name ""badName_contra"" doesn't conform to predefined naming style":HIGH
-invalid-name:43:4:43:13::"Type variable name ""a_BadName"" doesn't conform to predefined naming style":HIGH
-invalid-name:44:4:44:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to predefined naming style":HIGH
-typevar-name-incorrect-variance:44:4:44:26::"Type variable ""a_BadNameWithoutContra"" is contravariant, use ""a_BadNameWithoutContra_contra"" instead":INFERENCE
-invalid-name:46:13:46:29::"Type variable name ""a_BadName_contra"" doesn't conform to predefined naming style":HIGH
+invalid-name:35:0:35:10::"Type variable name ""CALLABLE_T"" doesn't conform to predefined naming style":HIGH
+invalid-name:36:0:36:10::"Type variable name ""DeviceType"" doesn't conform to predefined naming style":HIGH
+invalid-name:37:0:37:10::"Type variable name ""IPAddressU"" doesn't conform to predefined naming style":HIGH
+invalid-name:40:0:40:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
+invalid-name:41:0:41:10::"Type variable name ""badName_co"" doesn't conform to predefined naming style":HIGH
+invalid-name:42:0:42:14::"Type variable name ""badName_contra"" doesn't conform to predefined naming style":HIGH
+invalid-name:46:4:46:13::"Type variable name ""a_BadName"" doesn't conform to predefined naming style":HIGH
+invalid-name:47:4:47:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to predefined naming style":HIGH
+typevar-name-incorrect-variance:47:4:47:26::"Type variable ""a_BadNameWithoutContra"" is contravariant, use ""a_BadNameWithoutContra_contra"" instead":INFERENCE
+invalid-name:49:13:49:29::"Type variable name ""a_BadName_contra"" doesn't conform to predefined naming style":HIGH


### PR DESCRIPTION
## Description
Allow TypeVar names with multiple uppercase characters like `HVACModeT` and `IPAddress`. Note that if a uppercase suffix is added, it must be `T`. `IPAddressU` is still invalid.

Closes #5981

/CC: @DanielNoord