### PR TITLE
Account for more node types in handling of except block homonyms with comprehensions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,11 @@ What's New in Pylint 2.13.5?
 ============================
 Release date: TBA
 
+* Fix false positive regression in 2.13.0 for ``used-before-assignment`` for
+  homonyms between variable assignments in try/except blocks and variables in
+  subscripts in comprehensions.
+
+  Closes #6069
 
 
 What's New in Pylint 2.13.4?

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1520,8 +1520,8 @@ class VariablesChecker(BaseChecker):
         if node.name in current_consumer.consumed:
             # Avoid the case where there are homonyms inside function scope and
             # comprehension current scope (avoid bug #1731)
-            if utils.is_func_decorator(current_consumer.node) or not (
-                isinstance(node, nodes.ComprehensionScope)
+            if utils.is_func_decorator(current_consumer.node) or not isinstance(
+                node, nodes.ComprehensionScope
             ):
                 self._check_late_binding_closure(node)
                 self._loopvar_name(node)

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1513,7 +1513,13 @@ class VariablesChecker(BaseChecker):
                         isinstance(node.scope(), nodes.ComprehensionScope)
                         and isinstance(
                             node.parent,
-                            (nodes.Call, nodes.Compare, nodes.Keyword, nodes.Subscript),
+                            (
+                                nodes.Call,
+                                nodes.BaseContainer,
+                                nodes.Compare,
+                                nodes.Keyword,
+                                nodes.Subscript,
+                            ),
                         )
                     )
                 )

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1512,7 +1512,8 @@ class VariablesChecker(BaseChecker):
                     or (
                         isinstance(node.scope(), nodes.ComprehensionScope)
                         and isinstance(
-                            node.parent, (nodes.Call, nodes.Keyword, nodes.Subscript)
+                            node.parent,
+                            (nodes.Call, nodes.Compare, nodes.Keyword, nodes.Subscript),
                         )
                     )
                 )

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1508,9 +1508,12 @@ class VariablesChecker(BaseChecker):
                     self._has_homonym_in_comprehension_test(node)
                     # Or homonyms against values to keyword arguments
                     # (like "var" in "[func(arg=var) for var in expr()]")
+                    # (or "var" in "{var: data[var] for var in expr()}")
                     or (
                         isinstance(node.scope(), nodes.ComprehensionScope)
-                        and isinstance(node.parent, (nodes.Call, nodes.Keyword))
+                        and isinstance(
+                            node.parent, (nodes.Call, nodes.Keyword, nodes.Subscript)
+                        )
                     )
                 )
             ):

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2286,7 +2286,7 @@ class VariablesChecker(BaseChecker):
         global_names,
         nonlocal_names: Iterable[str],
         comprehension_target_names: List[str],
-    ):
+    ) -> None:
         # Ignore some special names specified by user configuration.
         if self._is_name_ignored(stmt, name):
             return

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -630,7 +630,7 @@ scope_type : {self._atomic.scope_type}
             return found_nodes
 
         # And no comprehension is under the node's frame
-        if VariablesChecker._comprehension_under_frame(node):
+        if VariablesChecker._comprehension_between_frame_and_node(node):
             return found_nodes
 
         # Filter out assignments in ExceptHandlers that node is not contained in
@@ -2478,8 +2478,8 @@ class VariablesChecker(BaseChecker):
         return name in self.config.allowed_redefined_builtins
 
     @staticmethod
-    def _comprehension_under_frame(node: nodes.Name) -> bool:
-        """Return True if `node`'s frame contains a ComprehensionScope."""
+    def _comprehension_between_frame_and_node(node: nodes.Name) -> bool:
+        """Return True if a ComprehensionScope intervenes between `node` and its frame."""
         closest_comprehension_scope = utils.get_node_first_ancestor_of_type(
             node, nodes.ComprehensionScope
         )

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1514,8 +1514,9 @@ class VariablesChecker(BaseChecker):
                         and isinstance(
                             node.parent,
                             (
-                                nodes.Call,
                                 nodes.BaseContainer,
+                                nodes.BinOp,
+                                nodes.Call,
                                 nodes.Compare,
                                 nodes.Keyword,
                                 nodes.Subscript,

--- a/tests/functional/u/unused/unused_argument.py
+++ b/tests/functional/u/unused/unused_argument.py
@@ -47,6 +47,12 @@ def metadata_from_dict(key):
     """
     return {key: str(value) for key, value in key.items()}
 
+
+def metadata_from_dict_2(key):
+    """Similar, but with more nesting"""
+    return {key: (a, b) for key, (a, b) in key.items()}
+
+
 # pylint: disable=too-few-public-methods,  misplaced-future,wrong-import-position
 from __future__ import print_function
 

--- a/tests/functional/u/unused/unused_argument.txt
+++ b/tests/functional/u/unused/unused_argument.txt
@@ -1,9 +1,9 @@
 unused-argument:3:16:3:21:test_unused:Unused argument 'first':HIGH
 unused-argument:3:23:3:29:test_unused:Unused argument 'second':HIGH
 unused-argument:32:29:32:32:Sub.newmethod:Unused argument 'aay':INFERENCE
-unused-argument:54:13:54:16:function:Unused argument 'arg':HIGH
-unused-argument:61:21:61:24:AAAA.method:Unused argument 'arg':INFERENCE
-unused-argument:68:0:None:None:AAAA.selected:Unused argument 'args':INFERENCE
-unused-argument:68:0:None:None:AAAA.selected:Unused argument 'kwargs':INFERENCE
-unused-argument:87:23:87:26:BBBB.__init__:Unused argument 'arg':INFERENCE
-unused-argument:98:34:98:39:Ancestor.set_thing:Unused argument 'other':INFERENCE
+unused-argument:60:13:60:16:function:Unused argument 'arg':HIGH
+unused-argument:67:21:67:24:AAAA.method:Unused argument 'arg':INFERENCE
+unused-argument:74:0:None:None:AAAA.selected:Unused argument 'args':INFERENCE
+unused-argument:74:0:None:None:AAAA.selected:Unused argument 'kwargs':INFERENCE
+unused-argument:93:23:93:26:BBBB.__init__:Unused argument 'arg':INFERENCE
+unused-argument:104:34:104:39:Ancestor.set_thing:Unused argument 'other':INFERENCE

--- a/tests/functional/u/used/used_before_assignment_comprehension_homonyms.py
+++ b/tests/functional/u/used/used_before_assignment_comprehension_homonyms.py
@@ -72,3 +72,14 @@ def func7():
     except ZeroDivisionError:
         i = None
         print(i, bools)
+
+
+def func8():
+    """Similar, but with a container"""
+    pairs = [(i, i) for i in range(3)]
+
+    try:
+        1 / 0
+    except ZeroDivisionError:
+        i = None
+        print(i, pairs)

--- a/tests/functional/u/used/used_before_assignment_comprehension_homonyms.py
+++ b/tests/functional/u/used/used_before_assignment_comprehension_homonyms.py
@@ -83,3 +83,14 @@ def func8():
     except ZeroDivisionError:
         i = None
         print(i, pairs)
+
+
+def func9():
+    """Similar, but with a binary op"""
+    bools = [str(i) | i for i in range(3)]
+
+    try:
+        1 / 0
+    except ZeroDivisionError:
+        i = None
+        print(i, bools)

--- a/tests/functional/u/used/used_before_assignment_comprehension_homonyms.py
+++ b/tests/functional/u/used/used_before_assignment_comprehension_homonyms.py
@@ -49,3 +49,15 @@ def func5():
     except ZeroDivisionError:
         k = None
         print(k, filtered)
+
+
+def func6(data, keys):
+    """Similar, but with a subscript in a key-value pair rather than the test
+    See https://github.com/PyCQA/pylint/issues/6069"""
+    try:
+        results = {key: data[key] for key in keys}
+    except KeyError as exc:
+        key, *_ = exc.args
+        raise Exception(f"{key} not found") from exc
+
+    return results

--- a/tests/functional/u/used/used_before_assignment_comprehension_homonyms.py
+++ b/tests/functional/u/used/used_before_assignment_comprehension_homonyms.py
@@ -85,12 +85,11 @@ def func8():
         print(i, pairs)
 
 
-def func9():
-    """Similar, but with a binary op"""
-    bools = [str(i) | i for i in range(3)]
+# Module level cases
 
-    try:
-        1 / 0
-    except ZeroDivisionError:
-        i = None
-        print(i, bools)
+module_ints = [j | j for j in range(3)]
+try:
+    1 / 0
+except ZeroDivisionError:
+    j = None
+    print(j, module_ints)

--- a/tests/functional/u/used/used_before_assignment_comprehension_homonyms.py
+++ b/tests/functional/u/used/used_before_assignment_comprehension_homonyms.py
@@ -61,3 +61,14 @@ def func6(data, keys):
         raise Exception(f"{key} not found") from exc
 
     return results
+
+
+def func7():
+    """Similar, but with a comparison"""
+    bools = [str(i) == i for i in range(3)]
+
+    try:
+        1 / 0
+    except ZeroDivisionError:
+        i = None
+        print(i, bools)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Several nodes types didn't meet the allow list for homynym handling b/w except blocks and comprehensions.

Closes #6069
