### PR TITLE
Add ``music21`` and remove ``graph-explorer`` from primer

### DIFF
--- a/tests/primer/packages_to_lint_batch_one.json
+++ b/tests/primer/packages_to_lint_batch_one.json
@@ -14,12 +14,6 @@
     "directories": ["src/flask"],
     "url": "https://github.com/pallets/flask.git"
   },
-  "graph-explorer": {
-    "branch": "master",
-    "directories": ["graph_explorer"],
-    "pylintrc_relpath": ".pylintrc",
-    "url": "https://github.com/vimeo/graph-explorer.git"
-  },
   "home-assistant": {
     "branch": "dev",
     "directories": ["homeassistant"],
@@ -29,5 +23,11 @@
     "branch": "master",
     "directories": ["keras"],
     "url": "https://github.com/keras-team/keras.git"
+  },
+  "music21": {
+    "branch": "master",
+    "directories": ["music21"],
+    "pylintrc_relpath": ".pylintrc",
+    "url": "https://github.com/cuthbertLab/music21"
   }
 }


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

See https://github.com/PyCQA/pylint/issues/6049#issuecomment-1086108440.

The other package got its last commit in 2015 and hasn't updated its `pylintrc`. This will become problematic and we should probably exclude it. Open to any other suggestions for now packages!