### PR TITLE
Deprecate ``find_pylintrc``

### DIFF
--- a/pylint/config/environment_variable.py
+++ b/pylint/config/environment_variable.py
@@ -2,6 +2,10 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
+import warnings
+
 from pylint.config.find_default_config_files import find_pylintrc
 
-PYLINTRC = find_pylintrc()
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    PYLINTRC = find_pylintrc()

--- a/pylint/config/find_default_config_files.py
+++ b/pylint/config/find_default_config_files.py
@@ -5,6 +5,7 @@
 import configparser
 import os
 import sys
+import warnings
 from typing import Iterator, Optional
 
 if sys.version_info >= (3, 11):
@@ -76,6 +77,14 @@ def find_default_config_files() -> Iterator[str]:
 
 def find_pylintrc() -> Optional[str]:
     """Search the pylint rc file and return its path if it finds it, else return None."""
+    # pylint: disable-next=fixme
+    # TODO: Remove this function in 3.0
+    warnings.warn(
+        "find_pylintrc and the PYLINTRC constant have been deprecated. "
+        "Use find_default_config_files if you want access to pylint's configuration file "
+        "finding logic.",
+        DeprecationWarning,
+    )
     for config_file in find_default_config_files():
         if config_file.endswith("pylintrc"):
             return config_file

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -681,11 +681,14 @@ def test_pylintrc() -> None:
         current_dir = getcwd()
         chdir(os.path.dirname(os.path.abspath(sys.executable)))
         try:
-            assert config.find_pylintrc() is None
+            with pytest.warns(DeprecationWarning):
+                assert config.find_pylintrc() is None
             os.environ["PYLINTRC"] = join(tempfile.gettempdir(), ".pylintrc")
-            assert config.find_pylintrc() is None
+            with pytest.warns(DeprecationWarning):
+                assert config.find_pylintrc() is None
             os.environ["PYLINTRC"] = "."
-            assert config.find_pylintrc() is None
+            with pytest.warns(DeprecationWarning):
+                assert config.find_pylintrc() is None
         finally:
             chdir(current_dir)
             reload(config)
@@ -706,7 +709,8 @@ def test_pylintrc_parentdir() -> None:
             ]
         )
         with fake_home():
-            assert config.find_pylintrc() is None
+            with pytest.warns(DeprecationWarning):
+                assert config.find_pylintrc() is None
         results = {
             "a": join(chroot, "a", "pylintrc"),
             "a/b": join(chroot, "a", "b", "pylintrc"),
@@ -716,7 +720,8 @@ def test_pylintrc_parentdir() -> None:
         }
         for basedir, expected in results.items():
             os.chdir(join(chroot, basedir))
-            assert config.find_pylintrc() == expected
+            with pytest.warns(DeprecationWarning):
+                assert config.find_pylintrc() == expected
 
 
 @pytest.mark.usefixtures("pop_pylintrc")
@@ -724,7 +729,8 @@ def test_pylintrc_parentdir_no_package() -> None:
     with tempdir() as chroot:
         with fake_home():
             create_files(["a/pylintrc", "a/b/pylintrc", "a/b/c/d/__init__.py"])
-            assert config.find_pylintrc() is None
+            with pytest.warns(DeprecationWarning):
+                assert config.find_pylintrc() is None
             results = {
                 "a": join(chroot, "a", "pylintrc"),
                 "a/b": join(chroot, "a", "b", "pylintrc"),
@@ -733,7 +739,8 @@ def test_pylintrc_parentdir_no_package() -> None:
             }
             for basedir, expected in results.items():
                 os.chdir(join(chroot, basedir))
-                assert config.find_pylintrc() == expected
+                with pytest.warns(DeprecationWarning):
+                    assert config.find_pylintrc() == expected
 
 
 class TestPreprocessOptions:


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

I wonder if this is considered external. It is in the `__all__` but there is no reason for anybody to use this, I think? We don't even use it as the logic for finding the configuration file has moved to `find_default_config_files`.