### PR TITLE
Remove the concept of checker priority

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,8 @@ Release date: TBA
 
   Closes #1555
 
+* The concept of checker priority has been removed.
+
 * Fix bug where specifically enabling just ``await-outside-async`` was not possible.
 
 ..

--- a/doc/how_tos/custom_checkers.rst
+++ b/doc/how_tos/custom_checkers.rst
@@ -50,7 +50,6 @@ Firstly we will need to fill in some required boilerplate:
       __implements__ = IAstroidChecker
 
       name = "unique-returns"
-      priority = -1
       msgs = {
           "W0001": (
               "Returns a non-unique constant.",
@@ -75,9 +74,6 @@ So far we have defined the following required components of our checker:
 
 * A name. The name is used to generate a special configuration
    section for the checker, when options have been provided.
-
-* A priority. This must be to be lower than 0. The checkers are ordered by
-   the priority when run, from the most negative to the most positive.
 
 * A message dictionary. Each checker is being used for finding problems
    in your code, the problems being displayed to the user through **messages**.

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -26,6 +26,7 @@ New checkers
 Removed checkers
 ================
 
+* The concept of checker priority has been removed.
 
 Extensions
 ==========

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -26,7 +26,6 @@ New checkers
 Removed checkers
 ================
 
-* The concept of checker priority has been removed.
 
 Extensions
 ==========
@@ -34,6 +33,8 @@ Extensions
 
 Other Changes
 =============
+
+* The concept of checker priority has been removed.
 
 * Fix false negative for ``no-member`` when attempting to assign an instance
   attribute to itself without any prior assignment.

--- a/examples/custom.py
+++ b/examples/custom.py
@@ -20,8 +20,6 @@ class MyAstroidChecker(BaseChecker):
 
     # The name defines a custom section of the config for this checker.
     name = "custom"
-    # The priority indicates the order that pylint will run the checkers.
-    priority = -1
     # This class variable declares the messages (ie the warnings and errors)
     # that the checker can emit.
     msgs = {

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -697,7 +697,6 @@ class ClassChecker(BaseChecker):
     name = "classes"
     # messages
     msgs = MSGS
-    priority = -2
     # configuration options
     options = (
         (

--- a/pylint/checkers/classes/special_methods_checker.py
+++ b/pylint/checkers/classes/special_methods_checker.py
@@ -132,7 +132,6 @@ class SpecialMethodsChecker(BaseChecker):
             "of the form tuple(tuple, dict)",
         ),
     }
-    priority = -2
 
     def __init__(self, linter=None):
         super().__init__(linter)

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -284,7 +284,6 @@ class MisdesignChecker(BaseChecker):
     name = "design"
     # messages
     msgs = MSGS
-    priority = -2
     # configuration options
     options = (
         (

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -231,7 +231,6 @@ class ExceptionsChecker(checkers.BaseChecker):
 
     name = "exceptions"
     msgs = MSGS
-    priority = -4
     options = (
         (
             "overgeneral-exceptions",

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -271,7 +271,6 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
 
     name = "imports"
     msgs = MSGS
-    priority = -2
     default_deprecated_modules = ()
 
     options = (

--- a/pylint/checkers/modified_iterating_checker.py
+++ b/pylint/checkers/modified_iterating_checker.py
@@ -50,7 +50,6 @@ class ModifiedIterationChecker(checkers.BaseChecker):
     }
 
     options = ()
-    priority = -2
 
     @utils.check_messages(
         "modified-iterating-list", "modified-iterating-dict", "modified-iterating-set"

--- a/pylint/checkers/newstyle.py
+++ b/pylint/checkers/newstyle.py
@@ -39,7 +39,6 @@ class NewStyleConflictChecker(BaseChecker):
     name = "newstyle"
     # messages
     msgs = MSGS
-    priority = -2
     # configuration options
     options = ()
 

--- a/pylint/checkers/non_ascii_names.py
+++ b/pylint/checkers/non_ascii_names.py
@@ -48,7 +48,6 @@ class NonAsciiNameChecker(base_checker.BaseChecker):
     """
 
     __implements__ = interfaces.IAstroidChecker
-    priority = -1
 
     msgs = {
         "C2401": (

--- a/pylint/checkers/refactoring/implicit_booleaness_checker.py
+++ b/pylint/checkers/refactoring/implicit_booleaness_checker.py
@@ -74,7 +74,6 @@ class ImplicitBooleanessChecker(checkers.BaseChecker):
         ),
     }
 
-    priority = -2
     options = ()
 
     @utils.check_messages("use-implicit-booleaness-not-len")

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -469,8 +469,6 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         ),
     )
 
-    priority = 0
-
     def __init__(self, linter=None):
         super().__init__(linter)
         self._return_nodes = {}

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -741,7 +741,6 @@ class TypeChecker(BaseChecker):
     name = "typecheck"
     # messages
     msgs = MSGS
-    priority = -1
     # configuration options
     options = (
         (

--- a/pylint/checkers/unicode.py
+++ b/pylint/checkers/unicode.py
@@ -315,7 +315,6 @@ class UnicodeChecker(pylint.checkers.BaseChecker):
     """
 
     __implements__ = pylint.interfaces.IRawChecker
-    priority = -1
 
     name = "unicode_checker"
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -985,7 +985,6 @@ class VariablesChecker(BaseChecker):
 
     name = "variables"
     msgs = MSGS
-    priority = -1
     options = (
         (
             "init-import",

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -38,8 +38,6 @@ class _ArgumentsManager:
             self._add_arguments_to_parser(provider.name, argument)
 
         # pylint: disable-next=fixme
-        # TODO: Do something with option provider priorities (see OptionsManagerMixIn.register_options_provider)
-        # pylint: disable-next=fixme
         # TODO: Do something with option groups within optdicts (see OptionsManagerMixIn.register_options_provider)
 
         # pylint: disable-next=fixme

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -87,13 +87,7 @@ class OptionsManagerMixIn:
 
     def register_options_provider(self, provider, own_group=True):
         """Register an options provider."""
-        assert provider.priority <= 0, "provider's priority can't be >= 0"
-        for i, options_provider in enumerate(self.options_providers):
-            if provider.priority > options_provider.priority:
-                self.options_providers.insert(i, provider)
-                break
-        else:
-            self.options_providers.append(provider)
+        self.options_providers.append(provider)
         non_group_spec_options = [
             option for option in provider.options if "group" not in option[1]
         ]

--- a/pylint/config/options_provider_mixin.py
+++ b/pylint/config/options_provider_mixin.py
@@ -16,7 +16,6 @@ class OptionsProviderMixIn:
     """Mixin to provide options to an OptionsManager."""
 
     # those attributes should be overridden
-    priority = -1
     name = "default"
     options: Tuple[Tuple[str, Dict[str, Any]], ...] = ()
     level = 0

--- a/pylint/extensions/broad_try_clause.py
+++ b/pylint/extensions/broad_try_clause.py
@@ -34,7 +34,6 @@ class BroadTryClauseChecker(checkers.BaseChecker):
         )
     }
 
-    priority = -2
     options = (
         (
             "max-try-statements",

--- a/pylint/extensions/code_style.py
+++ b/pylint/extensions/code_style.py
@@ -40,7 +40,6 @@ class CodeStyleChecker(BaseChecker):
     __implements__ = (IAstroidChecker,)
 
     name = "code_style"
-    priority = -1
     msgs = {
         "R6101": (
             "Consider using namedtuple or dataclass for dictionary values",

--- a/pylint/extensions/comparetozero.py
+++ b/pylint/extensions/comparetozero.py
@@ -41,7 +41,6 @@ class CompareToZeroChecker(checkers.BaseChecker):
         )
     }
 
-    priority = -2
     options = ()
 
     @utils.check_messages("compare-to-zero")

--- a/pylint/extensions/confusing_elif.py
+++ b/pylint/extensions/confusing_elif.py
@@ -20,7 +20,6 @@ class ConfusingConsecutiveElifChecker(BaseChecker):
     __implements__ = IAstroidChecker
 
     name = "confusing_elif"
-    priority = -1
     msgs = {
         "R5601": (
             "Consecutive elif with differing indentation level, consider creating a function to separate the inner elif",

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -186,8 +186,6 @@ class DocstringParameterChecker(BaseChecker):
         ),
     )
 
-    priority = -2
-
     constructor_names = {"__init__", "__new__"}
     not_needed_param_in_docstring = {"self", "cls"}
 

--- a/pylint/extensions/empty_comment.py
+++ b/pylint/extensions/empty_comment.py
@@ -52,7 +52,6 @@ class CommentChecker(BaseChecker):
         )
     }
     options = ()
-    priority = -1  # low priority
 
     def process_module(self, node: nodes.Module) -> None:
         with node.stream() as stream:

--- a/pylint/extensions/emptystring.py
+++ b/pylint/extensions/emptystring.py
@@ -36,7 +36,6 @@ class CompareToEmptyStringChecker(checkers.BaseChecker):
         )
     }
 
-    priority = -2
     options = ()
 
     @utils.check_messages("compare-to-empty-string")

--- a/pylint/extensions/overlapping_exceptions.py
+++ b/pylint/extensions/overlapping_exceptions.py
@@ -34,7 +34,6 @@ class OverlappingExceptionsChecker(checkers.BaseChecker):
             "Used when exceptions in handler overlap or are identical",
         )
     }
-    priority = -2
     options = ()
 
     @utils.check_messages("overlapping-except")

--- a/pylint/extensions/set_membership.py
+++ b/pylint/extensions/set_membership.py
@@ -19,7 +19,6 @@ class SetMembershipChecker(BaseChecker):
     __implements__ = (IAstroidChecker,)
 
     name = "set_membership"
-    priority = -1
     msgs = {
         "R6201": (
             "Consider using set for membership test",

--- a/pylint/extensions/typing.py
+++ b/pylint/extensions/typing.py
@@ -95,7 +95,6 @@ class TypingChecker(BaseChecker):
     __implements__ = (IAstroidChecker,)
 
     name = "typing"
-    priority = -1
     msgs = {
         "W6001": (
             "'%s' is deprecated, use '%s' instead",

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -5,7 +5,6 @@
 import collections
 import contextlib
 import functools
-import operator
 import os
 import sys
 import tokenize
@@ -214,7 +213,6 @@ class PyLinter(
     __implements__ = (interfaces.ITokenChecker,)
 
     name = MAIN_CHECKER_NAME
-    priority = 0
     level = 0
     msgs = MSGS
     # Will be used like this : datetime.now().strftime(crash_file_path)
@@ -765,7 +763,6 @@ class PyLinter(
 
     def register_checker(self, checker: checkers.BaseChecker) -> None:
         """This method auto registers the checker."""
-        assert checker.priority <= 0, "checker priority can't be >= 0"
         self._checkers[checker.name].append(checker)
         for r_id, r_title, r_cb in checker.reports:
             self.register_report(r_id, r_title, r_cb, checker)
@@ -974,10 +971,6 @@ class PyLinter(
             messages = {msg for msg in checker.msgs if self.is_message_enabled(msg)}
             if messages or any(self.report_is_enabled(r[0]) for r in checker.reports):
                 needed_checkers.append(checker)
-        # Sort checkers by priority
-        needed_checkers = sorted(
-            needed_checkers, key=operator.attrgetter("priority"), reverse=True
-        )
         return needed_checkers
 
     # pylint: disable=unused-argument


### PR DESCRIPTION
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

I don't really see what this does? There is this issue https://github.com/PyCQA/pylint/issues/229.
But it seems more like a "let's make a function that uses something that is already there" than something that actually adds something. When is it ever useful to have some checker be executed 50ms earlier than another?

I'd vote for removal. I don't consider this a breaking change because you can still define `priority` without it breaking anything.
And we can easily revert this commit if something does depend on it.