### PR TITLE
Add an explicit marker for ``pytest-timeout``

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,6 +85,7 @@ markers =
     primer_external_batch_one: Checks for crashes and errors when running pylint on external libs (batch one)
     primer_external_batch_two: Checks for crashes and errors when running pylint on external libs (batch two)
     benchmark: Baseline of pylint performance, if this regress something serious happened
+    timeout: Marks from pytest-timeout.
 
 [isort]
 profile = black


### PR DESCRIPTION


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description

To avoid "'timeout' not found in  configuration option"
When using --strict-markers with pytest locally.

Follow up to #5932 
