### PR TITLE
Rename remaining TypeVars

### DIFF
--- a/pylint/reporters/ureports/nodes.py
+++ b/pylint/reporters/ureports/nodes.py
@@ -14,9 +14,9 @@ from typing import Any, Callable, TypeVar
 
 from pylint.reporters.ureports.base_writer import BaseWriter
 
-T = TypeVar("T")
-VNodeT = TypeVar("VNodeT", bound="VNode")
-VisitLeaveFunction = Callable[[T, Any, Any], None]
+_T = TypeVar("_T")
+_VNodeT = TypeVar("_VNodeT", bound="VNode")
+VisitLeaveFunction = Callable[[_T, Any, Any], None]
 
 
 class VNode:
@@ -28,14 +28,14 @@ class VNode:
     def __iter__(self) -> Iterator[VNode]:
         return iter(self.children)
 
-    def accept(self: VNodeT, visitor: BaseWriter, *args: Any, **kwargs: Any) -> None:
-        func: VisitLeaveFunction[VNodeT] = getattr(
+    def accept(self: _VNodeT, visitor: BaseWriter, *args: Any, **kwargs: Any) -> None:
+        func: VisitLeaveFunction[_VNodeT] = getattr(
             visitor, f"visit_{self.visitor_name}"
         )
         return func(self, *args, **kwargs)
 
-    def leave(self: VNodeT, visitor: BaseWriter, *args: Any, **kwargs: Any) -> None:
-        func: VisitLeaveFunction[VNodeT] = getattr(
+    def leave(self: _VNodeT, visitor: BaseWriter, *args: Any, **kwargs: Any) -> None:
+        func: VisitLeaveFunction[_VNodeT] = getattr(
             visitor, f"leave_{self.visitor_name}"
         )
         return func(self, *args, **kwargs)

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -15,7 +15,7 @@ from pylint.interfaces import UNDEFINED, Confidence
 from pylint.message.message import Message
 from pylint.testutils.constants import UPDATE_OPTION
 
-T = TypeVar("T")
+_T = TypeVar("_T")
 
 
 class MessageTest(NamedTuple):
@@ -110,7 +110,7 @@ class OutputLine(NamedTuple):
         return int(column)
 
     @staticmethod
-    def _get_py38_none_value(value: T, check_endline: bool) -> T | None:
+    def _get_py38_none_value(value: _T, check_endline: bool) -> _T | None:
         """Used to make end_line and end_column None as indicated by our version compared to
         `min_pyver_end_position`.
         """


### PR DESCRIPTION
## Description
Followup to #6445
Rename TypeVars to better match the new naming style.