### PR TITLE
Write the exception message to stderr in `ASTWalker.walk`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -304,7 +304,7 @@ Release date: TBA
 
   Closes #4369 and #6523
 
-* Fix bug where it writes a plain text error message to stdout, invalidates output formats.
+* Fix bug where it writes a plain text error message to stdout, invalidating output formats.
 
   Closes #6597
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -304,6 +304,10 @@ Release date: TBA
 
   Closes #4369 and #6523
 
+* Fix bug where it writes a plain text error message to stdout, invalidates output formats.
+
+  Closes #6597
+
 * ``is_class_subscriptable_pep585_with_postponed_evaluation_enabled`` has been deprecated.
   Use ``subscriptable_with_postponed_evaluation_enabled`` instead.
 

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -249,7 +249,7 @@ Other Changes
 
   Closes #4369 and #6523
 
-* Fix bug where it writes a plain text error message to stdout, invalidates output formats.
+* Fix bug where it writes a plain text error message to stdout, invalidating output formats.
 
   Closes #6597
 

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -249,6 +249,10 @@ Other Changes
 
   Closes #4369 and #6523
 
+* Fix bug where it writes a plain text error message to stdout, invalidates output formats.
+
+  Closes #6597
+
 * ``is_class_subscriptable_pep585_with_postponed_evaluation_enabled`` has been deprecated.
   Use ``subscriptable_with_postponed_evaluation_enabled`` instead.
 

--- a/pylint/utils/ast_walker.py
+++ b/pylint/utils/ast_walker.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
+import sys
 import traceback
 from collections import defaultdict
 from collections.abc import Sequence
-import sys
 from typing import TYPE_CHECKING, Callable
 
 from astroid import nodes

--- a/pylint/utils/ast_walker.py
+++ b/pylint/utils/ast_walker.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import traceback
 from collections import defaultdict
 from collections.abc import Sequence
+import sys
 from typing import TYPE_CHECKING, Callable
 
 from astroid import nodes
@@ -95,7 +96,10 @@ class ASTWalker:
         except Exception:
             if self.exception_msg is False:
                 file = getattr(astroid.root(), "file", None)
-                print(f"Exception on node {repr(astroid)} in file '{file}'")
+                print(
+                    f"Exception on node {repr(astroid)} in file '{file}'",
+                    file=sys.stderr,
+                )
                 traceback.print_exc()
                 self.exception_msg = True
             raise


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

Write the exception message to stderr, otherwise stdout would produce invalid formatted outputs (e.g. `--output-format=json`).

Closes #6597
