### PR TITLE
docs: make it clearer that only additional __slots__ should be specified

### DIFF
--- a/doc/data/messages/r/redefined-slots-in-subclass/good.py
+++ b/doc/data/messages/r/redefined-slots-in-subclass/good.py
@@ -3,4 +3,4 @@ class Base:
 
 
 class Subclass(Base):
-    __slots__ = ("c", "d")
+    __slots__ = ("d",)


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

I found the "good" example for `redefined-slots-in-subclass` confusing since it added a new slot `"c"` instead of merely removing `"a"` which is the problem with the "bad" example. As per Python docs, subclasses "should only contain names of any _additional_ slots" https://docs.python.org/3/reference/datamodel.html#notes-on-using-slots