### PR TITLE
Better assert message for documentation tests

### DIFF
--- a/doc/test_messages_documentation.py
+++ b/doc/test_messages_documentation.py
@@ -146,9 +146,11 @@ class LintModuleTest:
         expected_messages = self._get_expected()
         actual_messages = self._get_actual()
         if self.is_good_test_file():
-            assert actual_messages.total() == 0  # type: ignore[attr-defined]
+            msg = "There should be no warning raised for 'goob.py'"
+            assert actual_messages.total() == 0, msg  # type: ignore[attr-defined]
         if self.is_bad_test_file():
-            assert actual_messages.total() > 0  # type: ignore[attr-defined]
+            msg = "There should be at least one warning raised for 'bad.py'"
+            assert actual_messages.total() > 0, msg  # type: ignore[attr-defined]
         assert expected_messages == actual_messages
 
 

--- a/doc/test_messages_documentation.py
+++ b/doc/test_messages_documentation.py
@@ -146,7 +146,7 @@ class LintModuleTest:
         expected_messages = self._get_expected()
         actual_messages = self._get_actual()
         if self.is_good_test_file():
-            msg = "There should be no warning raised for 'goob.py'"
+            msg = "There should be no warning raised for 'good.py'"
             assert actual_messages.total() == 0, msg  # type: ignore[attr-defined]
         if self.is_bad_test_file():
             msg = "There should be at least one warning raised for 'bad.py'"


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Originally included in #6574 but it's going to make the whole test suite be launched for every change.
