### PR TITLE
Fix a crash in `unnecessary-list-index-lookup` when incorrectly using `enumerate()`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -344,6 +344,11 @@ Release date: TBA
 
   Closes #6557
 
+* Fix a crash in ``unnecessary-list-index-lookup`` when incorrectly passing no
+  arguments to ``enumerate()``.
+
+  Closes #6603
+
 * Fix a crash when accessing ``__code__`` and assigning it to a variable.
 
   Closes #6539

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -644,6 +644,10 @@ Other Changes
 
   Closes #6414
 
+* Fix a crash in ``unnecessary-list-index-lookup`` when incorrectly passing no
+  arguments to ``enumerate()``.
+
+  Closes #6603
 
 * Fix false positives for ``no-name-in-module`` and ``import-error`` for ``numpy.distutils``
   and ``pydantic``.

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1996,6 +1996,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             not isinstance(node.iter, nodes.Call)
             or not isinstance(node.iter.func, nodes.Name)
             or not node.iter.func.name == "enumerate"
+            or not node.iter.args
             or not isinstance(node.iter.args[0], nodes.Name)
         ):
             return

--- a/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
+++ b/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
@@ -49,3 +49,7 @@ result = [my_list[idx] for idx, val in enumerate(my_list)] # [unnecessary-list-i
 pairs = [(0, 0)]
 for i, (a, b) in enumerate(pairs):
     print(pairs[i][0])
+
+# Regression test for https://github.com/PyCQA/pylint/issues/6603
+for i, num in enumerate():  # raises TypeError, but shouldn't crash pylint
+    pass


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Closes #6603
