### PR TITLE
Fix crash in ``unnecessary-list-index-lookup`` checker (#6049)

### DIFF
--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1994,6 +1994,11 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             # enumerate() result is being assigned without destructuring
             return
 
+        if not isinstance(node.target.elts[1], nodes.AssignName):
+            # The value is not being assigned to a single variable, e.g. being
+            # destructured, so we can't necessarily use it.
+            return
+
         iterating_object_name = node.iter.args[0].name
         value_variable = node.target.elts[1]
 

--- a/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
+++ b/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
@@ -44,3 +44,8 @@ result = [val for idx, val in enumerate(my_list) if my_list[idx] == 'a'] # [unne
 result = [val for idx, val in enumerate(my_list) if idx > 0 and my_list[idx - 1] == 'a']
 result = [val for idx, val in enumerate(my_list) if other_list[idx] == 'a']
 result = [my_list[idx] for idx, val in enumerate(my_list)] # [unnecessary-list-index-lookup]
+
+# Regression test for https://github.com/PyCQA/pylint/issues/6049
+pairs = [(0, 0)]
+for i, (a, b) in enumerate(pairs):
+    print(pairs[i][0])


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This fixes a crash in the `unnecessary-list-index-lookup` checker where the value from `enumerate()` is being destructured, and thus no variable name is available. There are conceivably some cases where we could still salvage a useful check here, but the possible benefit seems minor and the original motivation was to catch the simple cases, so I hope we can just ignore this case for now.

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #6049 
