### PR TITLE
Handle ``group`` in optdicts and ``option_groups``

### DIFF
--- a/pylint/config/argument.py
+++ b/pylint/config/argument.py
@@ -152,7 +152,14 @@ class _Argument:
     https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_argument
     """
 
-    def __init__(self, *, flags: List[str], arg_help: str, hide_help: bool) -> None:
+    def __init__(
+        self,
+        *,
+        flags: List[str],
+        arg_help: str,
+        hide_help: bool,
+        section: Optional[str],
+    ) -> None:
         self.flags = flags
         """The name of the argument."""
 
@@ -165,6 +172,9 @@ class _Argument:
 
         if hide_help:
             self.help = argparse.SUPPRESS
+
+        self.section = section
+        """The section to add this argument to."""
 
 
 class _BaseStoreArgument(_Argument):
@@ -183,8 +193,11 @@ class _BaseStoreArgument(_Argument):
         default: _ArgumentTypes,
         arg_help: str,
         hide_help: bool,
+        section: Optional[str],
     ) -> None:
-        super().__init__(flags=flags, arg_help=arg_help, hide_help=hide_help)
+        super().__init__(
+            flags=flags, arg_help=arg_help, hide_help=hide_help, section=section
+        )
 
         self.action = action
         """The action to perform with the argument."""
@@ -212,6 +225,7 @@ class _StoreArgument(_BaseStoreArgument):
         arg_help: str,
         metavar: str,
         hide_help: bool,
+        section: Optional[str],
     ) -> None:
         super().__init__(
             flags=flags,
@@ -219,6 +233,7 @@ class _StoreArgument(_BaseStoreArgument):
             default=default,
             arg_help=arg_help,
             hide_help=hide_help,
+            section=section,
         )
 
         self.type = _TYPE_TRANSFORMERS[arg_type]
@@ -255,6 +270,7 @@ class _StoreTrueArgument(_BaseStoreArgument):
         default: _ArgumentTypes,
         arg_help: str,
         hide_help: bool,
+        section: Optional[str],
     ) -> None:
         super().__init__(
             flags=flags,
@@ -262,6 +278,7 @@ class _StoreTrueArgument(_BaseStoreArgument):
             default=default,
             arg_help=arg_help,
             hide_help=hide_help,
+            section=section,
         )
 
 
@@ -284,8 +301,11 @@ class _DeprecationArgument(_Argument):
         arg_help: str,
         metavar: str,
         hide_help: bool,
+        section: Optional[str],
     ) -> None:
-        super().__init__(flags=flags, arg_help=arg_help, hide_help=hide_help)
+        super().__init__(
+            flags=flags, arg_help=arg_help, hide_help=hide_help, section=section
+        )
 
         self.action = action
         """The action to perform with the argument."""
@@ -329,6 +349,7 @@ class _StoreOldNamesArgument(_DeprecationArgument):
         metavar: str,
         hide_help: bool,
         kwargs: Dict[str, Any],
+        section: Optional[str],
     ) -> None:
         super().__init__(
             flags=flags,
@@ -339,6 +360,7 @@ class _StoreOldNamesArgument(_DeprecationArgument):
             arg_help=arg_help,
             metavar=metavar,
             hide_help=hide_help,
+            section=section,
         )
 
         self.kwargs = kwargs
@@ -364,6 +386,7 @@ class _StoreNewNamesArgument(_DeprecationArgument):
         metavar: str,
         hide_help: bool,
         kwargs: Dict[str, Any],
+        section: Optional[str],
     ) -> None:
         super().__init__(
             flags=flags,
@@ -374,6 +397,7 @@ class _StoreNewNamesArgument(_DeprecationArgument):
             arg_help=arg_help,
             metavar=metavar,
             hide_help=hide_help,
+            section=section,
         )
 
         self.kwargs = kwargs
@@ -396,8 +420,11 @@ class _CallableArgument(_Argument):
         arg_help: str,
         kwargs: Dict[str, Any],
         hide_help: bool,
+        section: Optional[str],
     ) -> None:
-        super().__init__(flags=flags, arg_help=arg_help, hide_help=hide_help)
+        super().__init__(
+            flags=flags, arg_help=arg_help, hide_help=hide_help, section=section
+        )
 
         self.action = action
         """The action to perform with the argument."""

--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -40,8 +40,6 @@ def _convert_option_to_argument(
             "Use 'hide' with a boolean to hide an option from the help message.",
             DeprecationWarning,
         )
-    # pylint: disable-next=fixme
-    # TODO: Do something with the 'group' keys of optdicts
 
     # Get the long and short flags
     flags = [f"--{opt}"]
@@ -64,6 +62,7 @@ def _convert_option_to_argument(
             default=optdict["default"],
             arg_help=optdict["help"],
             hide_help=optdict.get("hide", False),
+            section=optdict.get("group", None),
         )
     if not isinstance(action, str) and issubclass(action, _CallbackAction):
         return _CallableArgument(
@@ -72,6 +71,7 @@ def _convert_option_to_argument(
             arg_help=optdict["help"],
             kwargs=optdict["kwargs"],
             hide_help=optdict.get("hide", False),
+            section=optdict.get("group", None),
         )
     if "kwargs" in optdict:
         if "old_names" in optdict["kwargs"]:
@@ -84,6 +84,7 @@ def _convert_option_to_argument(
                 metavar=optdict["metavar"],
                 hide_help=optdict.get("hide", False),
                 kwargs=optdict["kwargs"],
+                section=optdict.get("group", None),
             )
         if "new_names" in optdict["kwargs"]:
             return _StoreNewNamesArgument(
@@ -95,6 +96,7 @@ def _convert_option_to_argument(
                 metavar=optdict["metavar"],
                 hide_help=optdict.get("hide", False),
                 kwargs=optdict["kwargs"],
+                section=optdict.get("group", None),
             )
     if "dest" in optdict:
         return _StoreOldNamesArgument(
@@ -106,6 +108,7 @@ def _convert_option_to_argument(
             metavar=optdict["metavar"],
             hide_help=optdict.get("hide", False),
             kwargs={"old_names": [optdict["dest"]]},
+            section=optdict.get("group", None),
         )
     return _StoreArgument(
         flags=flags,
@@ -116,6 +119,7 @@ def _convert_option_to_argument(
         arg_help=optdict["help"],
         metavar=optdict["metavar"],
         hide_help=optdict.get("hide", False),
+        section=optdict.get("group", None),
     )
 
 

--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -84,7 +84,7 @@ def _convert_option_to_argument(
                 metavar=optdict["metavar"],
                 hide_help=optdict.get("hide", False),
                 kwargs=optdict["kwargs"],
-                section=optdict.get("group", None),
+                section=optdict.get("group"),
             )
         if "new_names" in optdict["kwargs"]:
             return _StoreNewNamesArgument(

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -544,10 +544,10 @@ class PyLinter(
             ),
         )
 
-    base_option_groups = (
-        ("Messages control", "Options controlling analysis messages"),
-        ("Reports", "Options related to output formatting and reporting"),
-    )
+    option_groups_descs: Dict[str, str] = {
+        "Messages control": "Options controlling analysis messages",
+        "Reports": "Options related to output formatting and reporting",
+    }
 
     def __init__(
         self,
@@ -595,8 +595,13 @@ class PyLinter(
         self.options: Tuple[Tuple[str, OptionDict], ...] = (
             options + PyLinter.make_options()
         )
-        self.option_groups: Tuple[Tuple[str, str], ...] = (
-            option_groups + PyLinter.base_option_groups
+        for opt_group in option_groups:
+            self.option_groups_descs[opt_group[0]] = opt_group[1]
+        # pylint: disable-next=fixme
+        # TODO: Optparse: Remove this assignment after option_groups has been deprecated
+        self.option_groups: Tuple[Tuple[str, str], ...] = option_groups + (
+            ("Messages control", "Options controlling analysis messages"),
+            ("Reports", "Options related to output formatting and reporting"),
         )
         self._options_methods = {
             "enable": self.enable,


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This handles the last unsupported key in `optdicts`, a minor milestone 😄  

I'm also going to use `# TODO: Optparse: ...` from now on, because that makes it easier to recognise them.