### PR TITLE
Run deprecated checks with `--enable=deprecated*` after `disable=all`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,8 @@ Release date: TBA
 
   Closes #5224
 
+* Fixed failure to run deprecated checks with ``--enable=deprecated*`` after a ``disable=all``.
+
 * The ``config`` attribute of ``BaseChecker`` has been deprecated. You can use ``checker.linter.config``
   to access the global configuration object instead of a checker-specific object.
 

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -25,6 +25,8 @@ New checkers
 
   Closes #5895
 
+* Fixed failure to run deprecated checks with ``--enable=deprecated*`` after a ``disable=all``.
+
 * Add new check ``unnecessary-dunder-call`` for unnecessary dunder method calls.
 
   Closes #5936

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -59,6 +59,11 @@ class DeprecatedMixin(BaseChecker):
         ),
     }
 
+    def check_consistency(self):
+        """This is a mixin, so there is no expectation that the messages should be
+        mutually exclusive. They will overlap between checkers by design."""
+        pass
+
     @utils.check_messages(
         "deprecated-method",
         "deprecated-argument",

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -441,6 +441,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
             {"old_names": [("W1516", "lru-cache-decorating-method")]},
         ),
     }
+    msgs.update(DeprecatedMixin.msgs)
 
     def __init__(self, linter: PyLinter) -> None:
         BaseChecker.__init__(self, linter)

--- a/tests/functional/d/deprecated/deprecated_module_py3.rc
+++ b/tests/functional/d/deprecated/deprecated_module_py3.rc
@@ -1,5 +1,2 @@
 [typing]
 py-version=3.6
-
-[testoptions]
-exclude_from_minimal_messages_config=true

--- a/tests/functional/d/deprecated/deprecated_module_py310.rc
+++ b/tests/functional/d/deprecated/deprecated_module_py310.rc
@@ -1,3 +1,2 @@
 [testoptions]
 min_pyver = 3.10
-exclude_from_minimal_messages_config=true

--- a/tests/functional/d/deprecated/deprecated_module_py33.rc
+++ b/tests/functional/d/deprecated/deprecated_module_py33.rc
@@ -1,2 +1,0 @@
-[testoptions]
-exclude_from_minimal_messages_config=true

--- a/tests/functional/d/deprecated/deprecated_module_py36.rc
+++ b/tests/functional/d/deprecated/deprecated_module_py36.rc
@@ -1,2 +1,0 @@
-[testoptions]
-exclude_from_minimal_messages_config=true

--- a/tests/functional/d/deprecated/deprecated_module_py39_earlier_pyversion.rc
+++ b/tests/functional/d/deprecated/deprecated_module_py39_earlier_pyversion.rc
@@ -3,4 +3,3 @@ py-version=3.8
 
 [testoptions]
 min_pyver=3.9
-exclude_from_minimal_messages_config=true

--- a/tests/functional/d/deprecated/deprecated_relative_import/dot_relative_import.rc
+++ b/tests/functional/d/deprecated/deprecated_relative_import/dot_relative_import.rc
@@ -1,2 +1,0 @@
-[testoptions]
-exclude_from_minimal_messages_config=true

--- a/tests/functional/d/deprecated/deprecated_relative_import/subpackage/dot_dot_relative_import.rc
+++ b/tests/functional/d/deprecated/deprecated_relative_import/subpackage/dot_dot_relative_import.rc
@@ -1,2 +1,0 @@
-[testoptions]
-exclude_from_minimal_messages_config=true

--- a/tests/message/unittest_message_id_store.py
+++ b/tests/message/unittest_message_id_store.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from pylint import lint
+from pylint.checkers.deprecated import DeprecatedMixin
 from pylint.exceptions import InvalidMessageError, UnknownMessageError
 from pylint.message.message_definition import MessageDefinition
 from pylint.message.message_id_store import MessageIdStore
@@ -126,7 +127,7 @@ def test_exclusivity_of_msgids() -> None:
         ),
         "02": ("classes", "refactoring", "multiple_types"),
         "03": ("classes", "format"),
-        "04": ("imports", "spelling"),
+        "04": ("imports", "spelling", "stdlib"),  # stdlib is here because of DeprecatedMixin
         "05": ("consider-using-any-or-all", "miscellaneous"),
         "07": ("exceptions", "broad_try_clause", "overlap-except"),
         "12": ("design", "logging"),


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Before, the `deprecated-module` etc. checks did not run if they were enabled with `--enable` after a `--disable=all`.

Follow-up to [fabc645](https://github.com/PyCQA/pylint/pull/6246/commits/fabc6453cb8c8ef9b5622677ab554af157cf42bd).