### PR TITLE
Increase coverage for ``argparse``

### DIFF
--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import argparse
-import collections
 import configparser
 import copy
 import optparse  # pylint: disable=deprecated-module
@@ -16,6 +15,7 @@ import re
 import sys
 import textwrap
 import warnings
+from collections import OrderedDict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TextIO, Union
 
@@ -45,10 +45,6 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
-if sys.version_info <= (3, 7, 1):
-    from typing_extensions import OrderedDict
-else:
-    from typing import OrderedDict
 
 if TYPE_CHECKING:
     from pylint.config.arguments_provider import _ArgumentsProvider
@@ -86,7 +82,7 @@ class _ArgumentsManager:
         # list of registered options providers
         self.options_providers: list[ConfigProvider] = []
         # dictionary associating option name to checker
-        self._all_options: OrderedDict[str, ConfigProvider] = collections.OrderedDict()
+        self._all_options: OrderedDict[str, ConfigProvider] = OrderedDict()
         self._short_options: dict[str, str] = {}
         self._nocallback_options: dict[ConfigProvider, str] = {}
         self._mygroups: dict[str, optparse.OptionGroup] = {}

--- a/tests/config/test_argparse_config.py
+++ b/tests/config/test_argparse_config.py
@@ -9,6 +9,8 @@ from os.path import abspath, dirname, join
 
 import pytest
 
+from pylint.config.arguments_manager import _ArgumentsManager
+from pylint.config.exceptions import UnrecognizedArgumentAction
 from pylint.lint import Run
 
 HERE = abspath(dirname(__file__))
@@ -64,3 +66,14 @@ class TestDeprecationOptions:
         assert run.linter.config.ignore == run.linter.config.black_list
         assert run.linter.config.ignore_patterns == [re.compile("^\\.#")]
         assert run.linter.config.ignore_patterns == run.linter.config.black_list_re
+
+
+class TestArguments:
+    @staticmethod
+    def test_unrecognized_argument() -> None:
+        """Check that we correctly emit a warning for unrecognized argument types."""
+        manager = _ArgumentsManager(prog="test")
+        group = manager._arg_parser.add_argument_group(title="test")
+        with pytest.raises(UnrecognizedArgumentAction):
+            # We test with None as that is 'unrecognized'
+            manager._add_parser_option(group, None)  # type: ignore[arg-type]

--- a/tests/config/test_deprecations.py
+++ b/tests/config/test_deprecations.py
@@ -17,6 +17,21 @@ class SampleChecker(BaseChecker):
     options = (("test-opt", {"action": "store_true", "help": "help message"}),)
 
 
+class SampleCheckerTwo(BaseChecker):
+    options = (
+        ("test-opt-two", {"action": "store", "type": "string", "help": "help message"}),
+    )
+
+
+class SampleCheckerThree(BaseChecker):
+    options = (
+        (
+            "test-opt-three",
+            {"action": "store_true", "level": 1, "help": "help message"},
+        ),
+    )
+
+
 class TestDeprecationArgumentsManager:
     """Tests for deprecation warnings in the ArgumentsManager class."""
 
@@ -87,3 +102,13 @@ class TestDeprecationArgumentsManager:
 
         with pytest.warns(DeprecationWarning):
             assert self.linter.level is not None
+
+    def test_no_default_in_optdict(self) -> None:
+        """Test that not having a default value in a optiondict emits a DeprecationWarning."""
+        with pytest.warns(DeprecationWarning):
+            SampleCheckerTwo(self.linter)
+
+    def test_no_level_in_optdict(self) -> None:
+        """Test that not having a level value in a optiondict emits a DeprecationWarning."""
+        with pytest.warns(DeprecationWarning):
+            SampleCheckerThree(self.linter)


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

For all of these upcoming PRs:
They will get 100% coverage when we switch `pyreverse` and when we finally test on `3.11` (I'm keeping an eye on this, we're waiting on Github..).
Should be able to get ``pylint/config`` to 100%.