### PR TITLE
Don't emit broken typing errors inside TYPE_CHECKING blocks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -51,6 +51,9 @@ Release date: TBA
 
   Closes #5187
 
+* Don't emit ``broken-noreturn`` and ``broken-collections-callable`` errors
+  inside ``if TYPE_CHECKING`` blocks.
+
 
 What's New in Pylint 2.13.0?
 ============================

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -30,6 +30,8 @@ import astroid.objects
 from astroid import TooManyLevelsError, nodes
 from astroid.context import InferenceContext
 
+from pylint.constants import TYPING_TYPE_CHECKS_GUARDS
+
 COMP_NODE_TYPES = (
     nodes.ListComp,
     nodes.SetComp,
@@ -1708,3 +1710,12 @@ def get_node_first_ancestor_of_type_and_its_child(
             return (ancestor, child)
         child = ancestor
     return None, None
+
+
+def in_type_checking_block(node: nodes.NodeNG) -> bool:
+    """Check if a node is guarded by a TYPE_CHECKS guard."""
+    return any(
+        isinstance(ancestor, nodes.If)
+        and ancestor.test.as_string() in TYPING_TYPE_CHECKS_GUARDS
+        for ancestor in node.node_ancestors()
+    )

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -30,8 +30,11 @@ import astroid
 from astroid import nodes
 
 from pylint.checkers import BaseChecker, utils
-from pylint.checkers.utils import is_postponed_evaluation_enabled
-from pylint.constants import PY39_PLUS
+from pylint.checkers.utils import (
+    in_type_checking_block,
+    is_postponed_evaluation_enabled,
+)
+from pylint.constants import PY39_PLUS, TYPING_TYPE_CHECKS_GUARDS
 from pylint.interfaces import (
     CONTROL_FLOW,
     HIGH,
@@ -57,7 +60,6 @@ IGNORED_ARGUMENT_NAMES = re.compile("_.*|^ignored_|^unused_")
 # by astroid. Unfortunately this also messes up our explicit checks
 # for `abc`
 METACLASS_NAME_TRANSFORMS = {"_py_abc": "abc"}
-TYPING_TYPE_CHECKS_GUARDS = frozenset({"typing.TYPE_CHECKING", "TYPE_CHECKING"})
 BUILTIN_RANGE = "builtins.range"
 TYPING_MODULE = "typing"
 TYPING_NAMES = frozenset(
@@ -356,15 +358,6 @@ def _assigned_locally(name_node):
     """Checks if name_node has corresponding assign statement in same scope."""
     assign_stmts = name_node.scope().nodes_of_class(nodes.AssignName)
     return any(a.name == name_node.name for a in assign_stmts)
-
-
-def _is_type_checking_import(node: Union[nodes.Import, nodes.ImportFrom]) -> bool:
-    """Check if an import node is guarded by a TYPE_CHECKS guard."""
-    return any(
-        isinstance(ancestor, nodes.If)
-        and ancestor.test.as_string() in TYPING_TYPE_CHECKS_GUARDS
-        for ancestor in node.node_ancestors()
-    )
 
 
 def _has_locals_call_after_node(stmt, scope):
@@ -2735,7 +2728,7 @@ class VariablesChecker(BaseChecker):
                         msg = f"import {imported_name}"
                     else:
                         msg = f"{imported_name} imported as {as_name}"
-                    if not _is_type_checking_import(stmt):
+                    if not in_type_checking_block(stmt):
                         self.add_message("unused-import", args=msg, node=stmt)
                 elif isinstance(stmt, nodes.ImportFrom) and stmt.modname != FUTURE:
                     if SPECIAL_OBJ.search(imported_name):
@@ -2759,7 +2752,7 @@ class VariablesChecker(BaseChecker):
                             msg = f"{imported_name} imported from {stmt.modname}"
                         else:
                             msg = f"{imported_name} imported from {stmt.modname} as {as_name}"
-                        if not _is_type_checking_import(stmt):
+                        if not in_type_checking_block(stmt):
                             self.add_message("unused-import", args=msg, node=stmt)
 
         # Construct string for unused-wildcard-import message

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -193,3 +193,6 @@ INCOMPATIBLE_WITH_USELESS_SUPPRESSION = frozenset(
         "W1513",  # deprecated-decorator
     ]
 )
+
+
+TYPING_TYPE_CHECKS_GUARDS = frozenset({"typing.TYPE_CHECKING", "TYPE_CHECKING"})

--- a/pylint/extensions/typing.py
+++ b/pylint/extensions/typing.py
@@ -10,6 +10,7 @@ from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import (
     check_messages,
+    in_type_checking_block,
     is_node_in_type_annotation_context,
     is_postponed_evaluation_enabled,
     safe_infer,
@@ -355,8 +356,10 @@ class TypingChecker(BaseChecker):
             # NoReturn not part of a Union or Callable type
             return
 
-        if is_postponed_evaluation_enabled(node) and is_node_in_type_annotation_context(
-            node
+        if (
+            in_type_checking_block(node)
+            or is_postponed_evaluation_enabled(node)
+            and is_node_in_type_annotation_context(node)
         ):
             return
 
@@ -391,8 +394,10 @@ class TypingChecker(BaseChecker):
         self, node: Union[nodes.Name, nodes.Attribute]
     ) -> bool:
         """Check if node would be a broken location for collections.abc.Callable."""
-        if is_postponed_evaluation_enabled(node) and is_node_in_type_annotation_context(
-            node
+        if (
+            in_type_checking_block(node)
+            or is_postponed_evaluation_enabled(node)
+            and is_node_in_type_annotation_context(node)
         ):
             return False
 

--- a/tests/functional/ext/typing/typing_broken_callable.py
+++ b/tests/functional/ext/typing/typing_broken_callable.py
@@ -7,7 +7,7 @@ Use 'typing.Callable' instead.
 # pylint: disable=missing-docstring,unsubscriptable-object
 import collections.abc
 from collections.abc import Callable
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 Alias1 = Optional[Callable[[int], None]]  # [broken-collections-callable]
 Alias2 = Union[Callable[[int], None], None]  # [broken-collections-callable]
@@ -16,6 +16,10 @@ Alias3 = Optional[Callable[..., None]]
 Alias4 = Union[Callable[..., None], None]
 Alias5 = list[Callable[..., None]]
 Alias6 = Callable[[int], None]
+
+if TYPE_CHECKING:
+    # ok inside TYPE_CHECKING block
+    Alias7 = Optional[Callable[[int], None]]
 
 
 def func1() -> Optional[Callable[[int], None]]:  # [broken-collections-callable]

--- a/tests/functional/ext/typing/typing_broken_callable.txt
+++ b/tests/functional/ext/typing/typing_broken_callable.txt
@@ -1,4 +1,4 @@
 broken-collections-callable:12:18:12:26::'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE
 broken-collections-callable:13:15:13:23::'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE
-broken-collections-callable:21:24:21:32:func1:'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE
-broken-collections-callable:27:21:27:45:func3:'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE
+broken-collections-callable:25:24:25:32:func1:'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE
+broken-collections-callable:31:21:31:45:func3:'collections.abc.Callable' inside Optional and Union is broken in 3.9.0 / 3.9.1 (use 'typing.Callable' instead):INFERENCE

--- a/tests/functional/ext/typing/typing_broken_noreturn.py
+++ b/tests/functional/ext/typing/typing_broken_noreturn.py
@@ -6,7 +6,7 @@ If no runtime introspection is required, use string annotations instead.
 """
 # pylint: disable=missing-docstring
 import typing
-from typing import Callable, NoReturn, Union
+from typing import TYPE_CHECKING, Callable, NoReturn, Union
 
 import typing_extensions
 
@@ -30,3 +30,7 @@ def func5() -> Union[None, typing_extensions.NoReturn]:  # [broken-noreturn]
 Alias1 = NoReturn
 Alias2 = Callable[..., NoReturn]  # [broken-noreturn]
 Alias3 = Callable[..., "NoReturn"]
+
+if TYPE_CHECKING:
+    # ok inside TYPE_CHECKING block
+    Alias4 = Callable[..., NoReturn]

--- a/tests/functional/ext/typing/typing_broken_noreturn_future_import.py
+++ b/tests/functional/ext/typing/typing_broken_noreturn_future_import.py
@@ -11,7 +11,7 @@ not in a type annotation context.
 from __future__ import annotations
 
 import typing
-from typing import Callable, NoReturn, Union
+from typing import TYPE_CHECKING, Callable, NoReturn, Union
 
 import typing_extensions
 
@@ -35,3 +35,7 @@ def func5() -> Union[None, typing_extensions.NoReturn]:
 Alias1 = NoReturn
 Alias2 = Callable[..., NoReturn]  # [broken-noreturn]
 Alias3 = Callable[..., "NoReturn"]
+
+if TYPE_CHECKING:
+    # ok inside TYPE_CHECKING block
+    Alias4 = Callable[..., NoReturn]

--- a/tests/functional/ext/typing/typing_broken_noreturn_py372.py
+++ b/tests/functional/ext/typing/typing_broken_noreturn_py372.py
@@ -8,7 +8,7 @@ Don't emit errors if py-version set to >= 3.7.2.
 """
 # pylint: disable=missing-docstring
 import typing
-from typing import Callable, NoReturn, Union
+from typing import TYPE_CHECKING, Callable, NoReturn, Union
 
 import typing_extensions
 
@@ -32,3 +32,7 @@ def func5() -> Union[None, typing_extensions.NoReturn]:
 Alias1 = NoReturn
 Alias2 = Callable[..., NoReturn]
 Alias3 = Callable[..., "NoReturn"]
+
+if TYPE_CHECKING:
+    # ok inside TYPE_CHECKING block
+    Alias4 = Callable[..., NoReturn]


### PR DESCRIPTION
## Description
`broken-noreturn` and `broken-collections-callable` errors should not be emitted inside `if TYPE_CHECKING` blocks. At runtime `TYPE_CHECKING` is false and thus the block is never executed and cannot fail.