### PR TITLE
Allow subclassing Checker types instead of using ``__implements__``

### DIFF
--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -162,7 +162,10 @@ class BaseChecker(_ArgumentsProvider):
             existing_ids.append(message.msgid)
 
     def create_message_definition_from_tuple(self, msgid, msg_tuple):
-        if implements(self, (IRawChecker, ITokenChecker)):
+        if isinstance(self, (BaseTokenChecker, BaseRawFileChecker)):
+            default_scope = WarningScope.LINE
+        # TODO: Interfaces: Deprecate looking for implements here # pylint: disable=fixme
+        elif implements(self, (IRawChecker, ITokenChecker)):
             default_scope = WarningScope.LINE
         else:
             default_scope = WarningScope.NODE

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -18,8 +18,9 @@ import astroid
 from astroid import nodes
 
 from pylint.checkers import BaseChecker, BaseTokenChecker, utils
+from pylint.checkers.base_checker import BaseRawFileChecker
 from pylint.checkers.utils import check_messages
-from pylint.interfaces import IAstroidChecker, IRawChecker, ITokenChecker
+from pylint.interfaces import IAstroidChecker
 
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
@@ -616,10 +617,10 @@ class StringFormatChecker(BaseChecker):
                     break
 
 
-class StringConstantChecker(BaseTokenChecker):
+class StringConstantChecker(BaseTokenChecker, BaseRawFileChecker):
     """Check string literals."""
 
-    __implements__ = (IAstroidChecker, ITokenChecker, IRawChecker)
+    __implements__ = IAstroidChecker
     name = "string"
     msgs = {
         "W1401": (

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -17,8 +17,7 @@ from typing import TYPE_CHECKING
 import astroid
 from astroid import nodes
 
-from pylint.checkers import BaseChecker, BaseTokenChecker, utils
-from pylint.checkers.base_checker import BaseRawFileChecker
+from pylint.checkers import BaseChecker, BaseRawFileChecker, BaseTokenChecker, utils
 from pylint.checkers.utils import check_messages
 from pylint.interfaces import IAstroidChecker
 

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -879,10 +879,17 @@ class PyLinter(
         tokencheckers = [
             c
             for c in _checkers
-            if interfaces.implements(c, interfaces.ITokenChecker) and c is not self
+            if (
+                interfaces.implements(c, interfaces.ITokenChecker)
+                or isinstance(c, checkers.BaseTokenChecker)
+            )
+            and c is not self
         ]
         rawcheckers = [
-            c for c in _checkers if interfaces.implements(c, interfaces.IRawChecker)
+            c
+            for c in _checkers
+            if interfaces.implements(c, interfaces.IRawChecker)
+            or isinstance(c, checkers.BaseRawFileChecker)
         ]
         # notify global begin
         for checker in _checkers:


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Ref. #2287 

I changed `StringConstantChecker` already to fix coverage and show that we can still have multiple checker types in one checker.