### PR TITLE
Add a functional test for the spelling checker

### DIFF
--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -35,8 +35,11 @@ try:
         WikiWordFilter,
         get_tokenizer,
     )
+
+    PYENCHANT_AVAILABLE = True
 except ImportError:
     enchant = None
+    PYENCHANT_AVAILABLE = False
 
     class EmailFilter:  # type: ignore[no-redef]
         ...
@@ -62,17 +65,16 @@ except ImportError:
         return Filter()
 
 
-if enchant is not None:
-    br = enchant.Broker()
-    dicts = br.list_dicts()
-    dict_choices = [""] + [d[0] for d in dicts]
-    dicts = [f"{d[0]} ({d[1].name})" for d in dicts]
-    dicts = ", ".join(dicts)
-    instr = ""
+INSTALL_ENCHANT = " To make it work, install the 'python-enchant' package."
+if PYENCHANT_AVAILABLE:
+    broker = enchant.Broker()
+    enchant_dicts = broker.list_dicts()
+    enchant_dict_choices = [""] + [d[0] for d in enchant_dicts]
+    enchant_dicts = [f"{d[0]} ({d[1].name})" for d in enchant_dicts]
+    enchant_dicts = ", ".join(enchant_dicts)
 else:
-    dicts = "none"
-    dict_choices = [""]
-    instr = " To make it work, install the 'python-enchant' package."
+    enchant_dicts = "none"
+    enchant_dict_choices = [""]
 
 
 class WordsWithDigitsFilter(Filter):
@@ -235,9 +237,9 @@ class SpellingChecker(BaseTokenChecker):
                 "default": "",
                 "type": "choice",
                 "metavar": "<dict name>",
-                "choices": dict_choices,
+                "choices": enchant_dict_choices,
                 "help": "Spelling dictionary name. "
-                f"Available dictionaries: {dicts}.{instr}",
+                f"Available dictionaries: {enchant_dicts}.{INSTALL_ENCHANT}",
             },
         ),
         (

--- a/tests/functional/s/spelling/spelling.py
+++ b/tests/functional/s/spelling/spelling.py
@@ -1,0 +1,6 @@
+"""Functional test for speling.""" # [wrong-spelling-in-docstring, wrong-spelling-in-comment]
+
+# mispeled text # [wrong-spelling-in-comment]
+
+def function_name():
+    """mispeled text."""  # [wrong-spelling-in-docstring, wrong-spelling-in-comment]

--- a/tests/functional/s/spelling/spelling.rc
+++ b/tests/functional/s/spelling/spelling.rc
@@ -1,0 +1,2 @@
+[SPELLING]
+spelling-dict=en_US

--- a/tests/functional/s/spelling/spelling.txt
+++ b/tests/functional/s/spelling/spelling.txt
@@ -1,0 +1,20 @@
+wrong-spelling-in-comment:1:0:None:None::"Wrong spelling of a word 'docstring' in a comment:
+# [wrong-spelling-in-docstring, wrong-spelling-in-comment]
+                     ^^^^^^^^^
+Did you mean: ''doc string' or 'doc-string' or 'stringing''?":UNDEFINED
+wrong-spelling-in-docstring:1:0:None:None::"Wrong spelling of a word 'speling' in a docstring:
+Functional test for speling.
+                    ^^^^^^^
+Did you mean: ''spieling' or 'spelling' or 'spewing' or 'peeling''?":UNDEFINED
+wrong-spelling-in-comment:3:0:None:None::"Wrong spelling of a word 'mispeled' in a comment:
+# mispeled text # [wrong-spelling-in-comment]
+  ^^^^^^^^
+Did you mean: ''misspelled' or 'dispelled' or 'misspell' or 'misled''?":UNDEFINED
+wrong-spelling-in-comment:6:0:None:None::"Wrong spelling of a word 'docstring' in a comment:
+# [wrong-spelling-in-docstring, wrong-spelling-in-comment]
+                     ^^^^^^^^^
+Did you mean: ''doc string' or 'doc-string' or 'stringing''?":UNDEFINED
+wrong-spelling-in-docstring:6:0:None:None::"Wrong spelling of a word 'mispeled' in a docstring:
+mispeled text.
+^^^^^^^^
+Did you mean: ''misspelled' or 'dispelled' or 'misspell' or 'misled''?":UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Add a spelling functional tests:

Currently this fail with:
```
Traceback (most recent call last):
  File "/home/pierre/pylint/venv/bin/pylint", line 11, in <module>
    load_entry_point('pylint', 'console_scripts', 'pylint')()
  File "/home/pierre/pylint/pylint/__init__.py", line 22, in run_pylint
    PylintRun(argv or sys.argv[1:])
  File "/home/pierre/pylint/pylint/lint/run.py", line 350, in __init__
    args = _config_initialization(
  File "/home/pierre/pylint/pylint/config/config_initialization.py", line 59, in _config_initialization
    linter.load_plugin_modules(plugins)
  File "/home/pierre/pylint/pylint/lint/pylinter.py", line 644, in load_plugin_modules
    module.register(self)
  File "/home/pierre/pylint/pylint/checkers/spelling.py", line 449, in register
    linter.register_checker(SpellingChecker(linter))
  File "/home/pierre/pylint/pylint/lint/pylinter.py", line 768, in register_checker
    self.register_options_provider(checker)
  File "/home/pierre/pylint/pylint/config/option_manager_mixin.py", line 94, in register_options_provider
    self.add_option_group(
  File "/home/pierre/pylint/pylint/config/option_manager_mixin.py", line 131, in add_option_group
    self.add_optik_option(provider, group, opt, optdict)
  File "/home/pierre/pylint/pylint/config/option_manager_mixin.py", line 135, in add_optik_option
    option = optikcontainer.add_option(*args, **optdict)
  File "/usr/lib/python3.8/optparse.py", line 1008, in add_option
    self._check_conflict(option)
  File "/usr/lib/python3.8/optparse.py", line 980, in _check_conflict
    raise OptionConflictError(
optparse.OptionConflictError: option --spelling-dict: conflicting option string(s): --spelling-dict
```

In order to be able to add a mypy example in #5929 