### PR TITLE
Deprecate most methods of ``_ArgumentsProvider``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,12 @@ Release date: TBA
 
   Ref #5392
 
+* ``OptionsProviderMixIn`` has been replaced with ``ArgumentsProvider``. ``ArgumentsProvider`` is considered
+  private API and most methods that were public on ``OptionsProviderMixIn`` have now been deprecated and will
+  be removed in a future release.
+
+  Ref #5392
+
 * ``invalid-enum-extension``: Used when a class tries to extend an inherited Enum class.
 
   Closes #5501

--- a/doc/exts/pylint_extensions.py
+++ b/doc/exts/pylint_extensions.py
@@ -9,6 +9,7 @@
 import os
 import re
 import sys
+import warnings
 from typing import Optional
 
 import sphinx
@@ -91,20 +92,24 @@ def get_plugins_info(linter, doc_files):
                 doc = f.read()
         try:
             by_checker[checker]["checker"] = checker
-            by_checker[checker]["options"] += checker.options_and_values()
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=DeprecationWarning)
+                by_checker[checker]["options"] += checker.options_and_values()
             by_checker[checker]["msgs"].update(checker.msgs)
             by_checker[checker]["reports"] += checker.reports
             by_checker[checker]["doc"] += doc
             by_checker[checker]["module"] += module
         except KeyError:
-            by_checker[checker] = {
-                "checker": checker,
-                "options": list(checker.options_and_values()),
-                "msgs": dict(checker.msgs),
-                "reports": list(checker.reports),
-                "doc": doc,
-                "module": module,
-            }
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=DeprecationWarning)
+                by_checker[checker] = {
+                    "checker": checker,
+                    "options": list(checker.options_and_values()),
+                    "msgs": dict(checker.msgs),
+                    "reports": list(checker.reports),
+                    "doc": doc,
+                    "module": module,
+                }
     return by_checker
 
 

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -79,6 +79,12 @@ Other Changes
 
   Ref #5392
 
+* ``OptionsProviderMixIn`` has been replaced with ``ArgumentsProvider``. ``ArgumentsProvider`` is considered
+  private API and most methods that were public on ``OptionsProviderMixIn`` have now been deprecated and will
+  be removed in a future release.
+
+  Ref #5392
+
 * Fix false negative for ``bad-string-format-type`` if the value to be formatted is passed in
   as a variable holding a constant.
 

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
 import functools
+import warnings
 from inspect import cleandoc
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -67,9 +68,11 @@ class BaseChecker(_ArgumentsProvider):
 
         See: MessageHandlerMixIn.get_full_documentation()
         """
-        return self.get_full_documentation(
-            msgs=self.msgs, options=self.options_and_values(), reports=self.reports
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            return self.get_full_documentation(
+                msgs=self.msgs, options=self.options_and_values(), reports=self.reports
+            )
 
     def get_full_documentation(self, msgs, options, reports, doc=None, module=None):
         result = ""

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -373,22 +373,24 @@ class _ArgumentsManager:
         options_by_section: Dict[str, List[Tuple]] = {}
         sections = []
         for provider in self.options_providers:
-            for section, options in provider.options_by_section():
-                if section is None:
-                    section = provider.name
-                if section in skipsections:
-                    continue
-                options = [
-                    (n, d, v)
-                    for (n, d, v) in options
-                    if d.get("type") is not None and not d.get("deprecated")
-                ]
-                if not options:
-                    continue
-                if section not in sections:
-                    sections.append(section)
-                all_options = options_by_section.setdefault(section, [])
-                all_options += options
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=DeprecationWarning)
+                for section, options in provider.options_by_section():
+                    if section is None:
+                        section = provider.name
+                    if section in skipsections:
+                        continue
+                    options = [  # type: ignore[misc]
+                        (n, d, v)
+                        for (n, d, v) in options
+                        if d.get("type") is not None and not d.get("deprecated")
+                    ]
+                    if not options:
+                        continue
+                    if section not in sections:
+                        sections.append(section)
+                    all_options = options_by_section.setdefault(section, [])
+                    all_options += options
         stream = stream or sys.stdout
         printed = False
         for section in sections:
@@ -409,7 +411,9 @@ class _ArgumentsManager:
             DeprecationWarning,
         )
         for provider in self.options_providers:
-            provider.load_defaults()
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=DeprecationWarning)
+                provider.load_defaults()
 
     def read_config_file(
         self, config_file: Optional[Path] = None, verbose: bool = False

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -782,7 +782,9 @@ class PyLinter(
             self.register_options_provider(checker)
         if hasattr(checker, "msgs"):
             self.msgs_store.register_messages_from_checker(checker)
-        checker.load_defaults()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            checker.load_defaults()
         # Register the checker, but disable all of its messages.
         if not getattr(checker, "enabled", True):
             self.disable(checker.name)

--- a/pylint/utils/docs.py
+++ b/pylint/utils/docs.py
@@ -5,6 +5,7 @@
 """Various helper functions to create the docs of a linter object."""
 
 import sys
+import warnings
 from typing import TYPE_CHECKING, Dict, TextIO
 
 from pylint.constants import MAIN_CHECKER_NAME
@@ -22,16 +23,20 @@ def _get_checkers_infos(linter: "PyLinter") -> Dict[str, Dict]:
         if name != "master":
             try:
                 by_checker[name]["checker"] = checker
-                by_checker[name]["options"] += checker.options_and_values()
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", category=DeprecationWarning)
+                    by_checker[name]["options"] += checker.options_and_values()
                 by_checker[name]["msgs"].update(checker.msgs)
                 by_checker[name]["reports"] += checker.reports
             except KeyError:
-                by_checker[name] = {
-                    "checker": checker,
-                    "options": list(checker.options_and_values()),
-                    "msgs": dict(checker.msgs),
-                    "reports": list(checker.reports),
-                }
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", category=DeprecationWarning)
+                    by_checker[name] = {
+                        "checker": checker,
+                        "options": list(checker.options_and_values()),
+                        "msgs": dict(checker.msgs),
+                        "reports": list(checker.reports),
+                    }
     return by_checker
 
 
@@ -46,13 +51,15 @@ Pylint provides global options and switches.
         name = checker.name
         if name == MAIN_CHECKER_NAME:
             if checker.options:
-                for section, options in checker.options_by_section():
-                    if section is None:
-                        title = "General options"
-                    else:
-                        title = f"{section.capitalize()} options"
-                    result += get_rst_title(title, "~")
-                    result += f"{get_rst_section(None, options)}\n"
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", category=DeprecationWarning)
+                    for section, options in checker.options_by_section():
+                        if section is None:
+                            title = "General options"
+                        else:
+                            title = f"{section.capitalize()} options"
+                        result += get_rst_title(title, "~")
+                        result += f"{get_rst_section(None, options)}\n"
     result += get_rst_title("Pylint checkers' options and switches", "-")
     result += """\
 


### PR DESCRIPTION
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

One method remains. Since these methods are only used in `optparse` code I thought I would do most of them at once. We're nearing the end 😄 