### PR TITLE
Close and join pools correctly in ``parallel.py``

### DIFF
--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -175,6 +175,9 @@ def check_parallel(
             all_mapreduce_data[worker_idx].append(mapreduce_data)
             linter.msg_status |= msg_status
 
+        pool.close()
+        pool.join()
+
     _merge_mapreduce_data(linter, all_mapreduce_data)
     linter.stats = merge_stats([linter.stats] + all_stats)
 


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Another attempt. Probable culprit of our CI issues would be https://github.com/PyCQA/pylint/pull/5612.

Turns out `.join()` is necessary. I checked locally and with the `join()` statement here there are more calls to internal `join()` methods than when only relying on the termination as the context manager exits. So, although I don't really understand the internals of `multiprocessing` and `threading` the change to the contextmanager has changed behaviour.

The difference in behaviour comes from `terminate()` only joining the `worker_handler` and `join()` also closing the pools.