### PR TITLE
Add documentation examples of consider-using-f-string

### DIFF
--- a/doc/data/messages/c/consider-using-f-string/bad.py
+++ b/doc/data/messages/c/consider-using-f-string/bad.py
@@ -1,0 +1,5 @@
+menu = ('eggs', 'spam')
+
+order = "%s and %s" % menu # [consider-using-f-string]
+
+new_order = "{1} and {0}".format(menu[0], menu[1]) # [consider-using-f-string]

--- a/doc/data/messages/c/consider-using-f-string/bad.py
+++ b/doc/data/messages/c/consider-using-f-string/bad.py
@@ -1,4 +1,5 @@
 from string import Template
+
 menu = ('eggs', 'spam', 42.4)
 
 old_order = "%s and %s: %.2f ¤" % menu # [consider-using-f-string]

--- a/doc/data/messages/c/consider-using-f-string/bad.py
+++ b/doc/data/messages/c/consider-using-f-string/bad.py
@@ -1,5 +1,9 @@
-menu = ('eggs', 'spam')
+from string import Template
+menu = ('eggs', 'spam', 42.4)
 
-order = "%s and %s" % menu # [consider-using-f-string]
-
-new_order = "{1} and {0}".format(menu[0], menu[1]) # [consider-using-f-string]
+old_order = "%s and %s: %.2f ¤" % menu # [consider-using-f-string]
+beginner_order = menu[0] + " and " + menu[1] + ": " + str(menu[2]) + " ¤"
+joined_order = " and ".join(menu[:2])
+format_order = "{} and {}: {:0.2f} ¤".format(menu[0], menu[1], menu[2]) # [consider-using-f-string]
+named_format_order = "{eggs} and {spam}: {price:0.2f} ¤".format(eggs=menu[0], spam=menu[1], price=menu[2]) # [consider-using-f-string]
+template_order = Template('$eggs and $spam: $price ¤').substitute(eggs=menu[0], spam=menu[1], price=menu[2])

--- a/doc/data/messages/c/consider-using-f-string/details.rst
+++ b/doc/data/messages/c/consider-using-f-string/details.rst
@@ -1,0 +1,7 @@
+Formatted string literals (f-strings) give a concise, consistent syntax
+that can replace most use cases for the ``%`` formatting operator,
+``str.format()`` and ``string.Template``.
+
+F-strings can also perform better than alternatives; see
+`this tweet <https://twitter.com/raymondh/status/1205969258800275456>`_ for
+a simple example.

--- a/doc/data/messages/c/consider-using-f-string/details.rst
+++ b/doc/data/messages/c/consider-using-f-string/details.rst
@@ -2,6 +2,6 @@ Formatted string literals (f-strings) give a concise, consistent syntax
 that can replace most use cases for the ``%`` formatting operator,
 ``str.format()`` and ``string.Template``.
 
-F-strings can also perform better than alternatives; see
+F-strings also perform better than alternatives; see
 `this tweet <https://twitter.com/raymondh/status/1205969258800275456>`_ for
 a simple example.

--- a/doc/data/messages/c/consider-using-f-string/good.py
+++ b/doc/data/messages/c/consider-using-f-string/good.py
@@ -1,0 +1,5 @@
+menu = ('eggs', 'spam')
+
+order = f"{menu[0]} and {menu[1]}"
+
+new_order = f"{menu[1]} and {menu[0]}"

--- a/doc/data/messages/c/consider-using-f-string/good.py
+++ b/doc/data/messages/c/consider-using-f-string/good.py
@@ -1,5 +1,3 @@
-menu = ('eggs', 'spam')
+menu = ('eggs', 'spam', 42.4)
 
-order = f"{menu[0]} and {menu[1]}"
-
-new_order = f"{menu[1]} and {menu[0]}"
+f_string_order = f"{menu[0]} and {menu[1]}: {menu[2]:0.2f} ¤"


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Adds documentation examples for the `consider-using-f-string` checker. There didn't seem to be any examples in the `pylint-errors` repo that I could see, so I wrote a new one.

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Ref #5953 
