### PR TITLE
Fix version constraint in ``test_messages_documentation``

### DIFF
--- a/doc/test_messages_documentation.py
+++ b/doc/test_messages_documentation.py
@@ -6,7 +6,7 @@
 
 import sys
 
-if sys.version_info[:2] >= (3, 9):
+if sys.version_info[:2] > (3, 9):
     from collections import Counter
 else:
     from collections import Counter as _Counter


### PR DESCRIPTION

- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

[``Counter.total``](https://docs.python.org/3/library/collections.html#collections.Counter.total) was only added in Python 3.10, thus the check for the ``sys.version_info`` must be ``> (3, 9)`` instead ``>= (3, 9)``.