### PR TITLE
Exit gracefully for unrecognized command line options

### DIFF
--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -81,9 +81,7 @@ def _config_initialization(
             unrecognized_options.append(opt[1:])
     if unrecognized_options:
         msg = ", ".join(unrecognized_options)
-        linter._arg_parser.print_usage()
-        linter.add_message("unrecognized-option", line=0, args=msg)
-        sys.exit(1)
+        linter._arg_parser.error(f"Unrecognized option found: {msg}")
 
     # Set the current module to configuration as we don't know where
     # the --load-plugins key is coming from

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -81,8 +81,9 @@ def _config_initialization(
             unrecognized_options.append(opt[1:])
     if unrecognized_options:
         msg = ", ".join(unrecognized_options)
+        linter._arg_parser.print_usage()
         linter.add_message("unrecognized-option", line=0, args=msg)
-        raise _UnrecognizedOptionError(options=unrecognized_options)
+        sys.exit(1)
 
     # Set the current module to configuration as we don't know where
     # the --load-plugins key is coming from

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import pytest
 from pytest import CaptureFixture
 
-from pylint.config.exceptions import _UnrecognizedOptionError
 from pylint.lint import Run as LintRun
 from pylint.testutils._run import _Run as Run
 from pylint.testutils.configuration_test import run_using_a_configuration_file
@@ -65,17 +64,19 @@ def test_unknown_message_id(capsys: CaptureFixture) -> None:
 
 def test_unknown_option_name(capsys: CaptureFixture) -> None:
     """Check that we correctly raise a message on an unknown option."""
-    with pytest.raises(_UnrecognizedOptionError):
+    with pytest.raises(SystemExit):
         Run([str(EMPTY_MODULE), "--unknown-option=yes"], exit=False)
     output = capsys.readouterr()
+    assert "usage: pylint" in output.out
     assert "E0015: Unrecognized option found: unknown-option=yes" in output.out
 
 
 def test_unknown_short_option_name(capsys: CaptureFixture) -> None:
     """Check that we correctly raise a message on an unknown short option."""
-    with pytest.raises(_UnrecognizedOptionError):
+    with pytest.raises(SystemExit):
         Run([str(EMPTY_MODULE), "-Q"], exit=False)
     output = capsys.readouterr()
+    assert "usage: pylint" in output.out
     assert "E0015: Unrecognized option found: Q" in output.out
 
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -67,8 +67,8 @@ def test_unknown_option_name(capsys: CaptureFixture) -> None:
     with pytest.raises(SystemExit):
         Run([str(EMPTY_MODULE), "--unknown-option=yes"], exit=False)
     output = capsys.readouterr()
-    assert "usage: pylint" in output.out
-    assert "E0015: Unrecognized option found: unknown-option=yes" in output.out
+    assert "usage: pylint" in output.err
+    assert "Unrecognized option" in output.err
 
 
 def test_unknown_short_option_name(capsys: CaptureFixture) -> None:
@@ -76,8 +76,8 @@ def test_unknown_short_option_name(capsys: CaptureFixture) -> None:
     with pytest.raises(SystemExit):
         Run([str(EMPTY_MODULE), "-Q"], exit=False)
     output = capsys.readouterr()
-    assert "usage: pylint" in output.out
-    assert "E0015: Unrecognized option found: Q" in output.out
+    assert "usage: pylint" in output.err
+    assert "Unrecognized option" in output.err
 
 
 def test_unknown_confidence(capsys: CaptureFixture) -> None:


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Closes #6418.

We now print:
```console
❯ pylint -Q
usage: pylint [options]
************* Module Command line
Command line:1:0: E0015: Unrecognized option found: Q (unrecognized-option)
```