### PR TITLE
Don't emit unsubscriptable-object for string annotations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -303,6 +303,11 @@ Release date: TBA
 
   Closes #4369 and #6523
 
+* ``is_class_subscriptable_pep585_with_postponed_evaluation_enabled`` has been deprecated.
+  Use ``subscriptable_with_postponed_evaluation_enabled`` instead.
+
+  Ref #6536
+
 ..
   Insert your changelog randomly, it will reduce merge conflicts
   (Ie. not necessarily at the end)

--- a/ChangeLog
+++ b/ChangeLog
@@ -298,6 +298,11 @@ Release date: TBA
 
   Closes #6394
 
+* Don't emit ``unsubscriptable-object`` for string annotations.
+  Pylint doesn't check if class is only generic in type stubs only.
+
+  Closes #4369 and #6523
+
 ..
   Insert your changelog randomly, it will reduce merge conflicts
   (Ie. not necessarily at the end)

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -316,3 +316,8 @@ Other Changes
   Pylint doesn't check if class is only generic in type stubs only.
 
   Closes #4369 and #6523
+
+* ``is_class_subscriptable_pep585_with_postponed_evaluation_enabled`` has been deprecated.
+  Use ``subscriptable_with_postponed_evaluation_enabled`` instead.
+
+  Ref #6536

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -311,3 +311,8 @@ Other Changes
   option.
 
   Relates to #6493
+
+* Don't emit ``unsubscriptable-object`` for string annotations.
+  Pylint doesn't check if class is only generic in type stubs only.
+
+  Closes #4369 and #6523

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1397,6 +1397,12 @@ def is_class_subscriptable_pep585_with_postponed_evaluation_enabled(
     """Check if class is subscriptable with PEP 585 and
     postponed evaluation enabled.
     """
+    warnings.warn(
+        "'is_class_subscriptable_pep585_with_postponed_evaluation_enabled' has been "
+        "deprecated and will be removed in pylint 3.0. "
+        "Use 'subscriptable_with_postponed_evaluation_enabled' instead.",
+        DeprecationWarning,
+    )
     return (
         is_postponed_evaluation_enabled(node)
         and value.qname() in SUBSCRIPTABLE_CLASSES_PEP585

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1212,7 +1212,7 @@ def supports_getitem(value: nodes.NodeNG, node: nodes.NodeNG) -> bool:
     if isinstance(value, nodes.ClassDef):
         if _supports_protocol_method(value, CLASS_GETITEM_METHOD):
             return True
-        if is_class_subscriptable_pep585_with_postponed_evaluation_enabled(value, node):
+        if subscriptable_with_postponed_evaluation_enabled(node):
             return True
     return _supports_protocol(value, _supports_getitem_protocol)
 
@@ -1401,6 +1401,13 @@ def is_class_subscriptable_pep585_with_postponed_evaluation_enabled(
         is_postponed_evaluation_enabled(node)
         and value.qname() in SUBSCRIPTABLE_CLASSES_PEP585
         and is_node_in_type_annotation_context(node)
+    )
+
+
+def subscriptable_with_postponed_evaluation_enabled(node: nodes.NodeNG) -> bool:
+    """Check if class can be subscriptable in type annotation context."""
+    return is_postponed_evaluation_enabled(node) and is_node_in_type_annotation_context(
+        node
     )
 
 

--- a/tests/functional/g/generic_alias/generic_alias_postponed_evaluation_py37.py
+++ b/tests/functional/g/generic_alias/generic_alias_postponed_evaluation_py37.py
@@ -4,7 +4,7 @@ In type annotation context, they can be used with postponed evaluation enabled,
 starting with PY37.
 """
 # flake8: noqa
-# pylint: disable=missing-docstring,pointless-statement
+# pylint: disable=missing-docstring,pointless-statement,invalid-name
 # pylint: disable=too-few-public-methods,multiple-statements,line-too-long
 from __future__ import annotations
 
@@ -172,8 +172,18 @@ var_re_Match: re.Match[str]
 # unsubscriptable types
 var_abc_Hashable: collections.abc.Hashable
 var_abc_Sized: collections.abc.Sized
-var_abc_Hashable2: collections.abc.Hashable[int]  # [unsubscriptable-object]
-var_abc_Sized2: collections.abc.Sized[int]  # [unsubscriptable-object]
+var_abc_Hashable2: collections.abc.Hashable[int]  # string annotations aren't checked
+var_abc_Sized2: collections.abc.Sized[int]  # string annotations aren't checked
 
 # subscriptable with Python 3.9
 var_abc_ByteString: collections.abc.ByteString[int]
+
+
+# Generic in type stubs only -> string annotations aren't checked
+class A:
+    ...
+
+var_a1: A[str]  # string annotations aren't checked
+var_a2: "A[str]"  # string annotations aren't checked
+class B(A[str]):  # [unsubscriptable-object]
+    ...

--- a/tests/functional/g/generic_alias/generic_alias_postponed_evaluation_py37.txt
+++ b/tests/functional/g/generic_alias/generic_alias_postponed_evaluation_py37.txt
@@ -52,5 +52,4 @@ abstract-method:107:0:107:21:DerivedMultiple:Method '__len__' is abstract in cla
 abstract-method:112:0:112:24:CustomAbstractCls2:Method '__len__' is abstract in class 'Sized' but is not overridden:UNDEFINED
 unsubscriptable-object:112:48:112:72:CustomAbstractCls2:Value 'collections.abc.Iterable' is unsubscriptable:UNDEFINED
 abstract-method:114:0:114:26:CustomImplementation:Method '__len__' is abstract in class 'Sized' but is not overridden:UNDEFINED
-unsubscriptable-object:175:19:175:43::Value 'collections.abc.Hashable' is unsubscriptable:UNDEFINED
-unsubscriptable-object:176:16:176:37::Value 'collections.abc.Sized' is unsubscriptable:UNDEFINED
+unsubscriptable-object:188:8:188:9:B:Value 'A' is unsubscriptable:UNDEFINED

--- a/tests/functional/g/generic_alias/generic_alias_typing.py
+++ b/tests/functional/g/generic_alias/generic_alias_typing.py
@@ -1,6 +1,6 @@
 """Test generic alias support for typing.py types."""
 # flake8: noqa
-# pylint: disable=missing-docstring,pointless-statement
+# pylint: disable=missing-docstring,pointless-statement,invalid-name
 # pylint: disable=too-few-public-methods,multiple-statements,line-too-long, unnecessary-dunder-call
 import abc
 import typing
@@ -139,3 +139,13 @@ var_int: int[int]  # [unsubscriptable-object]
 var_bytestring2: typing.ByteString[int]  # [unsubscriptable-object]
 var_hashable2: typing.Hashable[int]  # [unsubscriptable-object]
 var_sized2: typing.Sized[int]  # [unsubscriptable-object]
+
+
+# Generic in type stubs only -> string annotations aren't checked
+class A:
+    ...
+
+var_a1: A[str]  # [unsubscriptable-object]
+var_a2: "A[str]"  # string annotations aren't checked
+class B(A[str]):  # [unsubscriptable-object]
+    ...

--- a/tests/functional/g/generic_alias/generic_alias_typing.txt
+++ b/tests/functional/g/generic_alias/generic_alias_typing.txt
@@ -17,3 +17,5 @@ unsubscriptable-object:138:9:138:12::Value 'int' is unsubscriptable:UNDEFINED
 unsubscriptable-object:139:17:139:34::Value 'typing.ByteString' is unsubscriptable:UNDEFINED
 unsubscriptable-object:140:15:140:30::Value 'typing.Hashable' is unsubscriptable:UNDEFINED
 unsubscriptable-object:141:12:141:24::Value 'typing.Sized' is unsubscriptable:UNDEFINED
+unsubscriptable-object:148:8:148:9::Value 'A' is unsubscriptable:UNDEFINED
+unsubscriptable-object:150:8:150:9:B:Value 'A' is unsubscriptable:UNDEFINED

--- a/tests/functional/p/postponed_evaluation_pep585.py
+++ b/tests/functional/p/postponed_evaluation_pep585.py
@@ -108,7 +108,7 @@ import re
 class OrderedDict:
     pass
 
-var12: OrderedDict[str, int]  # [unsubscriptable-object]
+var12: OrderedDict[str, int]  # string annotations aren't checked
 var13: list[int]
 var14: collections.OrderedDict[str, int]
 var15: collections.Counter[int]

--- a/tests/functional/p/postponed_evaluation_pep585.txt
+++ b/tests/functional/p/postponed_evaluation_pep585.txt
@@ -13,7 +13,6 @@ unsubscriptable-object:99:19:99:23::Value 'list' is unsubscriptable:UNDEFINED
 unsubscriptable-object:100:15:100:19::Value 'list' is unsubscriptable:UNDEFINED
 unsubscriptable-object:101:9:101:13::Value 'list' is unsubscriptable:UNDEFINED
 unsubscriptable-object:101:14:101:18::Value 'list' is unsubscriptable:UNDEFINED
-unsubscriptable-object:111:7:111:18::Value 'OrderedDict' is unsubscriptable:UNDEFINED
 unsubscriptable-object:121:20:121:24:func3:Value 'list' is unsubscriptable:UNDEFINED
 unsubscriptable-object:123:33:123:37:func3:Value 'list' is unsubscriptable:UNDEFINED
 unsubscriptable-object:126:14:126:18:func4:Value 'list' is unsubscriptable:UNDEFINED


### PR DESCRIPTION
## Description
We previously checked if a class is explicitly mentioned in PEP 585 as being subscriptable. That frequently results in errors as some classes are only generic in type stubs. We could continue to update the set of subscriptable names, but that still wouldn't cover custom packages and is impractical.

With this PR, pylint will ignore all string annotations (explicit or via `from __future__ import annotations`). We might miss a few issues, however those aren't runtime errors and a type checker is likely used anyway witch would catch these.

Not emitting false-positives is more important than catching all errors here IMO.

Closes #4369
Closes #6523
