### PR TITLE
Change documentation theme to use `furo` theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -103,17 +103,18 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "python_docs_theme"
+html_theme = "furo"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-    "collapsiblesidebar": True,
-    "issues_url": "https://github.com/pycqa/pylint/issues/new",
-    "root_name": "PyCQA",
-    "root_url": "https://meta.pycqa.org/en/latest/",
-}
+# TO-DO: Disable thme options too see how Furo themes look in default config
+# html_theme_options = {
+#     "collapsiblesidebar": True,
+#     "issues_url": "https://github.com/pycqa/pylint/issues/new",
+#     "root_name": "PyCQA",
+#     "root_url": "https://meta.pycqa.org/en/latest/",
+# }
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
@@ -146,9 +147,10 @@ html_last_updated_fmt = "%b %d, %Y"
 smartquotes = False
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {
-    "**": ["localtoc.html", "globaltoc.html", "relations.html", "sourcelink.html"]
-}
+# Use Default Furo Sidebar
+# html_sidebars = {
+#     "**": ["localtoc.html", "globaltoc.html", "relations.html", "sourcelink.html"]
+# }
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
 Sphinx==4.5.0
-python-docs-theme==2022.1
+furo==2022.3.4
 -e .


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

- change default documentation from `python-docs-theme` to `furo`
- change `conf.py` to use `furo` default config first to look what need to change
- add `furo` and remove `python-docs-theme` dep to `doc/requirement.txt` 

Ref #5953 
