### PR TITLE
Fix false negative for `protected-access` on functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,11 @@ Release date: TBA
 
   Closes #5803
 
+* Fix a false negative regression in 2.13.0 where ``protected-access`` was not
+  raised on functions.
+
+  Fixes #5989
+
 
 What's New in Pylint 2.13.1?
 ============================

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -980,7 +980,7 @@ a metaclass class method.",
                 if attribute.attrname != assign_attr.attrname:
                     continue
 
-                if self._is_type_self_call(attribute.expr):
+                if isinstance(attribute.expr, nodes.Call):
                     continue
 
                 if assign_attr.expr.name in {
@@ -2106,6 +2106,7 @@ a metaclass class method.",
         """Check if nodes.Name corresponds to first attribute variable name.
 
         Name is `self` for method, `cls` for classmethod and `mcs` for metaclass.
+        Static methods return False.
         """
         if self._first_attrs:
             first_attr = self._first_attrs[-1]
@@ -2115,6 +2116,8 @@ a metaclass class method.",
                 node, nodes.FunctionDef
             )
             if closest_func is None:
+                return False
+            if not closest_func.is_bound():
                 return False
             if not closest_func.args.args:
                 return False

--- a/tests/functional/p/protected_access.py
+++ b/tests/functional/p/protected_access.py
@@ -27,3 +27,17 @@ class MC:
 class Application(metaclass=MC):
     def __no_special__(cls):
         nargs = obj._nargs  # [protected-access]
+
+
+class Light:
+    @property
+    def _light_internal(self) -> None:
+        return None
+
+    @staticmethod
+    def func(light) -> None:
+        print(light._light_internal)  # [protected-access]
+
+
+def func(light: Light) -> None:
+    print(light._light_internal)  # [protected-access]

--- a/tests/functional/p/protected_access.txt
+++ b/tests/functional/p/protected_access.txt
@@ -1,2 +1,4 @@
 protected-access:17:0:17:9::Access to a protected member _teta of a client class:UNDEFINED
 protected-access:29:16:29:26:Application.__no_special__:Access to a protected member _nargs of a client class:UNDEFINED
+protected-access:39:14:39:35:Light.func:Access to a protected member _light_internal of a client class:UNDEFINED
+protected-access:43:10:43:31:func:Access to a protected member _light_internal of a client class:UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fixes a false negative regression in #5662.

Closes #5989
