### PR TITLE
Deprecate all old classes from ``optparse``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -47,6 +47,30 @@ Release date: TBA
 
   Ref #5392
 
+* ``UnsupportedAction`` has been deprecated.
+
+  Ref #5392
+
+* ``OptionsManagerMixIn`` has been deprecated.
+
+  Ref #5392
+
+* ``OptionParser`` has been deprecated.
+
+  Ref #5392
+
+* ``Option`` has been deprecated.
+
+  Ref #5392
+
+* ``OptionsProviderMixIn`` has been deprecated.
+
+  Ref #5392
+
+* ``ConfigurationMixIn`` has been deprecated.
+
+  Ref #5392
+
 * ``get_global_config`` has been deprecated. You can now access all global options from
   ``checker.linter.config``.
 

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -97,6 +97,30 @@ Other Changes
 
   Ref #5392
 
+* ``UnsupportedAction`` has been deprecated.
+
+  Ref #5392
+
+* ``OptionsManagerMixIn`` has been deprecated.
+
+  Ref #5392
+
+* ``OptionParser`` has been deprecated.
+
+  Ref #5392
+
+* ``Option`` has been deprecated.
+
+  Ref #5392
+
+* ``OptionsProviderMixIn`` has been deprecated.
+
+  Ref #5392
+
+* ``ConfigurationMixIn`` has been deprecated.
+
+  Ref #5392
+
 * ``get_global_config`` has been deprecated. You can now access all global options from
   ``checker.linter.config``.
 

--- a/pylint/config/__init__.py
+++ b/pylint/config/__init__.py
@@ -8,7 +8,7 @@ import pickle
 import sys
 from datetime import datetime
 
-from pylint.config.config_file_parser import _ConfigurationFileParser
+from pylint.config.arguments_provider import UnsupportedAction
 from pylint.config.configuration_mixin import ConfigurationMixIn
 from pylint.config.environment_variable import PYLINTRC
 from pylint.config.find_default_config_files import (
@@ -18,20 +18,19 @@ from pylint.config.find_default_config_files import (
 from pylint.config.option import Option
 from pylint.config.option_manager_mixin import OptionsManagerMixIn
 from pylint.config.option_parser import OptionParser
-from pylint.config.options_provider_mixin import OptionsProviderMixIn, UnsupportedAction
+from pylint.config.options_provider_mixin import OptionsProviderMixIn
 from pylint.constants import DEFAULT_PYLINT_HOME, OLD_DEFAULT_PYLINT_HOME, USER_HOME
 from pylint.utils import LinterStats
 
 __all__ = [
-    "_ConfigurationFileParser",
-    "ConfigurationMixIn",
+    "ConfigurationMixIn",  # Deprecated
     "find_default_config_files",
-    "find_pylintrc",
-    "Option",
-    "OptionsManagerMixIn",
-    "OptionParser",
-    "OptionsProviderMixIn",
-    "UnsupportedAction",
+    "find_pylintrc",  # Deprecated
+    "Option",  # Deprecated
+    "OptionsManagerMixIn",  # Deprecated
+    "OptionParser",  # Deprecated
+    "OptionsProviderMixIn",  # Deprecated
+    "UnsupportedAction",  # Deprecated
     "PYLINTRC",
     "USER_HOME",
 ]

--- a/pylint/config/arguments_provider.py
+++ b/pylint/config/arguments_provider.py
@@ -19,6 +19,14 @@ from pylint.typing import OptionDict, Options
 class UnsupportedAction(Exception):
     """Raised by set_option when it doesn't know what to do for an action."""
 
+    def __init__(self, *args: object) -> None:
+        # TODO: 3.0: Remove deprecated exception # pylint: disable=fixme
+        warnings.warn(
+            "UnsupportedAction has been deprecated and will be removed in pylint 3.0",
+            DeprecationWarning,
+        )
+        super().__init__(*args)
+
 
 class _ArgumentsProvider:
     """Base class for classes that provide arguments."""

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -8,7 +8,8 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pylint import config, reporters
+from pylint import reporters
+from pylint.config.config_file_parser import _ConfigurationFileParser
 from pylint.config.exceptions import _UnrecognizedOptionError
 from pylint.utils import utils
 
@@ -33,7 +34,7 @@ def _config_initialization(
     linter.set_current_module(str(config_file) if config_file else None)
 
     # Read the configuration file
-    config_file_parser = config._ConfigurationFileParser(verbose_mode, linter)
+    config_file_parser = _ConfigurationFileParser(verbose_mode, linter)
     try:
         config_data, config_args = config_file_parser.parse_config_file(
             file_path=config_file

--- a/pylint/config/configuration_mixin.py
+++ b/pylint/config/configuration_mixin.py
@@ -2,6 +2,8 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
+import warnings
+
 from pylint.config.option_manager_mixin import OptionsManagerMixIn
 from pylint.config.options_provider_mixin import OptionsProviderMixIn
 
@@ -12,6 +14,11 @@ class ConfigurationMixIn(OptionsManagerMixIn, OptionsProviderMixIn):
     """
 
     def __init__(self, *args, **kwargs):
+        # TODO: 3.0: Remove deprecated class # pylint: disable=fixme
+        warnings.warn(
+            "ConfigurationMixIn has been deprecated and will be removed in pylint 3.0",
+            DeprecationWarning,
+        )
         if not args:
             kwargs.setdefault("usage", "")
         OptionsManagerMixIn.__init__(self, *args, **kwargs)

--- a/pylint/config/option.py
+++ b/pylint/config/option.py
@@ -8,6 +8,7 @@ import copy
 import optparse  # pylint: disable=deprecated-module
 import pathlib
 import re
+import warnings
 from re import Pattern
 
 from pylint import utils
@@ -171,6 +172,11 @@ class Option(optparse.Option):
     TYPE_CHECKER["py_version"] = _py_version_validator
 
     def __init__(self, *opts, **attrs):
+        # TODO: 3.0: Remove deprecated class # pylint: disable=fixme
+        warnings.warn(
+            "Option has been deprecated and will be removed in pylint 3.0",
+            DeprecationWarning,
+        )
         super().__init__(*opts, **attrs)
         if hasattr(self, "hide") and self.hide:
             self.help = optparse.SUPPRESS_HELP

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -11,6 +11,7 @@ import copy
 import optparse  # pylint: disable=deprecated-module
 import os
 import sys
+import warnings
 from pathlib import Path
 from typing import TextIO
 
@@ -62,9 +63,11 @@ class OptionsManagerMixIn:
     """Handle configuration from both a configuration file and command line options."""
 
     def __init__(self, usage):
-        # pylint: disable-next=fixme
-        # TODO: Optparse: Deprecate this class when we don't use ConfigurationMixIn
-        # internally anymore
+        # TODO: 3.0: Remove deprecated class # pylint: disable=fixme
+        warnings.warn(
+            "OptionsManagerMixIn has been deprecated and will be removed in pylint 3.0",
+            DeprecationWarning,
+        )
         self.reset_parsers(usage)
         # list of registered options providers
         self.options_providers = []

--- a/pylint/config/option_parser.py
+++ b/pylint/config/option_parser.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
 import optparse  # pylint: disable=deprecated-module
+import warnings
 
 from pylint.config.option import Option
 
@@ -18,6 +19,11 @@ def _level_options(group, outputlevel):
 
 class OptionParser(optparse.OptionParser):
     def __init__(self, option_class, *args, **kwargs):
+        # TODO: 3.0: Remove deprecated class # pylint: disable=fixme
+        warnings.warn(
+            "OptionParser has been deprecated and will be removed in pylint 3.0",
+            DeprecationWarning,
+        )
         super().__init__(option_class=Option, *args, **kwargs)
 
     def format_option_help(self, formatter=None):

--- a/pylint/config/options_provider_mixin.py
+++ b/pylint/config/options_provider_mixin.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
 import optparse  # pylint: disable=deprecated-module
+import warnings
 
 from pylint.config.callback_actions import _CallbackAction
 from pylint.config.option import _validate
@@ -22,6 +23,11 @@ class OptionsProviderMixIn:
     level = 0
 
     def __init__(self):
+        # TODO: 3.0: Remove deprecated class # pylint: disable=fixme
+        warnings.warn(
+            "OptionsProviderMixIn has been deprecated and will be removed in pylint 3.0",
+            DeprecationWarning,
+        )
         self.config = optparse.Values()
         self.load_defaults()
 


### PR DESCRIPTION
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

🎉 

Bit premature because `pyreverse` is still using these, but we might as well deprecate them.