### PR TITLE
Avoid reporting superfluous-parens after an ``is not`` operator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -184,6 +184,10 @@ Release date: TBA
 
   Closes #4324
 
+* Avoid reporting ``superfluous-parens`` on expressions using the ``is not`` operator.
+
+  Closes #5930
+
 * Added the ``super-without-brackets`` checker, raised when a super call is missing its brackets.
 
   Closes #4008

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -611,6 +611,10 @@ Other Changes
 
   Closes #5931
 
+* Avoid reporting ``superfluous-parens`` on expressions using the ``is not`` operator.
+
+  Closes #5930
+
 * Fix a crash when linting a file that passes an integer ``mode=`` to
   ``open``
 

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -338,7 +338,11 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
             self._bracket_stack.pop()
         if tokens[start + 1].string != "(":
             return
-        if tokens[start].string == "not" and start > 0 and tokens[start - 1].string == "is":
+        if (
+            tokens[start].string == "not"
+            and start > 0
+            and tokens[start - 1].string == "is"
+        ):
             # If this is part of an `is not` expression, we have a binary operator
             # so the parentheses are not necessarily redundant.
             return

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -338,6 +338,10 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
             self._bracket_stack.pop()
         if tokens[start + 1].string != "(":
             return
+        if tokens[start].string == "not" and start > 0 and tokens[start - 1].string == "is":
+            # If this is part of an `is not` expression, we have a binary operator
+            # so the parentheses are not necessarily redundant.
+            return
         found_and_or = False
         contains_walrus_operator = False
         walrus_operator_depth = 0
@@ -411,7 +415,7 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
                 elif token[1] == "for":
                     return
                 # A generator expression can have an 'else' token in it.
-                # We check the rest of the tokens to see if any problems incur after
+                # We check the rest of the tokens to see if any problems occur after
                 # the 'else'.
                 elif token[1] == "else":
                     if "(" in (i.string for i in tokens[i:]):

--- a/tests/functional/s/superfluous_parens.py
+++ b/tests/functional/s/superfluous_parens.py
@@ -68,3 +68,10 @@ class ClassA:
 
     def __iter__(self):
         return ((k, getattr(self, k)) for k in self.keys)
+
+if (A == 2) is not (B == 2):
+    pass
+
+M = A is not (A <= H)
+M = True is not (M == K)
+M = True is not (True is not False)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The `superfluous-parens` checker was incorrectly reporting that parentheses after an `is not` expression were superfluous. The checker seemed to be assuming that any expression prefixed with `not` was a unary expression and not part of a larger expression that might need parentheses for correctness.

Closes #5930 
