### PR TITLE
Refactors in preparation of using ``namespace`` in ``PyLinter``

### DIFF
--- a/pylint/config/argument.py
+++ b/pylint/config/argument.py
@@ -91,7 +91,7 @@ def _non_empty_string_transformer(value: str) -> str:
 def _py_version_transformer(value: str) -> Tuple[int, ...]:
     """Transforms a version string into a version tuple."""
     try:
-        version = tuple(int(val) for val in value.split("."))
+        version = tuple(int(val) for val in value.replace(",", ".").split("."))
     except ValueError:
         raise argparse.ArgumentTypeError(
             f"{value} has an invalid format, should be a version string. E.g., '3.8'"

--- a/pylint/config/callback_actions.py
+++ b/pylint/config/callback_actions.py
@@ -257,7 +257,7 @@ class _ErrorsOnlyModeAction(_AccessRunObjectAction):
         values: Union[str, Sequence[Any], None],
         option_string: Optional[str] = "--errors-only",
     ) -> None:
-        self.run.linter.error_mode()
+        self.run.linter._error_mode = True
 
 
 class _LongHelpAction(_AccessRunObjectAction):

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -103,4 +103,6 @@ def _config_initialization(
         linter._arg_parser.print_help()
         sys.exit(32)
 
+    linter._parse_error_mode()
+
     return parsed_args_list

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -190,10 +190,10 @@ MSGS = {
 
 # pylint: disable=too-many-instance-attributes,too-many-public-methods
 class PyLinter(
+    _ArgumentsManager,
     config.OptionsManagerMixIn,
     reporters.ReportsHandlerMixIn,
     checkers.BaseTokenChecker,
-    _ArgumentsManager,
 ):
     """Lint Python modules using external checkers.
 

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -831,9 +831,14 @@ class PyLinter(
             for report_id, _, _ in _reporters:
                 self.disable_report(report_id)
 
-    def error_mode(self):
-        """Error mode: enable only errors; no reports, no persistent."""
-        self._error_mode = True
+    def _parse_error_mode(self) -> None:
+        """Parse the current state of the error mode.
+
+        Error mode: enable only errors; no reports, no persistent.
+        """
+        if not self._error_mode:
+            return
+
         self.disable_noerror_messages()
         self.disable("miscellaneous")
         self.set_option("reports", False)

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -392,7 +392,8 @@ def test_enable_checkers(linter: PyLinter) -> None:
 
 def test_errors_only(initialized_linter: PyLinter) -> None:
     linter = initialized_linter
-    linter.error_mode()
+    linter._error_mode = True
+    linter._parse_error_mode()
     checkers = linter.prepare_checkers()
     checker_names = {c.name for c in checkers}
     should_not = {"design", "format", "metrics", "miscellaneous", "similarities"}

--- a/tests/test_regr.py
+++ b/tests/test_regr.py
@@ -122,13 +122,13 @@ def test_pylint_config_attr() -> None:
     mod = astroid.MANAGER.ast_from_module_name("pylint.lint.pylinter")
     pylinter = mod["PyLinter"]
     expect = [
-        "OptionsManagerMixIn",
+        "_ArgumentsManager",
         "object",
+        "OptionsManagerMixIn",
         "ReportsHandlerMixIn",
         "BaseTokenChecker",
         "BaseChecker",
         "OptionsProviderMixIn",
-        "_ArgumentsManager",
     ]
     assert [c.name for c in pylinter.ancestors()] == expect
     assert list(astroid.Instance(pylinter).getattr("config"))


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Blocked by #6173.

Three small commits to fix some stuff that will break as soon as we change `self.config` to `self.namespace` in `PyLinter`.
