### PR TITLE
Refactor the help message

### DIFF
--- a/pylint/config/argument.py
+++ b/pylint/config/argument.py
@@ -151,13 +151,19 @@ class _Argument:
     https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_argument
     """
 
-    def __init__(self, *, flags: List[str], arg_help: str) -> None:
+    def __init__(self, *, flags: List[str], arg_help: str, hide_help: bool) -> None:
         self.flags = flags
         """The name of the argument."""
+
+        self.hide_help = hide_help
+        """Whether to hide this argument in the help message."""
 
         # argparse uses % formatting on help strings, so a % needs to be escaped
         self.help = arg_help.replace("%", "%%")
         """The description of the argument."""
+
+        if hide_help:
+            self.help = argparse.SUPPRESS
 
 
 class _BaseStoreArgument(_Argument):
@@ -175,8 +181,9 @@ class _BaseStoreArgument(_Argument):
         action: str,
         default: _ArgumentTypes,
         arg_help: str,
+        hide_help: bool,
     ) -> None:
-        super().__init__(flags=flags, arg_help=arg_help)
+        super().__init__(flags=flags, arg_help=arg_help, hide_help=hide_help)
 
         self.action = action
         """The action to perform with the argument."""
@@ -203,8 +210,15 @@ class _StoreArgument(_BaseStoreArgument):
         choices: Optional[List[str]],
         arg_help: str,
         metavar: str,
+        hide_help: bool,
     ) -> None:
-        super().__init__(flags=flags, action=action, default=default, arg_help=arg_help)
+        super().__init__(
+            flags=flags,
+            action=action,
+            default=default,
+            arg_help=arg_help,
+            hide_help=hide_help,
+        )
 
         self.type = _TYPE_TRANSFORMERS[arg_type]
         """A transformer function that returns a transformed type of the argument."""
@@ -239,8 +253,15 @@ class _StoreTrueArgument(_BaseStoreArgument):
         action: Literal["store_true"],
         default: _ArgumentTypes,
         arg_help: str,
+        hide_help: bool,
     ) -> None:
-        super().__init__(flags=flags, action=action, default=default, arg_help=arg_help)
+        super().__init__(
+            flags=flags,
+            action=action,
+            default=default,
+            arg_help=arg_help,
+            hide_help=hide_help,
+        )
 
 
 class _CallableArgument(_Argument):
@@ -258,8 +279,9 @@ class _CallableArgument(_Argument):
         action: Type[_CallbackAction],
         arg_help: str,
         kwargs: Dict[str, Any],
+        hide_help: bool,
     ) -> None:
-        super().__init__(flags=flags, arg_help=arg_help)
+        super().__init__(flags=flags, arg_help=arg_help, hide_help=hide_help)
 
         self.action = action
         """The action to perform with the argument."""

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -14,6 +14,7 @@ from pylint.config.argument import (
     _StoreTrueArgument,
 )
 from pylint.config.exceptions import UnrecognizedArgumentAction
+from pylint.config.help_formatter import _HelpFormatter
 from pylint.config.utils import _convert_option_to_argument
 
 if TYPE_CHECKING:
@@ -27,7 +28,12 @@ class _ArgumentsManager:
         self.namespace = argparse.Namespace()
         """Namespace for all options."""
 
-        self._arg_parser = argparse.ArgumentParser(prog="pylint", allow_abbrev=False)
+        self._arg_parser = argparse.ArgumentParser(
+            prog="pylint",
+            usage="%(prog)s [options]",
+            allow_abbrev=False,
+            formatter_class=_HelpFormatter,
+        )
         """The command line argument parser."""
 
         self._argument_groups_dict: Dict[str, argparse._ArgumentGroup] = {}

--- a/pylint/config/callback_actions.py
+++ b/pylint/config/callback_actions.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments, redefined-builtin
 
 """Callback actions for various options."""
 
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Optional, Sequence, Union
 from pylint import extensions, interfaces, utils
 
 if TYPE_CHECKING:
+    from pylint.config.help_formatter import _HelpFormatter
     from pylint.lint.run import Run
 
 
@@ -59,10 +60,10 @@ class _AccessRunObjectAction(_CallbackAction):
         nargs: None = None,
         const: None = None,
         default: None = None,
-        arg_type: None = None,
+        type: None = None,
         choices: None = None,
         required: bool = False,
-        help_msg: str = "",
+        help: str = "",
         metavar: str = "",
         **kwargs: "Run",
     ) -> None:
@@ -74,10 +75,10 @@ class _AccessRunObjectAction(_CallbackAction):
             0,
             const,
             default,
-            arg_type,
+            type,
             choices,
             required,
-            help_msg,
+            help,
             metavar,
         )
 
@@ -102,10 +103,10 @@ class _MessageHelpAction(_CallbackAction):
         nargs: None = None,
         const: None = None,
         default: None = None,
-        arg_type: None = None,
+        type: None = None,
         choices: None = None,
         required: bool = False,
-        help_msg: str = "",
+        help: str = "",
         metavar: str = "",
         **kwargs: "Run",
     ) -> None:
@@ -116,10 +117,10 @@ class _MessageHelpAction(_CallbackAction):
             "+",
             const,
             default,
-            arg_type,
+            type,
             choices,
             required,
-            help_msg,
+            help,
             metavar,
         )
 
@@ -299,5 +300,10 @@ class _LongHelpAction(_AccessRunObjectAction):
         values: Union[str, Sequence[Any], None],
         option_string: Optional[str] = "--long-help",
     ) -> None:
-        print(self.run.linter.help(1))
+        formatter: "_HelpFormatter" = self.run.linter._arg_parser._get_formatter()
+
+        # Add extra info as epilog to the help message
+        self.run.linter._arg_parser.epilog = formatter.get_long_description()
+        self.run.linter._arg_parser.print_help()
+
         sys.exit(0)

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -100,7 +100,7 @@ def _config_initialization(
     # args_list should now only be a list of files/directories to lint. All options have
     # been removed from the list
     if not parsed_args_list:
-        print(linter.help())
+        linter._arg_parser.print_help()
         sys.exit(32)
 
     return parsed_args_list

--- a/pylint/config/help_formatter.py
+++ b/pylint/config/help_formatter.py
@@ -1,0 +1,65 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+
+import argparse
+from typing import Optional
+
+from pylint.config.callback_actions import _CallbackAction
+from pylint.constants import DEFAULT_PYLINT_HOME, OLD_DEFAULT_PYLINT_HOME
+
+
+class _HelpFormatter(argparse.RawDescriptionHelpFormatter):
+    """Formatter for the help message emitted by argparse."""
+
+    def _get_help_string(self, action: argparse.Action) -> Optional[str]:
+        """Copied from argparse.ArgumentDefaultsHelpFormatter."""
+        assert action.help
+        help_string = action.help
+
+        # CallbackActions don't have a default
+        if isinstance(action, _CallbackAction):
+            return help_string
+
+        if "%(default)" not in help_string:
+            if action.default is not argparse.SUPPRESS:
+                defaulting_nargs = [argparse.OPTIONAL, argparse.ZERO_OR_MORE]
+                if action.option_strings or action.nargs in defaulting_nargs:
+                    help_string += " (default: %(default)s)"
+        return help_string
+
+    @staticmethod
+    def get_long_description() -> str:
+        return f"""
+Environment variables:
+    The following environment variables are used:
+        * PYLINTHOME    Path to the directory where persistent data for the run will
+                        be stored. If not found, it defaults to '{DEFAULT_PYLINT_HOME}'
+                        or '{OLD_DEFAULT_PYLINT_HOME}' (in the current working directory).
+        * PYLINTRC      Path to the configuration file. See the documentation for the method used
+                        to search for configuration file.
+
+Output:
+    Using the default text output, the message format is :
+
+        MESSAGE_TYPE: LINE_NUM:[OBJECT:] MESSAGE
+
+    There are 5 kind of message types :
+        * (I) info,         for informational messages
+        * (C) convention,   for programming standard violation
+        * (R) refactor,     for bad code smell
+        * (W) warning,      for python specific problems
+        * (E) error,        for probable bugs in the code
+        * (F) fatal,        if an error occurred which prevented pylint from doing further processing.
+
+Output status code:
+    Pylint should leave with following bitwise status codes:
+        * 0 if everything went fine
+        * 1 if a fatal message was issued
+        * 2 if an error message was issued
+        * 4 if a warning message was issued
+        * 8 if a refactor message was issued
+        * 16 if a convention message was issued
+        * 32 on usage error
+"""

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -331,15 +331,6 @@ class OptionsManagerMixIn:
                     setattr(config, attr, value)
             return args
 
-    def add_help_section(self, title, description, level=0):
-        """Add a dummy option section for help purpose."""
-        group = optparse.OptionGroup(
-            self.cmdline_parser, title=title.capitalize(), description=description
-        )
-        group.level = level
-        self._maxlevel = max(self._maxlevel, level)
-        self.cmdline_parser.add_option_group(group)
-
     def help(self, level=0):
         """Return the usage string for available options."""
         self.cmdline_parser.formatter.output_level = level

--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -5,6 +5,7 @@
 """Utils for arguments/options parsing and handling."""
 
 
+import warnings
 from typing import Any, Dict, Union
 
 from pylint.config.argument import _CallableArgument, _StoreArgument, _StoreTrueArgument
@@ -15,8 +16,14 @@ def _convert_option_to_argument(
     opt: str, optdict: Dict[str, Any]
 ) -> Union[_StoreArgument, _StoreTrueArgument, _CallableArgument]:
     """Convert an optdict to an Argument class instance."""
+    if "level" in optdict and "hide" not in optdict:
+        warnings.warn(
+            "The 'level' key in optdicts has been deprecated. "
+            "Use 'hide' with a boolean to hide an option from the help message.",
+            DeprecationWarning,
+        )
     # pylint: disable-next=fixme
-    # TODO: Do something with the 'group', 'level' and 'hide' keys of optdicts
+    # TODO: Do something with the 'group' keys of optdicts
 
     # pylint: disable-next=fixme
     # TODO: Do something with the 'dest' key and deprecation of options
@@ -41,6 +48,7 @@ def _convert_option_to_argument(
             action=action,
             default=optdict["default"],
             arg_help=optdict["help"],
+            hide_help=optdict.get("hide", False),
         )
     if not isinstance(action, str) and issubclass(action, _CallbackAction):
         return _CallableArgument(
@@ -48,6 +56,7 @@ def _convert_option_to_argument(
             action=action,
             arg_help=optdict["help"],
             kwargs=optdict["kwargs"],
+            hide_help=optdict.get("hide", False),
         )
     return _StoreArgument(
         flags=flags,
@@ -57,6 +66,7 @@ def _convert_option_to_argument(
         choices=choices,
         arg_help=optdict["help"],
         metavar=optdict["metavar"],
+        hide_help=optdict.get("hide", False),
     )
 
 

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -262,7 +262,6 @@ class PyLinter(
                     "default": True,
                     "type": "yn",
                     "metavar": "<y or n>",
-                    "level": 1,
                     "help": "Pickle collected data for later comparisons.",
                 },
             ),
@@ -272,7 +271,6 @@ class PyLinter(
                     "type": "csv",
                     "metavar": "<modules>",
                     "default": (),
-                    "level": 1,
                     "help": "List of plugins (as comma separated values of "
                     "python module names) to load, usually to register "
                     "additional checkers.",
@@ -310,7 +308,6 @@ class PyLinter(
                     "type": "string",
                     "metavar": "<python_expression>",
                     "group": "Reports",
-                    "level": 1,
                     "default": "max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + "
                     "convention) / statement) * 10))",
                     "help": "Python expression which should return a score less "

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -24,7 +24,7 @@ from pylint.config.callback_actions import (
     _VerboseModeAction,
 )
 from pylint.config.config_initialization import _config_initialization
-from pylint.constants import DEFAULT_PYLINT_HOME, OLD_DEFAULT_PYLINT_HOME, full_version
+from pylint.constants import full_version
 from pylint.lint.pylinter import PyLinter
 from pylint.lint.utils import ArgumentPreprocessingError, preprocess_options
 from pylint.utils import utils
@@ -159,7 +159,6 @@ group are mutually exclusive.",
                         "action": _DoNothingAction,
                         "kwargs": {},
                         "callback": Run._not_implemented_callback,
-                        "level": 1,
                         "help": "Python code to execute, usually for sys.path "
                         "manipulation such as pygtk.require().",
                     },
@@ -182,7 +181,6 @@ group are mutually exclusive.",
                         "kwargs": {"Run": self},
                         "callback": Run._not_implemented_callback,
                         "group": "Commands",
-                        "level": 1,
                         "help": "Display a list of all pylint's messages divided by whether "
                         "they are emittable with the given interpreter.",
                     },
@@ -194,7 +192,6 @@ group are mutually exclusive.",
                         "kwargs": {"Run": self},
                         "callback": Run._not_implemented_callback,
                         "group": "Commands",
-                        "level": 1,
                         "help": "Display a list of what messages are enabled, "
                         "disabled and non-emittable with the given configuration.",
                     },
@@ -206,7 +203,6 @@ group are mutually exclusive.",
                         "kwargs": {"Run": self},
                         "callback": Run._not_implemented_callback,
                         "group": "Commands",
-                        "level": 1,
                         "help": "List pylint's message groups.",
                     },
                 ),
@@ -217,7 +213,6 @@ group are mutually exclusive.",
                         "callback": Run._not_implemented_callback,
                         "kwargs": {"Run": self},
                         "group": "Commands",
-                        "level": 1,
                         "help": "Generate pylint's confidence levels.",
                     },
                 ),
@@ -228,7 +223,6 @@ group are mutually exclusive.",
                         "kwargs": {"Run": self},
                         "callback": Run._not_implemented_callback,
                         "group": "Commands",
-                        "level": 1,
                         "help": "List available extensions.",
                     },
                 ),
@@ -239,7 +233,6 @@ group are mutually exclusive.",
                         "kwargs": {"Run": self},
                         "callback": Run._not_implemented_callback,
                         "group": "Commands",
-                        "level": 1,
                         "help": "Generate pylint's full documentation.",
                     },
                 ),
@@ -307,52 +300,7 @@ group are mutually exclusive.",
         linter.load_default_plugins()
         # load command line plugins
         linter.load_plugin_modules(self._plugins)
-        # add some help section
-        linter.add_help_section(
-            "Environment variables",
-            f"""
-The following environment variables are used:
-    * PYLINTHOME
-    Path to the directory where persistent data for the run will be stored. If
-not found, it defaults to '{DEFAULT_PYLINT_HOME}' or '{OLD_DEFAULT_PYLINT_HOME}'
-(in the current working directory).
-    * PYLINTRC
-    Path to the configuration file. See the documentation for the method used
-to search for configuration file.
-""",
-            level=1,
-        )
-        linter.add_help_section(
-            "Output",
-            "Using the default text output, the message format is :                          \n"
-            "                                                                                \n"
-            "        MESSAGE_TYPE: LINE_NUM:[OBJECT:] MESSAGE                                \n"
-            "                                                                                \n"
-            "There are 5 kind of message types :                                             \n"
-            "    * (C) convention, for programming standard violation                        \n"
-            "    * (R) refactor, for bad code smell                                          \n"
-            "    * (W) warning, for python specific problems                                 \n"
-            "    * (E) error, for probable bugs in the code                                  \n"
-            "    * (F) fatal, if an error occurred which prevented pylint from doing further\n"
-            "processing.\n",
-            level=1,
-        )
-        linter.add_help_section(
-            "Output status code",
-            "Pylint should leave with following status code:                                 \n"
-            "    * 0 if everything went fine                                                 \n"
-            "    * 1 if a fatal message was issued                                           \n"
-            "    * 2 if an error message was issued                                          \n"
-            "    * 4 if a warning message was issued                                         \n"
-            "    * 8 if a refactor message was issued                                        \n"
-            "    * 16 if a convention message was issued                                     \n"
-            "    * 32 on usage error                                                         \n"
-            "                                                                                \n"
-            "status 1 to 16 will be bit-ORed so you can know which different categories has\n"
-            "been issued by analysing pylint output status code\n",
-            level=1,
-        )
-        # read configuration
+
         linter.disable("I")
         linter.enable("c-extension-no-member")
 

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -101,9 +101,13 @@ group are mutually exclusive.",
         exit=True,
         do_exit=UNUSED_PARAM_SENTINEL,
     ):  # pylint: disable=redefined-builtin
+        # Immediately exit if user asks for version
+        if "--version" in args:
+            print(full_version)
+            sys.exit(0)
+
         self._rcfile: Optional[str] = None
         self._output = None
-        self._version_asked = False
         self._plugins = []
         self.verbose = None
         try:
@@ -111,7 +115,6 @@ group are mutually exclusive.",
                 args,
                 {
                     # option: (callback, takearg)
-                    "version": (self.version_asked, False),
                     "init-hook": (cb_init_hook, True),
                     "rcfile": (self.cb_set_rcfile, True),
                     "load-plugins": (self.cb_add_plugins, True),
@@ -301,9 +304,6 @@ group are mutually exclusive.",
             pylintrc=self._rcfile,
         )
         # register standard checkers
-        if self._version_asked:
-            print(full_version)
-            sys.exit(0)
         linter.load_default_plugins()
         # load command line plugins
         linter.load_plugin_modules(self._plugins)
@@ -412,10 +412,6 @@ to search for configuration file.
                     sys.exit(self.linter.msg_status or 1)
             else:
                 sys.exit(self.linter.msg_status)
-
-    def version_asked(self, _, __):
-        """Callback for version (i.e. before option parsing)."""
-        self._version_asked = True
 
     def cb_set_rcfile(self, name: Literal["rcfile"], value: str) -> None:
         """Callback for option preprocessing (i.e. before option parsing)."""


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Blocked by #6143 and #6144

The second to last commit is a short refactor. The other is a refactor of how we generate the help message. I have chosen to deprecate the `level` option as it makes everything way more complicated than it needs to be. Some of the options with `level==1` should arguably be displayed always and it is pretty difficult to retrieve their original `help` message after they have been parsed as `SUPRESS` previously.
I think this makes it a lot simpler and doesn't change that much for the end-user.