### PR TITLE
Add examples for ``await-outside-async`` and fix activation of message

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,7 @@ Release date: TBA
 
   Closes #1555
 
+* Fix bug where specifically enabling just ``await-outside-async`` was not possible.
 
 ..
   Insert your changelog randomly, it will reduce merge conflicts

--- a/doc/data/messages/a/await-outside-async/bad.py
+++ b/doc/data/messages/a/await-outside-async/bad.py
@@ -1,0 +1,5 @@
+import asyncio
+
+
+def main():
+    await asyncio.sleep(1)  # [await-outside-async]

--- a/doc/data/messages/a/await-outside-async/good.py
+++ b/doc/data/messages/a/await-outside-async/good.py
@@ -1,0 +1,5 @@
+import asyncio
+
+
+async def main():
+    await asyncio.sleep(1)

--- a/doc/data/messages/a/await-outside-async/related.rst
+++ b/doc/data/messages/a/await-outside-async/related.rst
@@ -1,0 +1,1 @@
+- `PEP 492 <https://peps.python.org/pep-0492/#await-expression>`_


### PR DESCRIPTION

- [x] Add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

This adds examples and link to the relevant PEP for ``await-outside-async``. 
The new test case for checking the message docs actually found a bug (which cost me more time to find than I'd be willing to admit 😀 ): 
Because the relevant ``visit_await`` method was implemented in the wrong checker class (there are two in the module), it was not possible to disable all messages and then just enable ``await-outside-async`` again.
As both the impact and the fix of this are so minor I decided to directly fix this in this PR and only add a ChangeLog entry, without separate issue or whatsnew entry.
Let me know if you'd rather want to split this into two PRs.

Ref: #5953 
