### PR TITLE
Fix `AstCallbackMethod` typing

### DIFF
--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -12,10 +12,10 @@ import numbers
 import re
 import string
 import warnings
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from functools import lru_cache, partial
 from re import Match
-from typing import TypeVar
+from typing import TYPE_CHECKING, Callable, TypeVar
 
 import _string
 import astroid.objects
@@ -23,9 +23,13 @@ from astroid import TooManyLevelsError, nodes
 from astroid.context import InferenceContext
 
 from pylint.constants import TYPING_TYPE_CHECKS_GUARDS
-from pylint.typing import AstCallbackMethod
 
-T_Node = TypeVar("T_Node", bound=nodes.NodeNG)
+if TYPE_CHECKING:
+    from pylint.checkers import BaseChecker
+
+_NodeT = TypeVar("_NodeT", bound=nodes.NodeNG)
+_CheckerT = TypeVar("_CheckerT", bound="BaseChecker")
+AstCallbackMethod = Callable[[_CheckerT, _NodeT], None]
 
 COMP_NODE_TYPES = (
     nodes.ListComp,
@@ -427,7 +431,9 @@ def overrides_a_method(class_node: nodes.ClassDef, name: str) -> bool:
 
 def only_required_for_messages(
     *messages: str,
-) -> Callable[[AstCallbackMethod], AstCallbackMethod]:
+) -> Callable[
+    [AstCallbackMethod[_CheckerT, _NodeT]], AstCallbackMethod[_CheckerT, _NodeT]
+]:
     """Decorator to store messages that are handled by a checker method as an
     attribute of the function object.
 
@@ -438,8 +444,10 @@ def only_required_for_messages(
     of a class inheriting from ``BaseChecker``.
     """
 
-    def store_messages(func):
-        func.checks_msgs = messages
+    def store_messages(
+        func: AstCallbackMethod[_CheckerT, _NodeT]
+    ) -> AstCallbackMethod[_CheckerT, _NodeT]:
+        setattr(func, "checks_msgs", messages)
         return func
 
     return store_messages
@@ -447,7 +455,9 @@ def only_required_for_messages(
 
 def check_messages(
     *messages: str,
-) -> Callable[[AstCallbackMethod], AstCallbackMethod]:
+) -> Callable[
+    [AstCallbackMethod[_CheckerT, _NodeT]], AstCallbackMethod[_CheckerT, _NodeT]
+]:
     """Kept for backwards compatibility, deprecated.
 
     Use only_required_for_messages instead, which conveys the intent of the decorator much clearer.
@@ -1709,8 +1719,8 @@ def returns_bool(node: nodes.NodeNG) -> bool:
 
 
 def get_node_first_ancestor_of_type(
-    node: nodes.NodeNG, ancestor_type: type[T_Node] | tuple[type[T_Node], ...]
-) -> T_Node | None:
+    node: nodes.NodeNG, ancestor_type: type[_NodeT] | tuple[type[_NodeT], ...]
+) -> _NodeT | None:
     """Return the first parent node that is any of the provided types (or None)."""
     for ancestor in node.node_ancestors():
         if isinstance(ancestor, ancestor_type):
@@ -1719,8 +1729,8 @@ def get_node_first_ancestor_of_type(
 
 
 def get_node_first_ancestor_of_type_and_its_child(
-    node: nodes.NodeNG, ancestor_type: type[T_Node] | tuple[type[T_Node], ...]
-) -> tuple[None, None] | tuple[T_Node, nodes.NodeNG]:
+    node: nodes.NodeNG, ancestor_type: type[_NodeT] | tuple[type[_NodeT], ...]
+) -> tuple[None, None] | tuple[_NodeT, nodes.NodeNG]:
     """Modified version of get_node_first_ancestor_of_type to also return the
     descendant visited directly before reaching the sought ancestor.
 

--- a/pylint/typing.py
+++ b/pylint/typing.py
@@ -18,7 +18,6 @@ from typing import (
     Pattern,
     Tuple,
     Type,
-    TypeVar,
     Union,
 )
 
@@ -30,7 +29,6 @@ else:
 if TYPE_CHECKING:
     from astroid import nodes
 
-    from pylint.checkers import BaseChecker
     from pylint.config.callback_actions import _CallbackAction
     from pylint.reporters.ureports.nodes import Section
     from pylint.utils import LinterStats
@@ -116,10 +114,6 @@ Options = Tuple[Tuple[str, OptionDict], ...]
 
 AstCallback = Callable[["nodes.NodeNG"], None]
 """Callable representing a visit or leave function."""
-
-CheckerT_co = TypeVar("CheckerT_co", bound="BaseChecker", covariant=True)
-AstCallbackMethod = Callable[[CheckerT_co, "nodes.NodeNG"], None]
-"""Callable representing a visit or leave method."""
 
 ReportsCallable = Callable[["Section", "LinterStats", Optional["LinterStats"]], None]
 """Callable to create a report."""

--- a/tests/checkers/unittest_utils.py
+++ b/tests/checkers/unittest_utils.py
@@ -11,6 +11,7 @@ import pytest
 from astroid import nodes
 
 from pylint.checkers import utils
+from pylint.checkers.base_checker import BaseChecker
 
 
 @pytest.mark.parametrize(
@@ -478,9 +479,9 @@ def test_deprecation_is_inside_lambda() -> None:
 def test_deprecation_check_messages() -> None:
     with pytest.warns(DeprecationWarning) as records:
 
-        class Checker:  # pylint: disable=unused-variable
+        class Checker(BaseChecker):  # pylint: disable=unused-variable
             @utils.check_messages("my-message")
-            def visit_assname(self, node):
+            def visit_assname(self, node: nodes.NodeNG) -> None:
                 pass
 
         assert len(records) == 1

--- a/tests/utils/unittest_ast_walker.py
+++ b/tests/utils/unittest_ast_walker.py
@@ -8,6 +8,7 @@ import warnings
 
 import astroid
 
+from pylint.checkers.base_checker import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
 from pylint.utils import ASTWalker
 
@@ -20,7 +21,8 @@ class TestASTWalker:
         def is_message_enabled(self, msgid: str) -> bool:
             return self._msgs.get(msgid, True)
 
-    class Checker:
+    class Checker(BaseChecker):
+        # pylint: disable-next=super-init-not-called
         def __init__(self) -> None:
             self.called: set[str] = set()
 
@@ -46,12 +48,13 @@ class TestASTWalker:
         )
         walker = ASTWalker(linter)  # type: ignore[arg-type]
         checker = self.Checker()
-        walker.add_checker(checker)  # type: ignore[arg-type]
+        walker.add_checker(checker)
         walker.walk(astroid.parse("x = func()"))
         assert {"module", "assignname"} == checker.called
 
     def test_deprecated_methods(self) -> None:
-        class Checker:
+        class Checker(BaseChecker):
+            # pylint: disable-next=super-init-not-called
             def __init__(self) -> None:
                 self.called = False
 
@@ -62,7 +65,7 @@ class TestASTWalker:
         linter = self.MockLinter({"first-message": True})
         walker = ASTWalker(linter)  # type: ignore[arg-type]
         checker = Checker()
-        walker.add_checker(checker)  # type: ignore[arg-type]
+        walker.add_checker(checker)
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             walker.walk(astroid.parse("x = 1"))


### PR DESCRIPTION
## Description
Fix typing for `AstCallbackMethod` used in `check_messages` and `only_required_for_messages`. Generic type aliases need a subscript. Otherwise the TypeVar is interpreted as `Any`. Furthermore, the second parameter type also needs to be a TypeVar. That's because callback parameter are contravariant. I.e. if it's defined as `nodes.NodeNG`, we wouldn't be able to assign `nodes.Dict` to it.

Also renamed `T_Node` to `_NodeT` which better matches the new naming style. _`invalid-name` messages are disabled for pylint, which is why it didn't complain previously._ Will do a followup to rename the remaining TypeVars.

/CC: @DanielNoord