### PR TITLE
Examples for ``bad-format-character``

### DIFF
--- a/doc/data/messages/b/bad-format-character/bad.py
+++ b/doc/data/messages/b/bad-format-character/bad.py
@@ -1,0 +1,1 @@
+print("%s %z" % ("hello", "world"))  # [bad-format-character]

--- a/doc/data/messages/b/bad-format-character/details.rst
+++ b/doc/data/messages/b/bad-format-character/details.rst
@@ -1,0 +1,2 @@
+This check is currently only active for "old-style" string formatting as seen in the examples.
+See `Issue #6085 <https://github.com/PyCQA/pylint/issues/6085>`_ for more information.

--- a/doc/data/messages/b/bad-format-character/good.py
+++ b/doc/data/messages/b/bad-format-character/good.py
@@ -1,0 +1,1 @@
+print("%s %s" % ("hello", "world"))

--- a/doc/data/messages/b/bad-format-character/related.rst
+++ b/doc/data/messages/b/bad-format-character/related.rst
@@ -1,0 +1,2 @@
+- `Format String Syntax <https://docs.python.org/3/library/string.html#formatstrings>`_
+- `PyFormat <https://pyformat.info/>`_


### PR DESCRIPTION
Co-authored-by: Vladyslav Krylasov <vladyslav.krylasov@gmail.com>

- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description
Add examples for ``bad-format-character``.
I noticed that this currently only works for old-style formatting, so I opened issue #6085 and referenced it in the ``details.rst``.

Ref: #5953 
