### PR TITLE
Suppress ``useless-super-delegation`` if return type changed (#5822)

### DIFF
--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1299,8 +1299,8 @@ a metaclass class method.",
                     return
 
             if (
-                function.returns is not None and
-                meth_node.returns is None
+                function.returns is not None
+                and meth_node.returns is None
                 or meth_node.returns.as_string() != function.returns.as_string()
             ):
                 # Override adds typing information to the return type

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1299,9 +1299,9 @@ a metaclass class method.",
                     return
 
             if (
-                function.returns is not None and
-                meth_node.returns is not None and
-                meth_node.returns.as_string() != function.returns.as_string()
+                function.returns is not None
+                and meth_node.returns is not None
+                and meth_node.returns.as_string() != function.returns.as_string()
             ):
                 # Override adds typing information to the return type
                 return

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1299,9 +1299,9 @@ a metaclass class method.",
                     return
 
             if (
-                function.returns is not None
-                and meth_node.returns is None
-                or meth_node.returns.as_string() != function.returns.as_string()
+                function.returns is not None and
+                meth_node.returns is not None and
+                meth_node.returns.as_string() != function.returns.as_string()
             ):
                 # Override adds typing information to the return type
                 return

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1298,6 +1298,14 @@ a metaclass class method.",
                 if called_annotations != overridden_annotations:
                     return
 
+            if (
+                function.returns is not None and
+                meth_node.returns is None
+                or meth_node.returns.as_string() != function.returns.as_string()
+            ):
+                # Override adds typing information to the return type
+                return
+
         if _definition_equivalent_to_call(params, args):
             self.add_message(
                 "useless-super-delegation", node=function, args=(function.name,)

--- a/tests/functional/u/useless/useless_super_delegation_py35.py
+++ b/tests/functional/u/useless/useless_super_delegation_py35.py
@@ -36,7 +36,7 @@ class NoReturnType:
 class ReturnTypeSpecified(NoReturnType):
     choices = ['a', 'b']
 
-    def draw(self) -> str:
+    def draw(self) -> str: # [useless-super-delegation]
         return super().draw()
 
 class ReturnTypeSame(ReturnTypeAny):

--- a/tests/functional/u/useless/useless_super_delegation_py35.py
+++ b/tests/functional/u/useless/useless_super_delegation_py35.py
@@ -10,3 +10,37 @@ class UselessSuper(object):
 
     def useless(self, first, *, second=None, **kwargs): # [useless-super-delegation]
         return super().useless(first, second=second, **kwargs)
+
+# pylint: disable=wrong-import-position
+import random
+from typing import Any
+
+class ReturnTypeAny:
+    choices = ['a', 1, (2, 3)]
+
+    def draw(self) -> Any:
+        return random.choice(self.choices)
+
+class ReturnTypeNarrowed(ReturnTypeAny):
+    choices = [1, 2, 3]
+
+    def draw(self) -> int:
+        return super().draw()
+
+class NoReturnType:
+    choices = ['a', 1, (2, 3)]
+
+    def draw(self):
+        return random.choice(self.choices)
+
+class ReturnTypeSpecified(NoReturnType):
+    choices = ['a', 'b']
+
+    def draw(self) -> str:
+        return super().draw()
+
+class ReturnTypeSame(ReturnTypeAny):
+    choices = ['a', 'b']
+
+    def draw(self) -> Any: # [useless-super-delegation]
+        return super().draw()

--- a/tests/functional/u/useless/useless_super_delegation_py35.txt
+++ b/tests/functional/u/useless/useless_super_delegation_py35.txt
@@ -1,2 +1,3 @@
 useless-super-delegation:11:4:11:15:UselessSuper.useless:Useless super delegation in method 'useless':UNDEFINED
+useless-super-delegation:39:4:39:12:ReturnTypeSpecified.draw:Useless super delegation in method 'draw':UNDEFINED
 useless-super-delegation:45:4:45:12:ReturnTypeSame.draw:Useless super delegation in method 'draw':UNDEFINED

--- a/tests/functional/u/useless/useless_super_delegation_py35.txt
+++ b/tests/functional/u/useless/useless_super_delegation_py35.txt
@@ -1,1 +1,2 @@
 useless-super-delegation:11:4:11:15:UselessSuper.useless:Useless super delegation in method 'useless':UNDEFINED
+useless-super-delegation:45:4:45:12:ReturnTypeSame.draw:Useless super delegation in method 'draw':UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

In the `useless-super-delegation` checker, check whether the return type annotation has been specialized in the derived class. If so, then the override is not useless and we should not issue the warning.

Closes #5822 
