### PR TITLE
Fix false positive for ``unused-variable`` when specifying a metaclass via a call

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -247,6 +247,11 @@ Release date: TBA
 
   Closes #6414
 
+* Fix false positive for ``unused-variable`` for classes inside functions
+  and where a metaclass is provided via a call.
+
+  Closes #4020
+
 
 What's New in Pylint 2.13.7?
 ============================

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -607,6 +607,11 @@ Other Changes
 
   Closes #5769
 
+* Fix false positive for ``unused-variable`` for classes inside functions
+  and where a metaclass is provided via a call.
+
+  Closes #4020
+
 * Only raise ``not-callable`` when all the inferred values of a property are not callable.
 
   Closes #5931

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2806,6 +2806,10 @@ class VariablesChecker(BaseChecker):
             while not isinstance(attr, nodes.Name):
                 attr = attr.expr
             name = attr.name
+        elif isinstance(klass._metaclass, nodes.Call) and isinstance(
+            klass._metaclass.func, nodes.Name
+        ):
+            name = klass._metaclass.func.name
         elif metaclass:
             name = metaclass.root().name
 

--- a/tests/functional/b/bugfix_local_scope_metaclass_1177.py
+++ b/tests/functional/b/bugfix_local_scope_metaclass_1177.py
@@ -20,6 +20,16 @@ def func_scope():
     return Class2
 
 
+def func_scope_with_metaclass_from_call():
+    def get_type():
+        return type
+
+    class Class2(metaclass=get_type()):
+        pass
+
+    return Class2
+
+
 class ClassScope:
     class Meta3(type):
         pass


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Closes #4020
