### PR TITLE
Fix crash in `no-member` check for C extensions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -63,6 +63,7 @@ Release date: TBA
   attribute to itself without any prior assignment.
 
   Closes #1555
+  Closes #6221
 
 * The concept of checker priority has been removed.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -64,8 +64,8 @@ Release date: TBA
 
   Closes #1555
 
-* Fix crash (in unreleased development) in ``c-extension-no-member`` check when inspecting living objects
-  with ``extension-pkg-allow-list``.
+* Fix crash (in unreleased development) in ``no-member`` check when inspecting C
+  extension modules with ``extension-pkg-allow-list``.
 
   Closes #6221
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -64,11 +64,6 @@ Release date: TBA
 
   Closes #1555
 
-* Fix crash (in unreleased development) in ``no-member`` check when inspecting C
-  extension modules with ``extension-pkg-allow-list``.
-
-  Closes #6221
-
 * The concept of checker priority has been removed.
 
 * ``duplicate-argument-name`` now only raises once for each set of duplicated arguments.

--- a/ChangeLog
+++ b/ChangeLog
@@ -64,6 +64,11 @@ Release date: TBA
 
   Closes #1555
 
+* Fix crash (in unreleased development) in ``c-extension-no-member`` check when inspecting living objects
+  with ``extension-pkg-allow-list``.
+
+  Closes #6221
+
 * The concept of checker priority has been removed.
 
 * ``duplicate-argument-name`` now only raises once for each set of duplicated arguments.

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -81,3 +81,4 @@ Other Changes
   attribute to itself without any prior assignment.
 
   Closes #1555
+  Closes #6221

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1057,7 +1057,7 @@ accessed. Python regular expressions are accepted.",
                     # If owner was a living object, attr_nodes might be a node itself
                     # Faster than retrieving the module object and testing _is_c_extension()
                     # https://github.com/PyCQA/pylint/pull/6235#issuecomment-1093098869
-                    break   # pragma: no cover
+                    break  # pragma: no cover
                 for attr_node in attr_nodes:
                     attr_parent = attr_node.parent
                     # Skip augmented assignments

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1053,6 +1053,10 @@ accessed. Python regular expressions are accepted.",
                 missingattr.add((owner, name))
                 continue
             else:
+                if isinstance(attr_nodes, nodes.NodeNG):
+                    # If owner was a living object, attr_nodes might be a node itself
+                    # Faster than retrieving the module object and testing _is_c_extension()
+                    break
                 for attr_node in attr_nodes:
                     attr_parent = attr_node.parent
                     # Skip augmented assignments

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1056,7 +1056,8 @@ accessed. Python regular expressions are accepted.",
                 if isinstance(attr_nodes, nodes.NodeNG):
                     # If owner was a living object, attr_nodes might be a node itself
                     # Faster than retrieving the module object and testing _is_c_extension()
-                    break
+                    # https://github.com/PyCQA/pylint/pull/6235#issuecomment-1093098869
+                    break   # pragma: no cover
                 for attr_node in attr_nodes:
                     attr_parent = attr_node.parent
                     # Skip augmented assignments


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description


Closes #6221. Regression in 129c7302ceaabbbbf41a9872661a3550069b37e3 (unreleased 2.14)

- [ ] Add test
