### PR TITLE
Remove a cosmetic/semantic base class in the basic checker nebula

### DIFF
--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -15,7 +15,6 @@ from astroid import nodes
 from pylint import interfaces
 from pylint import utils as lint_utils
 from pylint.checkers import BaseChecker, utils
-from pylint.interfaces import IAstroidChecker
 from pylint.reporters.ureports import nodes as reporter_nodes
 from pylint.utils import LinterStats
 from pylint.utils.utils import get_global_option
@@ -27,13 +26,6 @@ if sys.version_info >= (3, 8):
     from typing import Literal
 else:
     from typing_extensions import Literal
-
-
-class _BasicChecker(BaseChecker):
-    """Permits separating multiple checks with the same checker name into classes/file."""
-
-    __implements__ = IAstroidChecker
-    name = "basic"
 
 
 REVERSED_PROTOCOL_METHOD = "__reversed__"
@@ -102,7 +94,7 @@ def report_by_type_stats(
     sect.append(reporter_nodes.Table(children=lines, cols=6, rheaders=1))
 
 
-class BasicChecker(_BasicChecker):
+class BasicChecker(BaseChecker):
     """Basic checker.
 
     Checks for :

--- a/pylint/checkers/base/basic_error_checker.py
+++ b/pylint/checkers/base/basic_error_checker.py
@@ -12,9 +12,9 @@ import astroid
 from astroid import nodes
 
 from pylint import utils as lint_utils
-from pylint.checkers import utils
-from pylint.checkers.base.basic_checker import _BasicChecker
+from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import infer_all
+from pylint.interfaces import IAstroidChecker
 
 ABC_METACLASSES = {"_py_abc.ABCMeta", "abc.ABCMeta"}  # Python 3.7+,
 # List of methods which can be redefined
@@ -94,7 +94,10 @@ def redefined_by_decorator(node):
     return False
 
 
-class BasicErrorChecker(_BasicChecker):
+class BasicErrorChecker(BaseChecker):
+
+    __implements__ = IAstroidChecker
+    name = "basic"
     msgs = {
         "E0100": (
             "__init__ method is a generator",

--- a/pylint/checkers/base/comparison_checker.py
+++ b/pylint/checkers/base/comparison_checker.py
@@ -7,8 +7,8 @@
 import astroid
 from astroid import nodes
 
-from pylint.checkers import utils
-from pylint.checkers.base.basic_checker import _BasicChecker
+from pylint.checkers import BaseChecker, utils
+from pylint.interfaces import IAstroidChecker
 
 LITERAL_NODE_TYPES = (nodes.Const, nodes.Dict, nodes.List, nodes.Set)
 COMPARISON_OPERATORS = frozenset(("==", "!=", "<", ">", "<=", ">="))
@@ -21,7 +21,7 @@ def _is_one_arg_pos_call(call):
     return isinstance(call, nodes.Call) and len(call.args) == 1 and not call.keywords
 
 
-class ComparisonChecker(_BasicChecker):
+class ComparisonChecker(BaseChecker):
     """Checks for comparisons.
 
     - singleton comparison: 'expr == True', 'expr == False' and 'expr == None'
@@ -30,6 +30,9 @@ class ComparisonChecker(_BasicChecker):
       a function
     """
 
+    __implements__ = IAstroidChecker
+
+    name = "basic"
     msgs = {
         "C0121": (
             "Comparison %s should be %s",

--- a/pylint/checkers/base/docstring_checker.py
+++ b/pylint/checkers/base/docstring_checker.py
@@ -11,8 +11,7 @@ import astroid
 from astroid import nodes
 
 from pylint import interfaces
-from pylint.checkers import utils
-from pylint.checkers.base.basic_checker import _BasicChecker
+from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import (
     is_overload_stub,
     is_property_deleter,
@@ -43,7 +42,10 @@ def _infer_dunder_doc_attribute(node):
     return docstring.value
 
 
-class DocStringChecker(_BasicChecker):
+class DocStringChecker(BaseChecker):
+    __implements__ = interfaces.IAstroidChecker
+
+    name = "basic"
     msgs = {
         "C0112": (
             "Empty %s docstring",

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -13,8 +13,7 @@ import astroid
 from astroid import nodes
 
 from pylint import constants, interfaces
-from pylint.checkers import utils
-from pylint.checkers.base.basic_checker import _BasicChecker
+from pylint.checkers import BaseChecker, utils
 from pylint.checkers.base.name_checker.naming_style import (
     KNOWN_NAME_TYPES,
     KNOWN_NAME_TYPES_WITH_STYLE,
@@ -24,6 +23,8 @@ from pylint.checkers.base.name_checker.naming_style import (
 from pylint.checkers.utils import is_property_deleter, is_property_setter
 
 # Default patterns for name types that do not have styles
+from pylint.interfaces import IAstroidChecker
+
 DEFAULT_PATTERNS = {
     "typevar": re.compile(
         r"^_{0,2}(?:[^\W\da-z_]+|(?:[^\W\da-z_]+[^\WA-Z_]+)+T?(?<!Type))(?:_co(?:ntra)?)?$"
@@ -122,7 +123,10 @@ def _is_multi_naming_match(match, node_type, confidence):
     )
 
 
-class NameChecker(_BasicChecker):
+class NameChecker(BaseChecker):
+    __implements__ = IAstroidChecker
+
+    name = "basic"
     msgs = {
         "C0103": (
             '%s name "%s" doesn\'t conform to %s',

--- a/pylint/checkers/base/pass_checker.py
+++ b/pylint/checkers/base/pass_checker.py
@@ -4,13 +4,16 @@
 
 from astroid import nodes
 
-from pylint.checkers import utils
-from pylint.checkers.base.basic_checker import _BasicChecker
+from pylint.checkers import BaseChecker, utils
+from pylint.interfaces import IAstroidChecker
 
 
-class PassChecker(_BasicChecker):
+class PassChecker(BaseChecker):
     """Check if the pass statement is really necessary."""
 
+    __implements__ = IAstroidChecker
+
+    name = "basic"
     msgs = {
         "W0107": (
             "Unnecessary pass statement",


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

See https://github.com/PyCQA/pylint/issues/6060#issuecomment-1085648352
