### PR TITLE
No longer care about ``interfaces.IAstroidChecker``

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -894,8 +894,7 @@ class PyLinter(
         # notify global begin
         for checker in _checkers:
             checker.open()
-            if interfaces.implements(checker, interfaces.IAstroidChecker):
-                walker.add_checker(checker)
+            walker.add_checker(checker)
 
         yield functools.partial(
             self.check_astroid_module,


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

It is not as if this interface is doing much...

https://github.com/PyCQA/pylint/blob/42134810ad1dfd019af8d5102ce5facb59b49ba8/pylint/interfaces.py#L99-L104

The only thing this changes is that ``RawTokenCheckers`` which don't have `IAstroidChecker` in their ``__implements__`` will also get added. However, as long as they don't define any ``visit_`` methods nothing changes. In fact, I think this is likely to prevent bugs as now classes which do have ``visit_`` methods but forget to add the ``__implements__`` line will still get called correctly.