### PR TITLE
Narrow the scope of the ``unnecessary-ellipsis`` checker 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,8 @@ What's New in Pylint 2.13.5?
 ============================
 Release date: TBA
 
+* Narrow the scope of the ``unnecessary-ellipsis`` checker to functions & classes which contain both a docstring and an ellipsis.
+
 
 
 What's New in Pylint 2.13.4?

--- a/ChangeLog
+++ b/ChangeLog
@@ -41,7 +41,9 @@ What's New in Pylint 2.13.5?
 ============================
 Release date: TBA
 
-* Narrow the scope of the ``unnecessary-ellipsis`` checker to functions & classes which contain both a docstring and an ellipsis.
+* Narrow the scope of the ``unnecessary-ellipsis`` checker to:
+  * functions & classes which contain both a docstring and an ellipsis.
+  * A body which contains an ellipsis ``nodes.Expr`` node & at least one other statement.
 
 
 

--- a/pylint/checkers/ellipsis_checker.py
+++ b/pylint/checkers/ellipsis_checker.py
@@ -24,8 +24,7 @@ class EllipsisChecker(BaseChecker):
             "unnecessary-ellipsis",
             "Used when the ellipsis constant is encountered and can be avoided. "
             "A line of code consisting of an ellipsis is unnecessary if "
-            "there is a docstring on the preceding line or if there is a "
-            "statement in the same scope.",
+            "there is a docstring on the preceding line.",
         )
     }
 
@@ -35,29 +34,13 @@ class EllipsisChecker(BaseChecker):
 
         Emits a warning when:
          - A line consisting of an ellipsis is preceded by a docstring.
-         - A statement exists in the same scope as the ellipsis.
-           For example: A function consisting of an ellipsis followed by a
-           return statement on the next line.
         """
         if (
             node.pytype() == "builtins.Ellipsis"
-            and not isinstance(
-                node.parent,
-                (
-                    nodes.AnnAssign,
-                    nodes.Arguments,
-                    nodes.Assign,
-                    nodes.BaseContainer,
-                    nodes.Call,
-                    nodes.Lambda,
-                ),
-            )
+            and isinstance(node.parent, nodes.Expr)
             and (
-                len(node.parent.parent.child_sequence(node.parent)) > 1
-                or (
-                    isinstance(node.parent.parent, (nodes.ClassDef, nodes.FunctionDef))
-                    and node.parent.parent.doc_node
-                )
+                isinstance(node.parent.parent, (nodes.ClassDef, nodes.FunctionDef))
+                and node.parent.parent.doc_node
             )
         ):
             self.add_message("unnecessary-ellipsis", node=node)

--- a/pylint/checkers/ellipsis_checker.py
+++ b/pylint/checkers/ellipsis_checker.py
@@ -24,7 +24,8 @@ class EllipsisChecker(BaseChecker):
             "unnecessary-ellipsis",
             "Used when the ellipsis constant is encountered and can be avoided. "
             "A line of code consisting of an ellipsis is unnecessary if "
-            "there is a docstring on the preceding line.",
+            "there is a docstring on the preceding line or if there is a "
+            "statement in the same scope.",
         )
     }
 
@@ -34,13 +35,19 @@ class EllipsisChecker(BaseChecker):
 
         Emits a warning when:
          - A line consisting of an ellipsis is preceded by a docstring.
+         - A statement exists in the same scope as the ellipsis.
+           For example: A function consisting of an ellipsis followed by a
+           return statement on the next line.
         """
         if (
             node.pytype() == "builtins.Ellipsis"
             and isinstance(node.parent, nodes.Expr)
             and (
-                isinstance(node.parent.parent, (nodes.ClassDef, nodes.FunctionDef))
-                and node.parent.parent.doc_node
+                (
+                    isinstance(node.parent.parent, (nodes.ClassDef, nodes.FunctionDef))
+                    and node.parent.parent.doc_node
+                )
+                or len(node.parent.parent.body) > 1
             )
         ):
             self.add_message("unnecessary-ellipsis", node=node)

--- a/tests/functional/u/unnecessary/unnecessary_ellipsis.py
+++ b/tests/functional/u/unnecessary/unnecessary_ellipsis.py
@@ -9,10 +9,10 @@ try:
     A = 2
 except ValueError:
     A = 24
-    ... # [unnecessary-ellipsis]
+    ...
 
 def ellipsis_and_subsequent_statement():
-    ... # [unnecessary-ellipsis]
+    ...
     return 0
 
 # The parent of ellipsis is an assignment

--- a/tests/functional/u/unnecessary/unnecessary_ellipsis.py
+++ b/tests/functional/u/unnecessary/unnecessary_ellipsis.py
@@ -9,10 +9,10 @@ try:
     A = 2
 except ValueError:
     A = 24
-    ...
+    ...  # [unnecessary-ellipsis]
 
 def ellipsis_and_subsequent_statement():
-    ...
+    ...  # [unnecessary-ellipsis]
     return 0
 
 # The parent of ellipsis is an assignment

--- a/tests/functional/u/unnecessary/unnecessary_ellipsis.txt
+++ b/tests/functional/u/unnecessary/unnecessary_ellipsis.txt
@@ -1,4 +1,2 @@
-unnecessary-ellipsis:12:4:12:7::Unnecessary ellipsis constant:UNDEFINED
-unnecessary-ellipsis:15:4:15:7:ellipsis_and_subsequent_statement:Unnecessary ellipsis constant:UNDEFINED
 unnecessary-ellipsis:50:4:50:7:docstring_and_ellipsis:Unnecessary ellipsis constant:UNDEFINED
 unnecessary-ellipsis:66:4:66:7:DocstringAndEllipsis:Unnecessary ellipsis constant:UNDEFINED

--- a/tests/functional/u/unnecessary/unnecessary_ellipsis.txt
+++ b/tests/functional/u/unnecessary/unnecessary_ellipsis.txt
@@ -1,2 +1,4 @@
+unnecessary-ellipsis:12:4:12:7::Unnecessary ellipsis constant:UNDEFINED
+unnecessary-ellipsis:15:4:15:7:ellipsis_and_subsequent_statement:Unnecessary ellipsis constant:UNDEFINED
 unnecessary-ellipsis:50:4:50:7:docstring_and_ellipsis:Unnecessary ellipsis constant:UNDEFINED
 unnecessary-ellipsis:66:4:66:7:DocstringAndEllipsis:Unnecessary ellipsis constant:UNDEFINED


### PR DESCRIPTION
Narrow the scope of the ``unnecessary-ellipsis`` checker to functions & classes which contain both a docstring and an ellipsis.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #XXX
