### PR TITLE
Remove unused ci settings

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.1
-        with:
-          fetch-depth: 0
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
         uses: actions/setup-python@v3.1.2

--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -33,8 +33,6 @@ jobs:
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.1
-        with:
-          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         id: python
         uses: actions/setup-python@v3.1.2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,8 +27,6 @@ jobs:
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.1
-        with:
-          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         id: python
         uses: actions/setup-python@v3.1.2
@@ -177,8 +175,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10"]
-    outputs:
-      python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
       - name: Set temp directory
         run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
@@ -186,8 +182,6 @@ jobs:
         # https://github.com/actions/virtual-environments/issues/712
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.1
-        with:
-          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         id: python
         uses: actions/setup-python@v3.1.2
@@ -229,13 +223,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["pypy-3.7"]
-    outputs:
-      python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.1
-        with:
-          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         id: python
         uses: actions/setup-python@v3.1.2


### PR DESCRIPTION
## Description
* `fetch-depth: 0` was added a while ago to support `setuptools_scm`. We have since moved away from it, thus the default of `1` is enough. It's no longer necessary to fetch the full repo history.
* `python-key` output for windows and pypy. Those became unnecessary when we merged the prepare and test jobs. Only the `python-key` fro `tests-linux` and `prepare-base` are still used in different jobs.

Astroid PR: https://github.com/PyCQA/astroid/pull/1524