### PR TITLE
Pass ``msg_store`` and ``node`` to ``FileState``

### DIFF
--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -159,6 +159,7 @@ def check_parallel(
             mapreduce_data,
         ) in pool.imap_unordered(_worker_check_single_file, files):
             linter.file_state.base_name = base_name
+            linter.file_state._is_base_filestate = False
             linter.set_current_module(module, file_path)
             for msg in messages:
                 linter.reporter.handle_message(msg)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -279,8 +279,13 @@ class PyLinter(
         self._dynamic_plugins: set[str] = set()
         """Set of loaded plugin names."""
 
+        # Attributes related to registering messages and their handling
+        self.msgs_store = MessageDefinitionStore()
+        self.msg_status = 0
+        self._by_id_managed_msgs: list[ManagedMessage] = []
+
         # Attributes related to visiting files
-        self.file_state = FileState()
+        self.file_state = FileState("BaseState", self.msgs_store)
         self.current_name: str | None = None
         self.current_file: str | None = None
         self._ignore_file = False
@@ -299,11 +304,6 @@ class PyLinter(
         self.fail_on_symbols: list[str] = []
         """List of message symbols on which pylint should fail, set by --fail-on."""
         self._error_mode = False
-
-        # Attributes related to registering messages and their handling
-        self.msgs_store = MessageDefinitionStore()
-        self.msg_status = 0
-        self._by_id_managed_msgs: list[ManagedMessage] = []
 
         reporters.ReportsHandlerMixIn.__init__(self)
         checkers.BaseChecker.__init__(self, self)
@@ -694,7 +694,7 @@ class PyLinter(
 
         self._ignore_file = False
 
-        self.file_state = FileState(file.modpath)
+        self.file_state = FileState(file.modpath, self.msgs_store, ast_node)
         # fix the current file (if the source file was not available or
         # if it's actually a c extension)
         self.current_file = ast_node.file

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -285,7 +285,7 @@ class PyLinter(
         self._by_id_managed_msgs: list[ManagedMessage] = []
 
         # Attributes related to visiting files
-        self.file_state = FileState("BaseState", self.msgs_store)
+        self.file_state = FileState("", self.msgs_store, is_base_filestate=True)
         self.current_name: str | None = None
         self.current_file: str | None = None
         self._ignore_file = False
@@ -969,8 +969,10 @@ class PyLinter(
         # Display whatever messages are left on the reporter.
         self.reporter.display_messages(report_nodes.Section())
 
-        if self.file_state.base_name is not None:
+        if not self.file_state._is_base_filestate:
             # load previous results if any
+            # TODO: 3.0: Remove assertion
+            assert self.file_state.base_name
             previous_stats = load_results(self.file_state.base_name)
             self.reporter.on_close(self.stats, previous_stats)
             if self.config.reports:
@@ -994,6 +996,7 @@ class PyLinter(
         # check with at least check 1 statements (usually 0 when there is a
         # syntax error preventing pylint from further processing)
         note = None
+        # TODO: 3.0: Remove assertion
         assert self.file_state.base_name
         previous_stats = load_results(self.file_state.base_name)
         if self.stats.statement == 0:

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -969,10 +969,12 @@ class PyLinter(
         # Display whatever messages are left on the reporter.
         self.reporter.display_messages(report_nodes.Section())
 
-        if not self.file_state._is_base_filestate:
+        # TODO: 3.0: Remove second half of if-statement
+        if (
+            not self.file_state._is_base_filestate
+            and self.file_state.base_name is not None
+        ):
             # load previous results if any
-            # TODO: 3.0: Remove assertion
-            assert self.file_state.base_name
             previous_stats = load_results(self.file_state.base_name)
             self.reporter.on_close(self.stats, previous_stats)
             if self.config.reports:
@@ -997,7 +999,7 @@ class PyLinter(
         # syntax error preventing pylint from further processing)
         note = None
         # TODO: 3.0: Remove assertion
-        assert self.file_state.base_name
+        assert self.file_state.base_name is not None
         previous_stats = load_results(self.file_state.base_name)
         if self.stats.statement == 0:
             return note

--- a/pylint/utils/file_state.py
+++ b/pylint/utils/file_state.py
@@ -39,6 +39,8 @@ class FileState:
         modname: str | None = None,
         msg_store: MessageDefinitionStore | None = None,
         node: nodes.Module | None = None,
+        *,
+        is_base_filestate: bool = False,
     ) -> None:
         if modname is None:
             warnings.warn(
@@ -65,6 +67,8 @@ class FileState:
         else:
             self._effective_max_line_number = None
         self._msgs_store = msg_store
+        self._is_base_filestate = is_base_filestate
+        """If this FileState is the base state made during initialization of PyLinter."""
 
     def collect_block_lines(
         self, msgs_store: MessageDefinitionStore, module_node: nodes.Module

--- a/pylint/utils/file_state.py
+++ b/pylint/utils/file_state.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import collections
 import sys
+import warnings
 from collections import defaultdict
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Dict
@@ -33,7 +34,24 @@ MessageStateDict = Dict[str, Dict[int, bool]]
 class FileState:
     """Hold internal state specific to the currently analyzed file."""
 
-    def __init__(self, modname: str | None = None) -> None:
+    def __init__(
+        self,
+        modname: str | None = None,
+        msg_store: MessageDefinitionStore | None = None,
+        node: nodes.Module | None = None,
+    ) -> None:
+        if modname is None:
+            warnings.warn(
+                "FileState needs a string as modname argument. "
+                "This argument will be required in pylint 3.0",
+                DeprecationWarning,
+            )
+        if msg_store is None:
+            warnings.warn(
+                "FileState needs a 'MessageDefinitionStore' as msg_store argument. "
+                "This argument will be required in pylint 3.0",
+                DeprecationWarning,
+            )
         self.base_name = modname
         self._module_msgs_state: MessageStateDict = {}
         self._raw_module_msgs_state: MessageStateDict = {}
@@ -41,7 +59,12 @@ class FileState:
             tuple[str, int], set[int]
         ] = collections.defaultdict(set)
         self._suppression_mapping: dict[tuple[str, int], int] = {}
-        self._effective_max_line_number: int | None = None
+        self._module = node
+        if node:
+            self._effective_max_line_number = node.tolineno
+        else:
+            self._effective_max_line_number = None
+        self._msgs_store = msg_store
 
     def collect_block_lines(
         self, msgs_store: MessageDefinitionStore, module_node: nodes.Module

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -191,7 +191,7 @@ def reporter():
 def initialized_linter(linter: PyLinter) -> PyLinter:
     linter.open()
     linter.set_current_module("toto", "mydir/toto")
-    linter.file_state = FileState("toto")
+    linter.file_state = FileState("toto", linter.msgs_store)
     return linter
 
 

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -22,8 +22,10 @@ from pylint.interfaces import (
     ITokenChecker,
 )
 from pylint.lint import PyLinter
+from pylint.message import MessageDefinitionStore
 from pylint.reporters import BaseReporter
 from pylint.reporters.ureports.nodes import Section
+from pylint.utils import FileState
 
 
 def test_mapreducemixin() -> None:
@@ -87,3 +89,14 @@ def test_load_and_save_results() -> None:
         save_results(object(), "")  # type: ignore[arg-type]
     with pytest.warns(DeprecationWarning):
         load_results("")
+
+
+def test_filestate() -> None:
+    """Test that FileState needs its arguments."""
+    with pytest.warns(DeprecationWarning):
+        FileState()
+    with pytest.warns(DeprecationWarning):
+        FileState("foo")
+    with pytest.warns(DeprecationWarning):
+        FileState(msg_store=MessageDefinitionStore())
+    FileState("foo", MessageDefinitionStore())


### PR DESCRIPTION
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

Base change required for https://github.com/PyCQA/pylint/pull/6556.
Let's also make `modname` required. It's a bit strange that we create a `FileState` before even encountering a file in the `__init__`, but refactoring that is not part of my plan for now.