### PR TITLE
Change confidence for `no-self-use` to `INFERENCE`

### DIFF
--- a/pylint/extensions/no_self_use.py
+++ b/pylint/extensions/no_self_use.py
@@ -16,7 +16,7 @@ from pylint.checkers.utils import (
     is_protocol_class,
     overrides_a_method,
 )
-from pylint.interfaces import HIGH
+from pylint.interfaces import INFERENCE
 
 if TYPE_CHECKING:
     from pylint.lint.pylinter import PyLinter
@@ -95,7 +95,7 @@ class NoSelfUseChecker(BaseChecker):
                     or is_overload_stub(node)
                 )
             ):
-                self.add_message("no-self-use", node=node, confidence=HIGH)
+                self.add_message("no-self-use", node=node, confidence=INFERENCE)
 
     leave_asyncfunctiondef = leave_functiondef
 

--- a/tests/functional/ext/no_self_use/no_self_use.txt
+++ b/tests/functional/ext/no_self_use/no_self_use.txt
@@ -1,3 +1,3 @@
-no-self-use:17:4:17:23:Toto.function_method:Method could be a function:HIGH
-no-self-use:25:4:25:35:Toto.async_function_method:Method could be a function:HIGH
-no-self-use:102:4:102:9:C.a:Method could be a function:HIGH
+no-self-use:17:4:17:23:Toto.function_method:Method could be a function:INFERENCE
+no-self-use:25:4:25:35:Toto.async_function_method:Method could be a function:INFERENCE
+no-self-use:102:4:102:9:C.a:Method could be a function:INFERENCE


### PR DESCRIPTION
## Description
Change confidence from `no-self-use` from `HIGH` to `INFERENCE`.

Although we don't use `safe_infer`, we do some (best effort) checks to see if the warning should be emitted, e.g. check for abstract methods. Those aren't perfect though, so I think `INFERENCE` is a better fit than `HIGH`.