### PR TITLE
Fix handling of default value for extend action in Python 3.7

### DIFF
--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -87,7 +87,7 @@ def _convert_option_to_argument(
         return _ExtendArgument(
             flags=flags,
             action=action,
-            default=default,
+            default=[] if default is None else default,
             arg_type=optdict["type"],
             choices=optdict.get("choices", None),
             arg_help=optdict.get("help", ""),

--- a/pylint/pyreverse/main.py
+++ b/pylint/pyreverse/main.py
@@ -61,7 +61,7 @@ OPTIONS: Options = (
             metavar="<class>",
             type="csv",
             dest="classes",
-            default=[],
+            default=None,
             help="create a class diagram with all classes related to <class>;\
  this uses by default the options -ASmy",
         ),


### PR DESCRIPTION
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Using `default=[]` in Python 3.7 has the effect that values passed in for this parameter will be stored in the default list object. In subsequent runs (in the same process), the default value is wrongly prepopulated.

Python 3.8 and above handle this situation better, but as we have to support Python 3.7 this fix is necessary.

Ref: https://github.com/PyCQA/pylint/pull/6449#issuecomment-1107831297

This change should be covered e.g. by `tests/pyreverse/test_main.py::test_command_line_arguments_defaults[classes-expected_default1]`.

