### PR TITLE
Use the standard config parser instead a new one in functional tests

### DIFF
--- a/.pyenchant_pylint_custom_dict.txt
+++ b/.pyenchant_pylint_custom_dict.txt
@@ -299,6 +299,7 @@ tbump
 tempfile
 testcase
 testdata
+testoptions
 tmp
 tokencheckers
 tokeninfo

--- a/pylint/testutils/functional/test_file.py
+++ b/pylint/testutils/functional/test_file.py
@@ -62,6 +62,7 @@ class FunctionalTestFile:
     def __init__(self, directory: str, filename: str) -> None:
         self._directory = directory
         self.base = filename.replace(".py", "")
+        # TODO: 2.15: Deprecate FunctionalTestFile.options and related code
         self.options: TestFileOptions = {
             "min_pyver": (2, 5),
             "max_pyver": (4, 0),

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -72,7 +72,7 @@ class LintModuleTest:
                 messages_to_enable.add("syntax-error")
             args.extend(["--disable=all", f"--enable={','.join(messages_to_enable)}"])
 
-        # Add 'testoptions'
+        # Add testoptions
         self._linter._arg_parser.add_argument(
             "--min_pyver", type=parse_python_version, default=(2, 5)
         )

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -72,7 +72,7 @@ class LintModuleTest:
                 messages_to_enable.add("syntax-error")
             args.extend(["--disable=all", f"--enable={','.join(messages_to_enable)}"])
 
-        # Add testoptions
+        # Add 'testoptions'
         self._linter._arg_parser.add_argument(
             "--min_pyver", type=parse_python_version, default=(2, 5)
         )


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Fixes the spurious warnings identified in https://github.com/PyCQA/pylint/issues/6570.

Ideally we should deprecate the use of `FunctionalTestFile.options` as we should just parse options like we normally parse the options file. But it is really not a priority and I want to focus attention on any regressions in `2.14` rather than add new ones.