### PR TITLE
Fix a failure to respect inline disables for `fixme`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,9 @@ Release date: TBA
 
 * ``BaseChecker`` classes now require the ``linter`` argument to be passed.
 
+* Fix a failure to respect inline disables for ``fixme`` occurring on the last line
+  of a module when pylint is launched with ``--enable=fixme``.
+
 * Update ``invalid-slots-object`` message to show bad object rather than its inferred value.
 
   Closes #6101

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -68,6 +68,9 @@ Other Changes
 
   Closes #6101
 
+* Fix a failure to respect inline disables for ``fixme`` occurring on the last line
+  of a module when pylint is launched with ``--enable=fixme``.
+
 * Removed the broken ``generate-man`` option.
 
   Closes #5283

--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -166,8 +166,8 @@ class EncodingChecker(BaseChecker):
                         line=comment.start[0],
                     )
                     continue
-                else:
-                    continue
+                self.linter.add_ignored_message("fixme", line=comment.start[0])
+                continue
 
             # emit warnings if necessary
             match = self._fixme_pattern.search("#" + comment_text.lower())

--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -159,15 +159,14 @@ class EncodingChecker(BaseChecker):
                     except PragmaParserError:
                         # Printing useful information dealing with this error is done in the lint package
                         pass
-                    if set(values) & set(self.linter.config.notes):
-                        continue
-                    self.linter.disable("fixme", scope="module", line=comment.start[0])
                 except ValueError:
                     self.add_message(
                         "bad-inline-option",
                         args=disable_option_match.group(1).strip(),
                         line=comment.start[0],
                     )
+                    continue
+                else:
                     continue
 
             # emit warnings if necessary

--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -161,6 +161,7 @@ class EncodingChecker(BaseChecker):
                         pass
                     if set(values) & set(self.linter.config.notes):
                         continue
+                    self.linter.disable("fixme", scope="module", line=comment.start[0])
                 except ValueError:
                     self.add_message(
                         "bad-inline-option",

--- a/tests/functional/f/fixme.rc
+++ b/tests/functional/f/fixme.rc
@@ -3,6 +3,3 @@
 notes=XXX,TODO,./TODO
 # Regular expression of note tags to take in consideration.
 notes-rgx=FIXME(?!.*ISSUE-\d+)|TO.*DO
-
-[testoptions]
-exclude_from_minimal_messages_config=true


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug   |

## Description

**Before**: `# pylint: disable=fixme` didn't work on the last line of a module if pylint was invoked with `--enable=fixme`.


Followup to 0281388, identifying and fixing the other functional bug revealed there.