### PR TITLE
Fix parsing of unknown message IDs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -90,6 +90,12 @@ Release date: TBA
 
   Closes #5205
 
+* ``bad-option-value`` will be emitted whenever a configuration value or command line invocation
+  includes an unknown message.
+
+  Closes #4324
+
+
 * Added the ``generate-toml-config`` option.
 
   Ref #5462

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -104,6 +104,11 @@ Other Changes
 
   Ref #5462
 
+* ``bad-option-value`` will be emitted whenever a configuration value or command line invocation
+  includes an unknown message.
+
+  Closes #4324
+
 * Fix false negative for ``bad-string-format-type`` if the value to be formatted is passed in
   as a variable holding a constant.
 

--- a/pylint/config/callback_actions.py
+++ b/pylint/config/callback_actions.py
@@ -382,9 +382,8 @@ class _DisableAction(_AccessLinterObjectAction):
             try:
                 self.linter.disable(msgid)
             except exceptions.UnknownMessageError:
-                # pylint: disable-next=fixme
-                # TODO: Optparse: Raise an informational warning here
-                pass
+                msg = f"{option_string}. Don't recognize message {msgid}."
+                self.linter.add_message("bad-option-value", args=msg, line=0)
 
 
 class _EnableAction(_AccessLinterObjectAction):
@@ -403,9 +402,8 @@ class _EnableAction(_AccessLinterObjectAction):
             try:
                 self.linter.enable(msgid)
             except exceptions.UnknownMessageError:
-                # pylint: disable-next=fixme
-                # TODO: Optparse: Raise an informational warning here
-                pass
+                msg = f"{option_string}. Don't recognize message {msgid}."
+                self.linter.add_message("bad-option-value", args=msg, line=0)
 
 
 class _OutputFormatAction(_AccessLinterObjectAction):

--- a/pylint/config/callback_actions.py
+++ b/pylint/config/callback_actions.py
@@ -378,13 +378,13 @@ class _DisableAction(_AccessLinterObjectAction):
     ) -> None:
         assert isinstance(values, (tuple, list))
         msgids = utils._check_csv(values[0])
-        try:
-            for msgid in msgids:
+        for msgid in msgids:
+            try:
                 self.linter.disable(msgid)
-        except exceptions.UnknownMessageError:
-            # pylint: disable-next=fixme
-            # TODO: Optparse: Raise an informational warning here
-            pass
+            except exceptions.UnknownMessageError:
+                # pylint: disable-next=fixme
+                # TODO: Optparse: Raise an informational warning here
+                pass
 
 
 class _EnableAction(_AccessLinterObjectAction):
@@ -399,13 +399,13 @@ class _EnableAction(_AccessLinterObjectAction):
     ) -> None:
         assert isinstance(values, (tuple, list))
         msgids = utils._check_csv(values[0])
-        try:
-            for msgid in msgids:
+        for msgid in msgids:
+            try:
                 self.linter.enable(msgid)
-        except exceptions.UnknownMessageError:
-            # pylint: disable-next=fixme
-            # TODO: Optparse: Raise an informational warning here
-            pass
+            except exceptions.UnknownMessageError:
+                # pylint: disable-next=fixme
+                # TODO: Optparse: Raise an informational warning here
+                pass
 
 
 class _OutputFormatAction(_AccessLinterObjectAction):

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -58,9 +58,17 @@ def _config_initialization(
     if reporter:
         linter.set_reporter(reporter)
 
+    # Set the current module to the command line
+    # to allow raising messages on it
+    linter.set_current_module("Command line")
+
     # Now we parse any options from the command line, so they can override
     # the configuration file
     parsed_args_list = linter._parse_command_line_configuration(args_list)
+
+    # Set the current module to configuration as we don't know where
+    # the --load-plugins key is coming from
+    linter.set_current_module("Command line or configuration file")
 
     # We have loaded configuration from config file and command line. Now, we can
     # load plugin specific configuration.

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -167,7 +167,7 @@ MSGS = {
         "Used when an unknown inline option is encountered.",
     ),
     "E0012": (
-        "Bad option value %r",
+        "Bad option value for %s",
         "bad-option-value",
         "Used when a bad value for an inline option is encountered.",
     ),
@@ -936,8 +936,9 @@ class PyLinter(
                         try:
                             meth(msgid, "module", l_start)
                         except exceptions.UnknownMessageError:
+                            msg = f"{pragma_repr.action}. Don't recognize message {msgid}."
                             self.add_message(
-                                "bad-option-value", args=msgid, line=start[0]
+                                "bad-option-value", args=msg, line=start[0]
                             )
             except UnRecognizedOptionError as err:
                 self.add_message(

--- a/tests/config/functional/toml/issue_4746/loaded_plugin_does_not_exists.2.out
+++ b/tests/config/functional/toml/issue_4746/loaded_plugin_does_not_exists.2.out
@@ -1,2 +1,2 @@
-************* Module {abspath}
-{relpath}:1:0: E0013: Plugin 'pylint_websockets' is impossible to load, is it installed ? ('No module named 'pylint_websockets'') (bad-plugin-value)
+************* Module Command line or configuration file
+Command line or configuration file:1:0: E0013: Plugin 'pylint_websockets' is impossible to load, is it installed ? ('No module named 'pylint_websockets'') (bad-plugin-value)

--- a/tests/config/functional/toml/unknown_msgid/enable_unknown_msgid.2.out
+++ b/tests/config/functional/toml/unknown_msgid/enable_unknown_msgid.2.out
@@ -1,0 +1,3 @@
+************* Module {abspath}
+{relpath}:1:0: E0012: Bad option value for --disable. Don't recognize message logging-not-layzy. (bad-option-value)
+{relpath}:1:0: E0012: Bad option value for --enable. Don't recognize message C00000. (bad-option-value)

--- a/tests/config/functional/toml/unknown_msgid/enable_unknown_msgid.result.json
+++ b/tests/config/functional/toml/unknown_msgid/enable_unknown_msgid.result.json
@@ -1,6 +1,7 @@
 {
   "functional_append": {
-    "enable": ["locally-disabled"]
+    "enable": ["locally-disabled"],
+    "disable": ["logging-format-interpolation"]
   },
   "functional_remove": {
     "disable": ["locally-disabled"]

--- a/tests/config/functional/toml/unknown_msgid/enable_unknown_msgid.toml
+++ b/tests/config/functional/toml/unknown_msgid/enable_unknown_msgid.toml
@@ -1,4 +1,6 @@
 # Check the behavior for unkonwn symbol/msgid
+# (Originally) reported in https://github.com/PyCQA/pylint/pull/6293
+
 [tool.pylint."messages control"]
 disable = "logging-not-layzy,logging-format-interpolation"
 enable = "locally-disabled,C00000"

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -7,8 +7,14 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from pylint.lint.run import Run
+from pytest import CaptureFixture
+
+from pylint.lint import Run
 from pylint.testutils.configuration_test import run_using_a_configuration_file
+
+HERE = Path(__file__).parent.absolute()
+REGRTEST_DATA_DIR = HERE / ".." / "regrtest_data"
+EMPTY_MODULE = REGRTEST_DATA_DIR / "empty.py"
 
 
 def check_configuration_file_reader(
@@ -45,3 +51,10 @@ reports = "yes"
     )
     mock_exit.assert_called_once_with(0)
     check_configuration_file_reader(runner)
+
+
+def test_unknown_message_id(capsys: CaptureFixture) -> None:
+    """Check that we correctly raise a message on an unknown id."""
+    Run([str(EMPTY_MODULE), "--disable=12345"], exit=False)
+    output = capsys.readouterr()
+    assert "Command line:1:0: E0012: Bad option value for --disable." in output.out

--- a/tests/functional/b/bad_option_value.txt
+++ b/tests/functional/b/bad_option_value.txt
@@ -1,1 +1,1 @@
-bad-option-value:1:0:None:None::Bad option value 'W04044':UNDEFINED
+bad-option-value:1:0:None:None::Bad option value for enable. Don't recognize message W04044.:UNDEFINED

--- a/tests/functional/u/use/use_symbolic_message_instead.txt
+++ b/tests/functional/u/use/use_symbolic_message_instead.txt
@@ -1,4 +1,4 @@
-bad-option-value:1:0:None:None::Bad option value 'T1234':UNDEFINED
+bad-option-value:1:0:None:None::Bad option value for disable. Don't recognize message T1234.:UNDEFINED
 use-symbolic-message-instead:1:0:None:None::"'C0111' is cryptic: use '# pylint: disable=missing-docstring' instead":UNDEFINED
 use-symbolic-message-instead:1:0:None:None::"'R0903' is cryptic: use '# pylint: disable=too-few-public-methods' instead":UNDEFINED
 use-symbolic-message-instead:2:0:None:None::"'c0111' is cryptic: use '# pylint: enable=missing-docstring' instead":UNDEFINED


### PR DESCRIPTION
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The `try...expect` should have been placed differently. The test was wrong here as well, `"logging-format-interpolation"` should be in `disable` even after the previous message is unknown.

@cdce8p This was caused because in the `homeassistant` config there is a message that has been removed. This caused us to stop parsing the `disable` key when we reached it.

Ref #6293.

Closes #4324.