### PR TITLE
Split checks and tests in CI

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,180 @@
+name: Checks
+
+on:
+  push:
+    branches:
+      - main
+      - 2.*
+  pull_request: ~
+
+env:
+  # Also change CACHE_VERSION in the other workflows
+  CACHE_VERSION: 5
+  DEFAULT_PYTHON: 3.8
+  PRE_COMMIT_CACHE: ~/.cache/pre-commit
+
+jobs:
+  prepare-base:
+    name: Prepare base dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      python-key: ${{ steps.generate-python-key.outputs.key }}
+      pre-commit-key: ${{ steps.generate-pre-commit-key.outputs.key }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v3.0.0
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v3.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Generate partial Python venv restore key
+        id: generate-python-key
+        run: >-
+          echo "::set-output name=key::base-venv-${{ env.CACHE_VERSION }}-${{
+            hashFiles('setup.cfg', 'requirements_test.txt', 'requirements_test_min.txt')
+          }}"
+      - name: Restore Python virtual environment
+        id: cache-venv
+        uses: actions/cache@v3.0.0
+        with:
+          path: venv
+          key: >-
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            steps.generate-python-key.outputs.key }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-base-venv-${{ env.CACHE_VERSION }}-
+      - name: Create Python virtual environment
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          python -m venv venv
+          . venv/bin/activate
+          python -m pip install -U pip setuptools wheel
+          pip install -U -r requirements_test.txt
+      - name: Generate pre-commit restore key
+        id: generate-pre-commit-key
+        run: >-
+          echo "::set-output name=key::pre-commit-${{ env.CACHE_VERSION }}-${{
+            hashFiles('.pre-commit-config.yaml') }}"
+      - name: Restore pre-commit environment
+        id: cache-precommit
+        uses: actions/cache@v3.0.0
+        with:
+          path: ${{ env.PRE_COMMIT_CACHE }}
+          key: >-
+            ${{ runner.os }}-${{ steps.generate-pre-commit-key.outputs.key }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-${{ env.CACHE_VERSION }}-
+      - name: Install pre-commit dependencies
+        if: steps.cache-precommit.outputs.cache-hit != 'true'
+        run: |
+          . venv/bin/activate
+          pre-commit install --install-hooks
+
+  pre-commit:
+    name: checks / pre-commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: prepare-base
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v3.0.0
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v3.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Restore Python virtual environment
+        id: cache-venv
+        uses: actions/cache@v3.0.0
+        with:
+          path: venv
+          key:
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            needs.prepare-base.outputs.python-key }}
+      - name: Fail job if Python cache restore failed
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore Python venv from cache"
+          exit 1
+      - name: Restore pre-commit environment
+        id: cache-precommit
+        uses: actions/cache@v3.0.0
+        with:
+          path: ${{ env.PRE_COMMIT_CACHE }}
+          key: ${{ runner.os }}-${{ needs.prepare-base.outputs.pre-commit-key }}
+      - name: Fail job if pre-commit cache restore failed
+        if: steps.cache-precommit.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore pre-commit environment from cache"
+          exit 1
+      - name: Run formatting check
+        run: |
+          . venv/bin/activate
+          pip install -e .
+          pre-commit run pylint --all-files
+
+  spelling:
+    name: checks / spelling
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: prepare-base
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v3.0.0
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v3.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Restore Python virtual environment
+        id: cache-venv
+        uses: actions/cache@v3.0.0
+        with:
+          path: venv
+          key:
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            needs.prepare-base.outputs.python-key }}
+      - name: Fail job if Python cache restore failed
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore Python venv from cache"
+          exit 1
+      - name: Run spelling checks
+        run: |
+          . venv/bin/activate
+          pytest tests/ -k unittest_spelling
+
+  documentation:
+    name: checks / documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: prepare-base
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v3.0.0
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v3.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Restore Python virtual environment
+        id: cache-venv
+        uses: actions/cache@v3.0.0
+        with:
+          path: venv
+          key:
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            needs.prepare-base.outputs.python-key }}
+      - name: Fail job if Python cache restore failed
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore Python venv from cache"
+          exit 1
+      - name: Run checks on documentation code examples
+        run: |
+          . venv/bin/activate
+          pytest doc/test_messages_documentation.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,186 +1,21 @@
-name: CI
+name: Tests
 
 on:
   push:
     branches:
       - main
       - 2.*
-  pull_request: ~
+  pull_request:
+    paths-ignore:
+      - doc/data/messages/**
 
 env:
-  # Also change CACHE_VERSION in the primer workflow
+  # Also change CACHE_VERSION in the other workflows
   CACHE_VERSION: 5
-  DEFAULT_PYTHON: 3.8
-  PRE_COMMIT_CACHE: ~/.cache/pre-commit
 
 jobs:
-  prepare-base:
-    name: Prepare base dependencies
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      python-key: ${{ steps.generate-python-key.outputs.key }}
-      pre-commit-key: ${{ steps.generate-pre-commit-key.outputs.key }}
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v3.0.0
-        with:
-          fetch-depth: 0
-      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-        id: python
-        uses: actions/setup-python@v3.0.0
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: Generate partial Python venv restore key
-        id: generate-python-key
-        run: >-
-          echo "::set-output name=key::base-venv-${{ env.CACHE_VERSION }}-${{
-            hashFiles('setup.cfg', 'requirements_test.txt', 'requirements_test_min.txt')
-          }}"
-      - name: Restore Python virtual environment
-        id: cache-venv
-        uses: actions/cache@v3.0.0
-        with:
-          path: venv
-          key: >-
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            steps.generate-python-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-base-venv-${{ env.CACHE_VERSION }}-
-      - name: Create Python virtual environment
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          python -m venv venv
-          . venv/bin/activate
-          python -m pip install -U pip setuptools wheel
-          pip install -U -r requirements_test.txt
-      - name: Generate pre-commit restore key
-        id: generate-pre-commit-key
-        run: >-
-          echo "::set-output name=key::pre-commit-${{ env.CACHE_VERSION }}-${{
-            hashFiles('.pre-commit-config.yaml') }}"
-      - name: Restore pre-commit environment
-        id: cache-precommit
-        uses: actions/cache@v3.0.0
-        with:
-          path: ${{ env.PRE_COMMIT_CACHE }}
-          key: >-
-            ${{ runner.os }}-${{ steps.generate-pre-commit-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-pre-commit-${{ env.CACHE_VERSION }}-
-      - name: Install pre-commit dependencies
-        if: steps.cache-precommit.outputs.cache-hit != 'true'
-        run: |
-          . venv/bin/activate
-          pre-commit install --install-hooks
-
-  formatting:
-    name: checks / pre-commit
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: prepare-base
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v3.0.0
-      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-        id: python
-        uses: actions/setup-python@v3.0.0
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: Restore Python virtual environment
-        id: cache-venv
-        uses: actions/cache@v3.0.0
-        with:
-          path: venv
-          key:
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            needs.prepare-base.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
-      - name: Restore pre-commit environment
-        id: cache-precommit
-        uses: actions/cache@v3.0.0
-        with:
-          path: ${{ env.PRE_COMMIT_CACHE }}
-          key: ${{ runner.os }}-${{ needs.prepare-base.outputs.pre-commit-key }}
-      - name: Fail job if pre-commit cache restore failed
-        if: steps.cache-precommit.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore pre-commit environment from cache"
-          exit 1
-      - name: Run formatting check
-        run: |
-          . venv/bin/activate
-          pip install -e .
-          pre-commit run pylint --all-files
-
-  spelling:
-    name: checks / spelling
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: prepare-base
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v3.0.0
-      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-        id: python
-        uses: actions/setup-python@v3.0.0
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: Restore Python virtual environment
-        id: cache-venv
-        uses: actions/cache@v3.0.0
-        with:
-          path: venv
-          key:
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            needs.prepare-base.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
-      - name: Run spelling checks
-        run: |
-          . venv/bin/activate
-          pytest tests/ -k unittest_spelling
-
-  documentation:
-    name: checks / documentation
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: prepare-base
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v3.0.0
-      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-        id: python
-        uses: actions/setup-python@v3.0.0
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: Restore Python virtual environment
-        id: cache-venv
-        uses: actions/cache@v3.0.0
-        with:
-          path: venv
-          key:
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            needs.prepare-base.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
-      - name: Run checks on documentation code examples
-        run: |
-          . venv/bin/activate
-          pytest doc/test_messages_documentation.py
-
   prepare-tests-linux:
-    name: tests / prepare / ${{ matrix.python-version }} / Linux
+    name: prepare / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -223,7 +58,7 @@ jobs:
           pip install -U -r requirements_test.txt
 
   pytest-linux:
-    name: tests / run / ${{ matrix.python-version }} / Linux
+    name: run / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: prepare-tests-linux
@@ -263,7 +98,7 @@ jobs:
           path: .coverage
 
   coverage:
-    name: tests / process / coverage
+    name: process / coverage
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: ["prepare-tests-linux", "pytest-linux"]
@@ -308,7 +143,7 @@ jobs:
           coveralls --rcfile=${{ env.COVERAGERC_FILE }} --service=github
 
   benchmark-linux:
-    name: tests / run benchmark / ${{ matrix.python-version }} / Linux
+    name: run benchmark / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: ["prepare-tests-linux", "pytest-linux"]
@@ -360,7 +195,7 @@ jobs:
           path: .benchmarks/
 
   prepare-tests-windows:
-    name: tests / prepare / ${{ matrix.python-version }} / Windows
+    name: prepare / ${{ matrix.python-version }} / Windows
     runs-on: windows-latest
     timeout-minutes: 10
     needs: pytest-linux
@@ -404,7 +239,7 @@ jobs:
           pip install -U -r requirements_test_min.txt
 
   pytest-windows:
-    name: tests / run / ${{ matrix.python-version }} / Windows
+    name: run / ${{ matrix.python-version }} / Windows
     runs-on: windows-latest
     timeout-minutes: 15
     needs: prepare-tests-windows
@@ -443,7 +278,7 @@ jobs:
           pytest -vv --durations=20 --benchmark-disable tests/
 
   prepare-tests-pypy:
-    name: tests / prepare / ${{ matrix.python-version }} / Linux
+    name: prepare / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -486,7 +321,7 @@ jobs:
           pip install -U -r requirements_test_min.txt
 
   pytest-pypy:
-    name: tests / run / ${{ matrix.python-version }} / Linux
+    name: run / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: prepare-tests-pypy


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

By splitting these we can easily tell the CI not to run the tests on any PR that only adds message data to the codebase.

This should significantly reduce the number of runners these PRs use up.