### PR TITLE
Enable usage of custom pylintrc file for message documentation tests

### DIFF
--- a/doc/data/messages/c/confusing-consecutive-elif/bad.py
+++ b/doc/data/messages/c/confusing-consecutive-elif/bad.py
@@ -1,0 +1,6 @@
+def myfunc(shall_continue: bool, shall_exit: bool):
+    if shall_continue:
+        if input("Are you sure?") == "y":
+            print("Moving on.")
+    elif shall_exit:  # [confusing-consecutive-elif]
+        print("Exiting.")

--- a/doc/data/messages/c/confusing-consecutive-elif/details.rst
+++ b/doc/data/messages/c/confusing-consecutive-elif/details.rst
@@ -1,2 +1,1 @@
-Following an indented ``if`` block directly with an ``elif`` of lower indentation can lead to confusion whether the unindent is deliberate or accidental.
-Adding an explicit ``else`` in the indented ``if`` statement, even if it only contains a ``pass`` statement, can help clarify the code.
+Creating a function for the nested conditional, or adding an explicit ``else`` in the indented ``if`` statement, even if it only contains a ``pass`` statement, can help clarify the code.

--- a/doc/data/messages/c/confusing-consecutive-elif/details.rst
+++ b/doc/data/messages/c/confusing-consecutive-elif/details.rst
@@ -1,2 +1,2 @@
-Following an indentend ``if`` block directly with an ``elif`` of lower indentation can lead to confusion whether the unindent is deliberate or accidental.
+Following an indented ``if`` block directly with an ``elif`` of lower indentation can lead to confusion whether the unindent is deliberate or accidental.
 Adding an explicit ``else`` in the indented ``if`` statement, even if it only contains a ``pass`` statement, can help clarify the code.

--- a/doc/data/messages/c/confusing-consecutive-elif/details.rst
+++ b/doc/data/messages/c/confusing-consecutive-elif/details.rst
@@ -1,0 +1,2 @@
+Following an indentend ``if`` block directly with an ``elif`` of lower indentation can lead to confusion whether the unindent is deliberate or accidental.
+Adding an explicit ``else`` in the indented ``if`` statement, even if it only contains a ``pass`` statement, can help clarify the code.

--- a/doc/data/messages/c/confusing-consecutive-elif/good.py
+++ b/doc/data/messages/c/confusing-consecutive-elif/good.py
@@ -1,0 +1,8 @@
+def myfunc(shall_continue: bool, shall_exit: bool):
+    if shall_continue:
+        if input("Are you sure?") == "y":
+            print("Moving on.")
+        else:
+            pass
+    elif shall_exit:
+        print("Exiting.")

--- a/doc/data/messages/c/confusing-consecutive-elif/good.py
+++ b/doc/data/messages/c/confusing-consecutive-elif/good.py
@@ -1,8 +1,22 @@
+# Option 1: add explicit 'else'
 def myfunc(shall_continue: bool, shall_exit: bool):
     if shall_continue:
         if input("Are you sure?") == "y":
             print("Moving on.")
         else:
             pass
+    elif shall_exit:
+        print("Exiting.")
+
+
+# Option 2: extract function
+def user_confirmation():
+    if input("Are you sure?") == "y":
+        print("Moving on.")
+
+
+def myfunc2(shall_continue: bool, shall_exit: bool):
+    if shall_continue:
+        user_confirmation()
     elif shall_exit:
         print("Exiting.")

--- a/doc/data/messages/c/confusing-consecutive-elif/pylintrc
+++ b/doc/data/messages/c/confusing-consecutive-elif/pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+load-plugins=pylint.extensions.confusing_elif

--- a/doc/test_messages_documentation.py
+++ b/doc/test_messages_documentation.py
@@ -7,7 +7,7 @@
 from collections import Counter
 from pathlib import Path
 from typing import Counter as CounterType
-from typing import List, TextIO, Tuple
+from typing import List, Optional, TextIO, Tuple
 
 import pytest
 
@@ -53,7 +53,13 @@ class LintModuleTest:
         self._linter.config.persistent = 0
         checkers.initialize(self._linter)
 
-        config_file = next(config.find_default_config_files(), None)
+        # Check if this message has a custom configuration file (e.g. for enabling optional checkers).
+        # If not, use the default configuration.
+        config_file: Optional[Path]
+        if (test_file[1].parent / "pylintrc").exists():
+            config_file = test_file[1].parent / "pylintrc"
+        else:
+            config_file = next(config.find_default_config_files(), None)
 
         _config_initialization(
             self._linter,


### PR DESCRIPTION
To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|    | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

In order to test some messages (e.g. for messages of optional checkers), we need a way to use a custom config.
With this modification it is possible to place a ``pylintrc`` file next to ``good.py`` and ``bad.py``.
To prove it works I added a documentation example for one of the optional checkers.

Ref: https://github.com/PyCQA/pylint/issues/5953#issuecomment-1085587049