### PR TITLE
Deprecate ignore-mixin-members + add ignored-checks-for-mixins

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -42,6 +42,11 @@ Release date: TBA
 
   Closes #578
 
+* The ``ignore-mixin-members`` option has been deprecated. You should now use the new
+  ``ignored-checks-for-mixins`` option.
+
+  Closes #5205
+
 * Added new checker ``unnecessary-list-index-lookup`` for indexing into a list while
   iterating over ``enumerate()``.
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -257,10 +257,9 @@ methods is doing nothing but raising NotImplementedError.
 5.2 How do I avoid "access to undefined member" messages in my mixin classes?
 -------------------------------------------------------------------------------
 
-To do so you have to set the ignore-mixin-members option to
-"yes" (this is the default value) and name your mixin class with
-a name which ends with "Mixin" or "mixin" (default) or change the
-default value by changing the mixin-class-rgx option.
+You should add the ``no-member`` message to your ``ignored-checks-for-mixins`` option
+and name your mixin class with a name which ends with "Mixin" or "mixin" (default)
+or change the default value by changing the ``mixin-class-rgx`` option.
 
 
 6. Troubleshooting

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -69,6 +69,11 @@ Other Changes
 
 * The ``set_config_directly`` decorator has been removed.
 
+* The ``ignore-mixin-members`` option has been deprecated. You should now use the new
+  ``ignored-checks-for-mixins`` option.
+
+  Closes #5205
+
 * Fix false negative for ``no-member`` when attempting to assign an instance
   attribute to itself without any prior assignment.
 

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -178,10 +178,6 @@ contextmanager-decorators=contextlib.contextmanager
 # expressions are accepted.
 generated-members=
 
-# Tells whether missing members accessed in mixin class should be ignored. A
-# mixin class is detected if its name ends with "mixin" (case insensitive).
-ignore-mixin-members=yes
-
 # Tells whether to warn about missing members when the owner of the attribute
 # is inferred to be None.
 ignore-none=yes

--- a/pylint/checkers/async.py
+++ b/pylint/checkers/async.py
@@ -38,10 +38,10 @@ class AsyncChecker(checkers.BaseChecker):
         ),
     }
 
+    def __init__(self, linter: "PyLinter") -> None:
+        super().__init__(linter, future_option_parsing=True)
+
     def open(self):
-        self._ignore_mixin_members = utils.get_global_option(
-            self, "ignore-mixin-members"
-        )
         self._mixin_class_rgx = utils.get_global_option(self, "mixin-class-rgx")
         self._async_generators = ["contextlib.asynccontextmanager"]
 
@@ -81,8 +81,10 @@ class AsyncChecker(checkers.BaseChecker):
                         if not checker_utils.has_known_bases(inferred):
                             continue
                         # Ignore mixin classes if they match the rgx option.
-                        if self._ignore_mixin_members and self._mixin_class_rgx.match(
-                            inferred.name
+                        if (
+                            "not-async-context-manager"
+                            in self.linter.namespace.ignored_checks_for_mixins
+                            and self._mixin_class_rgx.match(inferred.name)
                         ):
                             continue
                 else:

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -780,10 +780,6 @@ a metaclass class method.",
     def _dummy_rgx(self):
         return get_global_option(self, "dummy-variables-rgx", default=None)
 
-    @cached_property
-    def _ignore_mixin(self):
-        return get_global_option(self, "ignore-mixin-members", default=True)
-
     @check_messages(
         "abstract-method",
         "no-init",
@@ -1026,7 +1022,11 @@ a metaclass class method.",
 
     def _check_attribute_defined_outside_init(self, cnode: nodes.ClassDef) -> None:
         # check access to existent members on non metaclass classes
-        if self._ignore_mixin and self._mixin_class_rgx.match(cnode.name):
+        if (
+            "attribute-defined-outside-init"
+            in self.linter.namespace.ignored_checks_for_mixins
+            and self._mixin_class_rgx.match(cnode.name)
+        ):
             # We are in a mixin class. No need to try to figure out if
             # something is missing, since it is most likely that it will
             # miss.

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -764,8 +764,7 @@ class TypeChecker(BaseChecker):
                 "default": ".*[Mm]ixin",
                 "type": "regexp",
                 "metavar": "<regexp>",
-                "help": "Regex pattern to define which classes are considered mixins "
-                "ignore-mixin-members is set to 'yes'",
+                "help": "Regex pattern to define which classes are considered mixins.",
             },
         ),
         (
@@ -777,6 +776,21 @@ class TypeChecker(BaseChecker):
                 "help": "Tells whether missing members accessed in mixin "
                 "class should be ignored. A class is considered mixin if its name matches "
                 "the mixin-class-rgx option.",
+                "kwargs": {"new_names": ["ignore-checks-for-mixin"]},
+            },
+        ),
+        (
+            "ignored-checks-for-mixins",
+            {
+                "default": [
+                    "no-member",
+                    "not-async-context-manager",
+                    "not-context-manager",
+                    "attribute-defined-outside-init",
+                ],
+                "type": "csv",
+                "metavar": "<list of messages names>",
+                "help": "List of symbolic message names to ignore for Mixin members.",
             },
         ),
         (
@@ -1030,7 +1044,9 @@ accessed. Python regular expressions are accepted.",
                     owner,
                     name,
                     self._mixin_class_rgx,
-                    ignored_mixins=self.linter.namespace.ignore_mixin_members,
+                    ignored_mixins=(
+                        "no-member" in self.linter.namespace.ignored_checks_for_mixins
+                    ),
                     ignored_none=self.linter.namespace.ignore_none,
                 ):
                     continue
@@ -1762,7 +1778,10 @@ accessed. Python regular expressions are accepted.",
                         if not has_known_bases(inferred):
                             continue
                         # Just ignore mixin classes.
-                        if self.linter.namespace.ignore_mixin_members:
+                        if (
+                            "not-context-manager"
+                            in self.linter.namespace.ignored_checks_for_mixins
+                        ):
                             if inferred.name[-5:].lower() == "mixin":
                                 continue
 

--- a/pylint/config/argument.py
+++ b/pylint/config/argument.py
@@ -28,6 +28,7 @@ from typing import (
 from pylint import interfaces
 from pylint import utils as pylint_utils
 from pylint.config.callback_actions import _CallbackAction
+from pylint.config.deprecation_actions import _NewNamesAction, _OldNamesAction
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -262,6 +263,121 @@ class _StoreTrueArgument(_BaseStoreArgument):
             arg_help=arg_help,
             hide_help=hide_help,
         )
+
+
+class _DeprecationArgument(_Argument):
+    """Store arguments while also handling deprecation warnings for old and new names.
+
+    This is based on the parameters passed to argparse.ArgumentsParser.add_message.
+    See:
+    https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_argument
+    """
+
+    def __init__(
+        self,
+        *,
+        flags: List[str],
+        action: Type[argparse._StoreAction],
+        default: _ArgumentTypes,
+        arg_type: str,
+        choices: Optional[List[str]],
+        arg_help: str,
+        metavar: str,
+        hide_help: bool,
+    ) -> None:
+        super().__init__(flags=flags, arg_help=arg_help, hide_help=hide_help)
+
+        self.action = action
+        """The action to perform with the argument."""
+
+        self.default = default
+        """The default value of the argument."""
+
+        self.type = _TYPE_TRANSFORMERS[arg_type]
+        """A transformer function that returns a transformed type of the argument."""
+
+        self.choices = choices
+        """A list of possible choices for the argument.
+
+        None if there are no restrictions.
+        """
+
+        self.metavar = metavar
+        """The metavar of the argument.
+
+        See:
+        https://docs.python.org/3/library/argparse.html#metavar
+        """
+
+
+class _StoreOldNamesArgument(_DeprecationArgument):
+    """Store arguments while also handling old names.
+
+    This is based on the parameters passed to argparse.ArgumentsParser.add_message.
+    See:
+    https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_argument
+    """
+
+    def __init__(
+        self,
+        *,
+        flags: List[str],
+        default: _ArgumentTypes,
+        arg_type: str,
+        choices: Optional[List[str]],
+        arg_help: str,
+        metavar: str,
+        hide_help: bool,
+        kwargs: Dict[str, Any],
+    ) -> None:
+        super().__init__(
+            flags=flags,
+            action=_OldNamesAction,
+            default=default,
+            arg_type=arg_type,
+            choices=choices,
+            arg_help=arg_help,
+            metavar=metavar,
+            hide_help=hide_help,
+        )
+
+        self.kwargs = kwargs
+        """Any additional arguments passed to the action."""
+
+
+class _StoreNewNamesArgument(_DeprecationArgument):
+    """Store arguments while also emitting deprecation warnings.
+
+    This is based on the parameters passed to argparse.ArgumentsParser.add_message.
+    See:
+    https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_argument
+    """
+
+    def __init__(
+        self,
+        *,
+        flags: List[str],
+        default: _ArgumentTypes,
+        arg_type: str,
+        choices: Optional[List[str]],
+        arg_help: str,
+        metavar: str,
+        hide_help: bool,
+        kwargs: Dict[str, Any],
+    ) -> None:
+        super().__init__(
+            flags=flags,
+            action=_NewNamesAction,
+            default=default,
+            arg_type=arg_type,
+            choices=choices,
+            arg_help=arg_help,
+            metavar=metavar,
+            hide_help=hide_help,
+        )
+
+        self.kwargs = kwargs
+        """Any additional arguments passed to the action."""
 
 
 class _CallableArgument(_Argument):

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -11,6 +11,8 @@ from pylint.config.argument import (
     _Argument,
     _CallableArgument,
     _StoreArgument,
+    _StoreNewNamesArgument,
+    _StoreOldNamesArgument,
     _StoreTrueArgument,
 )
 from pylint.config.exceptions import UnrecognizedArgumentAction
@@ -71,6 +73,41 @@ class _ArgumentsManager:
         if isinstance(argument, _StoreArgument):
             section_group.add_argument(
                 *argument.flags,
+                action=argument.action,
+                default=argument.default,
+                type=argument.type,  # type: ignore[arg-type] # incorrect typing in typeshed
+                help=argument.help,
+                metavar=argument.metavar,
+                choices=argument.choices,
+            )
+        elif isinstance(argument, _StoreOldNamesArgument):
+            section_group.add_argument(
+                *argument.flags,
+                **argument.kwargs,
+                action=argument.action,
+                default=argument.default,
+                type=argument.type,  # type: ignore[arg-type] # incorrect typing in typeshed
+                help=argument.help,
+                metavar=argument.metavar,
+                choices=argument.choices,
+            )
+            # We add the old name as hidden option to make it's default value gets loaded when
+            # argparse initializes all options from the checker
+            assert argument.kwargs["old_names"]
+            for old_name in argument.kwargs["old_names"]:
+                section_group.add_argument(
+                    f"--{old_name}",
+                    action="store",
+                    default=argument.default,
+                    type=argument.type,  # type: ignore[arg-type] # incorrect typing in typeshed
+                    help=argparse.SUPPRESS,
+                    metavar=argument.metavar,
+                    choices=argument.choices,
+                )
+        elif isinstance(argument, _StoreNewNamesArgument):
+            section_group.add_argument(
+                *argument.flags,
+                **argument.kwargs,
                 action=argument.action,
                 default=argument.default,
                 type=argument.type,  # type: ignore[arg-type] # incorrect typing in typeshed

--- a/pylint/config/deprecation_actions.py
+++ b/pylint/config/deprecation_actions.py
@@ -1,0 +1,104 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+# pylint: disable=too-many-arguments, redefined-builtin
+
+"""Deprecated option actions."""
+
+import argparse
+import warnings
+from typing import Any, List, Optional, Sequence, Union
+
+
+class _OldNamesAction(argparse._StoreAction):
+    """Store action that also sets the value to old names."""
+
+    def __init__(
+        self,
+        option_strings: Sequence[str],
+        dest: str,
+        nargs: None = None,
+        const: None = None,
+        default: None = None,
+        type: None = None,
+        choices: None = None,
+        required: bool = False,
+        help: str = "",
+        metavar: str = "",
+        old_names: Optional[List[str]] = None,
+    ) -> None:
+        assert old_names
+        self.old_names = old_names
+        super().__init__(
+            option_strings,
+            dest,
+            "+",
+            const,
+            default,
+            type,
+            choices,
+            required,
+            help,
+            metavar,
+        )
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = None,
+    ):
+        assert isinstance(values, list)
+        setattr(namespace, self.dest, values[0])
+        for old_name in self.old_names:
+            setattr(namespace, old_name, values[0])
+
+
+class _NewNamesAction(argparse._StoreAction):
+    """Store action that also emits a deprecation warning about a new name."""
+
+    def __init__(
+        self,
+        option_strings: Sequence[str],
+        dest: str,
+        nargs: None = None,
+        const: None = None,
+        default: None = None,
+        type: None = None,
+        choices: None = None,
+        required: bool = False,
+        help: str = "",
+        metavar: str = "",
+        new_names: Optional[List[str]] = None,
+    ) -> None:
+        assert new_names
+        self.new_names = new_names
+        super().__init__(
+            option_strings,
+            dest,
+            "+",
+            const,
+            default,
+            type,
+            choices,
+            required,
+            help,
+            metavar,
+        )
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = None,
+    ):
+        assert isinstance(values, list)
+        setattr(namespace, self.dest, values[0])
+        warnings.warn(
+            f"{self.option_strings[0]} has been deprecated. Please look into "
+            f"using any of the following options: {', '.join(self.new_names)}.",
+            DeprecationWarning,
+        )

--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -10,7 +10,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 from pylint import extensions, utils
-from pylint.config.argument import _CallableArgument, _StoreArgument, _StoreTrueArgument
+from pylint.config.argument import (
+    _CallableArgument,
+    _StoreArgument,
+    _StoreNewNamesArgument,
+    _StoreOldNamesArgument,
+    _StoreTrueArgument,
+)
 from pylint.config.callback_actions import _CallbackAction
 from pylint.config.exceptions import ArgumentPreprocessingError
 
@@ -20,7 +26,13 @@ if TYPE_CHECKING:
 
 def _convert_option_to_argument(
     opt: str, optdict: Dict[str, Any]
-) -> Union[_StoreArgument, _StoreTrueArgument, _CallableArgument]:
+) -> Union[
+    _StoreArgument,
+    _StoreTrueArgument,
+    _CallableArgument,
+    _StoreOldNamesArgument,
+    _StoreNewNamesArgument,
+]:
     """Convert an optdict to an Argument class instance."""
     if "level" in optdict and "hide" not in optdict:
         warnings.warn(
@@ -30,9 +42,6 @@ def _convert_option_to_argument(
         )
     # pylint: disable-next=fixme
     # TODO: Do something with the 'group' keys of optdicts
-
-    # pylint: disable-next=fixme
-    # TODO: Do something with the 'dest' key and deprecation of options
 
     # Get the long and short flags
     flags = [f"--{opt}"]
@@ -63,6 +72,40 @@ def _convert_option_to_argument(
             arg_help=optdict["help"],
             kwargs=optdict["kwargs"],
             hide_help=optdict.get("hide", False),
+        )
+    if "kwargs" in optdict:
+        if "old_names" in optdict["kwargs"]:
+            return _StoreOldNamesArgument(
+                flags=flags,
+                default=optdict["default"],
+                arg_type=optdict["type"],
+                choices=choices,
+                arg_help=optdict["help"],
+                metavar=optdict["metavar"],
+                hide_help=optdict.get("hide", False),
+                kwargs=optdict["kwargs"],
+            )
+        if "new_names" in optdict["kwargs"]:
+            return _StoreNewNamesArgument(
+                flags=flags,
+                default=optdict["default"],
+                arg_type=optdict["type"],
+                choices=choices,
+                arg_help=optdict["help"],
+                metavar=optdict["metavar"],
+                hide_help=optdict.get("hide", False),
+                kwargs=optdict["kwargs"],
+            )
+    if "dest" in optdict:
+        return _StoreOldNamesArgument(
+            flags=flags,
+            default=optdict["default"],
+            arg_type=optdict["type"],
+            choices=choices,
+            arg_help=optdict["help"],
+            metavar=optdict["metavar"],
+            hide_help=optdict.get("hide", False),
+            kwargs={"old_names": [optdict["dest"]]},
         )
     return _StoreArgument(
         flags=flags,

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -228,6 +228,7 @@ class PyLinter(
                     "type": "csv",
                     "metavar": "<file>[,<file>...]",
                     "dest": "black_list",
+                    "kwargs": {"old_names": ["black_list"]},
                     "default": ("CVS",),
                     "help": "Files or directories to be skipped. "
                     "They should be base names, not paths.",

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -49,7 +49,6 @@ DEFAULT_LINE_LENGTH = 79
 
 # These are types used to overload get_global_option() and refer to the options type
 GLOBAL_OPTION_BOOL = Literal[
-    "ignore-mixin-members",
     "suggestion-mode",
     "analyse-fallback-blocks",
     "allow-global-unused-variables",

--- a/pylintrc
+++ b/pylintrc
@@ -371,10 +371,6 @@ property-classes=abc.abstractproperty
 
 [TYPECHECK]
 
-# Tells whether missing members accessed in mixin class should be ignored.
-# A class is considered mixin if its name matches the mixin-class-rgx option.
-ignore-mixin-members=yes
-
 # Regex pattern to define which classes are considered mixins if ignore-mixin-
 # members is set to 'yes'
 mixin-class-rgx=.*MixIn

--- a/tests/functional/m/mixin_class_rgx.rc
+++ b/tests/functional/m/mixin_class_rgx.rc
@@ -1,3 +1,2 @@
 [TYPECHECK]
-ignore-mixin-members=yes
 mixin-class-rgx=.*[Mm]ixin


### PR DESCRIPTION
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

Closes #5205.

Finally, the first real new option that comes from this migration. With the use of `new_names` and `old_names` we can now deprecate options and warn about them accordingly.

I have applied it to two options already.