### PR TITLE
Make ``BaseChecker`` a ``MapReduceMixin``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -66,7 +66,7 @@ Release date: TBA
 * ``MapReduceMixin`` has been deprecated. ``BaseChecker`` now implements ``get_map_data`` and
   ``reduce_map_data``. If a checker actually needs to reduce data it should define ``get_map_data``
   as returning something different than ``None`` and let its ``reduce_map_data`` handle a list
-  of the type returned by ``get_map_data``.
+  of the types returned by ``get_map_data``.
   An example can be seen by looking at ``pylint/checkers/similar.py``.
 
 * ``UnsupportedAction`` has been deprecated.

--- a/ChangeLog
+++ b/ChangeLog
@@ -63,6 +63,12 @@ Release date: TBA
 
   Ref #5392
 
+* ``MapReduceMixin`` has been deprecated. ``BaseChecker`` now implements ``get_map_data`` and
+  ``reduce_map_data``. If a checker actually needs to reduce data it should define ``get_map_data``
+  as returning something different than ``None`` and let its ``reduce_map_data`` handle a list
+  of the type returned by ``get_map_data``.
+  An example can be seen by looking at ``pylint/checkers/similar.py``.
+
 * ``UnsupportedAction`` has been deprecated.
 
   Ref #5392

--- a/doc/how_tos/custom_checkers.rst
+++ b/doc/how_tos/custom_checkers.rst
@@ -246,11 +246,11 @@ Now we can debug our checker!
 Parallelize a Checker
 ---------------------
 
-``BaseChecker`` have a ``get_map_data`` and a ``reduce_map_data`` function that
-permit to parallelize the checks when used with the ``-j`` otion. If a checker
+``BaseChecker`` has two methods ``get_map_data`` and ``reduce_map_data`` that
+permit to parallelize the checks when used with the ``-j`` option. If a checker
 actually needs to reduce data it should define ``get_map_data`` as returning
 something different than ``None`` and let its ``reduce_map_data`` handle a list
-of the type returned by ``get_map_data``.
+of the types returned by ``get_map_data``.
 
 An example can be seen by looking at ``pylint/checkers/similar.py``.
 

--- a/doc/how_tos/custom_checkers.rst
+++ b/doc/how_tos/custom_checkers.rst
@@ -243,6 +243,17 @@ Now we can debug our checker!
     environment variable or by adding the ``my_plugin.py``
     file to the ``pylint/checkers`` directory if running from source.
 
+Parallelize a Checker
+---------------------
+
+``BaseChecker`` have a ``get_map_data`` and a ``reduce_map_data`` function that
+permit to parallelize the checks when used with the ``-j`` otion. If a checker
+actually needs to reduce data it should define ``get_map_data`` as returning
+something different than ``None`` and let its ``reduce_map_data`` handle a list
+of the type returned by ``get_map_data``.
+
+An example can be seen by looking at ``pylint/checkers/similar.py``.
+
 Testing a Checker
 -----------------
 Pylint is very well suited to test driven development.

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -28,7 +28,7 @@ New checkers
 * ``MapReduceMixin`` has been deprecated. ``BaseChecker`` now implements ``get_map_data`` and
   ``reduce_map_data``. If a checker actually needs to reduce data it should define ``get_map_data``
   as returning something different than ``None`` and let its ``reduce_map_data`` handle a list
-  of the type returned by ``get_map_data``.
+  of the types returned by ``get_map_data``.
   An example can be seen by looking at ``pylint/checkers/similar.py``.
 
 * Add new check ``unnecessary-dunder-call`` for unnecessary dunder method calls.

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -25,6 +25,12 @@ New checkers
 
   Closes #5895
 
+* ``MapReduceMixin`` has been deprecated. ``BaseChecker`` now implements ``get_map_data`` and
+  ``reduce_map_data``. If a checker actually needs to reduce data it should define ``get_map_data``
+  as returning something different than ``None`` and let its ``reduce_map_data`` handle a list
+  of the type returned by ``get_map_data``.
+  An example can be seen by looking at ``pylint/checkers/similar.py``.
+
 * Add new check ``unnecessary-dunder-call`` for unnecessary dunder method calls.
 
   Closes #5936

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from astroid import nodes
 
+from pylint.checkers.mapreduce_checker import MapReduceMixin
 from pylint.config.arguments_provider import _ArgumentsProvider
 from pylint.constants import _MSG_ORDER, MAIN_CHECKER_NAME, WarningScope
 from pylint.exceptions import InvalidMessageError
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
 
 
 @functools.total_ordering
-class BaseChecker(_ArgumentsProvider):
+class BaseChecker(_ArgumentsProvider, MapReduceMixin):
 
     # checker name (you may reuse an existing one)
     name: str = ""
@@ -205,6 +206,12 @@ class BaseChecker(_ArgumentsProvider):
 
     def close(self):
         """Called after visiting project (i.e set of modules)."""
+
+    def get_map_data(self) -> Any:
+        return None
+
+    def reduce_map_data(self, linter: PyLinter, data: list[Any]) -> None:
+        return None
 
 
 class BaseTokenChecker(BaseChecker):

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any
 
 from astroid import nodes
 
-from pylint.checkers.mapreduce_checker import MapReduceMixin
 from pylint.config.arguments_provider import _ArgumentsProvider
 from pylint.constants import _MSG_ORDER, MAIN_CHECKER_NAME, WarningScope
 from pylint.exceptions import InvalidMessageError
@@ -25,7 +24,7 @@ if TYPE_CHECKING:
 
 
 @functools.total_ordering
-class BaseChecker(_ArgumentsProvider, MapReduceMixin):
+class BaseChecker(_ArgumentsProvider):
 
     # checker name (you may reuse an existing one)
     name: str = ""
@@ -207,9 +206,11 @@ class BaseChecker(_ArgumentsProvider, MapReduceMixin):
     def close(self):
         """Called after visiting project (i.e set of modules)."""
 
+    # pylint: disable-next=no-self-use
     def get_map_data(self) -> Any:
         return None
 
+    # pylint: disable-next=no-self-use, unused-argument
     def reduce_map_data(self, linter: PyLinter, data: list[Any]) -> None:
         return None
 

--- a/pylint/checkers/mapreduce_checker.py
+++ b/pylint/checkers/mapreduce_checker.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import abc
+import warnings
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -13,6 +14,13 @@ if TYPE_CHECKING:
 
 class MapReduceMixin(metaclass=abc.ABCMeta):
     """A mixin design to allow multiprocess/threaded runs of a Checker."""
+
+    def __init__(self) -> None:
+        warnings.warn(
+            "MapReduceMixin has been deprecated and will be removed in pylint 3.0. "
+            "To make a checker reduce map data simply implement get_map_data and reduce_map_data.",
+            DeprecationWarning,
+        )
 
     @abc.abstractmethod
     def get_map_data(self) -> Any:

--- a/pylint/checkers/mapreduce_checker.py
+++ b/pylint/checkers/mapreduce_checker.py
@@ -2,16 +2,22 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import abc
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pylint.lint import PyLinter
 
 
 class MapReduceMixin(metaclass=abc.ABCMeta):
     """A mixin design to allow multiprocess/threaded runs of a Checker."""
 
     @abc.abstractmethod
-    def get_map_data(self):
+    def get_map_data(self) -> Any:
         """Returns mergeable/reducible data that will be examined."""
 
     @abc.abstractmethod
-    def reduce_map_data(self, linter, data):
+    def reduce_map_data(self, linter: PyLinter, data: list[Any]) -> None:
         """For a given Checker, receives data for all mapped runs."""

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -47,7 +47,7 @@ from typing import (
 import astroid
 from astroid import nodes
 
-from pylint.checkers import BaseChecker, MapReduceMixin, table_lines_from_stats
+from pylint.checkers import BaseChecker, table_lines_from_stats
 from pylint.interfaces import IRawChecker
 from pylint.reporters.ureports.nodes import Table
 from pylint.typing import Options
@@ -727,7 +727,7 @@ def report_similarities(
 
 
 # wrapper to get a pylint checker from the similar class
-class SimilarChecker(BaseChecker, Similar, MapReduceMixin):
+class SimilarChecker(BaseChecker, Similar):
     """Checks for similarities and duplicated code.
 
     This computation may be memory / CPU intensive, so you

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -71,11 +71,9 @@ def _worker_check_single_file(
     _worker_linter.check_single_file_item(file_item)
     mapreduce_data = defaultdict(list)
     for checker in _worker_linter.get_checkers():
-        try:
-            data = checker.get_map_data()
-        except AttributeError:
-            continue
-        mapreduce_data[checker.name].append(data)
+        data = checker.get_map_data()
+        if data is not None:
+            mapreduce_data[checker.name].append(data)
     msgs = _worker_linter.reporter.messages
     assert isinstance(_worker_linter.reporter, reporters.CollectingReporter)
     _worker_linter.reporter.reset()
@@ -108,7 +106,7 @@ def _merge_mapreduce_data(
     # validation. The intent here is to collect all the mapreduce data for all checker-
     # runs across processes - that will then be passed to a static method on the
     # checkers to be reduced and further processed.
-    collated_map_reduce_data = defaultdict(list)
+    collated_map_reduce_data: defaultdict[str, list[Any]] = defaultdict(list)
     for linter_data in all_mapreduce_data.values():
         for run_data in linter_data:
             for checker_name, data in run_data.items():
@@ -132,8 +130,7 @@ def check_parallel(
     """Use the given linter to lint the files with given amount of workers (jobs).
 
     This splits the work filestream-by-filestream. If you need to do work across
-    multiple files, as in the similarity-checker, then inherit from MapReduceMixin and
-    implement the map/reduce mixin functionality.
+    multiple files, as in the similarity-checker, then implement the map/reduce mixin functionality.
     """
     # The linter is inherited by all the pool's workers, i.e. the linter
     # is identical to the linter object here. This is required so that

--- a/tests/checkers/unittest_similar.py
+++ b/tests/checkers/unittest_similar.py
@@ -376,7 +376,7 @@ def test_no_args() -> None:
 
 
 def test_get_map_data() -> None:
-    """Tests that a SimilarChecker respects the MapReduceMixin interface."""
+    """Tests that a SimilarChecker can return and reduce mapped data."""
     linter = PyLinter(reporter=Reporter())
     # Add a parallel checker to ensure it can map and reduce
     linter.register_checker(similar.SimilarChecker(linter))

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -19,7 +19,6 @@ from astroid import nodes
 import pylint.interfaces
 import pylint.lint.parallel
 from pylint.checkers.base_checker import BaseChecker
-from pylint.checkers.mapreduce_checker import MapReduceMixin
 from pylint.lint import PyLinter
 from pylint.lint.parallel import _worker_check_single_file as worker_check_single_file
 from pylint.lint.parallel import _worker_initialize as worker_initialize
@@ -73,7 +72,7 @@ class SequentialTestChecker(BaseChecker):
         self.data.append(record)
 
 
-class ParallelTestChecker(BaseChecker, MapReduceMixin):
+class ParallelTestChecker(BaseChecker):
     """A checker that does need to consolidate data.
 
     To simulate the need to consolidate data, this checker only

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,0 +1,26 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Check deprecation across the codebase."""
+
+from typing import Any
+
+import pytest
+
+from pylint.checkers.mapreduce_checker import MapReduceMixin
+from pylint.lint import PyLinter
+
+
+def test_mapreducemixin() -> None:
+    """Test that MapReduceMixin has been deprecated correctly."""
+
+    class MyChecker(MapReduceMixin):
+        def get_map_data(self) -> Any:
+            ...
+
+        def reduce_map_data(self, linter: PyLinter, data: list[Any]) -> None:
+            ...
+
+    with pytest.warns(DeprecationWarning):
+        MyChecker()

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -4,6 +4,8 @@
 
 """Check deprecation across the codebase."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import pytest


### PR DESCRIPTION
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

Kinda high priority since `main` is broken due to two `typing` PRs apparently depending on each other but passing on their own.

`main` complains about `checker.get_map_data()` and `checker.reduce_map_data` in `parallel.py`. Instead of adding ignores there I think `mypy` is actually right and warns of a design flaw. There is no need to separate these `MixIns` (ideally we would deprecate the `MixIn` as there is little overhead of making `BaseChecker` a `MapReduceMixin` and just having the methods do nothing.
That's why I propose this solution.