### PR TITLE
Fix a crash in the ``unsupported-membership-test`` checker involving tuple unpacking

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -186,6 +186,11 @@ What's New in Pylint 2.13.6?
 ============================
 Release date: TBA
 
+* Fix a crash in the ``unsupported-membership-test`` checker when assigning
+  multiple constants to class attributes including ``__iter__`` via unpacking.
+
+  Closes #6366
+
 * Asterisks are no longer required in Sphinx and Google style parameter documentation
   for ``missing-param-doc`` and are parsed correctly.
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -582,6 +582,11 @@ Other Changes
 
   Closes #5803
 
+* Fix a crash in the ``unsupported-membership-test`` checker when assigning
+  multiple constants to class attributes including ``__iter__`` via unpacking.
+
+  Closes #6366
+
 * Fix false positive for ``used-before-assignment`` for assignments taking place via
   nonlocal declarations after an earlier type annotation.
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1066,8 +1066,15 @@ def _supports_protocol_method(value: nodes.NodeNG, attr: str) -> bool:
         return False
 
     first = attributes[0]
+
+    # Return False if a constant is assigned
     if isinstance(first, nodes.AssignName):
-        if isinstance(first.parent.value, nodes.Const):
+        this_assign_parent = get_node_first_ancestor_of_type(first, nodes.Assign)
+        assert this_assign_parent is not None
+        if isinstance(this_assign_parent.value, nodes.BaseContainer):
+            if all(isinstance(n, nodes.Const) for n in this_assign_parent.value.elts):
+                return False
+        if isinstance(this_assign_parent.value, nodes.Const):
             return False
     return True
 

--- a/tests/functional/n/none_dunder_protocols.py
+++ b/tests/functional/n/none_dunder_protocols.py
@@ -25,6 +25,15 @@ class NonContainerClass(metaclass=MetaContainer):
     __iter__ = None
 
 
+class MultipleAssignmentNonesClass(metaclass=MetaContainer):
+    __len__, __iter__ = [None, None]
+
+
+class MultipleAssignmentLambdasClass(metaclass=MetaContainer):
+    """https://github.com/PyCQA/pylint/issues/6366"""
+    __len__, __iter__ = [lambda x: x] * 2
+
+
 def test():
     1 in NonIterableClass  # [unsupported-membership-test]
     1 in OldNonIterableClass  # [unsupported-membership-test]
@@ -32,3 +41,5 @@ def test():
     1 in NonIterableClass()  # [unsupported-membership-test]
     1 in OldNonIterableClass()  # [unsupported-membership-test]
     1 in NonContainerClass()  # [unsupported-membership-test]
+    1 in MultipleAssignmentNonesClass()  # [unsupported-membership-test]
+    1 in MultipleAssignmentLambdasClass()

--- a/tests/functional/n/none_dunder_protocols.txt
+++ b/tests/functional/n/none_dunder_protocols.txt
@@ -1,6 +1,7 @@
-unsupported-membership-test:29:9:29:25:test:Value 'NonIterableClass' doesn't support membership test:UNDEFINED
-unsupported-membership-test:30:9:30:28:test:Value 'OldNonIterableClass' doesn't support membership test:UNDEFINED
-unsupported-membership-test:31:9:31:26:test:Value 'NonContainerClass' doesn't support membership test:UNDEFINED
-unsupported-membership-test:32:9:32:27:test:Value 'NonIterableClass()' doesn't support membership test:UNDEFINED
-unsupported-membership-test:33:9:33:30:test:Value 'OldNonIterableClass()' doesn't support membership test:UNDEFINED
-unsupported-membership-test:34:9:34:28:test:Value 'NonContainerClass()' doesn't support membership test:UNDEFINED
+unsupported-membership-test:38:9:38:25:test:Value 'NonIterableClass' doesn't support membership test:UNDEFINED
+unsupported-membership-test:39:9:39:28:test:Value 'OldNonIterableClass' doesn't support membership test:UNDEFINED
+unsupported-membership-test:40:9:40:26:test:Value 'NonContainerClass' doesn't support membership test:UNDEFINED
+unsupported-membership-test:41:9:41:27:test:Value 'NonIterableClass()' doesn't support membership test:UNDEFINED
+unsupported-membership-test:42:9:42:30:test:Value 'OldNonIterableClass()' doesn't support membership test:UNDEFINED
+unsupported-membership-test:43:9:43:28:test:Value 'NonContainerClass()' doesn't support membership test:UNDEFINED
+unsupported-membership-test:44:9:44:39:test:Value 'MultipleAssignmentNonesClass()' doesn't support membership test:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
An assumption of direct parentage between `AssignName` and `Assign` was violated by tuple unpacking.

Closes #6366
