### PR TITLE
Create ``_ArgumentsProvider``

### DIFF
--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 from astroid import nodes
 
 from pylint.config import OptionsProviderMixIn
+from pylint.config.arguments_provider import _ArgumentsProvider
 from pylint.config.exceptions import MissingArgumentManager
 from pylint.constants import _MSG_ORDER, WarningScope
 from pylint.exceptions import InvalidMessageError
@@ -25,7 +26,7 @@ else:
 
 
 @functools.total_ordering
-class BaseChecker(OptionsProviderMixIn):
+class BaseChecker(_ArgumentsProvider, OptionsProviderMixIn):
 
     # checker name (you may reuse an existing one)
     name: str = ""
@@ -51,14 +52,14 @@ class BaseChecker(OptionsProviderMixIn):
         if self.name is not None:
             self.name = self.name.lower()
         self.linter = linter
-        super().__init__()
+        OptionsProviderMixIn.__init__(self)
 
         if future_option_parsing:
             # We need a PyLinter object that subclasses _ArgumentsManager to register options
-            if not self.linter:
+            if not linter:
                 raise MissingArgumentManager
 
-            self.linter._register_options_provider(self)
+            _ArgumentsProvider.__init__(self, linter)
 
     def __gt__(self, other):
         """Permit to sort a list of Checker by name."""

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -27,13 +27,13 @@ if TYPE_CHECKING:
 class _ArgumentsManager:
     """Arguments manager class used to handle command-line arguments and options."""
 
-    def __init__(self) -> None:
+    def __init__(self, prog: str, usage: Optional[str] = None) -> None:
         self.namespace = argparse.Namespace()
         """Namespace for all options."""
 
         self._arg_parser = argparse.ArgumentParser(
-            prog="pylint",
-            usage="%(prog)s [options]",
+            prog=prog,
+            usage=usage or "%(prog)s [options]",
             formatter_class=_HelpFormatter,
         )
         """The command line argument parser."""

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -21,7 +21,7 @@ from pylint.config.help_formatter import _HelpFormatter
 from pylint.config.utils import _convert_option_to_argument
 
 if TYPE_CHECKING:
-    from pylint import checkers
+    from pylint.config.arguments_provider import _ArgumentsProvider
 
 
 class _ArgumentsManager:
@@ -41,7 +41,7 @@ class _ArgumentsManager:
         self._argument_groups_dict: Dict[str, argparse._ArgumentGroup] = {}
         """Dictionary of all the argument groups."""
 
-    def _register_options_provider(self, provider: "checkers.BaseChecker") -> None:
+    def _register_options_provider(self, provider: "_ArgumentsProvider") -> None:
         """Register an options provider and load its defaults."""
         for opt, optdict in provider.options:
             argument = _convert_option_to_argument(opt, optdict)

--- a/pylint/config/arguments_provider.py
+++ b/pylint/config/arguments_provider.py
@@ -1,0 +1,23 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Arguments provider class used to expose options."""
+
+
+from pylint.config.arguments_manager import _ArgumentsManager
+from pylint.typing import Options
+
+
+class _ArgumentsProvider:
+    """Base class for classes that provide arguments."""
+
+    name: str
+
+    options: Options = ()
+
+    def __init__(self, arguments_manager: _ArgumentsManager) -> None:
+        self._arguments_manager = arguments_manager
+        """The manager that will parse and register any options provided."""
+
+        self._arguments_manager._register_options_provider(self)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -558,7 +558,7 @@ class PyLinter(
         # TODO: Deprecate passing the pylintrc parameter
         pylintrc: Optional[str] = None,  # pylint: disable=unused-argument
     ) -> None:
-        _ArgumentsManager.__init__(self)
+        _ArgumentsManager.__init__(self, prog="pylint")
 
         # Some stuff has to be done before initialization of other ancestors...
         # messages store / checkers / reporter / astroid manager

--- a/pylint/testutils/unittest_linter.py
+++ b/pylint/testutils/unittest_linter.py
@@ -21,7 +21,7 @@ class UnittestLinter(_ArgumentsManager):
     def __init__(self):
         self._messages = []
         self.stats = LinterStats()
-        _ArgumentsManager.__init__(self)
+        _ArgumentsManager.__init__(self, "pylint")
 
     def release_messages(self):
         try:

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -710,7 +710,7 @@ def test_pylintrc_parentdir_no_package() -> None:
                     assert config.find_pylintrc() == expected
 
 
-class _CustomPyLinter(PyLinter):
+class _CustomPyLinter(PyLinter):  # pylint: disable=too-many-ancestors
     @staticmethod
     def should_analyze_file(modname: str, path: str, is_argument: bool = False) -> bool:
         if os.path.basename(path) == "wrong.py":

--- a/tests/test_regr.py
+++ b/tests/test_regr.py
@@ -128,6 +128,7 @@ def test_pylint_config_attr() -> None:
         "ReportsHandlerMixIn",
         "BaseTokenChecker",
         "BaseChecker",
+        "_ArgumentsProvider",
         "OptionsProviderMixIn",
     ]
     assert [c.name for c in pylinter.ancestors()] == expect


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Blocked by #6183.

Turns out we do need `ArgumentsProvider` for our configuration stuff to work with `pyreverse`. I am planning to cut out some of the additional boilerplate though 😄 