### PR TITLE
Prevent `used-before-assignment` for assignment via nonlocal after type annotation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -71,6 +71,11 @@ Release date: TBA
   * functions & classes which contain both a docstring and an ellipsis.
   * A body which contains an ellipsis ``nodes.Expr`` node & at least one other statement.
 
+* Fix false positive for ``used-before-assignment`` for assignments taking place via
+  nonlocal declarations after an earlier type annotation.
+
+  Closes #5394
+
 * Fix crash for ``redefined-slots-in-subclass`` when the type of the slot is not a const or a string.
 
   Closes #6100

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -571,6 +571,11 @@ Other Changes
 
   Closes #5803
 
+* Fix false positive for ``used-before-assignment`` for assignments taking place via
+  nonlocal declarations after an earlier type annotation.
+
+  Closes #5394
+
 * Fix false positive for 'nonexistent-operator' when repeated '-' are
   separated (e.g. by parens).
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2088,6 +2088,20 @@ class VariablesChecker(BaseChecker):
         parent = node
         while parent is not defstmt_frame.parent:
             parent_scope = parent.scope()
+
+            # Find out if any nonlocals receive values in nested functions
+            for inner_func in parent_scope.nodes_of_class(nodes.FunctionDef):
+                if inner_func is parent_scope:
+                    continue
+                if any(
+                    node.name in nl.names
+                    for nl in inner_func.nodes_of_class(nodes.Nonlocal)
+                ) and any(
+                    node.name == an.name
+                    for an in inner_func.nodes_of_class(nodes.AssignName)
+                ):
+                    return False
+
             local_refs = parent_scope.locals.get(node.name, [])
             for ref_node in local_refs:
                 # If local ref is in the same frame as our node, but on a later lineno

--- a/tests/functional/u/used/used_before_assignment_nonlocal.py
+++ b/tests/functional/u/used/used_before_assignment_nonlocal.py
@@ -58,3 +58,35 @@ def nonlocal_in_ifexp():
     on_click(True)
 
 nonlocal_in_ifexp()
+
+
+def type_annotation_only_gets_value_via_nonlocal():
+    """https://github.com/PyCQA/pylint/issues/5394"""
+    some_num: int
+    def inner():
+        nonlocal some_num
+        some_num = 5
+    inner()
+    print(some_num)
+
+
+def type_annotation_only_gets_value_via_nonlocal_nested():
+    """Similar, with nesting"""
+    some_num: int
+    def inner():
+        def inner2():
+            nonlocal some_num
+            if (some_num := 5):
+                pass
+        inner2()
+    inner()
+    print(some_num)
+
+
+def type_annotation_never_gets_value_despite_nonlocal():
+    """Type annotation lacks a value despite nonlocal declaration"""
+    some_num: int
+    def inner():
+        nonlocal some_num
+    inner()
+    print(some_num)  # [used-before-assignment]

--- a/tests/functional/u/used/used_before_assignment_nonlocal.py
+++ b/tests/functional/u/used/used_before_assignment_nonlocal.py
@@ -76,8 +76,7 @@ def type_annotation_only_gets_value_via_nonlocal_nested():
     def inner():
         def inner2():
             nonlocal some_num
-            if (some_num := 5):
-                pass
+            some_num = 5
         inner2()
     inner()
     print(some_num)

--- a/tests/functional/u/used/used_before_assignment_nonlocal.txt
+++ b/tests/functional/u/used/used_before_assignment_nonlocal.txt
@@ -4,3 +4,4 @@ used-before-assignment:30:20:30:30:test_fail3:Using variable 'test_fail4' before
 used-before-assignment:34:22:34:32:test_fail4:Using variable 'test_fail5' before assignment:HIGH
 used-before-assignment:34:44:34:53:test_fail4:Using variable 'undefined' before assignment:HIGH
 used-before-assignment:40:18:40:28:test_fail5:Using variable 'undefined1' before assignment:HIGH
+used-before-assignment:92:10:92:18:type_annotation_never_gets_value_despite_nonlocal:Using variable 'some_num' before assignment:HIGH

--- a/tests/functional/u/used/used_before_assignment_nonlocal.txt
+++ b/tests/functional/u/used/used_before_assignment_nonlocal.txt
@@ -4,4 +4,4 @@ used-before-assignment:30:20:30:30:test_fail3:Using variable 'test_fail4' before
 used-before-assignment:34:22:34:32:test_fail4:Using variable 'test_fail5' before assignment:HIGH
 used-before-assignment:34:44:34:53:test_fail4:Using variable 'undefined' before assignment:HIGH
 used-before-assignment:40:18:40:28:test_fail5:Using variable 'undefined1' before assignment:HIGH
-used-before-assignment:92:10:92:18:type_annotation_never_gets_value_despite_nonlocal:Using variable 'some_num' before assignment:HIGH
+used-before-assignment:91:10:91:18:type_annotation_never_gets_value_despite_nonlocal:Using variable 'some_num' before assignment:HIGH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

I think it's important to solve the false positive instead of worrying too much about the possibility of false negatives from control-flow (for instance, if the inner function is never called).

Closes #5394
