### PR TITLE
Check documentation examples for fatal errors

### DIFF
--- a/doc/data/messages/a/assert-on-string-literal/details.rst
+++ b/doc/data/messages/a/assert-on-string-literal/details.rst
@@ -1,0 +1,1 @@
+Directly asserting a string literal will always pass.

--- a/doc/data/messages/a/assert-on-string-literal/good.py
+++ b/doc/data/messages/a/assert-on-string-literal/good.py
@@ -1,4 +1,4 @@
 def test():
-    actual = "test"
-    wanted = "Directly asserting a string literal will always pass"
-    assert actual == wanted
+    result = "result"
+    expected = "expected"
+    assert result == expected

--- a/doc/data/messages/a/assert-on-string-literal/good.py
+++ b/doc/data/messages/a/assert-on-string-literal/good.py
@@ -1,2 +1,4 @@
 def test():
-    # Nothing, as an assert of a string literal will always pass
+    actual = "test"
+    wanted = "Directly asserting a string literal will always pass"
+    assert actual == wanted

--- a/doc/data/messages/r/redundant-unittest-assert/details.rst
+++ b/doc/data/messages/r/redundant-unittest-assert/details.rst
@@ -1,0 +1,1 @@
+Directly asserting a string literal will always pass.

--- a/doc/data/messages/r/redundant-unittest-assert/good.py
+++ b/doc/data/messages/r/redundant-unittest-assert/good.py
@@ -3,4 +3,5 @@ import unittest
 
 class DummyTestCase(unittest.TestCase):
     def test_dummy(self):
-        # Nothing, as an assert of a string literal will always pass
+        actual = "test_result"
+        self.assertEqual(actual, "expected")

--- a/doc/test_messages_documentation.py
+++ b/doc/test_messages_documentation.py
@@ -148,7 +148,7 @@ class LintModuleTest:
         if self.is_good_test_file():
             assert actual_messages.total() == 0  # type: ignore[attr-defined]
         if self.is_bad_test_file():
-            assert actual_messages.total() == 0  # type: ignore[attr-defined]
+            assert actual_messages.total() > 0  # type: ignore[attr-defined]
         assert expected_messages == actual_messages
 
 

--- a/doc/test_messages_documentation.py
+++ b/doc/test_messages_documentation.py
@@ -91,7 +91,7 @@ class LintModuleTest:
             args_list=[
                 str(test_file[1]),
                 "--disable=all",
-                f"--enable={test_file[0]}",
+                f"--enable={test_file[0]},astroid-error,fatal,syntax-error",
             ],
             reporter=_test_reporter,
             config_file=config_file,
@@ -146,9 +146,9 @@ class LintModuleTest:
         expected_messages = self._get_expected()
         actual_messages = self._get_actual()
         if self.is_good_test_file():
-            assert actual_messages.total() == 0  # type: ignore[attr-defined]
+            assert actual_messages.total() == 0
         if self.is_bad_test_file():
-            assert actual_messages.total() > 0  # type: ignore[attr-defined]
+            assert actual_messages.total() > 0
         assert expected_messages == actual_messages
 
 

--- a/doc/test_messages_documentation.py
+++ b/doc/test_messages_documentation.py
@@ -146,9 +146,9 @@ class LintModuleTest:
         expected_messages = self._get_expected()
         actual_messages = self._get_actual()
         if self.is_good_test_file():
-            assert actual_messages.total() == 0
+            assert actual_messages.total() == 0  # type: ignore[attr-defined]
         if self.is_bad_test_file():
-            assert actual_messages.total() > 0
+            assert actual_messages.total() == 0  # type: ignore[attr-defined]
         assert expected_messages == actual_messages
 
 

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -71,6 +71,7 @@ class LintModuleTest:
                 # Always enable fatal errors
                 messages_to_enable.add("astroid-error")
                 messages_to_enable.add("fatal")
+                messages_to_enable.add("syntax-error")
             args.extend(["--disable=all", f"--enable={','.join(messages_to_enable)}"])
         _config_initialization(
             self._linter, args_list=args, config_file=rc_file, reporter=_test_reporter

--- a/tests/testutils/test_functional_testutils.py
+++ b/tests/testutils/test_functional_testutils.py
@@ -62,6 +62,7 @@ def test_minimal_messages_config_enabled(pytest_config) -> None:
             # Always enable fatal errors: important not to have false negatives
             "astroid-error",
             "fatal",
+            "syntax-error",
         )
     )
     assert not mod_test._linter.is_message_enabled("unused-import")


### PR DESCRIPTION
We missed the syntax error fixed in [98996bd](https://github.com/PyCQA/pylint/pull/6474/commits/98996bd25aa479e573c0d9dfbfe4283ab5e7373f) because we were disabling fatal errors when checking "good.py" in the message examples.

I also noticed `syntax-error` is slightly different from `astroid-error` so added it to the messages added in #6365