### PR TITLE
Fix false positive for ``unused-import`` when disabling both ``used-before-assignment`` and ``undefined-variable``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -71,6 +71,10 @@ Release date: TBA
   Closes #6069
   Closes #6136
 
+* Fix false positive for ``unused-import`` when disabling both ``used-before-assignment`` and ``undefined-variable``.
+
+  Closes #6089
+
 * Narrow the scope of the ``unnecessary-ellipsis`` checker to:
   * functions & classes which contain both a docstring and an ellipsis.
   * A body which contains an ellipsis ``nodes.Expr`` node & at least one other statement.

--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,10 @@ Release date: TBA
 
   Closes #5936
 
+* Fix false positive for ``unused-import`` when disabling both ``used-before-assignment`` and ``undefined-variable``.
+
+  Closes #6089
+
 * ``potential-index-error``: Emitted when the index of a list or tuple exceeds its length.
   This checker is currently quite conservative to avoid false positives. We welcome
   suggestions for improvements.

--- a/ChangeLog
+++ b/ChangeLog
@@ -23,10 +23,6 @@ Release date: TBA
 
   Closes #5936
 
-* Fix false positive for ``unused-import`` when disabling both ``used-before-assignment`` and ``undefined-variable``.
-
-  Closes #6089
-
 * ``potential-index-error``: Emitted when the index of a list or tuple exceeds its length.
   This checker is currently quite conservative to avoid false positives. We welcome
   suggestions for improvements.

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -132,6 +132,10 @@ Other Changes
 
   Closes #6028
 
+* Fix false positive for ``unused-import`` when disabling both ``used-before-assignment`` and ``undefined-variable``.
+
+  Closes #6089
+
 * Fix false positive for ``unnecessary-ellipsis`` when using an ellipsis as a default argument.
 
   Closes #5973

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -59,3 +59,7 @@ Other Changes
   attribute to itself without any prior assignment.
 
   Closes #1555
+
+* Fix false positive for ``unused-import`` when disabling both ``used-before-assignment`` and ``undefined-variable``.
+
+  Closes #6089

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -59,7 +59,3 @@ Other Changes
   attribute to itself without any prior assignment.
 
   Closes #1555
-
-* Fix false positive for ``unused-import`` when disabling both ``used-before-assignment`` and ``undefined-variable``.
-
-  Closes #6089

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1555,12 +1555,6 @@ class VariablesChecker(BaseChecker):
 
         self._check_late_binding_closure(node)
 
-        if not (
-            self._is_undefined_variable_enabled
-            or self._is_used_before_assignment_enabled
-        ):
-            return (VariableVisitConsumerAction.RETURN, found_nodes)
-
         defnode = utils.assign_parent(found_nodes[0])
         defstmt = defnode.statement(future=True)
         defframe = defstmt.frame(future=True)
@@ -1617,6 +1611,12 @@ class VariablesChecker(BaseChecker):
 
         if use_outer_definition:
             return (VariableVisitConsumerAction.CONTINUE, None)
+
+        if not (
+            self._is_undefined_variable_enabled
+            or self._is_used_before_assignment_enabled
+        ):
+            return (VariableVisitConsumerAction.RETURN, found_nodes)
 
         if (
             maybe_before_assign

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1609,6 +1609,12 @@ class VariablesChecker(BaseChecker):
         if use_outer_definition:
             return (VariableVisitConsumerAction.CONTINUE, None)
 
+        if not (
+            self._is_undefined_variable_enabled
+            or self._is_used_before_assignment_enabled
+        ):
+            return (VariableVisitConsumerAction.RETURN, found_nodes)
+
         if (
             maybe_before_assign
             and not utils.is_defined_before(node)

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1609,12 +1609,6 @@ class VariablesChecker(BaseChecker):
         if use_outer_definition:
             return (VariableVisitConsumerAction.CONTINUE, None)
 
-        if not (
-            self._is_undefined_variable_enabled
-            or self._is_used_before_assignment_enabled
-        ):
-            return (VariableVisitConsumerAction.RETURN, found_nodes)
-
         if (
             maybe_before_assign
             and not utils.is_defined_before(node)

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1090,9 +1090,6 @@ class VariablesChecker(BaseChecker):
         self._is_undefined_variable_enabled = self.linter.is_message_enabled(
             "undefined-variable"
         )
-        self._is_used_before_assignment_enabled = self.linter.is_message_enabled(
-            "used-before-assignment"
-        )
         self._is_undefined_loop_variable_enabled = self.linter.is_message_enabled(
             "undefined-loop-variable"
         )
@@ -1611,12 +1608,6 @@ class VariablesChecker(BaseChecker):
 
         if use_outer_definition:
             return (VariableVisitConsumerAction.CONTINUE, None)
-
-        if not (
-            self._is_undefined_variable_enabled
-            or self._is_used_before_assignment_enabled
-        ):
-            return (VariableVisitConsumerAction.RETURN, found_nodes)
 
         if (
             maybe_before_assign

--- a/tests/functional/u/unused/unused_import_everything_disabled.py
+++ b/tests/functional/u/unused/unused_import_everything_disabled.py
@@ -1,8 +1,17 @@
 """Test that unused-import is not emitted here when everything else is disabled
 
 https://github.com/PyCQA/pylint/issues/3445
+https://github.com/PyCQA/pylint/issues/6089
 """
+from math import e, pi
 from os import environ
 
 for k, v in environ.items():
     print(k, v)
+
+
+class MyClass:
+    """For the bug reported in #6089 it is important to use the same names for the class attributes as in the imports."""
+
+    e = float(e)
+    pi = pi


### PR DESCRIPTION
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
This should fix the false positive reported in #6089 (yes I named my branch wrong 😉).
But as I am not very familar with this part of the code base, I would like to ask @jacobtylerwalls for a review if moving this check can have other side effects than just a small performance loss.
Test suite is passing locally.

Closes #6089 
