### PR TITLE
Remove last use of ``config`` in ``PyLinter``

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -995,7 +995,7 @@ class PyLinter(
 
     def prepare_checkers(self):
         """Return checkers needed for activated messages and reports."""
-        if not self.config.reports:
+        if not self.namespace.reports:
             self.disable_reporters()
         # get needed checkers
         needed_checkers = [self]
@@ -1402,12 +1402,12 @@ class PyLinter(
             # load previous results if any
             previous_stats = config.load_results(self.file_state.base_name)
             self.reporter.on_close(self.stats, previous_stats)
-            if self.config.reports:
+            if self.namespace.reports:
                 sect = self.make_reports(self.stats, previous_stats)
             else:
                 sect = report_nodes.Section()
 
-            if self.config.reports:
+            if self.namespace.reports:
                 self.reporter.display_reports(sect)
             score_value = self._report_evaluation()
             # save results if persistent run

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -264,6 +264,15 @@ def get_global_option(
     until the given *option* will be found.
     If the option wasn't found, the *default* value will be returned.
     """
+
+    # # pylint: disable-next=fixme
+    # # TODO: Optparse: Potentially deprecate this.
+    # Firstly, try on the namespace object
+    try:
+        return getattr(checker.linter.namespace, option.replace("-", "_"))
+    except AttributeError:
+        pass
+
     # First, try in the given checker's config.
     # After that, look in the options providers.
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -23,7 +23,7 @@ def check_configuration_file_reader(
     for msgid in expected_disabled:
         assert not runner.linter.is_message_enabled(msgid)
     assert runner.linter.namespace.jobs == expected_jobs
-    assert bool(runner.linter.config.reports) == expected_reports_truthey
+    assert bool(runner.linter.namespace.reports) == expected_reports_truthey
 
 
 def test_can_read_toml_env_variable(tmp_path: Path, file_to_lint_path: str) -> None:

--- a/tests/unittest_reporting.py
+++ b/tests/unittest_reporting.py
@@ -177,8 +177,15 @@ def test_multi_format_output(tmp_path):
     with redirect_stdout(text):
         linter = PyLinter()
         linter.load_default_plugins()
+        # pylint: disable-next=fixme
+        # # TODO: Optparse: Fix how we set these options
+        linter.namespace.persistent = False
+        linter.namespace.reports = True
+        linter.namespace.score = True
+        linter._load_reporters(formats)
+
         linter.set_option("persistent", False)
-        linter.set_option("output-format", formats)
+        # linter.set_option("output-format", formats)
         linter.set_option("reports", True)
         linter.set_option("score", True)
 


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This is the last use of `.config` in any of the checkers 🎉 