### PR TITLE
Raise use_a_generator for `sum()`, `max()`, `min()`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,7 +10,7 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.14.rst'
 
-* Checker ``use_a_generator`` now checks also ``max()``, ``min()`` and ``sum()``.
+* The ``use_a_generator``checker now also checks ``max()``, ``min()`` and ``sum()``.
 
 * We have improved our recognition of inline disable and enable comments. It is
   now possible to disable ``bad-option-value`` inline  (as long as you disable it before

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,8 @@ Release date: TBA
 ..
   Put new features here and also in 'doc/whatsnew/2.14.rst'
 
+* Checker ``use_a_generator`` now checks also ``max()``, ``min()`` and ``sum()``.
+
 * We have improved our recognition of inline disable and enable comments. It is
   now possible to disable ``bad-option-value`` inline  (as long as you disable it before
   the bad option value is raised, i.e. ``disable=bad-option-value,bad-message`` not ``disable=bad-message,bad-option-value`` ) as well as certain other previously unsupported messages.

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -400,7 +400,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         "R1729": (
             "Use a generator instead '%s(%s)'",
             "use-a-generator",
-            "Comprehension inside of 'any' or 'all' is unnecessary. "
+            "Comprehension inside of 'any', 'all', 'max', 'min' and 'sum' is unnecessary. "
             "A generator would be sufficient and faster.",
         ),
         "R1730": (
@@ -987,9 +987,11 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                 self.add_message(message_name, node=node)
 
     def _check_consider_using_generator(self, node):
-        # 'any' and 'all' definitely should use generator, while 'list' and 'tuple' need to be considered first
-        # See https://github.com/PyCQA/pylint/pull/3309#discussion_r576683109
-        checked_call = ["any", "all", "list", "tuple"]
+        # 'any', 'all', 'sum', 'max', 'min' definitely should use generator, while 'list' and 'tuple'
+        # need to be considered first
+        # See https://github.com/PyCQA/pylint/pull/3309#discussion_r576683109 and
+        # https://peps.python.org/pep-0289/
+        checked_call = ["any", "all", "sum", "max", "min", "list", "tuple"]
         if (
             isinstance(node, nodes.Call)
             and node.func
@@ -1002,7 +1004,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                 # remove square brackets '[]'
                 inside_comp = node.args[0].as_string()[1:-1]
                 call_name = node.func.name
-                if call_name in {"any", "all"}:
+                if call_name in {"any", "all", "sum", "max", "min"}:
                     self.add_message(
                         "use-a-generator",
                         node=node,

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -400,7 +400,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         "R1729": (
             "Use a generator instead '%s(%s)'",
             "use-a-generator",
-            "Comprehension inside of 'any', 'all', 'max', 'min' and 'sum' is unnecessary. "
+            "Comprehension inside of 'any', 'all', 'max', 'min' or 'sum' is unnecessary. "
             "A generator would be sufficient and faster.",
         ),
         "R1730": (

--- a/tests/functional/u/use/use_a_generator.py
+++ b/tests/functional/u/use/use_a_generator.py
@@ -3,9 +3,18 @@
 
 any([])
 all([])
+sum([])
+min([])
+max([])
 
 any([0 for x in list(range(10))]) # [use-a-generator]
 all([0 for y in list(range(10))]) # [use-a-generator]
+sum([x*x for x in range(10)]) # [use-a-generator])
+min([x*x for x in range(10)]) # [use-a-generator])
+max([x*x for x in range(10)]) # [use-a-generator])
 
 any(0 for x in list(range(10)))
 all(0 for y in list(range(10)))
+sum(x*x for x in range(10))
+min(x*x for x in range(10))
+max(x*x for x in range(10))

--- a/tests/functional/u/use/use_a_generator.txt
+++ b/tests/functional/u/use/use_a_generator.txt
@@ -1,2 +1,5 @@
-use-a-generator:7:0:7:33::Use a generator instead 'any(0 for x in list(range(10)))':UNDEFINED
-use-a-generator:8:0:8:33::Use a generator instead 'all(0 for y in list(range(10)))':UNDEFINED
+use-a-generator:10:0:10:33::Use a generator instead 'any(0 for x in list(range(10)))':UNDEFINED
+use-a-generator:11:0:11:33::Use a generator instead 'all(0 for y in list(range(10)))':UNDEFINED
+use-a-generator:12:0:12:29::Use a generator instead 'sum(x * x for x in range(10))':UNDEFINED
+use-a-generator:13:0:13:29::Use a generator instead 'min(x * x for x in range(10))':UNDEFINED
+use-a-generator:14:0:14:29::Use a generator instead 'max(x * x for x in range(10))':UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|     | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Description

Based on https://peps.python.org/pep-0289/ also `sum()`, `max()`, `min()` should avoid using
lists. Using generator, the memory is not allocated for all items but the items are processed lazily.

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->
