### PR TITLE
Change 'nonexistent-operator' to allow repeated unary ops (with space or parens)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,11 @@ Release date: TBA
 
   Closes #578
 
+* Fix false positive for 'nonexistent-operator' when repeated '-' are
+  separated (e.g. by parens).
+
+  Closes #5769
+
 * Added new checker ``unnecessary-list-index-lookup`` for indexing into a list while
   iterating over ``enumerate()``.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -16,11 +16,6 @@ Release date: TBA
 
   Closes #578
 
-* Fix false positive for 'nonexistent-operator' when repeated '-' are
-  separated (e.g. by parens).
-
-  Closes #5769
-
 * Added new checker ``unnecessary-list-index-lookup`` for indexing into a list while
   iterating over ``enumerate()``.
 
@@ -41,6 +36,11 @@ What's New in Pylint 2.13.3?
 ============================
 Release date: TBA
 
+
+* Fix false positive for 'nonexistent-operator' when repeated '-' are
+  separated (e.g. by parens).
+
+  Closes #5769
 
 
 What's New in Pylint 2.13.2?

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -562,3 +562,8 @@ Other Changes
   "return (a or b) in iterable".
 
   Closes #5803
+
+* Fix false positive for 'nonexistent-operator' when repeated '-' are
+  separated (e.g. by parens).
+
+  Closes #5769

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -38,8 +38,3 @@ Other Changes
   attribute to itself without any prior assignment.
 
   Closes #1555
-
-* Fix false positive for 'nonexistent-operator' when repeated '-' are
-  separated (e.g. by parens).
-
-  Closes #5769

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -38,3 +38,8 @@ Other Changes
   attribute to itself without any prior assignment.
 
   Closes #1555
+
+* Fix false positive for 'nonexistent-operator' when repeated '-' are
+  separated (e.g. by parens).
+
+  Closes #5769

--- a/pylint/checkers/base/basic_error_checker.py
+++ b/pylint/checkers/base/basic_error_checker.py
@@ -387,6 +387,7 @@ class BasicErrorChecker(_BasicChecker):
             (node.op in "+-")
             and isinstance(node.operand, nodes.UnaryOp)
             and (node.operand.op == node.op)
+            and (node.col_offset + 1 == node.operand.col_offset)
         ):
             self.add_message("nonexistent-operator", node=node, args=node.op * 2)
 

--- a/tests/functional/n/nonexistent_operator.py
+++ b/tests/functional/n/nonexistent_operator.py
@@ -13,3 +13,7 @@ b = --a # [nonexistent-operator]
 b = a
 --a # [nonexistent-operator]
 c = (--a) * b # [nonexistent-operator]
+c = -(-a)
+c = +(+a)
+c = - -a
+c = + +a


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This PR relax requirements for the 'nonexistent-operator' checker to allow repeated unary ops, separated by spaces or with parens.

Closes #5769
