### PR TITLE
Fix false negative for ``bad-string-format-type`` when using a variable as input

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,9 @@ Release date: TBA
   Closes #5283
   Closes #1887
 
+* Fix false negative for ``bad-string-format-type`` if the value to be formatted is passed in
+  as a variable holding a constant.
+
 * Add new check ``unnecessary-dunder-call`` for unnecessary dunder method calls.
 
   Closes #5936

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -51,6 +51,9 @@ Other Changes
   Closes #5283
   Closes #1887
 
+* Fix false negative for ``bad-string-format-type`` if the value to be formatted is passed in
+  as a variable holding a constant.
+
 * The concept of checker priority has been removed.
 
 * The ``set_config_directly`` decorator has been removed.

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -244,7 +244,6 @@ class StringFormatChecker(BaseChecker):
         "format-needs-mapping",
         "too-many-format-args",
         "too-few-format-args",
-        "bad-string-format-type",
         "format-string-without-interpolation",
     )
     def visit_binop(self, node: nodes.BinOp) -> None:
@@ -353,9 +352,21 @@ class StringFormatChecker(BaseChecker):
             elif isinstance(args, (OTHER_NODES, (nodes.Dict, nodes.DictComp))):
                 args_elts = [args]
                 num_args = 1
+            elif isinstance(args, nodes.Name):
+                inferred = utils.safe_infer(args)
+                if isinstance(inferred, nodes.Tuple):
+                    # The variable is a tuple, so we need to get the elements
+                    # from it for further inspection
+                    args_elts = inferred.elts
+                    num_args = len(args_elts)
+                elif isinstance(inferred, nodes.Const):
+                    args_elts = [inferred]
+                    num_args = 1
+                else:
+                    num_args = None
             else:
-                # The RHS of the format specifier is a name or
-                # expression.  It could be a tuple of unknown size, so
+                # The RHS of the format specifier is an expression.
+                # It could be a tuple of unknown size, so
                 # there's nothing we can check.
                 num_args = None
             if num_args is not None:

--- a/tests/functional/b/bad_string_format_type.py
+++ b/tests/functional/b/bad_string_format_type.py
@@ -28,3 +28,11 @@ b"test".format(1, 2) # [no-member]
 "%(key)x" % {"key": 1.1}  # [bad-string-format-type]
 "%d" % []  # [bad-string-format-type]
 "%(key)d" % {"key": []}  # [bad-string-format-type]
+
+WORD = "abc"
+"%d" % WORD  # [bad-string-format-type]
+"%d %s" % (WORD, WORD)  # [bad-string-format-type]
+
+VALUES_TO_FORMAT = (1, "2", 3.0)
+"%d %s %f" % VALUES_TO_FORMAT
+"%d %d %f" % VALUES_TO_FORMAT  # [bad-string-format-type]

--- a/tests/functional/b/bad_string_format_type.py
+++ b/tests/functional/b/bad_string_format_type.py
@@ -44,3 +44,5 @@ def test_format(my_input_value, my_other_input_value):
     """
     print("%d" % my_input_value)
     print("%d %s" % (my_input_value, my_other_input_value))
+    to_be_formatted = (my_input_value, my_other_input_value)
+    print("%d %s" % to_be_formatted)

--- a/tests/functional/b/bad_string_format_type.py
+++ b/tests/functional/b/bad_string_format_type.py
@@ -36,3 +36,11 @@ WORD = "abc"
 VALUES_TO_FORMAT = (1, "2", 3.0)
 "%d %s %f" % VALUES_TO_FORMAT
 "%d %d %f" % VALUES_TO_FORMAT  # [bad-string-format-type]
+
+
+def test_format(my_input_value, my_other_input_value):
+    """In some cases it is not possible to determine the content of the input variable.
+    Pylint must not crash or yield false positives in such cases.
+    """
+    print("%d" % my_input_value)
+    print("%d %s" % (my_input_value, my_other_input_value))

--- a/tests/functional/b/bad_string_format_type.txt
+++ b/tests/functional/b/bad_string_format_type.txt
@@ -5,3 +5,6 @@ bad-string-format-type:27:0:27:10::Argument 'builtins.float' does not match form
 bad-string-format-type:28:0:28:24::Argument 'builtins.float' does not match format type 'x':UNDEFINED
 bad-string-format-type:29:0:29:9::Argument 'builtins.list' does not match format type 'd':UNDEFINED
 bad-string-format-type:30:0:30:23::Argument 'builtins.list' does not match format type 'd':UNDEFINED
+bad-string-format-type:33:0:33:11::Argument 'builtins.str' does not match format type 'd':UNDEFINED
+bad-string-format-type:34:0:34:22::Argument 'builtins.str' does not match format type 'd':UNDEFINED
+bad-string-format-type:38:0:38:29::Argument 'builtins.str' does not match format type 'd':UNDEFINED


### PR DESCRIPTION

- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

First and easy part of #6163.

After I started to work on this I realized that making ``bad-string-format-type`` and ``bad-format-character`` work on new-style formatting and f-strings will require a change to ``pylint.checkers.utils.parse_format_method_string``.
As this also leads to small adjustments in the callers of this function, I would rather do this in a separate PR, and then continue working on ``bas-string-format-type`` and ``bad-format-character``.
