### PR TITLE
Include ``testing_pylintrc`` in source and wheel distributions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,7 +37,9 @@ What's New in Pylint 2.13.4?
 ============================
 Release date: TBA
 
+* Include ``testing_pylintrc`` in source and wheel distributions.
 
+  Closes #6028
 
 
 What's New in Pylint 2.13.3?

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -128,6 +128,10 @@ Extensions
 Other Changes
 =============
 
+* Include ``testing_pylintrc`` in source and wheel distributions.
+
+  Closes #6028
+
 * Fix false positive for ``unnecessary-ellipsis`` when using an ellipsis as a default argument.
 
   Closes #5973

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,9 @@ console_scripts =
     pyreverse = pylint:run_pyreverse
     symilar = pylint:run_symilar
 
+[options.package_data]
+pylint = testutils/testing_pylintrc
+
 [aliases]
 test = pytest
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #6028. `testing_pylintrc` wasn't being included in package distributions. 
This should fix running tests via `tox` (this is where I encountered it) and any uses of `pylint.testutils`

<img width="1150" alt="image" src="https://user-images.githubusercontent.com/80432516/160600483-46cb5e34-a32f-4cdc-8dcc-a870ee9f63e6.png">
