### PR TITLE
Move utility function in testutil

### DIFF
--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -4,7 +4,22 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
+import sys
+from collections.abc import Iterator
+from typing import TextIO
+
+
+@contextlib.contextmanager
+def _patch_streams(out: TextIO) -> Iterator[None]:
+    """Patch and subsequently reset a text stream."""
+    sys.stderr = sys.stdout = out
+    try:
+        yield
+    finally:
+        sys.stderr = sys.__stderr__
+        sys.stdout = sys.__stdout__
 
 
 def create_files(paths: list[str], chroot: str = ".") -> None:

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -35,6 +35,7 @@ from pylint.lint.pylinter import PyLinter
 from pylint.message import Message
 from pylint.reporters import JSONReporter
 from pylint.reporters.text import BaseReporter, ColorizedTextReporter, TextReporter
+from pylint.testutils.utils import _patch_streams
 from pylint.utils import utils
 
 if sys.version_info >= (3, 11):
@@ -51,16 +52,6 @@ CLEAN_PATH = re.escape(dirname(dirname(__file__)) + os.path.sep)
 UNNECESSARY_LAMBDA = join(
     HERE, "functional", "u", "unnecessary", "unnecessary_lambda.py"
 )
-
-
-@contextlib.contextmanager
-def _patch_streams(out: TextIO) -> Iterator:
-    sys.stderr = sys.stdout = out
-    try:
-        yield
-    finally:
-        sys.stderr = sys.__stderr__
-        sys.stdout = sys.__stdout__
 
 
 @contextlib.contextmanager

--- a/tests/test_similar.py
+++ b/tests/test_similar.py
@@ -4,12 +4,9 @@
 
 from __future__ import annotations
 
-import contextlib
 import os
 import re
-import sys
 import warnings
-from collections.abc import Iterator
 from io import StringIO
 from os.path import abspath, dirname, join
 from typing import TextIO
@@ -17,20 +14,11 @@ from typing import TextIO
 import pytest
 
 from pylint.lint import Run
+from pylint.testutils.utils import _patch_streams
 
 HERE = abspath(dirname(__file__))
 DATA = join(HERE, "regrtest_data", "duplicate_code")
 CLEAN_PATH = re.escape(dirname(dirname(__file__)) + os.path.sep)
-
-
-@contextlib.contextmanager
-def _patch_streams(out: TextIO) -> Iterator:
-    sys.stderr = sys.stdout = out
-    try:
-        yield
-    finally:
-        sys.stderr = sys.__stderr__
-        sys.stdout = sys.__stdout__
 
 
 class TestSimilarCodeChecker:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Done to avoid duplication when bursting test_self.py during the migration to argparse.
