### PR TITLE
Move ``long-help`` to the ``Run`` class

### DIFF
--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -6,7 +6,6 @@ import collections
 import configparser
 import contextlib
 import copy
-import functools
 import optparse  # pylint: disable=deprecated-module
 import os
 import sys
@@ -250,21 +249,6 @@ class OptionsManagerMixIn:
         """Read the configuration file but do not load it (i.e. dispatching
         values to each option's provider)
         """
-        for help_level in range(1, self._maxlevel + 1):
-            opt = "-".join(["long"] * help_level) + "-help"
-            if opt in self._all_options:
-                break  # already processed
-            help_function = functools.partial(self.helpfunc, level=help_level)
-            help_msg = f"{' '.join(['more'] * help_level)} verbose help."
-            optdict = {
-                "action": "callback",
-                "callback": help_function,
-                "help": help_msg,
-            }
-            provider = self.options_providers[0]
-            self.add_optik_option(provider, self.cmdline_parser, opt, optdict)
-            provider.options += ((opt, optdict),)
-
         if config_file is None:
             config_file = self.config_file
         if config_file is not None:
@@ -386,7 +370,3 @@ class OptionsManagerMixIn:
         self.cmdline_parser.formatter.output_level = level
         with _patch_optparse():
             return self.cmdline_parser.format_help()
-
-    def helpfunc(self, option, opt, val, p, level):  # pylint: disable=unused-argument
-        print(self.help(level))
-        sys.exit(0)

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -2,11 +2,13 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
+import optparse  # pylint: disable=deprecated-module
 import os
 import sys
 import warnings
+from typing import NoReturn
 
-from pylint import __pkginfo__, extensions, interfaces
+from pylint import __pkginfo__, config, extensions, interfaces
 from pylint.config.config_initialization import _config_initialization
 from pylint.constants import DEFAULT_PYLINT_HOME, OLD_DEFAULT_PYLINT_HOME, full_version
 from pylint.lint.pylinter import PyLinter
@@ -267,6 +269,15 @@ group are mutually exclusive.",
                         "Use --list-extensions to see a list all available extensions.",
                     },
                 ),
+                (
+                    "long-help",
+                    {
+                        "action": "callback",
+                        "callback": self.cb_helpfunc,
+                        "help": "Show more verbose help.",
+                        "group": "Commands",
+                    },
+                ),
             ),
             option_groups=self.option_groups,
             pylintrc=self._rcfile,
@@ -460,3 +471,13 @@ to search for configuration file.
                 extension_name = f"pylint.extensions.{filename[:-3]}"
                 if extension_name not in self._plugins:
                     self._plugins.append(extension_name)
+
+    def cb_helpfunc(
+        self,
+        option: optparse.Option,
+        optname: str,
+        value: None,
+        parser: config.OptionParser,
+    ) -> NoReturn:
+        print(self.linter.help(1))
+        sys.exit(0)

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1318,3 +1318,12 @@ class TestRunTC:
                     ["."],
                     expected_output="No such file or directory",
                 )
+
+    @staticmethod
+    def test_long_help(capsys: pytest.CaptureFixture[str]) -> None:
+        """Test the long help flag."""
+        with pytest.raises(SystemExit) as ex:
+            Run(["--long-help"])
+        assert ex.value.code == 0
+        output = capsys.readouterr()
+        assert "Environment variables:" in output.out


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

I'm trying to clean up `read_config_file` to make it easier to port it to a new system.

This seems like it doesn't fit here. It was added in https://github.com/PyCQA/pylint/commit/3deb961d3583075e48fbdcb23cc2680fecf4329d and never touched (besides some refactoring). I think logilab might have used this internally, but it seems very illogical to define an option at config file parse time. It should be done earlier.

One change that comes from this is that the option has been moved. I tried to keep it in the same place, but I couldn't figure it out without a major refactor of the `optparse` code. That doesn't seem worth it.


```console
Options:
  -h, --help            show this help message and exit

  Master:
    --init-hook=<code>  Python code to execute, usually for sys.path
                        manipulation such as pygtk.require().
    -E, --errors-only   In error mode, checkers without error messages are
                        disabled and for others, only the ERROR messages are
                        displayed, and no reports are done by default.
    -v, --verbose       In verbose mode, extra non-checker-related info will
                        be displayed.
    --enable-all-extensions
                        Load and enable all available extensions. Use --list-
                        extensions to see a list all available extensions.
    --ignore=<file>[,<file>...]
                        Files or directories to be skipped. They should be
                        base names, not paths. [current: CVS]
    --ignore-patterns=<pattern>[,<pattern>...]
                        Files or directories matching the regex patterns are
                        skipped. The regex matches against base names, not
                        paths. The default value ignores emacs file locks
                        [current: ^\.#]
    --ignore-paths=<pattern>[,<pattern>...]
                        Add files or directories matching the regex patterns
                        to the ignore-list. The regex matches against paths
                        and can be in Posix or Windows format. [current: none]
    --persistent=<y or n>
                        Pickle collected data for later comparisons. [current:
                        yes]
    --load-plugins=<modules>
                        List of plugins (as comma separated values of python
                        module names) to load, usually to register additional
                        checkers. [current: pylint.extensions.check_elif,pylin
                        t.extensions.bad_builtin,pylint.extensions.docparams,p
                        ylint.extensions.for_any_all,pylint.extensions.set_mem
                        bership,pylint.extensions.code_style,pylint.extensions
                        .overlapping_exceptions,pylint.extensions.typing,pylin
                        t.extensions.redefined_variable_type,pylint.extensions
                        .comparison_placement]
    --fail-under=<score>
                        Specify a score threshold to be exceeded before
                        program exits with error. [current: 10.0]
    --fail-on=<msg ids>
                        Return non-zero exit code if any of these
                        messages/categories are detected, even if score is
                        above --fail-under value. Syntax same as enable.
                        Messages specified are enabled, while categories only
                        check already-enabled messages. [current: none]
    -j <n-processes>, --jobs=<n-processes>
                        Use multiple processes to speed up Pylint. Specifying
                        0 will auto-detect the number of processors available
                        to use. [current: 1]
    --limit-inference-results=<number-of-results>
                        Control the amount of potential inferred values when
                        inferring a single object. This can help the
                        performance when dealing with large functions or
                        complex, nested conditions.  [current: 100]
    --extension-pkg-allow-list=<pkg[,pkg]>
                        A comma-separated list of package or module names from
                        where C extensions may be loaded. Extensions are
                        loading into the active Python interpreter and may run
                        arbitrary code. [current: none]
    --extension-pkg-whitelist=<pkg[,pkg]>
                        A comma-separated list of package or module names from
                        where C extensions may be loaded. Extensions are
                        loading into the active Python interpreter and may run
                        arbitrary code. (This is an alternative name to
                        extension-pkg-allow-list for backward compatibility.)
                        [current: none]
    --suggestion-mode=<y or n>
                        When enabled, pylint would attempt to guess common
                        misconfiguration and emit user-friendly hints instead
                        of false-positive error messages. [current: yes]
    --exit-zero         Always return a 0 (non-error) status code, even if
                        lint errors are found. This is primarily useful in
                        continuous integration scripts.
    --from-stdin        Interpret the stdin as a python script, whose filename
                        needs to be passed as the module_or_package argument.
    --recursive=<yn>    Discover python modules and packages in the file
                        system subtree. [current: no]
    --py-version=<py_version>
                        Minimum Python version to use for version dependent
                        checks. Will default to the version used to run
                        pylint. [current: 3.6.2]

  Commands:
    --rcfile=<file>     Specify a configuration file to load.
    --output=<file>     Specify an output file.
    --help-msg=<msg-id>
                        Display a help message for the given message id and
                        exit. The value may be a comma separated list of
                        message ids.
    --list-msgs         Display a list of all pylint's messages divided by
                        whether they are emittable with the given interpreter.
    --list-msgs-enabled
                        Display a list of what messages are enabled, disabled
                        and non-emittable with the given configuration.
    --list-groups       List pylint's message groups.
    --list-conf-levels  Generate pylint's confidence levels.
    --list-extensions   List available extensions.
    --full-documentation
                        Generate pylint's full documentation.
    --generate-rcfile   Generate a sample configuration file according to the
                        current configuration. You can put other options
                        before this one to get them in the generated
                        configuration.
    --long-help         Show more verbose help.
```

vs.

```console
Usage: pylint [options]

Options:
  -h, --help            show this help message and exit
  --long-help           more verbose help.

  Master:
    --init-hook=<code>  Python code to execute, usually for sys.path
                        manipulation such as pygtk.require().
    -E, --errors-only   In error mode, checkers without error messages are
                        disabled and for others, only the ERROR messages are
                        displayed, and no reports are done by default.
    -v, --verbose       In verbose mode, extra non-checker-related info will
                        be displayed.
    --enable-all-extensions
                        Load and enable all available extensions. Use --list-
                        extensions to see a list all available extensions.
    --ignore=<file>[,<file>...]
                        Files or directories to be skipped. They should be
                        base names, not paths. [current: CVS]
    --ignore-patterns=<pattern>[,<pattern>...]
                        Files or directories matching the regex patterns are
                        skipped. The regex matches against base names, not
                        paths. The default value ignores emacs file locks
                        [current: ^\.#]
    --ignore-paths=<pattern>[,<pattern>...]
                        Add files or directories matching the regex patterns
                        to the ignore-list. The regex matches against paths
                        and can be in Posix or Windows format. [current: none]
    --persistent=<y or n>
                        Pickle collected data for later comparisons. [current:
                        yes]
    --load-plugins=<modules>
                        List of plugins (as comma separated values of python
                        module names) to load, usually to register additional
                        checkers. [current: pylint.extensions.check_elif,pylin
                        t.extensions.bad_builtin,pylint.extensions.docparams,p
                        ylint.extensions.for_any_all,pylint.extensions.set_mem
                        bership,pylint.extensions.code_style,pylint.extensions
                        .overlapping_exceptions,pylint.extensions.typing,pylin
                        t.extensions.redefined_variable_type,pylint.extensions
                        .comparison_placement]
    --fail-under=<score>
                        Specify a score threshold to be exceeded before
                        program exits with error. [current: 10.0]
    --fail-on=<msg ids>
                        Return non-zero exit code if any of these
                        messages/categories are detected, even if score is
                        above --fail-under value. Syntax same as enable.
                        Messages specified are enabled, while categories only
                        check already-enabled messages. [current: none]
    -j <n-processes>, --jobs=<n-processes>
                        Use multiple processes to speed up Pylint. Specifying
                        0 will auto-detect the number of processors available
                        to use. [current: 1]
    --limit-inference-results=<number-of-results>
                        Control the amount of potential inferred values when
                        inferring a single object. This can help the
                        performance when dealing with large functions or
                        complex, nested conditions.  [current: 100]
    --extension-pkg-allow-list=<pkg[,pkg]>
                        A comma-separated list of package or module names from
                        where C extensions may be loaded. Extensions are
                        loading into the active Python interpreter and may run
                        arbitrary code. [current: none]
    --extension-pkg-whitelist=<pkg[,pkg]>
                        A comma-separated list of package or module names from
                        where C extensions may be loaded. Extensions are
                        loading into the active Python interpreter and may run
                        arbitrary code. (This is an alternative name to
                        extension-pkg-allow-list for backward compatibility.)
                        [current: none]
    --suggestion-mode=<y or n>
                        When enabled, pylint would attempt to guess common
                        misconfiguration and emit user-friendly hints instead
                        of false-positive error messages. [current: yes]
    --exit-zero         Always return a 0 (non-error) status code, even if
                        lint errors are found. This is primarily useful in
                        continuous integration scripts.
    --from-stdin        Interpret the stdin as a python script, whose filename
                        needs to be passed as the module_or_package argument.
    --recursive=<yn>    Discover python modules and packages in the file
                        system subtree. [current: no]
    --py-version=<py_version>
                        Minimum Python version to use for version dependent
                        checks. Will default to the version used to run
                        pylint. [current: 3.6.2]

  Commands:
    --rcfile=<file>     Specify a configuration file to load.
    --output=<file>     Specify an output file.
    --help-msg=<msg-id>
                        Display a help message for the given message id and
                        exit. The value may be a comma separated list of
                        message ids.
    --list-msgs         Display a list of all pylint's messages divided by
                        whether they are emittable with the given interpreter.
    --list-msgs-enabled
                        Display a list of what messages are enabled, disabled
                        and non-emittable with the given configuration.
    --list-groups       List pylint's message groups.
    --list-conf-levels  Generate pylint's confidence levels.
    --list-extensions   List available extensions.
    --full-documentation
                        Generate pylint's full documentation.
    --generate-rcfile   Generate a sample configuration file according to the
                        current configuration. You can put other options
                        before this one to get them in the generated
                        configuration.
```