### PR TITLE
Add a _StoreTrueArgument class

### DIFF
--- a/pylint/config/argument.py
+++ b/pylint/config/argument.py
@@ -121,3 +121,47 @@ class _Argument:
         See:
         https://docs.python.org/3/library/argparse.html#metavar
         """
+
+
+class _StoreTrueArgument:
+    """Class representing a 'store_true' argument to be passed by an argparse.ArgumentsParser.
+
+    This is based on the parameters passed to argparse.ArgumentsParser.add_message.
+    See:
+    https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_argument
+    """
+
+    def __init__(
+        self,
+        flags: List[str],
+        action: str,
+        default: _ArgumentTypes,
+        choices: Optional[List[str]],
+        arg_help: str,
+        metavar: str,
+    ) -> None:
+        self.flags = flags
+        """The name of the argument."""
+
+        self.action = action
+        """The action to perform with the argument."""
+
+        self.default = default
+        """The default value of the argument."""
+
+        self.choices = choices
+        """A list of possible choices for the argument.
+
+        None if there are no restrictions.
+        """
+
+        # argparse uses % formatting on help strings, so a % needs to be escaped
+        self.help = arg_help.replace("%", "%%")
+        """The description of the argument."""
+
+        self.metavar = metavar
+        """The metavar of the argument.
+
+        See:
+        https://docs.python.org/3/library/argparse.html#metavar
+        """

--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -5,15 +5,17 @@
 """Utils for arguments/options parsing and handling."""
 
 
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
-from pylint.config.argument import _Argument
+from pylint.config.argument import _Argument, _StoreTrueArgument
 
 IMPLEMENTED_OPTDICT_KEYS = {"action", "default", "type", "choices", "help", "metavar"}
 """This is used to track our progress on accepting all optdict keys."""
 
 
-def _convert_option_to_argument(opt: str, optdict: Dict[str, Any]) -> _Argument:
+def _convert_option_to_argument(
+    opt: str, optdict: Dict[str, Any]
+) -> Union[_Argument, _StoreTrueArgument]:
     """Convert an optdict to an Argument class instance."""
     # See if the optdict contains any keys we don't yet implement
     # pylint: disable-next=fixme
@@ -23,9 +25,19 @@ def _convert_option_to_argument(opt: str, optdict: Dict[str, Any]) -> _Argument:
             print("Unhandled key found in Argument creation:", key)  # pragma: no cover
             print("It's value is:", value)  # pragma: no cover
 
+    action = optdict.get("action", "store")
+    if action == "store_true":
+        return _StoreTrueArgument(
+            flags=[f"--{opt}"],
+            action=action,
+            default=optdict["default"],
+            choices=optdict.get("choices", None),
+            arg_help=optdict["help"],
+            metavar=optdict["metavar"],
+        )
     return _Argument(
         flags=[f"--{opt}"],
-        action=optdict.get("action", "store"),
+        action=action,
         default=optdict["default"],
         arg_type=optdict["type"],
         choices=optdict.get("choices", None),

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -368,6 +368,7 @@ class PyLinter(
                 "enable",
                 {
                     "type": "csv",
+                    "default": (),
                     "metavar": "<msg ids>",
                     "short": "e",
                     "group": "Messages control",
@@ -384,6 +385,7 @@ class PyLinter(
                 {
                     "type": "csv",
                     "metavar": "<msg ids>",
+                    "default": (),
                     "short": "d",
                     "group": "Messages control",
                     "help": "Disable the message, report, category or checker "
@@ -404,6 +406,7 @@ class PyLinter(
                 "msg-template",
                 {
                     "type": "string",
+                    "default": "",
                     "metavar": "<template>",
                     "group": "Reports",
                     "help": (
@@ -498,6 +501,8 @@ class PyLinter(
                 "exit-zero",
                 {
                     "action": "store_true",
+                    "default": False,
+                    "metavar": "<flag>",
                     "help": (
                         "Always return a 0 (non-error) status code, even if "
                         "lint errors are found. This is primarily useful in "
@@ -509,6 +514,8 @@ class PyLinter(
                 "from-stdin",
                 {
                     "action": "store_true",
+                    "default": False,
+                    "metavar": "<flag>",
                     "help": (
                         "Interpret the stdin as a python script, whose filename "
                         "needs to be passed as the module_or_package argument."


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

**Need to rebase**.

`store_true` arguments can't have a `type`. I thought about subclassing this, but then I would need to change the order of the `__init__` parameters to provide a default value for `type`. I'll probably do that at the end but I want to wait for any other new action types I haven't thought about yet.