### PR TITLE
Work towards turning on ``future_option_parsing`` in ``PyLinter``

### DIFF
--- a/pylint/checkers/unicode.py
+++ b/pylint/checkers/unicode.py
@@ -100,7 +100,7 @@ BAD_CHARS = [
         "\\x1A",
         "E2512",
         (
-            "Ctrl+Z “End of text” on Windows. Some programs (such as type) ignore "
+            'Ctrl+Z "End of text" on Windows. Some programs (such as type) ignore '
             "the rest of the file after it."
         ),
     ),

--- a/pylint/config/argument.py
+++ b/pylint/config/argument.py
@@ -11,10 +11,22 @@ An Argument instance represents a pylint option to be handled by an argparse.Arg
 import argparse
 import pathlib
 import re
-from typing import Callable, Dict, List, Optional, Pattern, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Pattern,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 
 from pylint import interfaces
 from pylint import utils as pylint_utils
+from pylint.config.callback_actions import _CallbackAction
 
 _ArgumentTypes = Union[
     str,
@@ -199,3 +211,32 @@ class _StoreTrueArgument:
         # argparse uses % formatting on help strings, so a % needs to be escaped
         self.help = arg_help.replace("%", "%%")
         """The description of the argument."""
+
+
+class _CallableArgument:
+    """Class representing an callable argument to be parsed by an argparse.ArgumentsParser.
+
+    This is based on the parameters passed to argparse.ArgumentsParser.add_message.
+    See:
+    https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_argument
+    """
+
+    def __init__(
+        self,
+        flags: List[str],
+        action: Type[_CallbackAction],
+        arg_help: str,
+        kwargs: Dict[str, Any],
+    ) -> None:
+        self.flags = flags
+        """The name of the argument."""
+
+        self.action = action
+        """The action to perform with the argument."""
+
+        # argparse uses % formatting on help strings, so a % needs to be escaped
+        self.help = arg_help.replace("%", "%%")
+        """The description of the argument."""
+
+        self.kwargs = kwargs
+        """Any additional arguments passed to the action."""

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -7,7 +7,7 @@
 import argparse
 from typing import TYPE_CHECKING, Dict, List, Union
 
-from pylint.config.argument import _Argument, _StoreTrueArgument
+from pylint.config.argument import _Argument, _CallableArgument, _StoreTrueArgument
 from pylint.config.exceptions import UnrecognizedArgumentAction
 from pylint.config.utils import _convert_option_to_argument
 
@@ -44,7 +44,9 @@ class _ArgumentsManager:
         self._load_default_argument_values()
 
     def _add_arguments_to_parser(
-        self, section: str, argument: Union[_Argument, _StoreTrueArgument]
+        self,
+        section: str,
+        argument: Union[_Argument, _StoreTrueArgument, _CallableArgument],
     ) -> None:
         """Iterates over all argument sections and add them to the parser object."""
         try:
@@ -57,7 +59,7 @@ class _ArgumentsManager:
     @staticmethod
     def _add_parser_option(
         section_group: argparse._ArgumentGroup,
-        argument: Union[_Argument, _StoreTrueArgument],
+        argument: Union[_Argument, _StoreTrueArgument, _CallableArgument],
     ) -> None:
         """Add an argument."""
         if isinstance(argument, _Argument):
@@ -75,6 +77,13 @@ class _ArgumentsManager:
                 *argument.flags,
                 action=argument.action,
                 default=argument.default,
+                help=argument.help,
+            )
+        elif isinstance(argument, _CallableArgument):
+            section_group.add_argument(
+                *argument.flags,
+                **argument.kwargs,
+                action=argument.action,
                 help=argument.help,
             )
         else:

--- a/pylint/config/callback_actions.py
+++ b/pylint/config/callback_actions.py
@@ -130,12 +130,8 @@ class _MessageHelpAction(_CallbackAction):
         values: Union[str, Sequence[str], None],
         option_string: Optional[str] = "--help-msg",
     ) -> None:
-        if isinstance(values, (list, tuple)):
-            self.run.linter.msgs_store.help_message(values)
-        elif isinstance(values, str):
-            self.run.linter.msgs_store.help_message(utils._splitstrip(values))
-        else:
-            raise argparse.ArgumentTypeError(f"{values} should be a string.")
+        assert isinstance(values, (list, tuple))
+        self.run.linter.msgs_store.help_message(values)
         sys.exit(0)
 
 

--- a/pylint/config/callback_actions.py
+++ b/pylint/config/callback_actions.py
@@ -2,11 +2,20 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
+# pylint: disable=too-many-arguments
+
 """Callback actions for various options."""
 
 import abc
 import argparse
-from typing import Any, Optional, Sequence, Union
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional, Sequence, Union
+
+from pylint import extensions, interfaces, utils
+
+if TYPE_CHECKING:
+    from pylint.lint.run import Run
 
 
 class _CallbackAction(argparse.Action):
@@ -38,3 +47,261 @@ class _DoNothingAction(_CallbackAction):
         option_string: Optional[str] = None,
     ) -> None:
         return None
+
+
+class _AccessRunObjectAction(_CallbackAction):
+    """Action that has access to the Run object."""
+
+    def __init__(
+        self,
+        option_strings: Sequence[str],
+        dest: str,
+        nargs: None = None,
+        const: None = None,
+        default: None = None,
+        arg_type: None = None,
+        choices: None = None,
+        required: bool = False,
+        help_msg: str = "",
+        metavar: str = "",
+        **kwargs: "Run",
+    ) -> None:
+        self.run = kwargs["Run"]
+
+        super().__init__(
+            option_strings,
+            dest,
+            0,
+            const,
+            default,
+            arg_type,
+            choices,
+            required,
+            help_msg,
+            metavar,
+        )
+
+    @abc.abstractmethod
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = None,
+    ) -> None:
+        raise NotImplementedError
+
+
+class _MessageHelpAction(_CallbackAction):
+    """Display the help message of a message."""
+
+    def __init__(
+        self,
+        option_strings: Sequence[str],
+        dest: str,
+        nargs: None = None,
+        const: None = None,
+        default: None = None,
+        arg_type: None = None,
+        choices: None = None,
+        required: bool = False,
+        help_msg: str = "",
+        metavar: str = "",
+        **kwargs: "Run",
+    ) -> None:
+        self.run = kwargs["Run"]
+        super().__init__(
+            option_strings,
+            dest,
+            "+",
+            const,
+            default,
+            arg_type,
+            choices,
+            required,
+            help_msg,
+            metavar,
+        )
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[str], None],
+        option_string: Optional[str] = "--help-msg",
+    ) -> None:
+        if isinstance(values, (list, tuple)):
+            self.run.linter.msgs_store.help_message(values)
+        elif isinstance(values, str):
+            self.run.linter.msgs_store.help_message(utils._splitstrip(values))
+        else:
+            raise argparse.ArgumentTypeError(f"{values} should be a string.")
+        sys.exit(0)
+
+
+class _ListMessagesAction(_AccessRunObjectAction):
+    """Display all available messages."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = "--list-enabled",
+    ) -> None:
+        self.run.linter.msgs_store.list_messages()
+        sys.exit(0)
+
+
+class _ListMessagesEnabledAction(_AccessRunObjectAction):
+    """Display all enabled messages."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = "--list-msgs-enabled",
+    ) -> None:
+        self.run.linter.list_messages_enabled()
+        sys.exit(0)
+
+
+class _ListCheckGroupsAction(_AccessRunObjectAction):
+    """Display all the check groups that pylint knows about."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = "--list-groups",
+    ) -> None:
+        for check in self.run.linter.get_checker_names():
+            print(check)
+        sys.exit(0)
+
+
+class _ListConfidenceLevelsAction(_AccessRunObjectAction):
+    """Display all the confidence levels that pylint knows about."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = "--list-conf-levels",
+    ) -> None:
+        for level in interfaces.CONFIDENCE_LEVELS:
+            print(f"%-18s: {level}")
+        sys.exit(0)
+
+
+class _ListExtensionsAction(_AccessRunObjectAction):
+    """Display all extensions under pylint.extensions."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = "--list-extensions",
+    ) -> None:
+        for filename in Path(extensions.__file__).parent.iterdir():
+            if filename.suffix == ".py" and not filename.stem.startswith("_"):
+                extension_name, _, _ = filename.stem.partition(".")
+                print(f"pylint.extensions.{extension_name}")
+        sys.exit(0)
+
+
+class _FullDocumentationAction(_AccessRunObjectAction):
+    """Display the full documentation."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = "--full-documentation",
+    ) -> None:
+        utils.print_full_documentation(self.run.linter)
+        sys.exit(0)
+
+
+class _GenerateRCFileAction(_AccessRunObjectAction):
+    """Generate a pylintrc file."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = "--generate-rcfile",
+    ) -> None:
+        self.run.linter.generate_config(skipsections=("COMMANDS",))
+        sys.exit(0)
+
+
+class _ErrorsOnlyModeAction(_AccessRunObjectAction):
+    """Turn on errors-only mode.
+
+    Error mode:
+        * disable all but error messages
+        * disable the 'miscellaneous' checker which can be safely deactivated in
+          debug
+        * disable reports
+        * do not save execution information
+    """
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = "--errors-only",
+    ) -> None:
+        self.run.linter.error_mode()
+
+
+class _VerboseModeAction(_AccessRunObjectAction):
+    """Turn on verbose mode."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = "--verbose",
+    ) -> None:
+        self.run.verbose = True
+
+
+class _EnableAllExtensionsAction(_AccessRunObjectAction):
+    """Turn on all extensions."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = "--enable-all-extensions",
+    ) -> None:
+        for filename in Path(extensions.__file__).parent.iterdir():
+            if filename.suffix == (".py") and not filename.stem.startswith("_"):
+                extension_name = f"pylint.extensions.{filename.stem}"
+                if extension_name not in self.run._plugins:
+                    self.run._plugins.append(extension_name)
+
+
+class _LongHelpAction(_AccessRunObjectAction):
+    """Display the long help message."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = "--long-help",
+    ) -> None:
+        print(self.run.linter.help(1))
+        sys.exit(0)

--- a/pylint/config/option.py
+++ b/pylint/config/option.py
@@ -194,6 +194,8 @@ class Option(optparse.Option):
     optparse.Option.CHECK_METHODS[2] = _check_choice  # type: ignore[index]
 
     def process(self, opt, value, values, parser):
+        if self.callback and self.callback.__module__ == "pylint.lint.run":
+            return 1
         # First, convert the value(s) to the right type.  Howl if any
         # value(s) are bogus.
         value = self.convert_value(opt, value)

--- a/pylint/config/options_provider_mixin.py
+++ b/pylint/config/options_provider_mixin.py
@@ -5,6 +5,7 @@
 import optparse  # pylint: disable=deprecated-module
 from typing import Any, Dict, Tuple
 
+from pylint.config.callback_actions import _CallbackAction
 from pylint.config.option import _validate
 
 
@@ -72,10 +73,12 @@ class OptionsProviderMixIn:
                 setattr(self.config, optname, _list + (value,))
             else:
                 _list.append(value)
-        elif action == "callback":
-            optdict["callback"](None, optname, value, None)
-        elif not isinstance(action, str):
-            optdict["callback"](None, optname, value, None)
+        elif (
+            action == "callback"
+            or (not isinstance(action, str))
+            and issubclass(action, _CallbackAction)
+        ):
+            return
         else:
             raise UnsupportedAction(action)
 

--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -25,20 +25,33 @@ def _convert_option_to_argument(
             print("Unhandled key found in Argument creation:", key)  # pragma: no cover
             print("It's value is:", value)  # pragma: no cover
 
+    # Get the long and short flags
+    flags = [f"--{opt}"]
+    if "short" in optdict:
+        flags += [f"-{optdict['short']}"]
+
+    # Get the action type
     action = optdict.get("action", "store")
+
+    # pylint: disable-next=fixme
+    # TODO: Remove this handling after we have deprecated multiple-choice arguments
+    choices = optdict.get("choices", None)
+    if opt == "confidence":
+        choices = None
+
     if action == "store_true":
         return _StoreTrueArgument(
-            flags=[f"--{opt}"],
+            flags=flags,
             action=action,
             default=optdict["default"],
             arg_help=optdict["help"],
         )
     return _Argument(
-        flags=[f"--{opt}"],
+        flags=flags,
         action=action,
         default=optdict["default"],
         arg_type=optdict["type"],
-        choices=optdict.get("choices", None),
+        choices=choices,
         arg_help=optdict["help"],
         metavar=optdict["metavar"],
     )

--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -7,7 +7,8 @@
 
 from typing import Any, Dict, Union
 
-from pylint.config.argument import _Argument, _StoreTrueArgument
+from pylint.config.argument import _Argument, _CallableArgument, _StoreTrueArgument
+from pylint.config.callback_actions import _CallbackAction
 
 IMPLEMENTED_OPTDICT_KEYS = {"action", "default", "type", "choices", "help", "metavar"}
 """This is used to track our progress on accepting all optdict keys."""
@@ -15,7 +16,7 @@ IMPLEMENTED_OPTDICT_KEYS = {"action", "default", "type", "choices", "help", "met
 
 def _convert_option_to_argument(
     opt: str, optdict: Dict[str, Any]
-) -> Union[_Argument, _StoreTrueArgument]:
+) -> Union[_Argument, _StoreTrueArgument, _CallableArgument]:
     """Convert an optdict to an Argument class instance."""
     # See if the optdict contains any keys we don't yet implement
     # pylint: disable-next=fixme
@@ -45,6 +46,13 @@ def _convert_option_to_argument(
             action=action,
             default=optdict["default"],
             arg_help=optdict["help"],
+        )
+    if not isinstance(action, str) and issubclass(action, _CallbackAction):
+        return _CallableArgument(
+            flags=flags,
+            action=action,
+            arg_help=optdict["help"],
+            kwargs=optdict["kwargs"],
         )
     return _Argument(
         flags=flags,

--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -10,21 +10,16 @@ from typing import Any, Dict, Union
 from pylint.config.argument import _Argument, _CallableArgument, _StoreTrueArgument
 from pylint.config.callback_actions import _CallbackAction
 
-IMPLEMENTED_OPTDICT_KEYS = {"action", "default", "type", "choices", "help", "metavar"}
-"""This is used to track our progress on accepting all optdict keys."""
-
 
 def _convert_option_to_argument(
     opt: str, optdict: Dict[str, Any]
 ) -> Union[_Argument, _StoreTrueArgument, _CallableArgument]:
     """Convert an optdict to an Argument class instance."""
-    # See if the optdict contains any keys we don't yet implement
     # pylint: disable-next=fixme
-    # TODO: This should be removed once the migration to argparse is finished
-    for key, value in optdict.items():
-        if key not in IMPLEMENTED_OPTDICT_KEYS:
-            print("Unhandled key found in Argument creation:", key)  # pragma: no cover
-            print("It's value is:", value)  # pragma: no cover
+    # TODO: Do something with the 'group', 'level' and 'hide' keys of optdicts
+
+    # pylint: disable-next=fixme
+    # TODO: Do something with the 'dest' key and deprecation of options
 
     # Get the long and short flags
     flags = [f"--{opt}"]

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -361,7 +361,7 @@ class PyLinter(
                     "choices": interfaces.CONFIDENCE_LEVEL_NAMES,
                     "group": "Messages control",
                     "help": "Only show warnings with the listed confidence levels."
-                    f" Leave empty to show all. Valid levels: {', '.join(c.name for c in interfaces.CONFIDENCE_LEVELS)}.",
+                    f" Leave empty to show all. Valid levels: {', '.join(interfaces.CONFIDENCE_LEVEL_NAMES)}.",
                 },
             ),
             (

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -620,7 +620,7 @@ class PyLinter(
 
         reporters.ReportsHandlerMixIn.__init__(self)
         config.OptionsManagerMixIn.__init__(self, usage=__doc__)
-        checkers.BaseTokenChecker.__init__(self)
+        checkers.BaseTokenChecker.__init__(self, self, future_option_parsing=True)
         # provided reports
         self.reports = (
             ("RP0001", "Messages by category", report_total_messages_stats),

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -2,11 +2,10 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
-import optparse  # pylint: disable=deprecated-module
 import os
 import sys
 import warnings
-from typing import NoReturn, Optional
+from typing import Optional
 
 from pylint import config, extensions, interfaces
 from pylint.config.callback_actions import (
@@ -28,7 +27,7 @@ from pylint.config.config_initialization import _config_initialization
 from pylint.constants import DEFAULT_PYLINT_HOME, OLD_DEFAULT_PYLINT_HOME, full_version
 from pylint.lint.pylinter import PyLinter
 from pylint.lint.utils import ArgumentPreprocessingError, preprocess_options
-from pylint.utils import print_full_documentation, utils
+from pylint.utils import utils
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -90,8 +89,10 @@ group are mutually exclusive.",
     )
 
     @staticmethod
-    def _return_one(*args):  # pylint: disable=unused-argument
-        return 1
+    def _not_implemented_callback(*args, **kwargs):
+        # pylint: disable-next=fixme
+        # TODO: Remove after optparse has been deprecated
+        raise NotImplementedError
 
     def __init__(
         self,
@@ -134,7 +135,7 @@ group are mutually exclusive.",
                     {
                         "action": _DoNothingAction,
                         "kwargs": {},
-                        "callback": Run._return_one,
+                        "callback": Run._not_implemented_callback,
                         "group": "Commands",
                         "help": "Specify a configuration file to load.",
                     },
@@ -144,7 +145,7 @@ group are mutually exclusive.",
                     {
                         "action": _DoNothingAction,
                         "kwargs": {},
-                        "callback": Run._return_one,
+                        "callback": Run._not_implemented_callback,
                         "group": "Commands",
                         "help": "Specify an output file.",
                     },
@@ -154,7 +155,7 @@ group are mutually exclusive.",
                     {
                         "action": _DoNothingAction,
                         "kwargs": {},
-                        "callback": Run._return_one,
+                        "callback": Run._not_implemented_callback,
                         "level": 1,
                         "help": "Python code to execute, usually for sys.path "
                         "manipulation such as pygtk.require().",
@@ -165,7 +166,7 @@ group are mutually exclusive.",
                     {
                         "action": _MessageHelpAction,
                         "kwargs": {"Run": self},
-                        "callback": self.cb_help_message,
+                        "callback": Run._not_implemented_callback,
                         "group": "Commands",
                         "help": "Display a help message for the given message id and "
                         "exit. The value may be a comma separated list of message ids.",
@@ -176,7 +177,7 @@ group are mutually exclusive.",
                     {
                         "action": _ListMessagesAction,
                         "kwargs": {"Run": self},
-                        "callback": self.cb_list_messages,
+                        "callback": Run._not_implemented_callback,
                         "group": "Commands",
                         "level": 1,
                         "help": "Display a list of all pylint's messages divided by whether "
@@ -188,7 +189,7 @@ group are mutually exclusive.",
                     {
                         "action": _ListMessagesEnabledAction,
                         "kwargs": {"Run": self},
-                        "callback": self.cb_list_messages_enabled,
+                        "callback": Run._not_implemented_callback,
                         "group": "Commands",
                         "level": 1,
                         "help": "Display a list of what messages are enabled, "
@@ -200,7 +201,7 @@ group are mutually exclusive.",
                     {
                         "action": _ListCheckGroupsAction,
                         "kwargs": {"Run": self},
-                        "callback": self.cb_list_groups,
+                        "callback": Run._not_implemented_callback,
                         "group": "Commands",
                         "level": 1,
                         "help": "List pylint's message groups.",
@@ -210,7 +211,7 @@ group are mutually exclusive.",
                     "list-conf-levels",
                     {
                         "action": _ListConfidenceLevelsAction,
-                        "callback": cb_list_confidence_levels,
+                        "callback": Run._not_implemented_callback,
                         "kwargs": {"Run": self},
                         "group": "Commands",
                         "level": 1,
@@ -222,7 +223,7 @@ group are mutually exclusive.",
                     {
                         "action": _ListExtensionsAction,
                         "kwargs": {"Run": self},
-                        "callback": cb_list_extensions,
+                        "callback": Run._not_implemented_callback,
                         "group": "Commands",
                         "level": 1,
                         "help": "List available extensions.",
@@ -233,7 +234,7 @@ group are mutually exclusive.",
                     {
                         "action": _FullDocumentationAction,
                         "kwargs": {"Run": self},
-                        "callback": self.cb_full_documentation,
+                        "callback": Run._not_implemented_callback,
                         "group": "Commands",
                         "level": 1,
                         "help": "Generate pylint's full documentation.",
@@ -244,7 +245,7 @@ group are mutually exclusive.",
                     {
                         "action": _GenerateRCFileAction,
                         "kwargs": {"Run": self},
-                        "callback": self.cb_generate_config,
+                        "callback": Run._not_implemented_callback,
                         "group": "Commands",
                         "help": "Generate a sample configuration file according to "
                         "the current configuration. You can put other options "
@@ -257,7 +258,7 @@ group are mutually exclusive.",
                     {
                         "action": _ErrorsOnlyModeAction,
                         "kwargs": {"Run": self},
-                        "callback": self.cb_error_mode,
+                        "callback": Run._not_implemented_callback,
                         "short": "E",
                         "help": "In error mode, checkers without error messages are "
                         "disabled and for others, only the ERROR messages are "
@@ -269,7 +270,7 @@ group are mutually exclusive.",
                     {
                         "action": _VerboseModeAction,
                         "kwargs": {"Run": self},
-                        "callback": self.cb_verbose_mode,
+                        "callback": Run._not_implemented_callback,
                         "short": "v",
                         "help": "In verbose mode, extra non-checker-related info "
                         "will be displayed.",
@@ -280,7 +281,7 @@ group are mutually exclusive.",
                     {
                         "action": _EnableAllExtensionsAction,
                         "kwargs": {"Run": self},
-                        "callback": self.cb_enable_all_extensions,
+                        "callback": Run._not_implemented_callback,
                         "help": "Load and enable all available extensions. "
                         "Use --list-extensions to see a list all available extensions.",
                     },
@@ -290,7 +291,7 @@ group are mutually exclusive.",
                     {
                         "action": _LongHelpAction,
                         "kwargs": {"Run": self},
-                        "callback": self.cb_helpfunc,
+                        "callback": Run._not_implemented_callback,
                         "help": "Show more verbose help.",
                         "group": "Commands",
                     },
@@ -428,53 +429,6 @@ to search for configuration file.
         """Callback for option preprocessing (i.e. before option parsing)."""
         self._plugins.extend(utils._splitstrip(value))
 
-    def cb_error_mode(self, *args, **kwargs):
-        """Callback for --errors-only.
-
-        Error mode:
-        * disable all but error messages
-        * disable the 'miscellaneous' checker which can be safely deactivated in
-          debug
-        * disable reports
-        * do not save execution information
-        """
-        self.linter.error_mode()
-
-    def cb_generate_config(self, *args, **kwargs):
-        """Optik callback for sample config file generation."""
-        self.linter.generate_config(skipsections=("COMMANDS",))
-        sys.exit(0)
-
-    def cb_help_message(self, option, optname, value, parser):
-        """Optik callback for printing some help about a particular message."""
-        self.linter.msgs_store.help_message(utils._splitstrip(value))
-        sys.exit(0)
-
-    def cb_full_documentation(self, option, optname, value, parser):
-        """Optik callback for printing full documentation."""
-        print_full_documentation(self.linter)
-        sys.exit(0)
-
-    def cb_list_messages(self, option, optname, value, parser):
-        """Optik callback for printing available messages."""
-        self.linter.msgs_store.list_messages()
-        sys.exit(0)
-
-    def cb_list_messages_enabled(self, option, optname, value, parser):
-        """Optik callback for printing available messages."""
-        self.linter.list_messages_enabled()
-        sys.exit(0)
-
-    def cb_list_groups(self, *args, **kwargs):
-        """List all the check groups that pylint knows about.
-
-        These should be useful to know what check groups someone can disable
-        or enable.
-        """
-        for check in self.linter.get_checker_names():
-            print(check)
-        sys.exit(0)
-
     def cb_verbose_mode(self, *args, **kwargs):
         self.verbose = True
 
@@ -485,13 +439,3 @@ to search for configuration file.
                 extension_name = f"pylint.extensions.{filename[:-3]}"
                 if extension_name not in self._plugins:
                     self._plugins.append(extension_name)
-
-    def cb_helpfunc(
-        self,
-        option: optparse.Option,
-        optname: str,
-        value: None,
-        parser: config.OptionParser,
-    ) -> NoReturn:
-        print(self.linter.help(1))
-        sys.exit(0)

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -9,7 +9,21 @@ import warnings
 from typing import NoReturn, Optional
 
 from pylint import config, extensions, interfaces
-from pylint.config.callback_actions import _DoNothingAction
+from pylint.config.callback_actions import (
+    _DoNothingAction,
+    _EnableAllExtensionsAction,
+    _ErrorsOnlyModeAction,
+    _FullDocumentationAction,
+    _GenerateRCFileAction,
+    _ListCheckGroupsAction,
+    _ListConfidenceLevelsAction,
+    _ListExtensionsAction,
+    _ListMessagesAction,
+    _ListMessagesEnabledAction,
+    _LongHelpAction,
+    _MessageHelpAction,
+    _VerboseModeAction,
+)
 from pylint.config.config_initialization import _config_initialization
 from pylint.constants import DEFAULT_PYLINT_HOME, OLD_DEFAULT_PYLINT_HOME, full_version
 from pylint.lint.pylinter import PyLinter
@@ -119,10 +133,9 @@ group are mutually exclusive.",
                     "rcfile",
                     {
                         "action": _DoNothingAction,
+                        "kwargs": {},
                         "callback": Run._return_one,
                         "group": "Commands",
-                        "type": "string",
-                        "metavar": "<file>",
                         "help": "Specify a configuration file to load.",
                     },
                 ),
@@ -130,10 +143,9 @@ group are mutually exclusive.",
                     "output",
                     {
                         "action": _DoNothingAction,
+                        "kwargs": {},
                         "callback": Run._return_one,
                         "group": "Commands",
-                        "type": "string",
-                        "metavar": "<file>",
                         "help": "Specify an output file.",
                     },
                 ),
@@ -141,9 +153,8 @@ group are mutually exclusive.",
                     "init-hook",
                     {
                         "action": _DoNothingAction,
+                        "kwargs": {},
                         "callback": Run._return_one,
-                        "type": "string",
-                        "metavar": "<code>",
                         "level": 1,
                         "help": "Python code to execute, usually for sys.path "
                         "manipulation such as pygtk.require().",
@@ -152,9 +163,8 @@ group are mutually exclusive.",
                 (
                     "help-msg",
                     {
-                        "action": "callback",
-                        "type": "string",
-                        "metavar": "<msg-id>",
+                        "action": _MessageHelpAction,
+                        "kwargs": {"Run": self},
                         "callback": self.cb_help_message,
                         "group": "Commands",
                         "help": "Display a help message for the given message id and "
@@ -164,8 +174,8 @@ group are mutually exclusive.",
                 (
                     "list-msgs",
                     {
-                        "action": "callback",
-                        "metavar": "<msg-id>",
+                        "action": _ListMessagesAction,
+                        "kwargs": {"Run": self},
                         "callback": self.cb_list_messages,
                         "group": "Commands",
                         "level": 1,
@@ -176,8 +186,8 @@ group are mutually exclusive.",
                 (
                     "list-msgs-enabled",
                     {
-                        "action": "callback",
-                        "metavar": "<msg-id>",
+                        "action": _ListMessagesEnabledAction,
+                        "kwargs": {"Run": self},
                         "callback": self.cb_list_messages_enabled,
                         "group": "Commands",
                         "level": 1,
@@ -188,8 +198,8 @@ group are mutually exclusive.",
                 (
                     "list-groups",
                     {
-                        "action": "callback",
-                        "metavar": "<msg-id>",
+                        "action": _ListCheckGroupsAction,
+                        "kwargs": {"Run": self},
                         "callback": self.cb_list_groups,
                         "group": "Commands",
                         "level": 1,
@@ -199,8 +209,9 @@ group are mutually exclusive.",
                 (
                     "list-conf-levels",
                     {
-                        "action": "callback",
+                        "action": _ListConfidenceLevelsAction,
                         "callback": cb_list_confidence_levels,
+                        "kwargs": {"Run": self},
                         "group": "Commands",
                         "level": 1,
                         "help": "Generate pylint's confidence levels.",
@@ -209,7 +220,8 @@ group are mutually exclusive.",
                 (
                     "list-extensions",
                     {
-                        "action": "callback",
+                        "action": _ListExtensionsAction,
+                        "kwargs": {"Run": self},
                         "callback": cb_list_extensions,
                         "group": "Commands",
                         "level": 1,
@@ -219,8 +231,8 @@ group are mutually exclusive.",
                 (
                     "full-documentation",
                     {
-                        "action": "callback",
-                        "metavar": "<msg-id>",
+                        "action": _FullDocumentationAction,
+                        "kwargs": {"Run": self},
                         "callback": self.cb_full_documentation,
                         "group": "Commands",
                         "level": 1,
@@ -230,7 +242,8 @@ group are mutually exclusive.",
                 (
                     "generate-rcfile",
                     {
-                        "action": "callback",
+                        "action": _GenerateRCFileAction,
+                        "kwargs": {"Run": self},
                         "callback": self.cb_generate_config,
                         "group": "Commands",
                         "help": "Generate a sample configuration file according to "
@@ -242,7 +255,8 @@ group are mutually exclusive.",
                 (
                     "errors-only",
                     {
-                        "action": "callback",
+                        "action": _ErrorsOnlyModeAction,
+                        "kwargs": {"Run": self},
                         "callback": self.cb_error_mode,
                         "short": "E",
                         "help": "In error mode, checkers without error messages are "
@@ -253,7 +267,8 @@ group are mutually exclusive.",
                 (
                     "verbose",
                     {
-                        "action": "callback",
+                        "action": _VerboseModeAction,
+                        "kwargs": {"Run": self},
                         "callback": self.cb_verbose_mode,
                         "short": "v",
                         "help": "In verbose mode, extra non-checker-related info "
@@ -263,7 +278,8 @@ group are mutually exclusive.",
                 (
                     "enable-all-extensions",
                     {
-                        "action": "callback",
+                        "action": _EnableAllExtensionsAction,
+                        "kwargs": {"Run": self},
                         "callback": self.cb_enable_all_extensions,
                         "help": "Load and enable all available extensions. "
                         "Use --list-extensions to see a list all available extensions.",
@@ -272,7 +288,8 @@ group are mutually exclusive.",
                 (
                     "long-help",
                     {
-                        "action": "callback",
+                        "action": _LongHelpAction,
+                        "kwargs": {"Run": self},
                         "callback": self.cb_helpfunc,
                         "help": "Show more verbose help.",
                         "group": "Commands",

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -209,18 +209,6 @@ class TestRunTC:
             ["--exit-zero", join(HERE, "regrtest_data", "syntax_error.py")], code=0
         )
 
-    def test_generate_config_option(self) -> None:
-        self._runtest(["--generate-rcfile"], code=0)
-
-    def test_generate_config_option_order(self) -> None:
-        out1 = StringIO()
-        out2 = StringIO()
-        self._runtest(["--generate-rcfile"], code=0, out=out1)
-        self._runtest(["--generate-rcfile"], code=0, out=out2)
-        output1 = out1.getvalue()
-        output2 = out2.getvalue()
-        assert output1 == output2
-
     def test_generate_config_disable_symbolic_names(self) -> None:
         # Test that --generate-rcfile puts symbolic names in the --disable
         # option.
@@ -240,20 +228,8 @@ class TestRunTC:
         messages = utils._splitstrip(parser.get("MESSAGES CONTROL", "disable"))
         assert "suppressed-message" in messages
 
-    def test_generate_rcfile_no_obsolete_methods(self) -> None:
-        out = StringIO()
-        self._run_pylint(["--generate-rcfile"], out=out)
-        output = out.getvalue()
-        assert "profile" not in output
-
     def test_nonexistent_config_file(self) -> None:
         self._runtest(["--rcfile=/tmp/this_file_does_not_exist"], code=32)
-
-    def test_help_message_option(self) -> None:
-        self._runtest(["--help-msg", "W0101"], code=0)
-
-    def test_error_help_message_option(self) -> None:
-        self._runtest(["--help-msg", "WX101"], code=0)
 
     def test_error_missing_arguments(self) -> None:
         self._runtest([], code=32)
@@ -1224,22 +1200,6 @@ class TestRunTC:
         )
 
     @staticmethod
-    def test_enable_all_extensions() -> None:
-        """Test to see if --enable-all-extensions does indeed load all extensions."""
-        # Record all extensions
-        plugins = []
-        for filename in os.listdir(os.path.dirname(extensions.__file__)):
-            if filename.endswith(".py") and not filename.startswith("_"):
-                plugins.append(f"pylint.extensions.{filename[:-3]}")
-
-        # Check if they are loaded
-        runner = Run(
-            ["--enable-all-extensions", join(HERE, "regrtest_data", "empty.py")],
-            exit=False,
-        )
-        assert sorted(plugins) == sorted(runner.linter._dynamic_plugins)
-
-    @staticmethod
     def test_load_text_repoter_if_not_provided() -> None:
         """Test if PyLinter.reporter is a TextReporter if no reporter is provided."""
         linter = PyLinter()
@@ -1321,11 +1281,114 @@ class TestRunTC:
                     expected_output="No such file or directory",
                 )
 
+
+class TestCallbackOptions:
+    """Test for all callback options we support."""
+
     @staticmethod
-    def test_long_help(capsys: pytest.CaptureFixture[str]) -> None:
-        """Test the long help flag."""
-        with pytest.raises(SystemExit) as ex:
-            Run(["--long-help"])
-        assert ex.value.code == 0
-        output = capsys.readouterr()
-        assert "Environment variables:" in output.out
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            (["--list-msgs"], "Emittable messages with current interpreter:"),
+            (["--list-msgs-enabled"], "Enabled messages:"),
+            (["--list-groups"], "nonascii-checker"),
+            (["--list-conf-levels"], "Confidence(name='HIGH', description="),
+            (["--list-extensions"], "pylint.extensions.empty_comment"),
+            (["--full-documentation"], "Pylint global options and switches"),
+            (["--long-help"], "Environment variables:"),
+        ],
+    )
+    def test_output_of_callback_options(command: List[str], expected: str) -> None:
+        """Test whether certain strings are in the output of a callback command."""
+
+        process = subprocess.run(
+            [sys.executable, "-m", "pylint"] + command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            check=False,
+        )
+        assert expected in process.stdout
+
+    @staticmethod
+    def test_help_msg() -> None:
+        """Test the --help-msg flag."""
+
+        process = subprocess.run(
+            [sys.executable, "-m", "pylint", "--help-msg", "W0101"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            check=False,
+        )
+        assert ":unreachable (W0101)" in process.stdout
+
+        process = subprocess.run(
+            [sys.executable, "-m", "pylint", "--help-msg", "WX101"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            check=False,
+        )
+        assert "No such message id" in process.stdout
+
+        process = subprocess.run(
+            [sys.executable, "-m", "pylint", "--help-msg"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            check=False,
+        )
+        assert "--help-msg: expected at least one argumen" in process.stderr
+
+    @staticmethod
+    def test_generate_rcfile() -> None:
+        """Test the --generate-rcfile flag."""
+        process = subprocess.run(
+            [sys.executable, "-m", "pylint", "--generate-rcfile"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            check=False,
+        )
+        assert "[MASTER]" in process.stdout
+        assert "profile" not in process.stdout
+
+        process_two = subprocess.run(
+            [sys.executable, "-m", "pylint", "--generate-rcfile"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            check=False,
+        )
+        assert process.stdout == process_two.stdout
+
+    @staticmethod
+    def test_errors_only() -> None:
+        """Test the --errors-only flag."""
+        with pytest.raises(SystemExit):
+            run = Run(["--errors-only"])
+            assert run.linter._error_mode
+
+    @staticmethod
+    def test_verbose() -> None:
+        """Test the --verbose flag."""
+        with pytest.raises(SystemExit):
+            run = Run(["--verbose"])
+            assert run.verbose
+
+    @staticmethod
+    def test_enable_all_extensions() -> None:
+        """Test to see if --enable-all-extensions does indeed load all extensions."""
+        # Record all extensions
+        plugins = []
+        for filename in os.listdir(os.path.dirname(extensions.__file__)):
+            if filename.endswith(".py") and not filename.startswith("_"):
+                plugins.append(f"pylint.extensions.{filename[:-3]}")
+
+        # Check if they are loaded
+        runner = Run(
+            ["--enable-all-extensions", join(HERE, "regrtest_data", "empty.py")],
+            exit=False,
+        )
+        assert sorted(plugins) == sorted(runner.linter._dynamic_plugins)

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -475,7 +475,9 @@ class TestRunTC:
         self._test_output(
             [
                 f"--rcfile={config_path}",
-                "--help-msg=dummy-message-01,dummy-message-02",
+                "--help-msg",
+                "dummy-message-01",
+                "dummy-message-02",
             ],
             expected_output=expected,
         )


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This is best viewed from the commit view.

Tried to keep it as short as possible, but it's much easier to do this by flipping the switch once. I'll annotate a little bit.

Essentially after this PR all callback options such as ``--generate-rc-file`` are now handled by `argparse`.