### PR TITLE
More tests for config file finding, handle malformatted setup.cfg

### DIFF
--- a/pylint/config/find_default_config_files.py
+++ b/pylint/config/find_default_config_files.py
@@ -27,7 +27,10 @@ def _toml_has_config(path: Union[Path, str]) -> bool:
 
 def _cfg_has_config(path: Union[Path, str]) -> bool:
     parser = configparser.ConfigParser()
-    parser.read(path, encoding="utf-8")
+    try:
+        parser.read(path, encoding="utf-8")
+    except configparser.Error:
+        return False
     return any(section.startswith("pylint.") for section in parser.sections())
 
 

--- a/pylint/config/find_default_config_files.py
+++ b/pylint/config/find_default_config_files.py
@@ -6,7 +6,8 @@ import configparser
 import os
 import sys
 import warnings
-from typing import Iterator, Optional
+from pathlib import Path
+from typing import Iterator, Optional, Union
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -14,7 +15,7 @@ else:
     import tomli as tomllib
 
 
-def _toml_has_config(path):
+def _toml_has_config(path: Union[Path, str]) -> bool:
     with open(path, mode="rb") as toml_handle:
         try:
             content = tomllib.load(toml_handle)
@@ -30,7 +31,7 @@ def _toml_has_config(path):
     return True
 
 
-def _cfg_has_config(path):
+def _cfg_has_config(path: Union[Path, str]) -> bool:
     parser = configparser.ConfigParser()
     parser.read(path, encoding="utf-8")
     return any(section.startswith("pylint.") for section in parser.sections())

--- a/pylint/config/find_default_config_files.py
+++ b/pylint/config/find_default_config_files.py
@@ -22,13 +22,7 @@ def _toml_has_config(path: Union[Path, str]) -> bool:
         except tomllib.TOMLDecodeError as error:
             print(f"Failed to load '{path}': {error}")
             return False
-
-        try:
-            content["tool"]["pylint"]
-        except KeyError:
-            return False
-
-    return True
+    return "pylint" in content.get("tool", [])
 
 
 def _cfg_has_config(path: Union[Path, str]) -> bool:

--- a/tests/config/test_find_default_config_files.py
+++ b/tests/config/test_find_default_config_files.py
@@ -1,0 +1,68 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+from pathlib import Path
+
+import pytest
+
+from pylint.config.find_default_config_files import _cfg_has_config, _toml_has_config
+
+
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        ["", False],
+        ["(not toml valid)", False],
+        [
+            """
+[build-system]
+requires = ["setuptools ~= 58.0", "cython ~= 0.29.0"]
+""",
+            False,
+        ],
+        [
+            """
+[tool.pylint]
+missing-member-hint = true
+""",
+            True,
+        ],
+    ],
+)
+def test_toml_has_config(content: str, expected: bool, tmp_path: Path) -> None:
+    """Test that a toml file has a pylint config."""
+    fake_toml = tmp_path / "fake.toml"
+    with open(fake_toml, "w", encoding="utf8") as f:
+        f.write(content)
+    assert _toml_has_config(fake_toml) == expected
+
+
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        ["", False],
+        [
+            """
+[metadata]
+name = pylint
+""",
+            False,
+        ],
+        [
+            """
+[metadata]
+name = pylint
+
+[pylint.messages control]
+disable = logging-not-lazy,logging-format-interpolation
+""",
+            True,
+        ],
+    ],
+)
+def test_cfg_has_config(content: str, expected: str, tmp_path: Path) -> None:
+    """Test that a cfg file has a pylint config."""
+    fake_cfg = tmp_path / "fake.cfg"
+    with open(fake_cfg, "w", encoding="utf8") as f:
+        f.write(content)
+    assert _cfg_has_config(fake_cfg) == expected

--- a/tests/config/test_find_default_config_files.py
+++ b/tests/config/test_find_default_config_files.py
@@ -41,6 +41,7 @@ def test_toml_has_config(content: str, expected: bool, tmp_path: Path) -> None:
     "content,expected",
     [
         ["", False],
+        ["(not valid .cfg)", False],
         [
             """
 [metadata]


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

I added some tests for our config finding functions. I'm wondering if there's not something to do regarding ``find_pylintrc``. It's none if there is no pylintrc but there could be setup.cfg or pyproject.toml with valid configuration.

```python
def find_pylintrc() -> Optional[str]:
    """Search the pylint rc file and return its path if it finds it, else return None."""
    for config_file in find_default_config_files():
        if config_file.endswith("pylintrc"):
            return config_file
    return None
```    

Imo it could be nice to have a function : "recover configuration from wherever" and return a configuration object (which is why I made tests for the two important function to reach this goal). What do you think @DanielNoord ?