### PR TITLE
Prevent false positive `undefined-variable` for user-specified builtins given type annotations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -211,9 +211,6 @@ Release date: TBA
 
   Closes #6388
 
-* Fixed a false positive for ``redefined-builtin`` for builtins specified in
-  ``--allowed-redefined-builtins`` and redefined at a module scope.
-
 
 What's New in Pylint 2.13.5?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -211,6 +211,9 @@ Release date: TBA
 
   Closes #6388
 
+* Fixed a false positive for ``redefined-builtin`` for builtins specified in
+  ``--allowed-redefined-builtins`` and redefined at a module scope.
+
 
 What's New in Pylint 2.13.5?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -206,6 +206,11 @@ Release date: TBA
   Closes #5815
   Closes #5406
 
+* Fixed a false positive for ``unused-variable`` when a builtin specified in
+  ``--additional-builtins`` is given a type annotation.
+
+  Closes #6388
+
 
 What's New in Pylint 2.13.5?
 ============================

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -592,9 +592,6 @@ Other Changes
 
   Closes #6388
 
-* Fixed a false positive for ``redefined-builtin`` for builtins specified in
-  ``--allowed-redefined-builtins`` and redefined at a module scope.
-
 * Fix false positive for 'nonexistent-operator' when repeated '-' are
   separated (e.g. by parens).
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -592,6 +592,9 @@ Other Changes
 
   Closes #6388
 
+* Fixed a false positive for ``redefined-builtin`` for builtins specified in
+  ``--allowed-redefined-builtins`` and redefined at a module scope.
+
 * Fix false positive for 'nonexistent-operator' when repeated '-' are
   separated (e.g. by parens).
 

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -587,6 +587,11 @@ Other Changes
 
   Closes #5394
 
+* Fixed a false positive for ``unused-variable`` when a builtin specified in
+  ``--additional-builtins`` is given a type annotation.
+
+  Closes #6388
+
 * Fix false positive for 'nonexistent-operator' when repeated '-' are
   separated (e.g. by parens).
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1121,8 +1121,6 @@ class VariablesChecker(BaseChecker):
 
         for name, stmts in node.locals.items():
             if utils.is_builtin(name):
-                if self._allowed_redefined_builtin(name):
-                    continue
                 if self._should_ignore_redefined_builtin(stmts[0]) or name == "__doc__":
                     continue
                 self.add_message("redefined-builtin", args=name, node=stmts[0])

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1121,6 +1121,8 @@ class VariablesChecker(BaseChecker):
 
         for name, stmts in node.locals.items():
             if utils.is_builtin(name):
+                if self._allowed_redefined_builtin(name):
+                    continue
                 if self._should_ignore_redefined_builtin(stmts[0]) or name == "__doc__":
                     continue
                 self.add_message("redefined-builtin", args=name, node=stmts[0])
@@ -2066,7 +2068,9 @@ class VariablesChecker(BaseChecker):
         if not isinstance(defstmt, nodes.AnnAssign) or defstmt.value:
             return False
 
-        if node.name in self.linter.config.additional_builtins:
+        if node.name in self.linter.config.additional_builtins or utils.is_builtin(
+            node.name
+        ):
             return False
 
         defstmt_frame = defstmt.frame(future=True)

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2059,10 +2059,14 @@ class VariablesChecker(BaseChecker):
             or any(isinstance(arg, nodes.IfExp) for arg in value.args)
         )
 
-    @staticmethod
-    def _is_only_type_assignment(node: nodes.Name, defstmt: nodes.Statement) -> bool:
+    def _is_only_type_assignment(
+        self, node: nodes.Name, defstmt: nodes.Statement
+    ) -> bool:
         """Check if variable only gets assigned a type and never a value."""
         if not isinstance(defstmt, nodes.AnnAssign) or defstmt.value:
+            return False
+
+        if node.name in self.linter.config.additional_builtins:
             return False
 
         defstmt_frame = defstmt.frame(future=True)

--- a/tests/functional/u/undefined/undefined_variable_typing.py
+++ b/tests/functional/u/undefined/undefined_variable_typing.py
@@ -16,6 +16,8 @@ c = ...  # type: Bar.Boo
 
 if TYPE_CHECKING:
     __additional_builtin__: Dict[str, Any]
+    # For why this would emit redefined-builtin: https://github.com/PyCQA/pylint/pull/3643
+    # pylint: disable-next=redefined-builtin
     repr: Any
 
 

--- a/tests/functional/u/undefined/undefined_variable_typing.py
+++ b/tests/functional/u/undefined/undefined_variable_typing.py
@@ -16,8 +16,10 @@ c = ...  # type: Bar.Boo
 
 if TYPE_CHECKING:
     __additional_builtin__: Dict[str, Any]
+    repr: Any
 
 
 def run():
     """https://github.com/PyCQA/pylint/issues/6388"""
+    print(repr)
     return __additional_builtin__["test"]

--- a/tests/functional/u/undefined/undefined_variable_typing.py
+++ b/tests/functional/u/undefined/undefined_variable_typing.py
@@ -4,9 +4,20 @@
 # Ensure attribute lookups in type comments are accounted for.
 # Reported in https://github.com/PyCQA/pylint/issues/4603
 
+from typing import TYPE_CHECKING, Any, Dict
+
 import foo
 from foo import Bar, Boo
 
 a = ...  # type: foo.Bar
 b = ...  # type: foo.Bar[Boo]
 c = ...  # type: Bar.Boo
+
+
+if TYPE_CHECKING:
+    __additional_builtin__: Dict[str, Any]
+
+
+def run():
+    """https://github.com/PyCQA/pylint/issues/6388"""
+    return __additional_builtin__["test"]

--- a/tests/functional/u/undefined/undefined_variable_typing.rc
+++ b/tests/functional/u/undefined/undefined_variable_typing.rc
@@ -2,4 +2,3 @@
 except_implementations=PyPy
 [VARIABLES]
 additional-builtins=__additional_builtin__
-allowed-redefined-builtins=repr

--- a/tests/functional/u/undefined/undefined_variable_typing.rc
+++ b/tests/functional/u/undefined/undefined_variable_typing.rc
@@ -2,3 +2,4 @@
 except_implementations=PyPy
 [VARIABLES]
 additional-builtins=__additional_builtin__
+allowed-redefined-builtins=repr

--- a/tests/functional/u/undefined/undefined_variable_typing.rc
+++ b/tests/functional/u/undefined/undefined_variable_typing.rc
@@ -1,2 +1,4 @@
 [testoptions]
 except_implementations=PyPy
+[VARIABLES]
+additional_builtins=__additional_builtin__

--- a/tests/functional/u/undefined/undefined_variable_typing.rc
+++ b/tests/functional/u/undefined/undefined_variable_typing.rc
@@ -1,4 +1,4 @@
 [testoptions]
 except_implementations=PyPy
 [VARIABLES]
-additional_builtins=__additional_builtin__
+additional-builtins=__additional_builtin__


### PR DESCRIPTION


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

One of the code paths for `undefined-variable` wasn't checking the ``--additional-builtins`` option.

Closes #6388
