### PR TITLE
Create a path type of argument that automatically expand user/var

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -258,6 +258,13 @@ Release date: TBA
 
   Closes #5880
 
+* Pylint now expand the user path (i. e. ``~`` to ``home/yusef/``) and expands environment variable (i.e. ``home/$USER/$project``
+  to ``home/yusef/pylint`` if USER=yusef and project=pylint) for option given to pyreverse's ``output-directory``,
+  ``import-graph``, ``ext-import-graph``,  ``int-import-graph`` options, and the spell checker's ``spelling-private-dict-file``
+  option.
+
+  Relates to #6493
+
 ..
   Insert your changelog randomly, it will reduce merge conflicts
   (Ie. not necessarily at the end)

--- a/ChangeLog
+++ b/ChangeLog
@@ -258,8 +258,8 @@ Release date: TBA
 
   Closes #5880
 
-* Pylint now expand the user path (i. e. ``~`` to ``home/yusef/``) and expands environment variable (i.e. ``home/$USER/$project``
-  to ``home/yusef/pylint`` if USER=yusef and project=pylint) for option given to pyreverse's ``output-directory``,
+* Pylint now expands the user path (i.e. ``~`` to ``home/yusef/``) and expands environment variables (i.e. ``home/$USER/$project``
+  to ``home/yusef/pylint`` for ``USER=yusef`` and ``project=pylint``) for pyreverse's ``output-directory``,
   ``import-graph``, ``ext-import-graph``,  ``int-import-graph`` options, and the spell checker's ``spelling-private-dict-file``
   option.
 

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -259,8 +259,8 @@ Other Changes
 
   Closes #5608
 
-* Pylint now expand the user path (i. e. ``~`` to ``home/yusef/``) and expands environment variable (i.e. ``home/$USER/$project``
-  to ``home/yusef/pylint`` if USER=yusef and project=pylint) for option given to pyreverse's ``output-directory``,
+* Pylint now expands the user path (i.e. ``~`` to ``home/yusef/``) and expands environment variables (i.e. ``home/$USER/$project``
+  to ``home/yusef/pylint`` for ``USER=yusef`` and ``project=pylint``) for pyreverse's ``output-directory``,
   ``import-graph``, ``ext-import-graph``,  ``int-import-graph`` options, and the spell checker's ``spelling-private-dict-file``
   option.
 

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -258,3 +258,10 @@ Other Changes
   (optional extension) for redefinitions of outer loop variables by inner loops.
 
   Closes #5608
+
+* Pylint now expand the user path (i. e. ``~`` to ``home/yusef/``) and expands environment variable (i.e. ``home/$USER/$project``
+  to ``home/yusef/pylint`` if USER=yusef and project=pylint) for option given to pyreverse's ``output-directory``,
+  ``import-graph``, ``ext-import-graph``,  ``int-import-graph`` options, and the spell checker's ``spelling-private-dict-file``
+  option.
+
+  Relates to #6493

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -334,7 +334,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             "import-graph",
             {
                 "default": "",
-                "type": "string",
+                "type": "path",
                 "metavar": "<file.gv>",
                 "help": "Output a graph (.gv or any supported image format) of"
                 " all (i.e. internal and external) dependencies to the given file"
@@ -345,7 +345,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             "ext-import-graph",
             {
                 "default": "",
-                "type": "string",
+                "type": "path",
                 "metavar": "<file.gv>",
                 "help": "Output a graph (.gv or any supported image format)"
                 " of external dependencies to the given file"
@@ -356,7 +356,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             "int-import-graph",
             {
                 "default": "",
-                "type": "string",
+                "type": "path",
                 "metavar": "<file.gv>",
                 "help": "Output a graph (.gv or any supported image format)"
                 " of internal dependencies to the given file"

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 import tokenize
 from re import Pattern
@@ -227,7 +226,7 @@ class SpellingChecker(BaseTokenChecker):
             "spelling-private-dict-file",
             {
                 "default": "",
-                "type": "string",
+                "type": "path",
                 "metavar": "<path to file>",
                 "help": "A path to a file that contains the private "
                 "dictionary; one word per line.",
@@ -288,12 +287,6 @@ class SpellingChecker(BaseTokenChecker):
             w.strip()
             for w in self.linter.config.spelling_ignore_comment_directives.split(",")
         ]
-
-        # Expand tilde to allow e.g. spelling-private-dict-file = ~/.pylintdict
-        if self.linter.config.spelling_private_dict_file:
-            self.linter.config.spelling_private_dict_file = os.path.expanduser(
-                self.linter.config.spelling_private_dict_file
-            )
 
         if self.linter.config.spelling_private_dict_file:
             self.spelling_dict = enchant.DictWithPWL(

--- a/pylint/config/argument.py
+++ b/pylint/config/argument.py
@@ -10,6 +10,7 @@ An Argument instance represents a pylint option to be handled by an argparse.Arg
 from __future__ import annotations
 
 import argparse
+import os
 import pathlib
 import re
 import sys
@@ -80,6 +81,17 @@ def _non_empty_string_transformer(value: str) -> str:
     return pylint_utils._unquote(value)
 
 
+def _path_transformer(value: str) -> str:
+    """Check that a path is valid and expand user / variable."""
+    # Expand tilde to allow spelling-private-dict-file = ~/.pylintdict
+    value = os.path.expanduser(value)
+    value = os.path.expandvars(value)
+    # We'd need to distinguish between input path that should exist and output path that do not
+    # if not os.path.exists(value):
+    #     raise argparse.ArgumentTypeError(f"'{value}' is not a valid path is does not exists.")
+    return value
+
+
 def _py_version_transformer(value: str) -> tuple[int, ...]:
     """Transforms a version string into a version tuple."""
     try:
@@ -120,6 +132,7 @@ _TYPE_TRANSFORMERS: dict[str, Callable[[str], _ArgumentTypes]] = {
     "int": int,
     "confidence": _confidence_transformer,
     "non_empty_string": _non_empty_string_transformer,
+    "path": _path_transformer,
     "py_version": _py_version_transformer,
     "regexp": re.compile,
     "regexp_csv": _regexp_csv_transfomer,

--- a/pylint/config/argument.py
+++ b/pylint/config/argument.py
@@ -82,11 +82,8 @@ def _non_empty_string_transformer(value: str) -> str:
 
 
 def _path_transformer(value: str) -> str:
-    """Check that a path is valid and expand user / variable."""
-    # Expand tilde to allow spelling-private-dict-file = ~/.pylintdict
-    value = os.path.expanduser(value)
-    value = os.path.expandvars(value)
-    return value
+    """Expand user and variables in a path."""
+    return os.path.expandvars(os.path.expanduser(value))
 
 
 def _py_version_transformer(value: str) -> tuple[int, ...]:

--- a/pylint/config/argument.py
+++ b/pylint/config/argument.py
@@ -86,9 +86,6 @@ def _path_transformer(value: str) -> str:
     # Expand tilde to allow spelling-private-dict-file = ~/.pylintdict
     value = os.path.expanduser(value)
     value = os.path.expandvars(value)
-    # We'd need to distinguish between input path that should exist and output path that do not
-    # if not os.path.exists(value):
-    #     raise argparse.ArgumentTypeError(f"'{value}' is not a valid path is does not exists.")
     return value
 
 

--- a/pylint/pyreverse/main.py
+++ b/pylint/pyreverse/main.py
@@ -193,7 +193,7 @@ OPTIONS: Options = (
         "output-directory",
         dict(
             default="",
-            type="string",
+            type="path",
             short="d",
             action="store",
             metavar="<output_directory>",


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

Refactor prior to #6493, permitted by the migration to argparse. It could permit to expanduser in various pylint configuration / options, so it's a feature.
