### PR TITLE
fix link in `missing-format-argument-key`

### DIFF
--- a/doc/data/messages/m/missing-format-argument-key/related.rst
+++ b/doc/data/messages/m/missing-format-argument-key/related.rst
@@ -1,2 +1,2 @@
-`PEP 3101 <https://peps.python.org/pep-3101/>`_
-`Custom String Formmating <https://docs.python.org/3/library/string.html#custom-string-formatting>`_
+* `PEP 3101 <https://peps.python.org/pep-3101/>`_
+* `Custom String Formmating <https://docs.python.org/3/library/string.html#custom-string-formatting>`_


### PR DESCRIPTION
fix link to use for `missing-format-argument-key` in `related.rst`

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

-fix link in related.rst with `* ...`

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->