### PR TITLE
Move changelog for redefined-loop-name and add "Checker" to class name

### DIFF
--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -57,11 +57,6 @@ New checkers
 
   Closes #4525
 
-* Added optional extension ``redefined-loop-name`` to emit messages when a loop variable
-  is redefined in the loop body.
-
-  Closes #5072
-
 * Added new message called ``duplicate-value`` which identifies duplicate values inside sets.
 
   Closes #5880
@@ -85,6 +80,13 @@ Removed checkers
 
 Extensions
 ==========
+
+* ``RedefinedLoopNameChecker``
+
+    * Added optional extension ``redefined-loop-name`` to emit messages when a loop variable
+      is redefined in the loop body.
+
+      Closes #5072
 
 * ``DocStringStyleChecker``
 

--- a/pylint/extensions/redefined_loop_name.py
+++ b/pylint/extensions/redefined_loop_name.py
@@ -14,7 +14,7 @@ from pylint.interfaces import HIGH
 from pylint.lint import PyLinter
 
 
-class RedefinedLoopName(checkers.BaseChecker):
+class RedefinedLoopNameChecker(checkers.BaseChecker):
 
     name = "redefined-loop-name"
 
@@ -86,4 +86,4 @@ class RedefinedLoopName(checkers.BaseChecker):
 
 
 def register(linter: PyLinter) -> None:
-    linter.register_checker(RedefinedLoopName(linter))
+    linter.register_checker(RedefinedLoopNameChecker(linter))


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |


## Description

Noticed from looking at #6448 that I didn't put my changelog for #5649 under "extensions". While there, noticed I also left out the word "Checker" in the class name.
