### PR TITLE
Finish typing of `pylint.pyreverse.utils`

### DIFF
--- a/pylint/pyreverse/utils.py
+++ b/pylint/pyreverse/utils.py
@@ -170,7 +170,7 @@ class ASTWalker:
             e_method, l_method = methods
         return e_method, l_method
 
-    def visit(self, node: nodes.NodeNG) -> None:
+    def visit(self, node: nodes.NodeNG) -> Any:
         """Walk on the tree from <node>, getting callbacks from handler."""
         method = self.get_callbacks(node)[0]
         if method is not None:

--- a/pylint/pyreverse/utils.py
+++ b/pylint/pyreverse/utils.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
     _CallbackT = Callable[
         [nodes.NodeNG],
-        Optional[Union[Tuple[ClassDiagram], Tuple[PackageDiagram, ClassDiagram]]],
+        Union[Tuple[ClassDiagram], Tuple[PackageDiagram, ClassDiagram], None],
     ]
     _CallbackTupleT = Tuple[Optional[_CallbackT], Optional[_CallbackT]]
 

--- a/pylint/pyreverse/utils.py
+++ b/pylint/pyreverse/utils.py
@@ -11,21 +11,21 @@ import re
 import shutil
 import subprocess
 import sys
-from typing import TYPE_CHECKING, Any, Callable, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union
 
 import astroid
 from astroid import nodes
 
 if TYPE_CHECKING:
-    # pylint: disable=unsupported-binary-operation
     from pylint.pyreverse.diadefslib import DiaDefGenerator
     from pylint.pyreverse.diagrams import ClassDiagram, PackageDiagram
     from pylint.pyreverse.inspector import Linker
 
     _CallbackT = Callable[
-        [nodes.NodeNG], Tuple[ClassDiagram] | Tuple[PackageDiagram, ClassDiagram] | None
+        [nodes.NodeNG],
+        Optional[Union[Tuple[ClassDiagram], Tuple[PackageDiagram, ClassDiagram]]],
     ]
-    _CallbackTupleT = Tuple[_CallbackT | None, _CallbackT | None]
+    _CallbackTupleT = Tuple[Optional[_CallbackT], Optional[_CallbackT]]
 
 
 RCFILE = ".pyreverserc"


### PR DESCRIPTION
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``


## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This module already had some typing, added typing to the classes and functions that did not have any yet.

Running with `mypy --strict` four issues remain, which I can't wrap my head around why `mypy` complains about them:
```
pylint [typing-pyreverse-p3] % mypy --strict pylint/pyreverse/utils.py           
pylint/pyreverse/utils.py:72: error: Returning Any from function declared to return "bool"  [no-any-return]
pylint/pyreverse/utils.py:77: error: Returning Any from function declared to return "bool"  [no-any-return]
pylint/pyreverse/utils.py:213: error: Returning Any from function declared to return "str"  [no-any-return]
pylint/pyreverse/utils.py:215: error: Returning Any from function declared to return "str"  [no-any-return]
Found 4 errors in 1 file (checked 1 source file)
```
