### PR TITLE
Make the enable and disable config attributes an actual list

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1820,9 +1820,9 @@ class PyLinter(  # type: ignore[misc]
         self.namespace.disable = []
         for mid, val in self._msgs_state.items():
             if val:
-                self.namespace.enable.append(self._message_symbol(mid))
+                self.namespace.enable += self._message_symbol(mid)
             else:
-                self.namespace.disable.append(self._message_symbol(mid))
+                self.namespace.disable += self._message_symbol(mid)
 
     def _register_by_id_managed_msg(
         self, msgid_or_symbol: str, line: Optional[int], is_disabled: bool = True

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1722,17 +1722,6 @@ class PyLinter(  # type: ignore[misc]
 
     # Setting the state (disabled/enabled) of messages and registering them
 
-    def _message_symbol(self, msgid: str) -> List[str]:
-        """Get the message symbol of the given message id.
-
-        Return the original message id if the message does not
-        exist.
-        """
-        try:
-            return [md.symbol for md in self.msgs_store.get_message_definitions(msgid)]
-        except exceptions.UnknownMessageError:
-            return [msgid]
-
     def _set_one_msg_status(
         self, scope: str, msg: MessageDefinition, line: Optional[int], enable: bool
     ) -> None:
@@ -1818,11 +1807,15 @@ class PyLinter(  # type: ignore[misc]
         # sync configuration object
         self.namespace.enable = []
         self.namespace.disable = []
-        for mid, val in self._msgs_state.items():
-            if val:
-                self.namespace.enable += self._message_symbol(mid)
+        for msgid_or_symbol, is_enabled in self._msgs_state.items():
+            symbols = [
+                m.symbol
+                for m in self.msgs_store.get_message_definitions(msgid_or_symbol)
+            ]
+            if is_enabled:
+                self.namespace.enable += symbols
             else:
-                self.namespace.disable += self._message_symbol(mid)
+                self.namespace.disable += symbols
 
     def _register_by_id_managed_msg(
         self, msgid_or_symbol: str, line: Optional[int], is_disabled: bool = True

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -3,7 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
 import sys
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 from astroid import nodes
 
@@ -51,6 +51,13 @@ class MessageDefinition:
             raise InvalidMessageError(f"Invalid message id {msgid!r}")
         if msgid[0] not in MSG_TYPES:
             raise InvalidMessageError(f"Bad message type {msgid[0]} in {msgid!r}")
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, MessageDefinition)
+            and self.msgid == other.msgid
+            and self.symbol == other.symbol
+        )
 
     def __repr__(self) -> str:
         return f"MessageDefinition:{self.symbol} ({self.msgid})"

--- a/tests/config/functional/ini/pylintrc_with_message_control.result.json
+++ b/tests/config/functional/ini/pylintrc_with_message_control.result.json
@@ -1,6 +1,6 @@
 {
   "functional_append": {
-    "disable": [["logging-not-lazy"], ["logging-format-interpolation"]]
+    "disable": ["logging-not-lazy", "logging-format-interpolation"]
   },
   "jobs": 10,
   "reports": true

--- a/tests/config/functional/setup_cfg/setup_cfg_with_message_control.result.json
+++ b/tests/config/functional/setup_cfg/setup_cfg_with_message_control.result.json
@@ -1,6 +1,6 @@
 {
   "functional_append": {
-    "disable": [["logging-not-lazy"], ["logging-format-interpolation"]]
+    "disable": ["logging-not-lazy", "logging-format-interpolation"]
   },
   "jobs": 10,
   "reports": true

--- a/tests/config/functional/toml/issue_3181/top_level_list_of_disable.result.json
+++ b/tests/config/functional/toml/issue_3181/top_level_list_of_disable.result.json
@@ -1,6 +1,6 @@
 {
   "functional_append": {
-    "disable": [["singleton-comparison"]]
+    "disable": ["singleton-comparison"]
   },
   "max_line_length": 120
 }

--- a/tests/config/functional/toml/issue_4580/rich_types.result.json
+++ b/tests/config/functional/toml/issue_4580/rich_types.result.json
@@ -1,6 +1,6 @@
 {
   "functional_append": {
-    "disable": [["logging-not-lazy"], ["logging-format-interpolation"]]
+    "disable": ["logging-not-lazy", "logging-format-interpolation"]
   },
   "jobs": 10,
   "reports": true

--- a/tests/config/functional/toml/issue_4580/top_level_disable.result.json
+++ b/tests/config/functional/toml/issue_4580/top_level_disable.result.json
@@ -1,5 +1,5 @@
 {
   "functional_append": {
-    "disable": [["logging-not-lazy"], ["logging-format-interpolation"]]
+    "disable": ["logging-not-lazy", "logging-format-interpolation"]
   }
 }

--- a/tests/config/functional/toml/issue_4580/valid_data_for_basic.result.json
+++ b/tests/config/functional/toml/issue_4580/valid_data_for_basic.result.json
@@ -1,6 +1,6 @@
 {
   "functional_append": {
-    "disable": [["logging-not-lazy"], ["logging-format-interpolation"]]
+    "disable": ["logging-not-lazy", "logging-format-interpolation"]
   },
   "load_plugins": []
 }

--- a/tests/config/functional/toml/issue_4580/valid_data_for_import.result.json
+++ b/tests/config/functional/toml/issue_4580/valid_data_for_import.result.json
@@ -1,6 +1,6 @@
 {
   "functional_append": {
-    "disable": [["logging-not-lazy"], ["logging-format-interpolation"]]
+    "disable": ["logging-not-lazy", "logging-format-interpolation"]
   },
   "preferred_modules": ["a:b"]
 }

--- a/tests/config/functional/toml/rich_types.result.json
+++ b/tests/config/functional/toml/rich_types.result.json
@@ -1,6 +1,6 @@
 {
   "functional_append": {
-    "disable": [["logging-not-lazy"], ["logging-format-interpolation"]]
+    "disable": ["logging-not-lazy", "logging-format-interpolation"]
   },
   "jobs": 10,
   "reports": true

--- a/tests/config/functional/toml/toml_with_enable.result.json
+++ b/tests/config/functional/toml/toml_with_enable.result.json
@@ -1,9 +1,9 @@
 {
   "functional_append": {
-    "disable": [["logging-not-lazy"], ["logging-format-interpolation"]],
-    "enable": [["suppressed-message"], ["locally-disabled"]]
+    "disable": ["logging-not-lazy", "logging-format-interpolation"],
+    "enable": ["suppressed-message", "locally-disabled"]
   },
   "functional_remove": {
-    "disable": [["suppressed-message"], ["locally-disabled"]]
+    "disable": ["suppressed-message", "locally-disabled"]
   }
 }

--- a/tests/config/functional/toml/toml_with_message_control.result.json
+++ b/tests/config/functional/toml/toml_with_message_control.result.json
@@ -1,6 +1,6 @@
 {
   "functional_append": {
-    "disable": [["logging-not-lazy"], ["logging-format-interpolation"]]
+    "disable": ["logging-not-lazy", "logging-format-interpolation"]
   },
   "jobs": 10,
   "reports": true

--- a/tests/config/functional/toml/unknown_msgid/enable_unknown_msgid.result.json
+++ b/tests/config/functional/toml/unknown_msgid/enable_unknown_msgid.result.json
@@ -1,0 +1,9 @@
+{
+  "functional_append": {
+    "disable": ["logging-format-interpolation"],
+    "enable": ["locally-disabled"]
+  },
+  "functional_remove": {
+    "disable": ["locally-disabled"]
+  }
+}

--- a/tests/config/functional/toml/unknown_msgid/enable_unknown_msgid.toml
+++ b/tests/config/functional/toml/unknown_msgid/enable_unknown_msgid.toml
@@ -1,0 +1,4 @@
+# Check the behavior for unkonwn symbol/msgid
+[tool.pylint."messages control"]
+disable = "logging-not-layzy,logging-format-interpolation"
+enable = "locally-disabled,C00000"


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

I tried to find when this was actually introduced and went back 8+ years into the code but couldn't find the specific commit that did this.

I don't think the current attribute is how we want this to be: why would it be 
```python
self.namespace.disable = [["raw-checker-failed"], ["bad-inline-option"], ["locally-disabled"]]
```
instead of
```python
self.namespace.disable = ["raw-checker-failed", "bad-inline-option", "locally-disabled"]
```

Also note, we don't actually use this config attribute 😅 The only time this gets accessed is during `--generate-rcfile` and `--generate-toml-config`. The other times we simply call `self.linter.disable()` or `enable()` and only update this attribute in `_set_msg_status`. It's just used as reference, but `namespace.disable` or `namespace.enable` serves no other purposes beyond that as far as I can see.