### PR TITLE
Allow setting a ``CallbackAction`` instead of ``"callback"``

### DIFF
--- a/pylint/config/callback_actions.py
+++ b/pylint/config/callback_actions.py
@@ -1,0 +1,40 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Callback actions for various options."""
+
+import abc
+import argparse
+from typing import Any, Optional, Sequence, Union
+
+
+class _CallbackAction(argparse.Action):
+    """Custom callback action."""
+
+    @abc.abstractmethod
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = None,
+    ) -> None:
+        raise NotImplementedError
+
+
+class _DoNothingAction(_CallbackAction):
+    """Action that just passes.
+
+    This action is used to allow pre-processing of certain options
+    without erroring when they are then processed again by argparse.
+    """
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = None,
+    ) -> None:
+        return None

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -126,6 +126,8 @@ class OptionsManagerMixIn:
                 self.cfgfile_parser.add_section(group_name)
         # add provider's specific options
         for opt, optdict in options:
+            if not isinstance(optdict.get("action", "store"), str):
+                optdict["action"] = "callback"
             self.add_optik_option(provider, group, opt, optdict)
 
     def add_optik_option(self, provider, optikcontainer, opt, optdict):

--- a/pylint/config/options_provider_mixin.py
+++ b/pylint/config/options_provider_mixin.py
@@ -74,6 +74,8 @@ class OptionsProviderMixIn:
                 _list.append(value)
         elif action == "callback":
             optdict["callback"](None, optname, value, None)
+        elif not isinstance(action, str):
+            optdict["callback"](None, optname, value, None)
         else:
             raise UnsupportedAction(action)
 

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -9,6 +9,7 @@ import warnings
 from typing import NoReturn, Optional
 
 from pylint import config, extensions, interfaces
+from pylint.config.callback_actions import _DoNothingAction
 from pylint.config.config_initialization import _config_initialization
 from pylint.constants import DEFAULT_PYLINT_HOME, OLD_DEFAULT_PYLINT_HOME, full_version
 from pylint.lint.pylinter import PyLinter
@@ -117,7 +118,7 @@ group are mutually exclusive.",
                 (
                     "rcfile",
                     {
-                        "action": "callback",
+                        "action": _DoNothingAction,
                         "callback": Run._return_one,
                         "group": "Commands",
                         "type": "string",
@@ -128,7 +129,7 @@ group are mutually exclusive.",
                 (
                     "output",
                     {
-                        "action": "callback",
+                        "action": _DoNothingAction,
                         "callback": Run._return_one,
                         "group": "Commands",
                         "type": "string",
@@ -139,7 +140,7 @@ group are mutually exclusive.",
                 (
                     "init-hook",
                     {
-                        "action": "callback",
+                        "action": _DoNothingAction,
                         "callback": Run._return_one,
                         "type": "string",
                         "metavar": "<code>",


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This probably won't work and might need some refactoring. However, setting custom callback actions on `"action"` is how this should be done in `argparse`. This at least allows `optparse` to handle those while I figure out how to pass stuff like `linter` and `Run` to these callback actions.

This is thus necessary boilerplate to make reviewing later on easier.