### PR TITLE
Fix a crash in `unnecessary-dict-index-lookup` when subscripting an attribute

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -327,6 +327,10 @@ Release date: TBA
 
  Relates to #6531
 
+* Fix a crash in ``unnecessary-dict-index-lookup`` when subscripting an attribute.
+
+  Closes #6557
+
 * Fix a crash when accessing ``__code__`` and assigning it to a variable.
 
   Closes #6539

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -653,3 +653,7 @@ Other Changes
 * Fix ``IndexError`` crash in ``uninferable_final_decorators`` method.
 
  Relates to #6531
+
+* Fix a crash in ``unnecessary-dict-index-lookup`` when subscripting an attribute.
+
+  Closes #6557

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1959,6 +1959,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                     elif isinstance(value, nodes.Subscript):
                         if (
                             not isinstance(node.target, nodes.AssignName)
+                            or not isinstance(value.value, nodes.Name)
                             or node.target.name != value.value.name
                             or iterating_object_name != subscript.value.as_string()
                         ):

--- a/tests/functional/u/unnecessary/unnecessary_dict_index_lookup.py
+++ b/tests/functional/u/unnecessary/unnecessary_dict_index_lookup.py
@@ -112,3 +112,10 @@ for key, val in outer_dict.items():
 d = {}
 for key, in d.items():
     print(d[key])
+
+# Test subscripting an attribute
+# https://github.com/PyCQA/pylint/issues/6557
+f = Foo()
+for input_output in d.items():
+    f.input_output = input_output  # pylint: disable=attribute-defined-outside-init
+    print(d[f.input_output[0]])


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #6557
