### PR TITLE
Remove pointless ``check_messages`` decorators

### DIFF
--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -16,7 +16,6 @@ from astroid import nodes
 
 from pylint.checkers import BaseChecker, DeprecatedMixin
 from pylint.checkers.utils import (
-    check_messages,
     get_import_name,
     is_from_fallback_block,
     is_node_in_guarded_import_block,
@@ -420,7 +419,6 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
         """Callback returning the deprecated modules."""
         return self.linter.config.deprecated_modules
 
-    @check_messages(*MSGS)
     def visit_import(self, node: nodes.Import) -> None:
         """Triggered when an import statement is seen."""
         self._check_reimport(node)
@@ -446,7 +444,6 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
 
             self._add_imported_module(node, imported_module.name)
 
-    @check_messages(*MSGS)
     def visit_importfrom(self, node: nodes.ImportFrom) -> None:
         """Triggered when a from statement is seen."""
         basename = node.modname
@@ -474,7 +471,6 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             else:
                 self._add_imported_module(node, imported_module.name)
 
-    @check_messages(*MSGS)
     def leave_module(self, node: nodes.Module) -> None:
         # Check imports are grouped by category (standard, 3rd party, local)
         std_imports, ext_imports, loc_imports = self._check_imports_order(node)

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -14,7 +14,7 @@ from astroid import nodes
 
 from pylint import checkers, interfaces
 from pylint.checkers import utils
-from pylint.checkers.utils import check_messages, infer_all
+from pylint.checkers.utils import infer_all
 
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
@@ -180,7 +180,6 @@ class LoggingChecker(checkers.BaseChecker):
             if module in self._logging_modules:
                 self._logging_names.add(as_name or module)
 
-    @check_messages(*MSGS)
     def visit_call(self, node: nodes.Call) -> None:
         """Checks calls to logging methods."""
 

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -405,7 +405,6 @@ class StringFormatChecker(BaseChecker):
                 return
         self.add_message("f-string-without-interpolation", node=node)
 
-    @check_messages(*MSGS)
     def visit_call(self, node: nodes.Call) -> None:
         func = utils.safe_infer(node.func)
         if (

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1294,7 +1294,6 @@ accessed. Python regular expressions are accepted.",
             self.add_message("isinstance-second-argument-not-valid-type", node=node)
 
     # pylint: disable=too-many-branches,too-many-locals
-    @check_messages(*(list(MSGS.keys())))
     def visit_call(self, node: nodes.Call) -> None:
         """Check that called functions/methods are inferred to callable objects,
         and that passed arguments match the parameters in the inferred function.
@@ -1831,12 +1830,10 @@ accessed. Python regular expressions are accepted.",
                 self.add_message("unsupported-binary-operation", args=msg, node=node)
                 break
 
-    @check_messages("unsupported-binary-operation")
     def _visit_binop(self, node: nodes.BinOp) -> None:
         """Detect TypeErrors for binary arithmetic operands."""
         self._check_binop_errors(node)
 
-    @check_messages("unsupported-binary-operation")
     def _visit_augassign(self, node: nodes.AugAssign) -> None:
         """Detect TypeErrors for augmented binary arithmetic operands."""
         self._check_binop_errors(node)

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1830,10 +1830,20 @@ accessed. Python regular expressions are accepted.",
                 self.add_message("unsupported-binary-operation", args=msg, node=node)
                 break
 
+    # pylint: disable-next=fixme
+    # TODO: This check was disabled (by adding the leading underscore)
+    # due to false positives several years ago - can we re-enable it?
+    # https://github.com/PyCQA/pylint/issues/6359
+    @check_messages("unsupported-binary-operation")
     def _visit_binop(self, node: nodes.BinOp) -> None:
         """Detect TypeErrors for binary arithmetic operands."""
         self._check_binop_errors(node)
 
+    # pylint: disable-next=fixme
+    # TODO: This check was disabled (by adding the leading underscore)
+    # due to false positives several years ago - can we re-enable it?
+    # https://github.com/PyCQA/pylint/issues/6359
+    @check_messages("unsupported-binary-operation")
     def _visit_augassign(self, node: nodes.AugAssign) -> None:
         """Detect TypeErrors for augmented binary arithmetic operands."""
         self._check_binop_errors(node)


### PR DESCRIPTION

- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

As discussed in #6060, ``@check_messages`` has no effect in the following cases:

1. Decorating a method that does not start with ``visit_*`` or ``leave_*``: https://github.com/PyCQA/pylint/blob/ebf7bd6793dc484513455d0c47acd6a285a8d1a5/pylint/utils/ast_walker.py#L35-L46)
2. Passing in all messages this checker defines with ``@check_messages(*MSGS)``. This has the same effect as not decorating it at all:
https://github.com/PyCQA/pylint/blob/ebf7bd6793dc484513455d0c47acd6a285a8d1a5/pylint/utils/ast_walker.py#L20-L23
If none of the checker's messages is enabled, we won't load it anyway: 
https://github.com/PyCQA/pylint/blob/ebf7bd6793dc484513455d0c47acd6a285a8d1a5/pylint/lint/pylinter.py#L987-L997


