### PR TITLE
Fix false positive for `undefined-loop-variable` when a loop else raises or returns

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -247,6 +247,11 @@ Release date: TBA
 
   Closes #6414
 
+* Fix a false positive for ``undefined-loop-variable`` when the ``else`` of a ``for``
+  loop raises or returns.
+
+  Closes #5971
+
 
 What's New in Pylint 2.13.7?
 ============================

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -607,6 +607,11 @@ Other Changes
 
   Closes #5769
 
+* Fix a false positive for ``undefined-loop-variable`` when the ``else`` of a ``for``
+  loop raises or returns.
+
+  Closes #5971
+
 * Only raise ``not-callable`` when all the inferred values of a property are not callable.
 
   Closes #5931

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2242,11 +2242,16 @@ class VariablesChecker(BaseChecker):
         ):
             return
 
-        # For functions we can do more by inferring the length of the itered object
         if not isinstance(assign, nodes.For):
             self.add_message("undefined-loop-variable", args=node.name, node=node)
             return
+        if any(
+            isinstance(else_stmt, (nodes.Return, nodes.Raise))
+            for else_stmt in assign.orelse
+        ):
+            return
 
+        # For functions we can do more by inferring the length of the itered object
         try:
             inferred = next(assign.iter.infer())
         except astroid.InferenceError:

--- a/tests/functional/u/undefined/undefined_loop_variable.py
+++ b/tests/functional/u/undefined/undefined_loop_variable.py
@@ -91,6 +91,22 @@ def test(content):
         handle_line(layne)
 
 
+def for_else_returns(iterable):
+    for thing in iterable:
+        break
+    else:
+        return
+    print(thing)
+
+
+def for_else_raises(iterable):
+    for thing in iterable:
+        break
+    else:
+        raise Exception
+    print(thing)
+
+
 lst = []
 lst2 = [1, 2, 3]
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #5971
