### PR TITLE
Functional tests for ``pyreverse``

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: copyright-notice
         args: ["--notice=script/copyright.txt", "--enforce-all"]
-        exclude: tests/functional/|tests/input|doc/data/messages|examples/|setup.py|tests(/\w*)*data/
+        exclude: tests(/\w*)*/functional/|tests/input|doc/data/messages|examples/|setup.py|tests(/\w*)*data/
         types: [python]
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.32.0

--- a/pylint/testutils/pyreverse.py
+++ b/pylint/testutils/pyreverse.py
@@ -102,7 +102,7 @@ def get_functional_test_files(
 
 
 def _read_config(config_file: Path) -> TestFileOptions:
-    config = configparser.SafeConfigParser()
+    config = configparser.ConfigParser()
     config.read(str(config_file))
     return {
         "output_formats": config.get(

--- a/pylint/testutils/pyreverse.py
+++ b/pylint/testutils/pyreverse.py
@@ -5,6 +5,16 @@
 from __future__ import annotations
 
 import argparse
+import configparser
+import shlex
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 
 # This class could and should be replaced with a simple dataclass when support for Python < 3.7 is dropped.
@@ -54,3 +64,51 @@ class PyreverseConfig(
         self.ignore_list = ignore_list
         self.project = project
         self.output_directory = output_directory
+
+
+class TestFileOptions(TypedDict):
+    output_formats: list[str]
+    command_line_args: list[str]
+
+
+class FunctionalPyreverseTestfile(NamedTuple):
+    """Named tuple containing the test file and the expected output."""
+
+    source: Path
+    options: TestFileOptions
+
+
+def get_functional_test_files(
+    root_directory: Path,
+) -> list[FunctionalPyreverseTestfile]:
+    """Get all functional test files from the given directory."""
+    test_files = []
+    for path in root_directory.rglob("*.py"):
+        config_file = path.with_suffix(".rc")
+        if config_file.exists():
+            test_files.append(
+                FunctionalPyreverseTestfile(
+                    source=path, options=_read_config(config_file)
+                )
+            )
+        else:
+            test_files.append(
+                FunctionalPyreverseTestfile(
+                    source=path,
+                    options={"output_formats": ["mmd"], "command_line_args": []},
+                )
+            )
+    return test_files
+
+
+def _read_config(config_file: Path) -> TestFileOptions:
+    config = configparser.SafeConfigParser()
+    config.read(str(config_file))
+    return {
+        "output_formats": config.get(
+            "testoptions", "output_formats", fallback="mmd"
+        ).split(","),
+        "command_line_args": shlex.split(
+            config.get("testoptions", "command_line_args", fallback="")
+        ),
+    }

--- a/tests/pyreverse/functional/class_diagrams/attributes/instance_attributes.mmd
+++ b/tests/pyreverse/functional/class_diagrams/attributes/instance_attributes.mmd
@@ -1,0 +1,6 @@
+classDiagram
+  class InstanceAttributes {
+    my_int_with_type_hint : int
+    my_int_without_type_hint : int
+    my_optional_int : Optional[int]
+  }

--- a/tests/pyreverse/functional/class_diagrams/attributes/instance_attributes.py
+++ b/tests/pyreverse/functional/class_diagrams/attributes/instance_attributes.py
@@ -1,0 +1,5 @@
+class InstanceAttributes:
+    def __init__(self):
+        self.my_int_without_type_hint = 1
+        self.my_int_with_type_hint: int = 2
+        self.my_optional_int: int = None

--- a/tests/pyreverse/functional/class_diagrams/colorized_output/colorized.puml
+++ b/tests/pyreverse/functional/class_diagrams/colorized_output/colorized.puml
@@ -1,0 +1,42 @@
+@startuml classes
+set namespaceSeparator none
+class "CheckerCollector" as colorized.CheckerCollector #aliceblue {
+  checker1
+  checker2
+  checker3
+}
+class "ElseifUsedChecker" as pylint.extensions.check_elif.ElseifUsedChecker #antiquewhite {
+  msgs : dict
+  name : str
+  leave_module(_: nodes.Module) -> None
+  process_tokens(tokens: list[TokenInfo]) -> None
+  visit_if(node: nodes.If) -> None
+}
+class "ExceptionsChecker" as pylint.checkers.exceptions.ExceptionsChecker #aquamarine {
+  msgs : dict
+  name : str
+  options : tuple
+  open()
+  visit_binop(node: nodes.BinOp) -> None
+  visit_compare(node: nodes.Compare) -> None
+  visit_raise(node: nodes.Raise) -> None
+  visit_tryexcept(node: nodes.TryExcept) -> None
+}
+class "StdlibChecker" as pylint.checkers.stdlib.StdlibChecker #aquamarine {
+  msgs : dict
+  name : str
+  deprecated_arguments(method: str)
+  deprecated_classes(module: str)
+  deprecated_decorators() -> Iterable
+  deprecated_methods()
+  visit_boolop(node: nodes.BoolOp) -> None
+  visit_call(node: nodes.Call) -> None
+  visit_functiondef(node: nodes.FunctionDef) -> None
+  visit_if(node: nodes.If) -> None
+  visit_ifexp(node: nodes.IfExp) -> None
+  visit_unaryop(node: nodes.UnaryOp) -> None
+}
+pylint.checkers.exceptions.ExceptionsChecker --* colorized.CheckerCollector : checker1
+pylint.checkers.stdlib.StdlibChecker --* colorized.CheckerCollector : checker3
+pylint.extensions.check_elif.ElseifUsedChecker --* colorized.CheckerCollector : checker2
+@enduml

--- a/tests/pyreverse/functional/class_diagrams/colorized_output/colorized.py
+++ b/tests/pyreverse/functional/class_diagrams/colorized_output/colorized.py
@@ -1,0 +1,10 @@
+from pylint.checkers.exceptions import ExceptionsChecker
+from pylint.checkers.stdlib import StdlibChecker
+from pylint.extensions.check_elif import ElseifUsedChecker
+
+
+class CheckerCollector:
+    def __init__(self):
+        self.checker1 = ExceptionsChecker(None)
+        self.checker2 = ElseifUsedChecker(None)
+        self.checker3 = StdlibChecker(None)

--- a/tests/pyreverse/functional/class_diagrams/colorized_output/colorized.rc
+++ b/tests/pyreverse/functional/class_diagrams/colorized_output/colorized.rc
@@ -1,0 +1,3 @@
+[testoptions]
+output_formats=puml
+command_line_args=-S --colorized --max-color-depth=2

--- a/tests/pyreverse/functional/class_diagrams/inheritance/simple_inheritance.mmd
+++ b/tests/pyreverse/functional/class_diagrams/inheritance/simple_inheritance.mmd
@@ -1,0 +1,6 @@
+classDiagram
+  class Child {
+  }
+  class Parent {
+  }
+  Child --|> Parent

--- a/tests/pyreverse/functional/class_diagrams/inheritance/simple_inheritance.py
+++ b/tests/pyreverse/functional/class_diagrams/inheritance/simple_inheritance.py
@@ -1,0 +1,6 @@
+class Parent:
+    """parent class"""
+
+
+class Child(Parent):
+    """child class"""

--- a/tests/pyreverse/test_pyreverse_functional.py
+++ b/tests/pyreverse/test_pyreverse_functional.py
@@ -1,6 +1,7 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
 from pathlib import Path
 
 import pytest

--- a/tests/pyreverse/test_pyreverse_functional.py
+++ b/tests/pyreverse/test_pyreverse_functional.py
@@ -1,0 +1,51 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+from py._path.local import LocalPath  # type: ignore[import]
+
+from pylint.pyreverse.main import Run
+
+
+class FunctionalPyreverseTestfile(NamedTuple):
+    """Named tuple containing the test file and the expected output."""
+
+    source: Path
+    expectation: Path
+
+
+def get_functional_test_files(
+    root_directory: Path,
+) -> list[FunctionalPyreverseTestfile]:
+    """Get all functional test files from the given directory."""
+    return [
+        FunctionalPyreverseTestfile(
+            source=test_file, expectation=test_file.with_suffix(".mmd")
+        )
+        for test_file in root_directory.rglob("*.py")
+    ]
+
+
+FUNCTIONAL_DIR = Path(__file__).parent / "functional"
+CLASS_DIAGRAM_TESTS = get_functional_test_files(FUNCTIONAL_DIR / "class_diagrams")
+CLASS_DIAGRAM_TEST_IDS = [testfile.source.stem for testfile in CLASS_DIAGRAM_TESTS]
+
+
+@pytest.mark.parametrize(
+    "testfile",
+    CLASS_DIAGRAM_TESTS,
+    ids=CLASS_DIAGRAM_TEST_IDS,
+)
+def test_class_diagrams(
+    testfile: FunctionalPyreverseTestfile, tmpdir: LocalPath
+) -> None:
+    input_file = testfile.source
+    with pytest.raises(SystemExit) as sys_exit:
+        Run(["-o", "mmd", "-d", str(tmpdir), str(input_file)])
+    assert sys_exit.value.code == 0
+    assert testfile.expectation.read_text(encoding="utf8") == Path(
+        tmpdir / "classes.mmd"
+    ).read_text(encoding="utf8")

--- a/tests/pyreverse/test_pyreverse_functional.py
+++ b/tests/pyreverse/test_pyreverse_functional.py
@@ -1,6 +1,8 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+from __future__ import annotations
+
 from pathlib import Path
 from typing import NamedTuple
 

--- a/tests/pyreverse/test_pyreverse_functional.py
+++ b/tests/pyreverse/test_pyreverse_functional.py
@@ -1,35 +1,16 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
-from __future__ import annotations
-
 from pathlib import Path
-from typing import NamedTuple
 
 import pytest
 from py._path.local import LocalPath  # type: ignore[import]
 
 from pylint.pyreverse.main import Run
-
-
-class FunctionalPyreverseTestfile(NamedTuple):
-    """Named tuple containing the test file and the expected output."""
-
-    source: Path
-    expectation: Path
-
-
-def get_functional_test_files(
-    root_directory: Path,
-) -> list[FunctionalPyreverseTestfile]:
-    """Get all functional test files from the given directory."""
-    return [
-        FunctionalPyreverseTestfile(
-            source=test_file, expectation=test_file.with_suffix(".mmd")
-        )
-        for test_file in root_directory.rglob("*.py")
-    ]
-
+from pylint.testutils.pyreverse import (
+    FunctionalPyreverseTestfile,
+    get_functional_test_files,
+)
 
 FUNCTIONAL_DIR = Path(__file__).parent / "functional"
 CLASS_DIAGRAM_TESTS = get_functional_test_files(FUNCTIONAL_DIR / "class_diagrams")
@@ -45,9 +26,13 @@ def test_class_diagrams(
     testfile: FunctionalPyreverseTestfile, tmpdir: LocalPath
 ) -> None:
     input_file = testfile.source
-    with pytest.raises(SystemExit) as sys_exit:
-        Run(["-o", "mmd", "-d", str(tmpdir), str(input_file)])
-    assert sys_exit.value.code == 0
-    assert testfile.expectation.read_text(encoding="utf8") == Path(
-        tmpdir / "classes.mmd"
-    ).read_text(encoding="utf8")
+    for output_format in testfile.options["output_formats"]:
+        with pytest.raises(SystemExit) as sys_exit:
+            args = ["-o", f"{output_format}", "-d", str(tmpdir)]
+            args.extend(testfile.options["command_line_args"])
+            args += [str(input_file)]
+            Run(args)
+        assert sys_exit.value.code == 0
+        assert testfile.source.with_suffix(f".{output_format}").read_text(
+            encoding="utf8"
+        ) == Path(tmpdir / f"classes.{output_format}").read_text(encoding="utf8")


### PR DESCRIPTION
- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

I would like to add a more flexible construct for functional tests of ``pyreverse``.
PR #6434 once again showed me that the current test suite is not ideal. 
In general I want to see how the new feature looks like in a final diagram, so I have to ask the contributor to include new, suitable code in `tests/data`. 
This in turn means she/he needs to update **all** generated output files for every possible format, which is cumbersome.
It also does not necessarily makes sense if a PR does not touch the ``Printer`` classes, as it would be enough to check the output with one format, and not for all. 

Moreover, the test data becomes really bloated, and if the current tests fail you have to dig deep to see what feature of ``pyreverse`` is actually broken. 

This PR is currently an early WIP, so you can give feedback on the general direction.
Here is what's on my mind how to approach this:

* Create a folder structure in the form of `tests/pyreverse/functional/<diagram_type>/<feature>`, where `feature` are things like different types of relationships between two nodes. 
* Use MermaidJS as default output format. The reason is that it can be rendered natively in Github, which should make reviewing functional tests a lot easier.
* ~(Still ToDo, maybe at a later point when we first see the necessity for it)~ allow for optional configuration files analogous to the normal functional tests, to be able to choose a different output format for example.

Let me know what you think.