### PR TITLE
Add documentation and code examples for ``consider-using-with``

### DIFF
--- a/doc/data/messages/c/consider-using-with/bad.py
+++ b/doc/data/messages/c/consider-using-with/bad.py
@@ -1,0 +1,3 @@
+file = open("foo.txt", "r", encoding="utf8")  # [consider-using-with]
+contents = file.read()
+file.close()

--- a/doc/data/messages/c/consider-using-with/details.rst
+++ b/doc/data/messages/c/consider-using-with/details.rst
@@ -1,0 +1,6 @@
+This message applies to callables of Python's stdlib which can be replaced by a ``with`` statement.
+It is suppressed in the following cases:
+
+- the call is located inside a context manager
+- the call result is returned from the enclosing function
+- the call result is used in a ``with`` statement itself

--- a/doc/data/messages/c/consider-using-with/good.py
+++ b/doc/data/messages/c/consider-using-with/good.py
@@ -1,0 +1,2 @@
+with open("foo.txt", "r", encoding="utf8") as file:
+    contents = file.read()

--- a/doc/data/messages/c/consider-using-with/related.rst
+++ b/doc/data/messages/c/consider-using-with/related.rst
@@ -1,0 +1,1 @@
+- `PEP 343 <https://peps.python.org/pep-0343/>`_


### PR DESCRIPTION
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

Good and bad examples for ``consider-using-with``.
I decided to stick with the most obvious example. 
The original PR and list of stdlib callables that are checked is based on [this blog post](https://johnlekberg.com/blog/2020-10-11-ctx-manage.html).
Should we include that in ``related.rst``, or should we stick to the official documentation only?

Ref: #5953
