### PR TITLE
Add ``_ArgumentsManager.set_option`` and deprecate old option setters

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,11 @@ Release date: TBA
 
   Ref #5392
 
+* The ``set_option`` method of ``BaseChecker`` has been deprecated. You can use ``checker.linter.set_option``
+  to set an option on the global configuration object instead of a checker-specific object.
+
+  Ref #5392
+
 * The ``config`` attribute of ``PyLinter`` is now of the ``argparse.Namespace`` type instead of
   ``optparse.Values``.
 

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -78,6 +78,11 @@ Other Changes
 
   Ref #5392
 
+* The ``set_option`` method of ``BaseChecker`` has been deprecated. You can use ``checker.linter.set_option``
+  to set an option on the global configuration object instead of a checker-specific object.
+
+  Ref #5392
+
 * The ``config`` attribute of ``PyLinter`` is now of the ``argparse.Namespace`` type instead of
   ``optparse.Values``.
 

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -798,33 +798,18 @@ class SimilarChecker(BaseChecker, Similar, MapReduceMixin):
         Overridden to report options setting to Similar
         """
         # pylint: disable-next=fixme
-        # TODO: Refactor after OptionProvider has been moved to argparse
-        BaseChecker.set_option(self, optname, value, action, optdict)
+        # TODO: Deprecate the non required arguments
+        self.linter.set_option(optname, value)
         if optname == "min-similarity-lines":
-            self.min_lines = (
-                getattr(self.linter.namespace, "min_similarity_lines", None)
-                or self.config.min_similarity_lines
-            )
+            self.min_lines = self.linter.namespace.min_similarity_lines
         elif optname == "ignore-comments":
-            self.ignore_comments = (
-                getattr(self.linter.namespace, "ignore_comments", None)
-                or self.config.ignore_comments
-            )
+            self.ignore_comments = self.linter.namespace.ignore_comments
         elif optname == "ignore-docstrings":
-            self.ignore_docstrings = (
-                getattr(self.linter.namespace, "ignore_docstrings", None)
-                or self.config.ignore_docstrings
-            )
+            self.ignore_docstrings = self.linter.namespace.ignore_docstrings
         elif optname == "ignore-imports":
-            self.ignore_imports = (
-                getattr(self.linter.namespace, "ignore_imports", None)
-                or self.config.ignore_imports
-            )
+            self.ignore_imports = self.linter.namespace.ignore_imports
         elif optname == "ignore-signatures":
-            self.ignore_signatures = (
-                getattr(self.linter.namespace, "ignore_signatures", None)
-                or self.config.ignore_signatures
-            )
+            self.ignore_signatures = self.linter.namespace.ignore_signatures
 
     def open(self):
         """Init the checkers: reset linesets and statistics information."""

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -988,7 +988,7 @@ class VariablesChecker(BaseChecker):
         (
             "init-import",
             {
-                "default": 0,
+                "default": False,
                 "type": "yn",
                 "metavar": "<y or n>",
                 "help": "Tells whether we should check for unused import in "

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -694,7 +694,7 @@ class _ArgumentsManager:
         optname: str,
         value: Any,
         action: Optional[str] = "default_value",
-        optdict: Union[None, str, OptionDict] = "default_value",
+        optdict: None | str | OptionDict = "default_value",
     ) -> None:
         """Set an option on the namespace object."""
         # TODO: 3.0: Remove deprecated arguments. # pylint: disable=fixme

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -693,7 +693,7 @@ class _ArgumentsManager:
         self,
         optname: str,
         value: Any,
-        action: Optional[str] = "default_value",
+        action: str | None = "default_value",
         optdict: None | str | OptionDict = "default_value",
     ) -> None:
         """Set an option on the namespace object."""

--- a/pylint/config/arguments_provider.py
+++ b/pylint/config/arguments_provider.py
@@ -10,8 +10,6 @@ import warnings
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from pylint.config.arguments_manager import _ArgumentsManager
-from pylint.config.callback_actions import _CallbackAction
-from pylint.config.option import _validate
 from pylint.typing import OptionDict, Options
 
 
@@ -93,53 +91,16 @@ class _ArgumentsProvider:
         )
         return getattr(self._arguments_manager.namespace, opt.replace("-", "_"), None)
 
-    # pylint: disable-next=fixme
-    # TODO: Optparse: Refactor and deprecate set_option
+    # pylint: disable-next=unused-argument
     def set_option(self, optname, value, action=None, optdict=None):
-        """Method called to set an option (registered in the options list)."""
-        if optdict is None:
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=DeprecationWarning)
-                optdict = self.get_option_def(optname)
-        if value is not None:
-            value = _validate(value, optdict, optname)
-        if action is None:
-            action = optdict.get("action", "store")
-        if action == "store":
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=DeprecationWarning)
-                setattr(self.config, self.option_attrname(optname, optdict), value)
-        elif action in {"store_true", "count"}:
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=DeprecationWarning)
-                setattr(self.config, self.option_attrname(optname, optdict), value)
-        elif action == "store_false":
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=DeprecationWarning)
-                setattr(self.config, self.option_attrname(optname, optdict), value)
-        elif action == "append":
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=DeprecationWarning)
-                optname = self.option_attrname(optname, optdict)
-            _list = getattr(self.config, optname, None)
-            if _list is None:
-                if isinstance(value, (list, tuple)):
-                    _list = value
-                elif value is not None:
-                    _list = [value]
-                setattr(self.config, optname, _list)
-            elif isinstance(_list, tuple):
-                setattr(self.config, optname, _list + (value,))
-            else:
-                _list.append(value)
-        elif (
-            action == "callback"
-            or (not isinstance(action, str))
-            and issubclass(action, _CallbackAction)
-        ):
-            return
-        else:
-            raise UnsupportedAction(action)
+        """DEPRECATED: Method called to set an option (registered in the options list)."""
+        # TODO: 3.0: Remove deprecated method. # pylint: disable=fixme
+        warnings.warn(
+            "set_option has been deprecated. You can use _arguments_manager.set_option "
+            "or linter.set_option to set options on the global configuration object.",
+            DeprecationWarning,
+        )
+        self._arguments_manager.set_option(optname, value)
 
     def get_option_def(self, opt: str) -> OptionDict:
         """DEPRECATED: Return the dictionary defining an option given its name.

--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -138,7 +138,7 @@ def _convert_option_to_argument(
 def _parse_rich_type_value(value: Any) -> str:
     """Parse rich (toml) types into strings."""
     if isinstance(value, (list, tuple)):
-        return ",".join(value)
+        return ",".join(_parse_rich_type_value(i) for i in value)
     if isinstance(value, re.Pattern):
         return value.pattern
     if isinstance(value, dict):

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -753,37 +753,6 @@ class PyLinter(  # type: ignore[misc]
         self.reporter = reporter
         reporter.linter = self
 
-    def set_option(self, optname, value, action=None, optdict=None):
-        """Overridden from config.OptionsProviderMixin to handle some
-        special options
-        """
-        if optname in self._options_methods or optname in self._bw_options_methods:
-            if value:
-                try:
-                    meth = self._options_methods[optname]
-                except KeyError:
-                    meth = self._bw_options_methods[optname]
-                    warnings.warn(
-                        f"{optname} is deprecated, replace it by {optname.split('-')[0]}",
-                        DeprecationWarning,
-                    )
-                value = utils._check_csv(value)
-                if isinstance(value, (list, tuple)):
-                    for _id in value:
-                        meth(_id, ignore_unknown=True)
-                else:
-                    meth(value)
-                return  # no need to call set_option, disable/enable methods do it
-        elif optname == "output-format":
-            assert isinstance(
-                value, str
-            ), "'output-format' should be a comma separated string of reporters"
-            self._load_reporters(value)
-        try:
-            checkers.BaseTokenChecker.set_option(self, optname, value, action, optdict)
-        except config.UnsupportedAction:
-            print(f"option {optname} can't be read from config file", file=sys.stderr)
-
     def register_reporter(self, reporter_class: Type[reporters.BaseReporter]) -> None:
         """Registers a reporter class on the _reporters attribute."""
         self._reporters[reporter_class.name] = reporter_class


### PR DESCRIPTION
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

Bit of a larger one.

@Pierre-Sassoulas  Let me know what you think of my hack of deprecating unwanted arguments. It's not pretty, but it might work and is more efficient than doing it with `inspect` or something like that.