### PR TITLE
Some refactors of configuration file discovery

### DIFF
--- a/doc/test_messages_documentation.py
+++ b/doc/test_messages_documentation.py
@@ -11,7 +11,7 @@ from typing import List, TextIO, Tuple
 
 import pytest
 
-from pylint import checkers
+from pylint import checkers, config
 from pylint.config.config_initialization import _config_initialization
 from pylint.lint import PyLinter
 from pylint.message.message import Message
@@ -53,6 +53,8 @@ class LintModuleTest:
         self._linter.config.persistent = 0
         checkers.initialize(self._linter)
 
+        config_file = next(config.find_default_config_files(), None)
+
         _config_initialization(
             self._linter,
             args_list=[
@@ -61,6 +63,7 @@ class LintModuleTest:
                 f"--enable={test_file[0]}",
             ],
             reporter=_test_reporter,
+            config_file=config_file,
         )
 
     def runTest(self) -> None:

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -4,7 +4,7 @@
 
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, List, Union
 
 from pylint import reporters
 from pylint.utils import utils
@@ -18,18 +18,23 @@ def _config_initialization(
     args_list: List[str],
     reporter: Union[reporters.BaseReporter, reporters.MultiReporter, None] = None,
     config_file: Union[None, str, Path] = None,
-    verbose_mode: Optional[bool] = None,
+    verbose_mode: bool = False,
 ) -> List[str]:
     """Parse all available options, read config files and command line arguments and
     set options accordingly.
     """
+    # Convert config_file in a Path and string
+    config_file_path = Path(config_file) if config_file else None
+    config_file = str(config_file) if config_file else None
+
     # Set the current module to the configuration file
     # to allow raising messages on the configuration file.
-    linter.set_current_module(linter.config_file)
+    linter.set_current_module(config_file)
 
-    # Read the config file. The parser is stored on linter.cfgfile_parser
+    # Read the configuration file
     try:
-        linter.read_config_file(config_file=config_file, verbose=verbose_mode)
+        # The parser is stored on linter.cfgfile_parser
+        linter.read_config_file(config_file=config_file_path, verbose=verbose_mode)
     except OSError as ex:
         print(ex, file=sys.stderr)
         sys.exit(32)

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -257,7 +257,7 @@ class OptionsManagerMixIn:
 
             if config_file.suffix == ".toml":
                 try:
-                    self._parse_toml(config_file, parser)
+                    self._parse_toml(config_file, self.cfgfile_parser)
                 except tomllib.TOMLDecodeError as e:
                     self.add_message("config-parse-error", line=0, args=str(e))  # type: ignore[attr-defined]
             else:

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -275,7 +275,7 @@ class OptionsManagerMixIn:
         if not verbose:
             return
         if config_file and config_file.exists():
-            msg = f"Using config file {str(config_file)}"
+            msg = f"Using config file '{config_file}'"
         else:
             msg = "No config file found, using default configuration"
         print(msg, file=sys.stderr)

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -258,7 +258,7 @@ class OptionsManagerMixIn:
             parser = self.cfgfile_parser
             if config_file.suffix == ".toml":
                 try:
-                    self._parse_toml(config_file, self.cfgfile_parser)
+                    self._parse_toml(config_file, parser)
                 except tomllib.TOMLDecodeError as e:
                     self.add_message("config-parse-error", line=0, args=str(e))  # type: ignore[attr-defined]
             else:

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -265,7 +265,7 @@ class OptionsManagerMixIn:
                 with open(config_file, encoding="utf_8_sig") as fp:
                     self.cfgfile_parser.read_file(fp)
                 # normalize each section's title
-                for sect, values in list(parser._sections.items()):
+                for sect, values in list(self.cfgfile_parser._sections.items()):
                     if sect.startswith("pylint."):
                         sect = sect[len("pylint.") :]
                     if not sect.isupper() and values:

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -255,7 +255,6 @@ class OptionsManagerMixIn:
             if not config_file.exists():
                 raise OSError(f"The config file {str(config_file)} doesn't exist!")
 
-            parser = self.cfgfile_parser
             if config_file.suffix == ".toml":
                 try:
                     self._parse_toml(config_file, parser)
@@ -264,13 +263,13 @@ class OptionsManagerMixIn:
             else:
                 # Use this encoding in order to strip the BOM marker, if any.
                 with open(config_file, encoding="utf_8_sig") as fp:
-                    parser.read_file(fp)
+                    self.cfgfile_parser.read_file(fp)
                 # normalize each section's title
                 for sect, values in list(parser._sections.items()):
                     if sect.startswith("pylint."):
                         sect = sect[len("pylint.") :]
                     if not sect.isupper() and values:
-                        parser._sections[sect.upper()] = values
+                        self.cfgfile_parser._sections[sect.upper()] = values
 
         if not verbose:
             return

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -255,6 +255,7 @@ class OptionsManagerMixIn:
             if not config_file.exists():
                 raise OSError(f"The config file {str(config_file)} doesn't exist!")
 
+            parser = self.cfgfile_parser
             if config_file.suffix == ".toml":
                 try:
                     self._parse_toml(config_file, self.cfgfile_parser)
@@ -263,13 +264,13 @@ class OptionsManagerMixIn:
             else:
                 # Use this encoding in order to strip the BOM marker, if any.
                 with open(config_file, encoding="utf_8_sig") as fp:
-                    self.cfgfile_parser.read_file(fp)
+                    parser.read_file(fp)
                 # normalize each section's title
-                for sect, values in list(self.cfgfile_parser._sections.items()):
+                for sect, values in list(parser._sections.items()):
                     if sect.startswith("pylint."):
                         sect = sect[len("pylint.") :]
                     if not sect.isupper() and values:
-                        self.cfgfile_parser._sections[sect.upper()] = values
+                        parser._sections[sect.upper()] = values
 
         if not verbose:
             return

--- a/pylint/config/options_provider_mixin.py
+++ b/pylint/config/options_provider_mixin.py
@@ -107,4 +107,4 @@ class OptionsProviderMixIn:
         if options is None:
             options = self.options
         for optname, optdict in options:
-            yield (optname, optdict, self.option_value(optname))
+            yield optname, optdict, self.option_value(optname)

--- a/pylint/config/options_provider_mixin.py
+++ b/pylint/config/options_provider_mixin.py
@@ -67,8 +67,7 @@ class OptionsProviderMixIn:
                 if isinstance(value, (list, tuple)):
                     _list = value
                 elif value is not None:
-                    _list = []
-                    _list.append(value)
+                    _list = [value]
                 setattr(self.config, optname, _list)
             elif isinstance(_list, tuple):
                 setattr(self.config, optname, _list + (value,))

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -550,7 +550,9 @@ class PyLinter(
         options: Tuple[Tuple[str, OptionDict], ...] = (),
         reporter: Union[reporters.BaseReporter, reporters.MultiReporter, None] = None,
         option_groups: Tuple[Tuple[str, str], ...] = (),
-        pylintrc: Optional[str] = None,
+        # pylint: disable-next=fixme
+        # TODO: Deprecate passing the pylintrc parameter
+        pylintrc: Optional[str] = None,  # pylint: disable=unused-argument
     ) -> None:
         config._ArgumentsManager.__init__(self)
 
@@ -612,10 +614,7 @@ class PyLinter(
         self._by_id_managed_msgs: List[ManagedMessage] = []
 
         reporters.ReportsHandlerMixIn.__init__(self)
-        super().__init__(
-            usage=__doc__,
-            config_file=pylintrc or next(config.find_default_config_files(), None),
-        )
+        config.OptionsManagerMixIn.__init__(self, usage=__doc__)
         checkers.BaseTokenChecker.__init__(self)
         # provided reports
         self.reports = (

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -6,7 +6,7 @@ import optparse  # pylint: disable=deprecated-module
 import os
 import sys
 import warnings
-from typing import NoReturn
+from typing import NoReturn, Optional
 
 from pylint import __pkginfo__, config, extensions, interfaces
 from pylint.config.config_initialization import _config_initialization
@@ -14,6 +14,11 @@ from pylint.constants import DEFAULT_PYLINT_HOME, OLD_DEFAULT_PYLINT_HOME, full_
 from pylint.lint.pylinter import PyLinter
 from pylint.lint.utils import ArgumentPreprocessingError, preprocess_options
 from pylint.utils import print_full_documentation, utils
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 try:
     import multiprocessing
@@ -80,7 +85,7 @@ group are mutually exclusive.",
         exit=True,
         do_exit=UNUSED_PARAM_SENTINEL,
     ):  # pylint: disable=redefined-builtin
-        self._rcfile = None
+        self._rcfile: Optional[str] = None
         self._output = None
         self._version_asked = False
         self._plugins = []
@@ -102,6 +107,10 @@ group are mutually exclusive.",
         except ArgumentPreprocessingError as ex:
             print(ex, file=sys.stderr)
             sys.exit(32)
+
+        # Determine configuration file
+        if self._rcfile is None:
+            self._rcfile = next(config.find_default_config_files(), None)
 
         self.linter = linter = self.LinterClass(
             (
@@ -338,7 +347,9 @@ to search for configuration file.
         linter.disable("I")
         linter.enable("c-extension-no-member")
 
-        args = _config_initialization(linter, args, reporter, verbose_mode=self.verbose)
+        args = _config_initialization(
+            linter, args, reporter, config_file=self._rcfile, verbose_mode=self.verbose
+        )
 
         if linter.config.jobs < 0:
             print(
@@ -397,7 +408,7 @@ to search for configuration file.
         """Callback for version (i.e. before option parsing)."""
         self._version_asked = True
 
-    def cb_set_rcfile(self, name, value):
+    def cb_set_rcfile(self, name: Literal["rcfile"], value: str) -> None:
         """Callback for option preprocessing (i.e. before option parsing)."""
         self._rcfile = value
 


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Sorry for this being a bit all over the place...

These are some basic refactors all related to `read_config_file` to make the parameters that get passed to that function a little more logical. That makes it easier to write a new function that doesn't need to handle some of the non-sensical parameters.

I also removed the configuration file discovery out of `PyLinter` into `Run`. Since the configuration is done in `Run` it makes no sense to do that discovery in `PyLinter`.