### PR TITLE
Number of small refactors in ``_config_initialization``

### DIFF
--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -156,10 +156,3 @@ class _ArgumentsManager:
         )
 
         return parsed_args
-
-    def _parse_plugin_configuration(self) -> None:
-        # pylint: disable-next=fixme
-        # TODO: This is not currently implemented.
-        # Perhaps we should also change the name to distuingish it better?
-        # See PyLinter.load_plugin_configuration
-        pass

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -76,10 +76,6 @@ def _config_initialization(
             exc.code = 32
         raise
 
-    # We have loaded configuration from config file and command line. Now, we can
-    # load plugin specific configuration.
-    linter.load_plugin_configuration()
-
     # pylint: disable-next=fixme
     # TODO: Start of the implemenation of argument parsing with argparse
     # When finished this should replace the implementation based on optparse
@@ -91,17 +87,18 @@ def _config_initialization(
     # the configuration file
     parsed_args_list = linter._parse_command_line_configuration(args_list)
 
-    # Lastly we parse any options from plugins
-    linter._parse_plugin_configuration()
-
-    # Now that plugins are loaded, get list of all fail_on messages, and enable them
-    linter.enable_fail_on_messages()
+    # We have loaded configuration from config file and command line. Now, we can
+    # load plugin specific configuration.
+    linter.load_plugin_configuration()
 
     # args_list should now only be a list of files/directories to lint. All options have
     # been removed from the list
     if not parsed_args_list:
         linter._arg_parser.print_help()
         sys.exit(32)
+
+    # Now that plugins are loaded, get list of all fail_on messages, and enable them
+    linter.enable_fail_on_messages()
 
     linter._parse_error_mode()
 

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -39,24 +39,20 @@ def _config_initialization(
         print(ex, file=sys.stderr)
         sys.exit(32)
 
+    # Run init hook, if present, before loading plugins
+    if "init-hook" in config_data:
+        exec(utils._unquote(config_data["init-hook"]))  # pylint: disable=exec-used
+
+    # Load plugins if specified in the config file
+    if "load-plugins" in config_data:
+        linter.load_plugin_modules(utils._splitstrip(config_data["load-plugins"]))
+
     try:
         # The parser is stored on linter.cfgfile_parser
         linter.read_config_file(config_file=config_file_path, verbose=verbose_mode)
     except OSError as ex:
         print(ex, file=sys.stderr)
         sys.exit(32)
-    config_parser = linter.cfgfile_parser
-
-    # Run init hook, if present, before loading plugins
-    if config_parser.has_option("MASTER", "init-hook"):
-        exec(  # pylint: disable=exec-used
-            utils._unquote(config_parser.get("MASTER", "init-hook"))
-        )
-
-    # Load plugins if specified in the config file
-    if config_parser.has_option("MASTER", "load-plugins"):
-        plugins = utils._splitstrip(config_parser.get("MASTER", "load-plugins"))
-        linter.load_plugin_modules(plugins)
 
     # Now we can load file config, plugins (which can
     # provide options) have been registered

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -651,7 +651,7 @@ class PyLinter(
             except ModuleNotFoundError:
                 pass
 
-    def load_plugin_configuration(self):
+    def load_plugin_configuration(self) -> None:
         """Call the configuration hook for plugins.
 
         This walks through the list of plugins, grabs the "load_configuration"

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -637,10 +637,8 @@ class PyLinter(
         checkers.initialize(self)
         reporters.initialize(self)
 
-    def load_plugin_modules(self, modnames):
-        """Take a list of module names which are pylint plugins and load
-        and register them
-        """
+    def load_plugin_modules(self, modnames: List[str]) -> None:
+        """Check a list pylint plugins modules, load and register them."""
         for modname in modnames:
             if modname in self._dynamic_plugins:
                 continue


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description


I think this means that ``_config_initialization`` is done expect for the removal of dead code after `optparse` is removed at some point.
