### PR TITLE
Create ``_ConfigurationFileParser`` class

### DIFF
--- a/pylint/config/__init__.py
+++ b/pylint/config/__init__.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 from pylint.config.argument import _Argument
 from pylint.config.arguments_manager import _ArgumentsManager
+from pylint.config.config_file_parser import _ConfigurationFileParser
 from pylint.config.configuration_mixin import ConfigurationMixIn
 from pylint.config.environment_variable import PYLINTRC
 from pylint.config.find_default_config_files import (
@@ -27,6 +28,7 @@ from pylint.utils import LinterStats
 __all__ = [
     "_Argument",
     "_ArgumentsManager",
+    "_ConfigurationFileParser",
     "ConfigurationMixIn",
     "find_default_config_files",
     "find_pylintrc",

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -5,7 +5,6 @@
 """Arguments manager class used to handle command-line arguments and options."""
 
 import argparse
-import configparser
 from typing import TYPE_CHECKING, Dict, List
 
 from pylint.config.argument import _Argument
@@ -75,14 +74,11 @@ class _ArgumentsManager:
         """Loads the default values of all registered options."""
         self.namespace = self._arg_parser.parse_args([], self.namespace)
 
-    def _parse_configuration_file(
-        self, config_parser: configparser.ConfigParser
-    ) -> None:
+    def _parse_configuration_file(self, config_data: Dict[str, str]) -> None:
         """Parse the arguments found in a configuration file into the namespace."""
         arguments = []
-        for section in config_parser.sections():
-            for opt, value in config_parser.items(section):
-                arguments.extend([f"--{opt}", value])
+        for opt, value in config_data.items():
+            arguments.extend([f"--{opt}", value])
         # pylint: disable-next=fixme
         # TODO: This should parse_args instead of parse_known_args
         self.namespace = self._arg_parser.parse_known_args(arguments, self.namespace)[0]

--- a/pylint/config/config_file_parser.py
+++ b/pylint/config/config_file_parser.py
@@ -44,8 +44,6 @@ class _ConfigurationFileParser:
     @staticmethod
     def _parse_toml_value(value: Any) -> str:
         """Parse rich toml types into strings."""
-        if isinstance(value, bool):
-            return "True" if value else "False"
         if isinstance(value, list):
             return ",".join(value)
         return str(value)

--- a/pylint/config/config_file_parser.py
+++ b/pylint/config/config_file_parser.py
@@ -1,0 +1,94 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Configuration file parser class."""
+
+import configparser
+import os
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+if TYPE_CHECKING:
+    from pylint.lint import PyLinter
+
+
+class _ConfigurationFileParser:
+    """Class to parse various formats of configuration files."""
+
+    def __init__(self, verbose: bool, linter: "PyLinter") -> None:
+        self.verbose_mode = verbose
+        self.linter = linter
+
+    @staticmethod
+    def _parse_ini_file(file_path: Path) -> Dict[str, str]:
+        """Parse and handle errors of a ini configuration file."""
+        parser = configparser.ConfigParser(inline_comment_prefixes=("#", ";"))
+
+        # Use this encoding in order to strip the BOM marker, if any.
+        with open(file_path, encoding="utf_8_sig") as fp:
+            parser.read_file(fp)
+
+        config_content: Dict[str, str] = {}
+        for section in parser.sections():
+            for opt in parser[section]:
+                config_content[opt] = parser[section][opt]
+        return config_content
+
+    @staticmethod
+    def _parse_toml_value(value: Any) -> str:
+        """Parse rich toml types into strings."""
+        if isinstance(value, bool):
+            return "True" if value else "False"
+        if isinstance(value, list):
+            return ",".join(value)
+        return str(value)
+
+    def _parse_toml_file(self, file_path: Path) -> Dict[str, str]:
+        """Parse and handle errors of a toml configuration file."""
+        try:
+            with open(file_path, mode="rb") as fp:
+                content = tomllib.load(fp)
+        except tomllib.TOMLDecodeError as e:
+            self.linter.add_message("config-parse-error", line=0, args=str(e))
+            return {}
+
+        try:
+            sections_values = content["tool"]["pylint"]
+        except KeyError:
+            return {}
+
+        config_content: Dict[str, str] = {}
+        for opt, values in sections_values.items():
+            if isinstance(values, dict):
+                for config, value in values.items():
+                    config_content[config] = self._parse_toml_value(value)
+            else:
+                config_content[opt] = self._parse_toml_value(values)
+        return config_content
+
+    def parse_config_file(self, file_path: Optional[Path]) -> Dict[str, str]:
+        """Parse a config file and return str-str pairs."""
+        if file_path is None:
+            if self.verbose_mode:
+                print(
+                    "No config file found, using default configuration", file=sys.stderr
+                )
+            return {}
+
+        file_path = Path(os.path.expandvars(file_path)).expanduser()
+        if not file_path.exists():
+            raise OSError(f"The config file {file_path} doesn't exist!")
+
+        if self.verbose_mode:
+            print(f"Using config file {file_path}", file=sys.stderr)
+
+        if file_path.suffix == ".toml":
+            return self._parse_toml_file(file_path)
+        return self._parse_ini_file(file_path)

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Union
 
-from pylint import reporters
+from pylint import config, reporters
 from pylint.utils import utils
 
 if TYPE_CHECKING:
@@ -39,6 +39,13 @@ def _config_initialization(
         print(ex, file=sys.stderr)
         sys.exit(32)
     config_parser = linter.cfgfile_parser
+
+    config_file_parser = config._ConfigurationFileParser(verbose_mode, linter)
+    try:
+        config_data = config_file_parser.parse_config_file(file_path=config_file_path)
+    except OSError as ex:
+        print(ex, file=sys.stderr)
+        sys.exit(32)
 
     # Run init hook, if present, before loading plugins
     if config_parser.has_option("MASTER", "init-hook"):
@@ -84,7 +91,7 @@ def _config_initialization(
     # When finished this should replace the implementation based on optparse
 
     # First we parse any options from a configuration file
-    linter._parse_configuration_file(config_parser)
+    linter._parse_configuration_file(config_data)
 
     # Second we parse any options from the command line, so they can override
     # the configuration file

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -253,8 +253,8 @@ class OptionsManagerMixIn:
             if config_file.suffix == ".toml":
                 try:
                     self._parse_toml(config_file, parser)
-                except tomllib.TOMLDecodeError as e:
-                    self.add_message("config-parse-error", line=0, args=str(e))  # type: ignore[attr-defined]
+                except tomllib.TOMLDecodeError:
+                    pass
             else:
                 # Use this encoding in order to strip the BOM marker, if any.
                 with open(config_file, encoding="utf_8_sig") as fp:


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Blocked by #6052.

Last commit introduces a new configuration parser. After some debating with myself I have opted to retain the idea of transforming all rich types into strings. `argparse` can only handle strings. We could inject the rich types into the `Namespace` object but I decided against it. Stuff like that is what makes the current configuration handling so difficult to understand. Let's separate things clearly: a file parser parses a file and an argument parser parses arguments.

The commit also introduces other changes that followed from these changes.

One major change is that we will now allow configuration in `.toml` files without the sections. I have not yet implemented this for the `ini` files (and wonder if I ever will) but in `.toml` you can now do:
```toml
[tool.pylint]
missing-member-hint = true

[tool.pylint."TYPECHECK"]
missing-member-hint = true

[tool.pylint."I-ORDER-MY-SECTIONS-THE-WAY-I-WANT-TO"]
missing-member-hint = true
```