### PR TITLE
Add a documentation for simplifiable if expression

### DIFF
--- a/doc/data/messages/s/simplifiable-if-expression/bad.py
+++ b/doc/data/messages/s/simplifiable-if-expression/bad.py
@@ -1,0 +1,9 @@
+FLYING_THINGS = ["bird", "plane", "superman", "this example"]
+
+
+def is_flying_thing(an_object):
+    return True if an_object in FLYING_THINGS else False  # [simplifiable-if-expression]
+
+
+def is_not_flying_thing(an_object):
+    return False if an_object in FLYING_THINGS else True  # [simplifiable-if-expression]

--- a/doc/data/messages/s/simplifiable-if-expression/details.rst
+++ b/doc/data/messages/s/simplifiable-if-expression/details.rst
@@ -1,1 +1,0 @@
-You can help us make the doc better `by contributing <https://github.com/PyCQA/pylint/issues/5953>`_ !

--- a/doc/data/messages/s/simplifiable-if-expression/good.py
+++ b/doc/data/messages/s/simplifiable-if-expression/good.py
@@ -1,1 +1,9 @@
-# This is a placeholder for correct code for this message.
+FLYING_THINGS = ["bird", "plane", "superman", "this example"]
+
+
+def is_flying_thing(an_object):
+    return an_object in FLYING_THINGS
+
+
+def is_not_flying_thing(an_object):
+    return an_object not in FLYING_THINGS

--- a/doc/data/messages/s/simplifiable-if-expression/related.rst
+++ b/doc/data/messages/s/simplifiable-if-expression/related.rst
@@ -1,0 +1,1 @@
+- `Simplifying an 'if' statement with bool() <https://stackoverflow.com/questions/49546992/>`_

--- a/doc/data/messages/s/simplifiable-if-statement/bad.py
+++ b/doc/data/messages/s/simplifiable-if-statement/bad.py
@@ -1,0 +1,9 @@
+FLYING_THINGS = ["bird", "plane", "superman", "this example"]
+
+
+def is_flying_animal(an_object):
+    if isinstance(an_object, Animal) and an_object in FLYING_THINGS:  # [simplifiable-if-statement]
+        is_flying = True
+    else:
+        is_flying = False
+    return is_flying

--- a/doc/data/messages/s/simplifiable-if-statement/details.rst
+++ b/doc/data/messages/s/simplifiable-if-statement/details.rst
@@ -1,1 +1,0 @@
-You can help us make the doc better `by contributing <https://github.com/PyCQA/pylint/issues/5953>`_ !

--- a/doc/data/messages/s/simplifiable-if-statement/good.py
+++ b/doc/data/messages/s/simplifiable-if-statement/good.py
@@ -1,1 +1,6 @@
-# This is a placeholder for correct code for this message.
+FLYING_THINGS = ["bird", "plane", "superman", "this example"]
+
+
+def is_flying_animal(an_object):
+    is_flying = isinstance(an_object, Animal) and an_object.name in FLYING_THINGS
+    return is_flying

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -344,7 +344,8 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         "R1719": (
             "The if expression can be replaced with %s",
             "simplifiable-if-expression",
-            "Used when an if expression can be replaced with 'bool(test)'.",
+            "Used when an if expression can be replaced with 'bool(test)' "
+            "or simply 'test' if the boolean cast is implicit.",
         ),
         "R1720": (
             'Unnecessary "%s" after "raise", %s',

--- a/tests/functional/s/simplifiable/simplifiable_if_expression.py
+++ b/tests/functional/s/simplifiable/simplifiable_if_expression.py
@@ -7,17 +7,21 @@ def test_simplifiable_1(arg):
     # Simple test that can be replaced by bool(arg)
     return True if arg else False # [simplifiable-if-expression]
 
+
 def test_simplifiable_2(arg):
     # Simple test that can be replaced by not arg
     return False if arg else True # [simplifiable-if-expression]
+
 
 def test_simplifiable_3(arg):
     # Simple test that can be replaced by arg == 1
     return True if arg == 1 else False # [simplifiable-if-expression]
 
+
 def test_simplifiable_4(arg):
     # Simple test that can be replaced by not (arg == 1)
     return False if arg == 1 else True # [simplifiable-if-expression]
+
 
 def test_not_simplifiable(arg):
     x = True if arg else True
@@ -25,3 +29,25 @@ def test_not_simplifiable(arg):
     t = False if arg != 1 else False
     t2 = None if arg > 3 else False
     return x, y, t, t2
+
+
+def convoluted_function():
+    a = []
+    b = []
+    if bool('special test'):
+        a = True
+    else:
+        b = False
+    return a + b
+
+
+FLYING_THINGS = ["bird", "plane", "superman", "this example"]
+
+
+def is_flying_animal(an_object):
+    is_flying = False
+    if isinstance(an_object, str) and an_object in FLYING_THINGS:  # [simplifiable-if-statement]
+        is_flying = True
+    else:
+        is_flying = False
+    return is_flying

--- a/tests/functional/s/simplifiable/simplifiable_if_expression.txt
+++ b/tests/functional/s/simplifiable/simplifiable_if_expression.txt
@@ -1,4 +1,5 @@
 simplifiable-if-expression:8:11:8:33:test_simplifiable_1:The if expression can be replaced with 'bool(test)':UNDEFINED
-simplifiable-if-expression:12:11:12:33:test_simplifiable_2:The if expression can be replaced with 'not test':UNDEFINED
-simplifiable-if-expression:16:11:16:38:test_simplifiable_3:The if expression can be replaced with 'test':UNDEFINED
-simplifiable-if-expression:20:11:20:38:test_simplifiable_4:The if expression can be replaced with 'not test':UNDEFINED
+simplifiable-if-expression:13:11:13:33:test_simplifiable_2:The if expression can be replaced with 'not test':UNDEFINED
+simplifiable-if-expression:18:11:18:38:test_simplifiable_3:The if expression can be replaced with 'test':UNDEFINED
+simplifiable-if-expression:23:11:23:38:test_simplifiable_4:The if expression can be replaced with 'not test':UNDEFINED
+simplifiable-if-statement:49:4:52:25:is_flying_animal:The if statement can be replaced with 'var = bool(test)':UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

I realized during implementation that simplifiable if expression became worst and that I disagree with https://github.com/PyCQA/pylint/issues/1984 basically. If there are two values but one if the opposite of the other we can pretty much simplify the if expression. It look like the example from the issue come directly from [this stackoverflow question](https://stackoverflow.com/questions/49546992/) but the top answer make a compelling point that this is simplifiable.

Refs #5953 
Closes #5882 
