### PR TITLE
Remove release note for unreleased crash fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -344,11 +344,6 @@ Release date: TBA
 
   Closes #6557
 
-* Fix a crash in ``unnecessary-list-index-lookup`` when incorrectly passing no
-  arguments to ``enumerate()``.
-
-  Closes #6603
-
 * Fix a crash when accessing ``__code__`` and assigning it to a variable.
 
   Closes #6539

--- a/doc/whatsnew/2.13.rst
+++ b/doc/whatsnew/2.13.rst
@@ -644,11 +644,6 @@ Other Changes
 
   Closes #6414
 
-* Fix a crash in ``unnecessary-list-index-lookup`` when incorrectly passing no
-  arguments to ``enumerate()``.
-
-  Closes #6603
-
 * Fix false positives for ``no-name-in-module`` and ``import-error`` for ``numpy.distutils``
   and ``pydantic``.
 


### PR DESCRIPTION
Followup to #6603. Remove release note since this was actually an unreleased issue in 2.14.