### PR TITLE
Fix handling of "for x in x" homonyms

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -66,6 +66,11 @@ Release date: TBA
 
   Closes #6069
 
+* Fix false positive for ``unused-variable`` (in unreleased development) for
+  patterns like ``[_ for same_name in same_name]``.
+
+  Closes #6136
+
 * Narrow the scope of the ``unnecessary-ellipsis`` checker to:
   * functions & classes which contain both a docstring and an ellipsis.
   * A body which contains an ellipsis ``nodes.Expr`` node & at least one other statement.

--- a/ChangeLog
+++ b/ChangeLog
@@ -65,12 +65,7 @@ Release date: TBA
   subscripts in comprehensions.
 
   Closes #6069
-
-* Fix false positive for ``unused-variable`` (in unreleased development) for
-  patterns like ``[_ for same_name in same_name]``.
-
   Closes #6136
-
 * Narrow the scope of the ``unnecessary-ellipsis`` checker to:
   * functions & classes which contain both a docstring and an ellipsis.
   * A body which contains an ellipsis ``nodes.Expr`` node & at least one other statement.

--- a/ChangeLog
+++ b/ChangeLog
@@ -66,6 +66,7 @@ Release date: TBA
 
   Closes #6069
   Closes #6136
+
 * Narrow the scope of the ``unnecessary-ellipsis`` checker to:
   * functions & classes which contain both a docstring and an ellipsis.
   * A body which contains an ellipsis ``nodes.Expr`` node & at least one other statement.

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2305,11 +2305,14 @@ class VariablesChecker(BaseChecker):
             if global_names and _import_name_is_global(stmt, global_names):
                 return
 
+        # Ignore names in comprehension targets
+        if name in comprehension_target_names:
+            return
+
         argnames = node.argnames()
         # Care about functions with unknown argument (builtins)
         if name in argnames:
-            if name not in comprehension_target_names:
-                self._check_unused_arguments(name, node, stmt, argnames, nonlocal_names)
+            self._check_unused_arguments(name, node, stmt, argnames, nonlocal_names)
         else:
             if stmt.parent and isinstance(
                 stmt.parent, (nodes.Assign, nodes.AnnAssign, nodes.Tuple)

--- a/tests/functional/u/undefined/undefined_variable_py38.py
+++ b/tests/functional/u/undefined/undefined_variable_py38.py
@@ -123,7 +123,7 @@ def type_annotation_used_after_comprehension():
 
 def type_annotation_unused_after_comprehension():
     """https://github.com/PyCQA/pylint/issues/5326"""
-    my_int: int  # [unused-variable]
+    my_int: int
     _ = [print(sep=my_int, end=my_int) for my_int in range(10)]
 
 

--- a/tests/functional/u/undefined/undefined_variable_py38.txt
+++ b/tests/functional/u/undefined/undefined_variable_py38.txt
@@ -2,7 +2,6 @@ undefined-variable:42:6:42:16::Undefined variable 'no_default':UNDEFINED
 undefined-variable:50:6:50:22::Undefined variable 'again_no_default':UNDEFINED
 undefined-variable:76:6:76:19::Undefined variable 'else_assign_1':INFERENCE
 undefined-variable:99:6:99:19::Undefined variable 'else_assign_2':INFERENCE
-unused-variable:126:4:126:10:type_annotation_unused_after_comprehension:Unused variable 'my_int':UNDEFINED
 used-before-assignment:134:10:134:16:type_annotation_used_improperly_after_comprehension:Using variable 'my_int' before assignment:HIGH
 used-before-assignment:141:10:141:16:type_annotation_used_improperly_after_comprehension_2:Using variable 'my_int' before assignment:HIGH
 used-before-assignment:171:12:171:16:expression_in_ternary_operator_inside_container_wrong_position:Using variable 'val3' before assignment:HIGH

--- a/tests/functional/u/unused/unused_variable.py
+++ b/tests/functional/u/unused/unused_variable.py
@@ -172,3 +172,10 @@ def main(lst):
     print(e)  # [undefined-loop-variable]
 
 main([])
+
+
+def func5():
+    """No unused-variable for a container if iterated in comprehension"""
+    x = []
+    # Test case requires homonym between "for x" and "in x"
+    assert [True for x in x]


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description


Closes #6136

Extends the fix from #6073. (There, I had to be careful to not emit `unused-argument`, since that's all the test suite alerted me to, but with diffing primer output locally, I noticed the same deal with `unused-variable`. So I handle that the same way.)
