### PR TITLE
Fix crash for ``unneccessary-ellipsis`` checker 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,10 @@ Release date: TBA
 
 * Fix bug where specifically enabling just ``await-outside-async`` was not possible.
 
+* Fix crash for ``unneccessary-ellipsis`` checker when an ellipsis is used inside of a list.
+
+  Closes #6037
+
 ..
   Insert your changelog randomly, it will reduce merge conflicts
   (Ie. not necessarily at the end)

--- a/ChangeLog
+++ b/ChangeLog
@@ -45,6 +45,7 @@ Release date: TBA
 inside of a container.
 
   Closes #6037
+  Closes #6048
 
 What's New in Pylint 2.13.3?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -41,8 +41,7 @@ Release date: TBA
 
   Closes #6028
 
-* Fix crash for ``unneccessary-ellipsis`` checker when an ellipsis is used
-inside of a container.
+* Fix crash for ``unneccessary-ellipsis`` checker when an ellipsis is used inside of a container.
 
   Closes #6037
   Closes #6048

--- a/ChangeLog
+++ b/ChangeLog
@@ -46,7 +46,6 @@ inside of a container.
 
   Closes #6037
 
-
 What's New in Pylint 2.13.3?
 ============================
 Release date: 2022-03-29

--- a/ChangeLog
+++ b/ChangeLog
@@ -41,7 +41,8 @@ Release date: TBA
 
   Closes #6028
 
-* Fix crash for ``unneccessary-ellipsis`` checker when an ellipsis is used inside of a list.
+* Fix crash for ``unneccessary-ellipsis`` checker when an ellipsis is used
+inside of a container.
 
   Closes #6037
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -28,10 +28,6 @@ Release date: TBA
 
 * Fix bug where specifically enabling just ``await-outside-async`` was not possible.
 
-* Fix crash for ``unneccessary-ellipsis`` checker when an ellipsis is used inside of a list.
-
-  Closes #6037
-
 ..
   Insert your changelog randomly, it will reduce merge conflicts
   (Ie. not necessarily at the end)
@@ -44,6 +40,10 @@ Release date: TBA
 * Include ``testing_pylintrc`` in source and wheel distributions.
 
   Closes #6028
+
+* Fix crash for ``unneccessary-ellipsis`` checker when an ellipsis is used inside of a list.
+
+  Closes #6037
 
 
 What's New in Pylint 2.13.3?

--- a/pylint/checkers/ellipsis_checker.py
+++ b/pylint/checkers/ellipsis_checker.py
@@ -39,16 +39,17 @@ class EllipsisChecker(BaseChecker):
            For example: A function consisting of an ellipsis followed by a
            return statement on the next line.
         """
+        #breakpoint()
         if (
             node.pytype() == "builtins.Ellipsis"
             and not isinstance(
                 node.parent,
                 (
-                    nodes.Assign,
                     nodes.AnnAssign,
-                    nodes.Call,
                     nodes.Arguments,
-                    nodes.List,
+                    nodes.Assign,
+                    nodes.BaseContainer,
+                    nodes.Call,
                 ),
             )
             and (

--- a/pylint/checkers/ellipsis_checker.py
+++ b/pylint/checkers/ellipsis_checker.py
@@ -39,7 +39,6 @@ class EllipsisChecker(BaseChecker):
            For example: A function consisting of an ellipsis followed by a
            return statement on the next line.
         """
-        # breakpoint()
         if (
             node.pytype() == "builtins.Ellipsis"
             and not isinstance(

--- a/pylint/checkers/ellipsis_checker.py
+++ b/pylint/checkers/ellipsis_checker.py
@@ -43,7 +43,13 @@ class EllipsisChecker(BaseChecker):
             node.pytype() == "builtins.Ellipsis"
             and not isinstance(
                 node.parent,
-                (nodes.Assign, nodes.AnnAssign, nodes.Call, nodes.Arguments, nodes.List),
+                (
+                    nodes.Assign,
+                    nodes.AnnAssign,
+                    nodes.Call,
+                    nodes.Arguments,
+                    nodes.List,
+                ),
             )
             and (
                 len(node.parent.parent.child_sequence(node.parent)) > 1

--- a/pylint/checkers/ellipsis_checker.py
+++ b/pylint/checkers/ellipsis_checker.py
@@ -39,7 +39,7 @@ class EllipsisChecker(BaseChecker):
            For example: A function consisting of an ellipsis followed by a
            return statement on the next line.
         """
-        #breakpoint()
+        # breakpoint()
         if (
             node.pytype() == "builtins.Ellipsis"
             and not isinstance(

--- a/pylint/checkers/ellipsis_checker.py
+++ b/pylint/checkers/ellipsis_checker.py
@@ -43,7 +43,7 @@ class EllipsisChecker(BaseChecker):
             node.pytype() == "builtins.Ellipsis"
             and not isinstance(
                 node.parent,
-                (nodes.Assign, nodes.AnnAssign, nodes.Call, nodes.Arguments),
+                (nodes.Assign, nodes.AnnAssign, nodes.Call, nodes.Arguments, nodes.List),
             )
             and (
                 len(node.parent.parent.child_sequence(node.parent)) > 1

--- a/tests/functional/u/unnecessary/unnecessary_ellipsis.py
+++ b/tests/functional/u/unnecessary/unnecessary_ellipsis.py
@@ -103,6 +103,12 @@ def func_with_ellipsis_default_arg(a = ...) -> None:
     "Some docstring."
 
 
-# Ignore if the ellipsis is inside a list
-x = [...]
-y = {'a': [...]}
+# Ignore if the ellipsis is inside a container:
+my_list = [...]
+my_tuple = (...,)
+my_set = {...}
+
+# Ellipsis inside a container which is a value in a dictionary
+a = {'x': [...]}
+b = {'x': {...}}
+c = {'x': (...,)}

--- a/tests/functional/u/unnecessary/unnecessary_ellipsis.py
+++ b/tests/functional/u/unnecessary/unnecessary_ellipsis.py
@@ -101,3 +101,8 @@ class MyIntegerList(List[int]):
 # Ellipsis is allowed as a default argument
 def func_with_ellipsis_default_arg(a = ...) -> None:
     "Some docstring."
+
+
+# Ignore if the ellipsis is inside a list
+x = [...]
+y = {'a': [...]}

--- a/tests/functional/u/unnecessary/unnecessary_ellipsis.py
+++ b/tests/functional/u/unnecessary/unnecessary_ellipsis.py
@@ -109,6 +109,6 @@ my_tuple = (...,)
 my_set = {...}
 
 # Ellipsis inside a container which is a value in a dictionary
-a = {'x': [...]}
-b = {'x': {...}}
-c = {'x': (...,)}
+mydict1 = {'x': [...]}
+mydict2 = {'x': {...}}
+mydict3 = {'x': (...,)}


### PR DESCRIPTION
Fix crash for ``unneccessary-ellipsis`` checker when an ellipsis is used inside of a list.

Closes #6037
Closes #6048 

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #XXX
