### PR TITLE
Fix invalid-enum-extension with IntFlag

### DIFF
--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -818,17 +818,17 @@ a metaclass class method.",
             ):
                 self.add_message("inherit-non-class", args=base.as_string(), node=node)
 
-            if (
-                isinstance(ancestor, nodes.ClassDef)
-                and ancestor.is_subtype_of("enum.Enum")
-                and any(isinstance(stmt, nodes.Assign) for stmt in ancestor.body)
+            if isinstance(ancestor, nodes.ClassDef) and ancestor.is_subtype_of(
+                "enum.Enum"
             ):
-                self.add_message(
-                    "invalid-enum-extension",
-                    args=ancestor.name,
-                    node=node,
-                    confidence=INFERENCE,
-                )
+                members = ancestor.getattr("__members__")
+                if members and isinstance(members[0], nodes.Dict) and members[0].items:
+                    self.add_message(
+                        "invalid-enum-extension",
+                        args=ancestor.name,
+                        node=node,
+                        confidence=INFERENCE,
+                    )
 
             if ancestor.name == object.__name__:
                 self.add_message(

--- a/tests/functional/i/invalid/invalid_enum_extension.py
+++ b/tests/functional/i/invalid/invalid_enum_extension.py
@@ -1,6 +1,6 @@
 """Test check for classes extending an Enum class."""
 # pylint: disable=missing-class-docstring,invalid-name
-from enum import Enum
+from enum import Enum, IntFlag
 
 # We don't flag the Enum class itself
 class A(Enum):
@@ -19,3 +19,8 @@ class C(Enum):
 
 class D(C):
     x = 3
+
+
+class CustomFlags(IntFlag):
+    SUPPORT_OPEN = 1
+    SUPPORT_CLOSE = 2


### PR DESCRIPTION
## Description
Fix unreleased issue with `invalid-enum-extension` and `IntFlag`.

```py
class CustomFlags(IntFlag):
    SUPPORT_OPEN = 1
    SUPPORT_CLOSE = 2
```

Unfortunately, that still leaves a corner case which would probably require astroid changes.
It shouldn't be too common though, so we might be fine waiting for a bug report on this one.
```py
from enum import IntFlag, Enum

class C(Enum):
    def func(self):
        ...

    a = func


class D(C):  # false-positive: invalid-enum-extension
    C = 3
```

Closes #6295
