### PR TITLE
Correct link to VSCode IDE integration documentation

### DIFF
--- a/doc/user_guide/ide-integration.rst
+++ b/doc/user_guide/ide-integration.rst
@@ -16,6 +16,8 @@ To use Pylint with:
  - PyCharm_, see :ref:`the section below <pylint_in_pycharm>`,
  - TextMate_, see :ref:`the section below <pylint_in_textmate>`
  - `Visual Studio Code`_, see https://code.visualstudio.com/docs/python/linting,
+  - `Visual Studio Code Pylint Extension`_ see, https://marketplace.visualstudio.com/items?itemName=ms-python.pylint,
+ - `Visual Studio`_, see https://docs.microsoft.com/en-us/visualstudio/python/linting-python-code,
  - `Jupyter Notebook`_, see https://github.com/nbQA-dev/nbQA,
 
 Pylint is integrated in:

--- a/doc/user_guide/ide-integration.rst
+++ b/doc/user_guide/ide-integration.rst
@@ -15,9 +15,9 @@ To use Pylint with:
  - WingIDE_, see https://wingware.com/doc/warnings/external-checkers,
  - PyCharm_, see :ref:`the section below <pylint_in_pycharm>`,
  - TextMate_, see :ref:`the section below <pylint_in_textmate>`
-- `Visual Studio Code`_, see https://code.visualstudio.com/docs/python/linting,
-- `Visual Studio Code Pylint Extension`_ see, https://marketplace.visualstudio.com/items?itemName=ms-python.pylint,
-- `Visual Studio`_, see https://docs.microsoft.com/en-us/visualstudio/python/linting-python-code,
+ - `Visual Studio Code`_, see https://code.visualstudio.com/docs/python/linting,
+ - `Visual Studio Code`_ Pylint Extension see, https://marketplace.visualstudio.com/items?itemName=ms-python.pylint,
+ - `Visual Studio`_, see https://docs.microsoft.com/en-us/visualstudio/python/linting-python-code,
  - `Jupyter Notebook`_, see https://github.com/nbQA-dev/nbQA,
 
 Pylint is integrated in:

--- a/doc/user_guide/ide-integration.rst
+++ b/doc/user_guide/ide-integration.rst
@@ -15,7 +15,7 @@ To use Pylint with:
  - WingIDE_, see https://wingware.com/doc/warnings/external-checkers,
  - PyCharm_, see :ref:`the section below <pylint_in_pycharm>`,
  - TextMate_, see :ref:`the section below <pylint_in_textmate>`
- - `Visual Studio Code`_, see https://docs.microsoft.com/en-us/visualstudio/python/linting-python-code,
+ - `Visual Studio Code`_, see https://code.visualstudio.com/docs/python/linting,
  - `Jupyter Notebook`_, see https://github.com/nbQA-dev/nbQA,
 
 Pylint is integrated in:

--- a/doc/user_guide/ide-integration.rst
+++ b/doc/user_guide/ide-integration.rst
@@ -15,9 +15,9 @@ To use Pylint with:
  - WingIDE_, see https://wingware.com/doc/warnings/external-checkers,
  - PyCharm_, see :ref:`the section below <pylint_in_pycharm>`,
  - TextMate_, see :ref:`the section below <pylint_in_textmate>`
- - `Visual Studio Code`_, see https://code.visualstudio.com/docs/python/linting,
-  - `Visual Studio Code Pylint Extension`_ see, https://marketplace.visualstudio.com/items?itemName=ms-python.pylint,
- - `Visual Studio`_, see https://docs.microsoft.com/en-us/visualstudio/python/linting-python-code,
+- `Visual Studio Code`_, see https://code.visualstudio.com/docs/python/linting,
+- `Visual Studio Code Pylint Extension`_ see, https://marketplace.visualstudio.com/items?itemName=ms-python.pylint,
+- `Visual Studio`_, see https://docs.microsoft.com/en-us/visualstudio/python/linting-python-code,
  - `Jupyter Notebook`_, see https://github.com/nbQA-dev/nbQA,
 
 Pylint is integrated in:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

A link in the user guide claiming to point to VSCode IDE integration documentation was actually pointing to Visual Studio integration documentation. 

This corrects that documentation page.

### Links
- [New link to VSCode docs](https://code.visualstudio.com/docs/python/linting).
- [Old link to Visual Studio docs](https://docs.microsoft.com/en-us/visualstudio/python/linting-python-code)
- [Pylink docs page for IDE integrations](https://pylint.pycqa.org/en/latest/user_guide/ide-integration.html)

Closes #6533 

### Additional Concerns

Does the change log need to be updated for a change this small? I did not do so.
