### PR TITLE
Total ordering unit test

### DIFF
--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -61,7 +61,15 @@ class BaseChecker(OptionsProviderMixIn):
 
     def __gt__(self, other):
         """Permit to sort a list of Checker by name."""
-        return f"{self.name}{self.msgs}" > (f"{other.name}{other.msgs}")
+        return f"{self.name}{self.msgs}" > f"{other.name}{other.msgs}"
+
+    def __eq__(self, other):
+        """Permit to assert Checkers are equal."""
+        return f"{self.name}{self.msgs}" == f"{other.name}{other.msgs}"
+
+    def __hash__(self):
+        """Make Checker hashable."""
+        return hash(f"{self.name}{self.msgs}")
 
     def __repr__(self):
         status = "Checker" if self.enabled else "Disabled checker"

--- a/tests/checkers/unittest_base_checker.py
+++ b/tests/checkers/unittest_base_checker.py
@@ -33,6 +33,17 @@ class LessBasicChecker(OtherBasicChecker):
     )
 
 
+class DifferentBasicChecker(BaseChecker):
+    name = "different"
+    msgs = {
+        "W0002": (
+            "Blah blah example.",
+            "blah-blah-example",
+            "I only exist to be different to OtherBasicChecker :(",
+        )
+    }
+
+
 def test_base_checker_doc() -> None:
     basic = OtherBasicChecker()
     expected_beginning = """\
@@ -65,3 +76,11 @@ Basic checker Messages
 
     assert str(less_basic) == expected_beginning + expected_middle + expected_end
     assert repr(less_basic) == repr(basic)
+
+
+def test_base_checker_ordering():
+    fake_checker_1 = OtherBasicChecker()
+    fake_checker_2 = LessBasicChecker()
+    fake_checker_3 = DifferentBasicChecker()
+    assert fake_checker_1 < fake_checker_3
+    assert fake_checker_2 < fake_checker_3

--- a/tests/checkers/unittest_base_checker.py
+++ b/tests/checkers/unittest_base_checker.py
@@ -85,3 +85,4 @@ def test_base_checker_ordering() -> None:
     fake_checker_3 = DifferentBasicChecker()
     assert fake_checker_1 < fake_checker_3
     assert fake_checker_2 < fake_checker_3
+    assert fake_checker_1 == fake_checker_2

--- a/tests/checkers/unittest_base_checker.py
+++ b/tests/checkers/unittest_base_checker.py
@@ -78,7 +78,8 @@ Basic checker Messages
     assert repr(less_basic) == repr(basic)
 
 
-def test_base_checker_ordering():
+def test_base_checker_ordering() -> None:
+    """Test ordering of checkers based on their __gt__ method."""
     fake_checker_1 = OtherBasicChecker()
     fake_checker_2 = LessBasicChecker()
     fake_checker_3 = DifferentBasicChecker()


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #6045. Adds a unit test for the `__gt__` method mentioned in the linked issue.

N.B. since we don't currently implement a `__eq__` method (as described in the [docs](https://docs.python.org/3/library/functools.html#functools.total_ordering)) we can't currently assert something like `fake_checker_1 == fake_checker_2` even though they have the same name and args.

Didn't add it in since we're only really doing this for coverage and seems unnecessary, but happy to add in for completeness if desired.
