### PR TITLE
Move general options to ``PyLinter`` from individual checkers 

### DIFF
--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -360,19 +360,6 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             },
         ),
         (
-            "analyse-fallback-blocks",
-            {
-                "default": False,
-                "type": "yn",
-                "metavar": "<y or n>",
-                "help": "Analyse import fallback blocks. This can be used to "
-                "support both Python 2 and 3 compatible code, which "
-                "means that the block might have code that exists "
-                "only in one or another interpreter, leading to false "
-                "positives when analysed.",
-            },
-        ),
-        (
             "allow-wildcard-with-all",
             {
                 "default": False,

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -803,20 +803,6 @@ class TypeChecker(BaseChecker):
                 "of the attribute is inferred to be None.",
             },
         ),
-        (
-            "ignored-modules",
-            {
-                "default": (),
-                "type": "csv",
-                "metavar": "<module names>",
-                "help": "List of module names for which member attributes "
-                "should not be checked (useful for modules/projects "
-                "where namespaces are manipulated during runtime and "
-                "thus existing member attributes cannot be "
-                "deduced by static analysis). It supports qualified "
-                "module names, as well as Unix pattern matching.",
-            },
-        ),
         # the defaults here are *stdlib* names that (almost) always
         # lead to false positives, since their idiomatic use is
         # 'too dynamic' for pylint to grok.

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -552,6 +552,33 @@ class PyLinter(  # type: ignore[misc]
                     ),
                 },
             ),
+            (
+                "ignored-modules",
+                {
+                    "default": (),
+                    "type": "csv",
+                    "metavar": "<module names>",
+                    "help": "List of module names for which member attributes "
+                    "should not be checked (useful for modules/projects "
+                    "where namespaces are manipulated during runtime and "
+                    "thus existing member attributes cannot be "
+                    "deduced by static analysis). It supports qualified "
+                    "module names, as well as Unix pattern matching.",
+                },
+            ),
+            (
+                "analyse-fallback-blocks",
+                {
+                    "default": False,
+                    "type": "yn",
+                    "metavar": "<y or n>",
+                    "help": "Analyse import fallback blocks. This can be used to "
+                    "support both Python 2 and 3 compatible code, which "
+                    "means that the block might have code that exists "
+                    "only in one or another interpreter, leading to false "
+                    "positives when analysed.",
+                },
+            ),
         )
 
     option_groups_descs = {


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

These options are used in multiple checkers. This fails our tests because when we only load the checker that "borrows" the option we don't load the actual option. Defining these options on `PyLinter` solves this as we then load them when we initialise `UnittestLinter`.

So it's mainly a change necessary for our unittests but would also allow to only load `PyLinter` and one of the "borrowing" checkers (if we ever support that) without breaking the borrowing checker.