### PR TITLE
Better error message when we cant write the crash files

### DIFF
--- a/pylint/config/__init__.py
+++ b/pylint/config/__init__.py
@@ -71,11 +71,10 @@ else:
             pathlib.Path(PYLINT_HOME).mkdir(parents=True, exist_ok=True)
             with open(spam_prevention_file, "w", encoding="utf8") as f:
                 f.write("")
-        except Exception:  # pylint: disable=broad-except
-            # Can't write in PYLINT_HOME ?
+        except Exception as exc:  # pylint: disable=broad-except
             print(
                 "Can't write the file that was supposed to "
-                f"prevent pylint.d deprecation spam in {PYLINT_HOME}."
+                f"prevent 'pylint.d' deprecation spam in {PYLINT_HOME} because of {exc}."
             )
 
 

--- a/pylint/lint/utils.py
+++ b/pylint/lint/utils.py
@@ -51,13 +51,16 @@ When parsing the following file:
 pylint crashed with a ``{ex.__class__.__name__}`` and with the following stacktrace:
 ```
 """
+    template += traceback.format_exc()
+    template += "```\n"
     try:
         with open(issue_template_path, "a", encoding="utf8") as f:
             f.write(template)
-            traceback.print_exc(file=f)
-            f.write("```\n")
-    except FileNotFoundError:
-        print(f"Can't write the issue template for the crash in {issue_template_path}.")
+    except FileNotFoundError as exc:
+        print(
+            f"Can't write the issue template for the crash in {issue_template_path} "
+            f"because of: '{exc}', here's the content anyway:\n{template}."
+        )
     return issue_template_path
 
 

--- a/pylint/lint/utils.py
+++ b/pylint/lint/utils.py
@@ -56,10 +56,10 @@ pylint crashed with a ``{ex.__class__.__name__}`` and with the following stacktr
     try:
         with open(issue_template_path, "a", encoding="utf8") as f:
             f.write(template)
-    except FileNotFoundError as exc:
+    except Exception as exc:  # pylint: disable=broad-except
         print(
             f"Can't write the issue template for the crash in {issue_template_path} "
-            f"because of: '{exc}', here's the content anyway:\n{template}."
+            f"because of: '{exc}'\nHere's the content anyway:\n{template}."
         )
     return issue_template_path
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :scroll: Docs          |

## Description

Follow-up to crashes in 2.13.0 there were not reported properly see https://github.com/PyCQA/pylint/issues/5969#issuecomment-1079581083
