### PR TITLE
Remove TODOs in `unused-variable` tests

### DIFF
--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2356,12 +2356,6 @@ class VariablesChecker(BaseChecker):
             if utils.is_overload_stub(node):
                 return
 
-            # Special case for exception variable
-            if isinstance(stmt.parent, nodes.ExceptHandler) and any(
-                n.name == name for n in stmt.parent.nodes_of_class(nodes.Name)
-            ):
-                return
-
             self.add_message(message_name, args=name, node=stmt)
 
     def _is_name_ignored(self, stmt, name):

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2356,6 +2356,12 @@ class VariablesChecker(BaseChecker):
             if utils.is_overload_stub(node):
                 return
 
+            # Special case for exception variable
+            if isinstance(stmt.parent, nodes.ExceptHandler) and any(
+                n.name == name for n in stmt.parent.nodes_of_class(nodes.Name)
+            ):
+                return
+
             self.add_message(message_name, args=name, node=stmt)
 
     def _is_name_ignored(self, stmt, name):

--- a/tests/functional/u/unused/unused_variable.py
+++ b/tests/functional/u/unused/unused_variable.py
@@ -66,7 +66,7 @@ def hello(arg):
         return True
     raise Exception
 
-# pylint: disable=redefined-outer-name, wrong-import-position,misplaced-future
+# pylint: disable=wrong-import-position,misplaced-future
 from __future__ import print_function
 PATH = OS = collections = deque = None
 
@@ -94,6 +94,7 @@ def test_global():
     """ Test various assignments of global
     variables through imports.
     """
+    # pylint: disable=redefined-outer-name
     global PATH, OS, collections, deque  # [global-variable-not-assigned, global-variable-not-assigned]
     from os import path as PATH
     import os as OS
@@ -111,17 +112,15 @@ def function2():
     try:
         1 / 0
     except ZeroDivisionError as error:
-    # TODO fix bug for not identifying unused variables in nested exceptions see issue #4391
         try:
             1 / 0
-        except ZeroDivisionError as error:
+        except ZeroDivisionError as error:  # [redefined-outer-name]
             raise Exception("") from error
 
 def func():
     try:
         1 / 0
     except ZeroDivisionError as error:
-    # TODO fix bug for not identifying unused variables in nested exceptions see issue #4391
         try:
             1 / 0
         except error:
@@ -131,7 +130,6 @@ def func2():
     try:
         1 / 0
     except ZeroDivisionError as error:
-    # TODO fix bug for not identifying unused variables in nested exceptions see issue #4391
         try:
             1 / 0
         except:
@@ -144,7 +142,7 @@ def func3():
         print(f"{error}")
         try:
             1 / 2
-        except TypeError as error:  # [unused-variable]
+        except TypeError as error:  # [unused-variable, redefined-outer-name]
             print("warning")
 
 def func4():
@@ -153,8 +151,7 @@ def func4():
     except ZeroDivisionError as error:  # [unused-variable]
         try:
             1 / 0
-        except ZeroDivisionError as error:
-            # TODO fix bug for not identifying unused variables in nested exceptions see issue #4391
+        except ZeroDivisionError as error:  # [redefined-outer-name]
             print("error")
 
 

--- a/tests/functional/u/unused/unused_variable.txt
+++ b/tests/functional/u/unused/unused_variable.txt
@@ -13,14 +13,17 @@ unused-import:55:4:55:38:unused_import_from:Unused namedtuple imported from coll
 unused-import:59:4:59:40:unused_import_in_function:Unused hexdigits imported from string:UNDEFINED
 unused-variable:64:4:64:10:hello:Unused variable 'my_var':UNDEFINED
 unused-variable:76:4:76:8:function:Unused variable 'aaaa':UNDEFINED
-global-variable-not-assigned:97:4:97:39:test_global:Using global for 'PATH' but no assignment is done:UNDEFINED
-global-variable-not-assigned:97:4:97:39:test_global:Using global for 'deque' but no assignment is done:UNDEFINED
-unused-import:103:4:103:28:test_global:Unused platform imported from sys:UNDEFINED
-unused-import:104:4:104:38:test_global:Unused version imported from sys as VERSION:UNDEFINED
-unused-import:105:4:105:15:test_global:Unused import this:UNDEFINED
-unused-import:106:4:106:19:test_global:Unused re imported as RE:UNDEFINED
-unused-variable:110:4:110:10:function2:Unused variable 'unused':UNDEFINED
-unused-variable:147:8:148:28:func3:Unused variable 'error':UNDEFINED
-unused-variable:153:4:158:26:func4:Unused variable 'error':UNDEFINED
-unused-variable:165:4:166:12:main:Unused variable 'e':UNDEFINED
-undefined-loop-variable:172:10:172:11:main:Using possibly undefined loop variable 'e':UNDEFINED
+global-variable-not-assigned:98:4:98:39:test_global:Using global for 'PATH' but no assignment is done:UNDEFINED
+global-variable-not-assigned:98:4:98:39:test_global:Using global for 'deque' but no assignment is done:UNDEFINED
+unused-import:104:4:104:28:test_global:Unused platform imported from sys:UNDEFINED
+unused-import:105:4:105:38:test_global:Unused version imported from sys as VERSION:UNDEFINED
+unused-import:106:4:106:15:test_global:Unused import this:UNDEFINED
+unused-import:107:4:107:19:test_global:Unused re imported as RE:UNDEFINED
+unused-variable:111:4:111:10:function2:Unused variable 'unused':UNDEFINED
+redefined-outer-name:117:8:118:42:function2:Redefining name 'error' from outer scope (line 114):UNDEFINED
+redefined-outer-name:145:8:146:28:func3:Redefining name 'error' from outer scope (line 141):UNDEFINED
+unused-variable:145:8:146:28:func3:Unused variable 'error':UNDEFINED
+unused-variable:151:4:155:26:func4:Unused variable 'error':UNDEFINED
+redefined-outer-name:154:8:155:26:func4:Redefining name 'error' from outer scope (line 151):UNDEFINED
+unused-variable:162:4:163:12:main:Unused variable 'e':UNDEFINED
+undefined-loop-variable:169:10:169:11:main:Using possibly undefined loop variable 'e':UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
Per discussion on #4391, which we closed, I think we can stick to the one-warning-per-variable-per-scope contract, so these TODOs are out of date.

If we want to look into adding warnings, we can do it more broadly in #5838.
