### PR TITLE
Add an assertion to check that the documentation structure is correct

### DIFF
--- a/doc/test_messages_documentation.py
+++ b/doc/test_messages_documentation.py
@@ -38,11 +38,12 @@ def get_functional_test_files_from_directory(input_dir: Path) -> List[Tuple[str,
     This also checks the formatting of related.rst files.
     """
     suite: List[Tuple[str, Path]] = []
+
     for subdirectory in input_dir.iterdir():
         for message_dir in subdirectory.iterdir():
             assert_msg = (
                 f"{subdirectory}: '{message_dir.name}' is in the wrong "
-                f"directory: it does not start by '{subdirectory.name}'"
+                f"directory: it does not start with '{subdirectory.name}'"
             )
             assert message_dir.name.startswith(subdirectory.name), assert_msg
             if (message_dir / "good.py").exists():

--- a/doc/test_messages_documentation.py
+++ b/doc/test_messages_documentation.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
-"""Functional tests for the code examples in the messages documentation."""
+"""Functional tests for the code examples in the messages' documentation."""
 
 import sys
 
@@ -38,9 +38,13 @@ def get_functional_test_files_from_directory(input_dir: Path) -> List[Tuple[str,
     This also checks the formatting of related.rst files.
     """
     suite: List[Tuple[str, Path]] = []
-
     for subdirectory in input_dir.iterdir():
         for message_dir in subdirectory.iterdir():
+            assert_msg = (
+                f"{subdirectory}: '{message_dir.name}' is in the wrong "
+                f"directory: it does not start by '{subdirectory.name}'"
+            )
+            assert message_dir.name.startswith(subdirectory.name), assert_msg
             if (message_dir / "good.py").exists():
                 suite.append(
                     (message_dir.stem, message_dir / "good.py"),


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description

Follow-up to an issue where the documentation being in the wrong directory result in the documentation not displaying the content silently in #6404 
