### PR TITLE
[--long-help] Remove redundant default description in message

### DIFF
--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -242,7 +242,7 @@ class ExceptionsChecker(checkers.BaseChecker):
                 "default": OVERGENERAL_EXCEPTIONS,
                 "type": "csv",
                 "metavar": "<comma-separated class names>",
-                "help": "Exceptions that will emit a warning when being caught.",
+                "help": "Exceptions that will emit a warning when caught.",
             },
         ),
     )

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -242,9 +242,7 @@ class ExceptionsChecker(checkers.BaseChecker):
                 "default": OVERGENERAL_EXCEPTIONS,
                 "type": "csv",
                 "metavar": "<comma-separated class names>",
-                "help": "Exceptions that will emit a warning "  # pylint: disable=consider-using-f-string
-                'when being caught. Defaults to "%s".'
-                % (", ".join(OVERGENERAL_EXCEPTIONS),),
+                "help": "Exceptions that will emit a warning when being caught.",
             },
         ),
     )


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Text was:
```
  --overgeneral-exceptions <comma-separated class names>
                        Exceptions that will emit a warning when being caught. Defaults to "BaseException, Exception". (default: ('BaseException', 'Exception'))
```
Now:
```
  --overgeneral-exceptions <comma-separated class names>
                        Exceptions that will emit a warning when being caught. (default: ('BaseException', 'Exception'))
```