### PR TITLE
Fix saving of persistent data files on different drives

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -293,6 +293,11 @@ Release date: TBA
 
   Closes #5502
 
+* Fix saving of persistent data files in environments where the user's cache
+  directory and the linted file are on a different drive.
+
+  Closes #6394
+
 ..
   Insert your changelog randomly, it will reduce merge conflicts
   (Ie. not necessarily at the end)
@@ -302,10 +307,6 @@ What's New in Pylint 2.13.9?
 ============================
 Release date: TBA
 
-* Fix saving of persistent data files in environments where the user's cache
-  directory and the linted file are on a different drive.
-
-  Closes #6394
 
 
 What's New in Pylint 2.13.8?

--- a/ChangeLog
+++ b/ChangeLog
@@ -302,6 +302,10 @@ What's New in Pylint 2.13.9?
 ============================
 Release date: TBA
 
+* Fix saving of persistent data files in environments where the user's cache
+  directory and the linted file are on a different drive.
+
+  Closes #6394
 
 
 What's New in Pylint 2.13.8?

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -639,8 +639,3 @@ Other Changes
   ``open``
 
   Closes #6414
-
-* Fix saving of persistent data files in environments where the user's cache
-  directory and the linted file are on a different drive.
-
-  Closes #6394

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -639,3 +639,8 @@ Other Changes
   ``open``
 
   Closes #6414
+
+* Fix saving of persistent data files in environments where the user's cache
+  directory and the linted file are on a different drive.
+
+  Closes #6394

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -266,6 +266,11 @@ Other Changes
 
   Closes #5670
 
+* Fix saving of persistent data files in environments where the user's cache
+  directory and the linted file are on a different drive.
+
+  Closes #6394
+
 * The ``method-cache-max-size-none`` checker will now also check ``functools.cache``.
 
   Closes #5670

--- a/pylint/lint/caching.py
+++ b/pylint/lint/caching.py
@@ -16,7 +16,12 @@ from pylint.utils import LinterStats
 def _get_pdata_path(
     base_name: Path, recurs: int, pylint_home: Path = Path(PYLINT_HOME)
 ) -> Path:
-    underscored_name = "_".join(str(p) for p in base_name.parts)
+    # We strip all characters that can't be used in a filename
+    # Also strip '/' and '\\' because we want to create a single file, not sub-directories
+    underscored_name = "_".join(
+        str(p.replace(":", "_").replace("/", "_").replace("\\", "_"))
+        for p in base_name.parts
+    )
     return pylint_home / f"{underscored_name}_{recurs}.stats"
 
 

--- a/tests/lint/test_caching.py
+++ b/tests/lint/test_caching.py
@@ -5,6 +5,7 @@
 # Pytest fixtures work like this by design
 # pylint: disable=redefined-outer-name
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -18,15 +19,67 @@ PYLINT_HOME_PATH = Path(PYLINT_HOME)
 
 
 @pytest.mark.parametrize(
-    "path,recur,expected",
+    "path,recur,pylint_home,expected",
     [
-        ["", 1, PYLINT_HOME_PATH / "_1.stats"],
-        ["", 2, PYLINT_HOME_PATH / "_2.stats"],
-        ["a/path", 42, PYLINT_HOME_PATH / "a_path_42.stats"],
+        ["", 1, PYLINT_HOME_PATH, PYLINT_HOME_PATH / "_1.stats"],
+        ["", 2, PYLINT_HOME_PATH, PYLINT_HOME_PATH / "_2.stats"],
+        ["a/path", 42, PYLINT_HOME_PATH, PYLINT_HOME_PATH / "a_path_42.stats"],
     ],
 )
-def test__get_pdata_path(path: str, recur: int, expected: Path) -> None:
-    assert _get_pdata_path(Path(path), recur) == expected
+def test__get_pdata_path(
+    path: str, recur: int, pylint_home: Path, expected: Path
+) -> None:
+    assert _get_pdata_path(Path(path), recur, pylint_home) == expected
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Path type of *nix")
+@pytest.mark.parametrize(
+    "path,recur,pylint_home,expected",
+    [
+        [
+            "/workspace/MyDir/test.py",
+            1,
+            Path("/root/.cache/pylint"),
+            Path("/root/.cache/pylint") / "__workspace_MyDir_test.py_1.stats",
+        ],
+        [
+            "/workspace/MyDir/test.py",
+            1,
+            Path("//host/computer/.cache"),
+            Path("//host/computer/.cache") / "__workspace_MyDir_test.py_1.stats",
+        ],
+    ],
+)
+def test__get_pdata_path_nix(
+    path: str, recur: int, pylint_home: Path, expected: Path
+) -> None:
+    """test__get_pdata_path but specifically for *nix system paths."""
+    assert _get_pdata_path(Path(path), recur, pylint_home) == expected
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Path type of windows")
+@pytest.mark.parametrize(
+    "path,recur,pylint_home,expected",
+    [
+        [
+            "D:\\MyDir\\test.py",
+            1,
+            Path("C:\\Users\\MyPylintHome"),
+            Path("C:\\Users\\MyPylintHome") / "D___MyDir_test.py_1.stats",
+        ],
+        [
+            "C:\\MyDir\\test.py",
+            1,
+            Path("C:\\Users\\MyPylintHome"),
+            Path("C:\\Users\\MyPylintHome") / "C___MyDir_test.py_1.stats",
+        ],
+    ],
+)
+def test__get_pdata_path_windows(
+    path: str, recur: int, pylint_home: Path, expected: Path
+) -> None:
+    """test__get_pdata_path but specifically for windows."""
+    assert _get_pdata_path(Path(path), recur, pylint_home) == expected
 
 
 @pytest.fixture


### PR DESCRIPTION
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #6394 and the underlying problem. See for reference also [Fix saving of persistent data files on different drives](https://github.com/PyCQA/pylint/commit/01ffb60ff4094a0876517f826e54a805cfb50279) and https://github.com/DanielNoord/pylint/pull/135.

Basically drive letters are not handled very well when you concatenate two paths with different drives. We now normalise one of the paths to make sure this is handled better.
Tests show behaviour on both *nix and Windows.