### PR TITLE
Fix E1102 / ``not-callable`` false positive for property that returns a lambda function conditionally

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,10 +9,6 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.14.rst'
 
-* Only raise ``not-callable`` when all the inferred values of a property are not callable.
-
-  Closes #5931
-
 
 * Add new check ``unnecessary-dunder-call`` for unnecessary dunder method calls.
 
@@ -53,6 +49,9 @@ Release date: TBA
   * functions & classes which contain both a docstring and an ellipsis.
   * A body which contains an ellipsis ``nodes.Expr`` node & at least one other statement.
 
+* Only raise ``not-callable`` when all the inferred values of a property are not callable.
+
+  Closes #5931
 
 
 What's New in Pylint 2.13.4?

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,7 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.14.rst'
 
-* Only raise ``not-callable`` when all the inferred values of an expression are not callable.
+* Only raise ``not-callable`` when all the inferred values of a property are not callable.
 
   Closes #5931
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,10 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.14.rst'
 
+* Only raise ``not-callable`` when all the inferred values of an expression are not callable.
+
+  Closes #5931
+
 
 * Add new check ``unnecessary-dunder-call`` for unnecessary dunder method calls.
 

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -38,6 +38,10 @@ Extensions
 Other Changes
 =============
 
+* Only raise ``not-callable`` when all the inferred values of an expression are not callable.
+
+  Closes #5931
+
 * Fix false negative for ``no-member`` when attempting to assign an instance
   attribute to itself without any prior assignment.
 

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -38,7 +38,7 @@ Extensions
 Other Changes
 =============
 
-* Only raise ``not-callable`` when all the inferred values of an expression are not callable.
+* Only raise ``not-callable`` when all the inferred values of a property are not callable.
 
   Closes #5931
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1232,8 +1232,10 @@ accessed. Python regular expressions are accepted.",
                 except astroid.InferenceError:
                     continue
 
-                if astroid.Uninferable in call_results:
-                    # We were unable to infer some return value of the call, skipping
+                if all(
+                    return_node is astroid.Uninferable for return_node in call_results
+                ):
+                    # We were unable to infer return values of the call, skipping
                     continue
 
                 if any(return_node.callable() for return_node in call_results):

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1232,10 +1232,8 @@ accessed. Python regular expressions are accepted.",
                 except astroid.InferenceError:
                     continue
 
-                if all(
-                    return_node is astroid.Uninferable for return_node in call_results
-                ):
-                    # We were unable to infer return values of the call, skipping
+                if astroid.Uninferable in call_results:
+                    # We were unable to infer some return value of the call, skipping
                     continue
 
                 if any(return_node.callable() for return_node in call_results):

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1229,23 +1229,24 @@ accessed. Python regular expressions are accepted.",
             if decorated_with_property(attr):
                 try:
                     call_results = list(attr.infer_call_result(node))
-
-                    if all(
-                        return_node is astroid.Uninferable
-                        for return_node in call_results
-                    ):
-                        # We were unable to infer return values of the call, skipping
-                        continue
-
-                    if any(return_node.callable() for return_node in call_results):
-                        # Only raise this issue if *all* the inferred values are not callable
-                        continue
-
-                    self.add_message(
-                        "not-callable", node=node, args=node.func.as_string()
-                    )
                 except astroid.InferenceError:
                     continue
+
+                if all(
+                    return_node is astroid.Uninferable
+                    for return_node in call_results
+                ):
+                    # We were unable to infer return values of the call, skipping
+                    continue
+
+                if any(return_node.callable() for return_node in call_results):
+                    # Only raise this issue if *all* the inferred values are not callable
+                    continue
+
+                self.add_message(
+                    "not-callable", node=node, args=node.func.as_string()
+                )
+                
 
     def _check_argument_order(self, node, call_site, called, called_param_names):
         """Match the supplied argument names against the function parameters.

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1227,7 +1227,7 @@ accessed. Python regular expressions are accepted.",
             # Decorated, see if it is decorated with a property.
             # Also, check the returns and see if they are callable.
             if decorated_with_property(attr):
-                call_results = attr.infer_call_result(node)
+                call_results = list(attr.infer_call_result(node))
 
                 try:
                     if all(

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1233,8 +1233,7 @@ accessed. Python regular expressions are accepted.",
                     continue
 
                 if all(
-                    return_node is astroid.Uninferable
-                    for return_node in call_results
+                    return_node is astroid.Uninferable for return_node in call_results
                 ):
                     # We were unable to infer return values of the call, skipping
                     continue
@@ -1243,10 +1242,7 @@ accessed. Python regular expressions are accepted.",
                     # Only raise this issue if *all* the inferred values are not callable
                     continue
 
-                self.add_message(
-                    "not-callable", node=node, args=node.func.as_string()
-                )
-                
+                self.add_message("not-callable", node=node, args=node.func.as_string())
 
     def _check_argument_order(self, node, call_site, called, called_param_names):
         """Match the supplied argument names against the function parameters.

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1227,9 +1227,9 @@ accessed. Python regular expressions are accepted.",
             # Decorated, see if it is decorated with a property.
             # Also, check the returns and see if they are callable.
             if decorated_with_property(attr):
-                call_results = list(attr.infer_call_result(node))
-
                 try:
+                    call_results = list(attr.infer_call_result(node))
+
                     if all(
                         return_node is astroid.Uninferable
                         for return_node in call_results

--- a/tests/functional/n/not_callable.py
+++ b/tests/functional/n/not_callable.py
@@ -200,3 +200,27 @@ def get_number(arg):
 
 
 get_number(10)()  # [not-callable]
+
+class Klass:
+    def __init__(self):
+        self._x = None
+
+    @property
+    def myproperty(self):
+        if self._x is None:
+            self._x = lambda: None
+        return self._x
+
+myobject = Klass()
+myobject.myproperty()
+
+class Klass2:
+    @property
+    def something(self):
+        if __file__.startswith('s'):
+            return str
+
+        return 'abcd'
+
+obj2 = Klass2()
+obj2.something()


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Update E1102 to only be raised when no inferred value is callable.

Resolves #5931

