### PR TITLE
``redefined-slots-in-subclass`` crash when slot type is neither a string or constant node

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -49,6 +49,10 @@ Release date: TBA
   * functions & classes which contain both a docstring and an ellipsis.
   * A body which contains an ellipsis ``nodes.Expr`` node & at least one other statement.
 
+* Fix crash for ``redefined-slots-in-subclass`` when the type of the slot is not a const or a string.
+
+  Closes #6100
+
 
 
 What's New in Pylint 2.13.4?

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1380,7 +1380,7 @@ a metaclass class method.",
                 slots_names.append(slot.value)
             else:
                 inferred_slot = safe_infer(slot)
-                if inferred_slot:
+                if isinstance(inferred_slot, str):
                     slots_names.append(inferred_slot.value)
 
         # Slots of all parent classes

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1380,8 +1380,9 @@ a metaclass class method.",
                 slots_names.append(slot.value)
             else:
                 inferred_slot = safe_infer(slot)
-                if isinstance(inferred_slot, str):
-                    slots_names.append(inferred_slot.value)
+                inferred_slot_value = getattr(inferred_slot, "value", None)
+                if isinstance(inferred_slot_value, str):
+                    slots_names.append(inferred_slot_value)
 
         # Slots of all parent classes
         ancestors_slots_names = {

--- a/tests/functional/r/redefined/redefined_slots.py
+++ b/tests/functional/r/redefined/redefined_slots.py
@@ -31,3 +31,10 @@ class Subclass3(Base, Base2):
        Redefining the `i`, `j`, `k` slot already defined in `Base2`
     """
     __slots__ = ("a", "b", "c", "i", "j", "k", "l", "m", "n")  # [redefined-slots-in-subclass]
+
+
+
+# https://github.com/PyCQA/pylint/issues/6100
+class MyClass:
+    """No crash when the type of the slot is not a Const or a str"""
+    __slots__ = [str]

--- a/tests/functional/r/redefined/redefined_slots.py
+++ b/tests/functional/r/redefined/redefined_slots.py
@@ -1,6 +1,6 @@
 """Checks that a subclass does not redefine a slot which has been defined in a parent class."""
 
-# pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods, invalid-slots-object
 
 from collections import deque
 

--- a/tests/functional/r/redefined/redefined_slots.py
+++ b/tests/functional/r/redefined/redefined_slots.py
@@ -33,7 +33,6 @@ class Subclass3(Base, Base2):
     __slots__ = ("a", "b", "c", "i", "j", "k", "l", "m", "n")  # [redefined-slots-in-subclass]
 
 
-
 # https://github.com/PyCQA/pylint/issues/6100
 class MyClass:
     """No crash when the type of the slot is not a Const or a str"""


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #6100
