### PR TITLE
Prevent false negatives for fatal errors with `--minimal-messages-config`

### DIFF
--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -68,6 +68,9 @@ class LintModuleTest:
         if config and config.getoption("minimal_messages_config"):
             with self._open_source_file() as f:
                 messages_to_enable = {msg[1] for msg in self.get_expected_messages(f)}
+                # Always enable fatal errors
+                messages_to_enable.add("astroid-error")
+                messages_to_enable.add("fatal")
             args.extend(["--disable=all", f"--enable={','.join(messages_to_enable)}"])
         _config_initialization(
             self._linter, args_list=args, config_file=rc_file, reporter=_test_reporter

--- a/tests/testutils/test_functional_testutils.py
+++ b/tests/testutils/test_functional_testutils.py
@@ -59,6 +59,9 @@ def test_minimal_messages_config_enabled(pytest_config) -> None:
             "consider-using-with",
             "unspecified-encoding",
             "consider-using-f-string",
+            # Always enable fatal errors: important not to have false negatives
+            "astroid-error",
+            "fatal",
         )
     )
     assert not mod_test._linter.is_message_enabled("unused-import")


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

`--minimal-messages-config` is an awesome testing tool. But while working on #6362, I found it surprising that crashes were silenced. There were a couple moments where I thought I had a solution that would pass the tests, only to find later that fatal errors were being silenced. (Unbeknownst to me, I was generating a bunch of crash_reports.txt, but pytest was green.)

By design, this tool allows false negatives for unmentioned errors. But I think `astroid-error` and `fatal`, which are the two errors `pylint` emits when any internal failure occurs, should be included with the "minimal" config, because we don't really need to test the isolation of `astroid-error` and `fatal`. It's more important to not have false negatives for crashes IMO.