### PR TITLE
Decrease number of runners used in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,11 +14,12 @@ env:
   CACHE_VERSION: 6
 
 jobs:
-  prepare-tests-linux:
-    name: prepare / ${{ matrix.python-version }} / Linux
+  tests-linux:
+    name: run / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 25
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
     outputs:
@@ -56,37 +57,6 @@ jobs:
           . venv/bin/activate
           python -m pip install -U pip setuptools wheel
           pip install -U -r requirements_test.txt
-
-  pytest-linux:
-    name: run / ${{ matrix.python-version }} / Linux
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    needs: prepare-tests-linux
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v3.0.0
-      - name: Set up Python ${{ matrix.python-version }}
-        id: python
-        uses: actions/setup-python@v3.1.0
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Restore Python virtual environment
-        id: cache-venv
-        uses: actions/cache@v3.0.1
-        with:
-          path: venv
-          key:
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            needs.prepare-tests-linux.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
       - name: Run pytest
         run: |
           . venv/bin/activate
@@ -101,7 +71,7 @@ jobs:
     name: process / coverage
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: ["prepare-tests-linux", "pytest-linux"]
+    needs: tests-linux
     strategy:
       matrix:
         python-version: [3.8]
@@ -122,7 +92,7 @@ jobs:
           path: venv
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            needs.prepare-tests-linux.outputs.python-key }}
+            needs.tests-linux.outputs.python-key }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -146,7 +116,7 @@ jobs:
     name: run benchmark / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: ["prepare-tests-linux", "pytest-linux"]
+    needs: tests-linux
     strategy:
       fail-fast: false
       matrix:
@@ -166,7 +136,7 @@ jobs:
           path: venv
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            needs.prepare-tests-linux.outputs.python-key }}
+            needs.tests-linux.outputs.python-key }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -194,17 +164,22 @@ jobs:
             steps.artifact-name-suffix.outputs.datetime }}
           path: .benchmarks/
 
-  prepare-tests-windows:
-    name: prepare / ${{ matrix.python-version }} / Windows
+  tests-windows:
+    name: run / ${{ matrix.python-version }} / Windows
     runs-on: windows-latest
-    timeout-minutes: 10
-    needs: pytest-linux
+    timeout-minutes: 25
+    needs: tests-linux
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
+      - name: Set temp directory
+        run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
+        # Workaround to set correct temp directory on Windows
+        # https://github.com/actions/virtual-environments/issues/712
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.0
         with:
@@ -237,51 +212,17 @@ jobs:
           . venv\\Scripts\\activate
           python -m pip install -U pip setuptools wheel
           pip install -U -r requirements_test_min.txt
-
-  pytest-windows:
-    name: run / ${{ matrix.python-version }} / Windows
-    runs-on: windows-latest
-    timeout-minutes: 15
-    needs: prepare-tests-windows
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
-    steps:
-      - name: Set temp directory
-        run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
-        # Workaround to set correct temp directory on Windows
-        # https://github.com/actions/virtual-environments/issues/712
-      - name: Check out code from GitHub
-        uses: actions/checkout@v3.0.0
-      - name: Set up Python ${{ matrix.python-version }}
-        id: python
-        uses: actions/setup-python@v3.1.0
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Restore Python virtual environment
-        id: cache-venv
-        uses: actions/cache@v3.0.1
-        with:
-          path: venv
-          key:
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            needs.prepare-tests-windows.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
       - name: Run pytest
         run: |
           . venv\\Scripts\\activate
           pytest -vv --durations=20 --benchmark-disable tests/
 
-  prepare-tests-pypy:
-    name: prepare / ${{ matrix.python-version }} / Linux
+  tests-pypy:
+    name: run / ${{ matrix.python-version }} / Linux
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 25
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["pypy-3.6", "pypy-3.7"]
     outputs:
@@ -319,37 +260,6 @@ jobs:
           . venv/bin/activate
           python -m pip install -U pip setuptools wheel
           pip install -U -r requirements_test_min.txt
-
-  pytest-pypy:
-    name: run / ${{ matrix.python-version }} / Linux
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    needs: prepare-tests-pypy
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["pypy-3.6", "pypy-3.7"]
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v3.0.0
-      - name: Set up Python ${{ matrix.python-version }}
-        id: python
-        uses: actions/setup-python@v3.1.0
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Restore Python virtual environment
-        id: cache-venv
-        uses: actions/cache@v3.0.1
-        with:
-          path: venv
-          key:
-            ${{ runner.os }}-${{ matrix.python-version }}-${{
-            needs.prepare-tests-pypy.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
       - name: Run pytest
         run: |
           . venv/bin/activate

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -120,7 +120,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.0


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This should improve the speed of our CI. Since all tests jobs now depend on `Linux` passing there is really no need to separate these set-ups steps. They just take extra time setting up Python, checking out code and restoring the venv. That can all be done in the same runner: freeing up more runners and decreasing the overall runtime of the CI.