### PR TITLE
Replace `pip install -e` with `pip install -r requirements_test_min.txt`

### DIFF
--- a/doc/development_guide/testing.rst
+++ b/doc/development_guide/testing.rst
@@ -15,7 +15,7 @@ unless they include tests.
 
 Before you start testing your code, you need to install your source-code package locally.
 Suppose you have cloned pylint into a directory, say my-pylint.
-To set up your environment for testing, open a terminal and run::
+To set up your environment for testing, open a terminal and run:
 
     cd my-pylint
     pip install -r requirements_test_min.txt

--- a/doc/development_guide/testing.rst
+++ b/doc/development_guide/testing.rst
@@ -14,9 +14,11 @@ Pylint is very well tested and has a high code coverage. New contributions are n
 unless they include tests.
 
 Before you start testing your code, you need to install your source-code package locally.
-To set up your environment for testing, open a terminal outside of your forked repository and run:
+Suppose you have cloned pylint into a directory, say my-pylint.
+To set up your environment for testing, open a terminal and run::
 
-      pip install -e <forked_repo_dir_name>
+    cd my-pylint
+    pip install -r requirements_test_min.txt
 
 This ensures your testing environment is similar to Pylint's testing environment on GitHub.
 

--- a/doc/development_guide/testing.rst
+++ b/doc/development_guide/testing.rst
@@ -14,7 +14,7 @@ Pylint is very well tested and has a high code coverage. New contributions are n
 unless they include tests.
 
 Before you start testing your code, you need to install your source-code package locally.
-Suppose you have cloned pylint into a directory, say my-pylint.
+Suppose you have cloned pylint into a directory, say ``my-pylint``.
 To set up your environment for testing, open a terminal and run:
 
     cd my-pylint


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Update the instructions in /doc/development_guide/testing.rst for telling how to initialize the testing environment. These instructions now (roughly) match the instructions in README.rst.

Closes #6570.