### PR TITLE
`unnecessary-ellipsis` false positive: allow ellipsis as default argument

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,10 +10,6 @@ Release date: TBA
   Put new features here and also in 'doc/whatsnew/2.14.rst'
 
 
-* Fix false positive for ``unnecessary-ellipsis`` when using an ellipsis as a default argument.
-
-  Closes #5973
-
 * ``potential-index-error``: Emitted when the index of a list or tuple exceeds its length.
   This checker is currently quite conservative to avoid false positives. We welcome
   suggestions for improvements.
@@ -39,6 +35,10 @@ Release date: TBA
 What's New in Pylint 2.13.3?
 ============================
 Release date: TBA
+
+* Fix false positive for ``unnecessary-ellipsis`` when using an ellipsis as a default argument.
+
+  Closes #5973
 
 * Fix crash involving unbalanced tuple unpacking.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,10 @@ Release date: TBA
   Put new features here and also in 'doc/whatsnew/2.14.rst'
 
 
+* Fix false positive for ``unnecessary-ellipsis`` when using an ellipsis as a default argument.
+
+  Closes #5973
+
 * ``potential-index-error``: Emitted when the index of a list or tuple exceeds its length.
   This checker is currently quite conservative to avoid false positives. We welcome
   suggestions for improvements.

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -128,6 +128,10 @@ Extensions
 Other Changes
 =============
 
+* Fix false positive for ``unnecessary-ellipsis`` when using an ellipsis as a default argument.
+
+  Closes #5973
+
 * Add missing dunder methods to ``unexpected-special-method-signature`` check.
 
 * No longer emit ``no-member`` in for loops that reference ``self`` if the binary operation that

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -34,10 +34,6 @@ Extensions
 Other Changes
 =============
 
-* Fix false positive for ``unnecessary-ellipsis`` when using an ellipsis as a default argument.
-
-  Closes #5973
-
 * Fix false negative for ``no-member`` when attempting to assign an instance
   attribute to itself without any prior assignment.
 

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -34,6 +34,10 @@ Extensions
 Other Changes
 =============
 
+* Fix false positive for ``unnecessary-ellipsis`` when using an ellipsis as a default argument.
+
+  Closes #5973
+
 * Fix false negative for ``no-member`` when attempting to assign an instance
   attribute to itself without any prior assignment.
 

--- a/pylint/checkers/ellipsis_checker.py
+++ b/pylint/checkers/ellipsis_checker.py
@@ -41,7 +41,10 @@ class EllipsisChecker(BaseChecker):
         """
         if (
             node.pytype() == "builtins.Ellipsis"
-            and not isinstance(node.parent, (nodes.Assign, nodes.AnnAssign, nodes.Call))
+            and not isinstance(
+                node.parent,
+                (nodes.Assign, nodes.AnnAssign, nodes.Call, nodes.Arguments),
+            )
             and (
                 len(node.parent.parent.child_sequence(node.parent)) > 1
                 or (

--- a/tests/functional/u/unnecessary/unnecessary_ellipsis.py
+++ b/tests/functional/u/unnecessary/unnecessary_ellipsis.py
@@ -1,6 +1,6 @@
 """Emit a warning when the ellipsis constant is used and can be avoided"""
 
-# pylint: disable=missing-docstring, too-few-public-methods
+# pylint: disable=missing-docstring, too-few-public-methods, invalid-name, unused-argument
 
 from typing import List, overload, Union
 
@@ -97,3 +97,7 @@ class MyIntegerList(List[int]):
             ...
         else:
             raise TypeError(...)
+
+# Ellipsis is allowed as a default argument
+def func_with_ellipsis_default_arg(a = ...) -> None:
+    "Some docstring."


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [X] Add a ChangeLog entry describing what your PR does.
- [X] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [X] Write a good description on what the PR does.
- [X] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #5973

Fix false positive for ``unnecessary-ellipsis`` when using an ellipsis as a default argument.
