### PR TITLE
Remove `utils.subscriptable_with_postponed_evaluation_enabled`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -314,7 +314,8 @@ Release date: TBA
   Closes #6597
 
 * ``is_class_subscriptable_pep585_with_postponed_evaluation_enabled`` has been deprecated.
-  Use ``subscriptable_with_postponed_evaluation_enabled`` instead.
+  Use ``is_postponed_evaluation_enabled(node) and is_node_in_type_annotation_context(node)``
+  instead.
 
   Ref #6536
 

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -359,6 +359,7 @@ Deprecations
   Ref #5392
 
 * ``is_class_subscriptable_pep585_with_postponed_evaluation_enabled`` has been deprecated.
-  Use ``subscriptable_with_postponed_evaluation_enabled`` instead.
+  Use ``is_postponed_evaluation_enabled(node) and is_node_in_type_annotation_context(node)``
+  instead.
 
   Ref #6536

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -215,7 +215,6 @@ Other Changes
 
 * The ``set_config_directly`` decorator has been removed.
 
-
 * Fix falsely issuing ``useless-suppression`` on the ``wrong-import-position`` checker.
 
   Closes #5219
@@ -252,11 +251,6 @@ Other Changes
 * Fix bug where it writes a plain text error message to stdout, invalidating output formats.
 
   Closes #6597
-
-* ``is_class_subscriptable_pep585_with_postponed_evaluation_enabled`` has been deprecated.
-  Use ``subscriptable_with_postponed_evaluation_enabled`` instead.
-
-  Ref #6536
 
 * The refactoring checker now also raises 'consider-using-a-generator' messages for
   ``max()``, ``min()`` and ``sum()``.
@@ -363,3 +357,8 @@ Deprecations
   be removed in a future release.
 
   Ref #5392
+
+* ``is_class_subscriptable_pep585_with_postponed_evaluation_enabled`` has been deprecated.
+  Use ``subscriptable_with_postponed_evaluation_enabled`` instead.
+
+  Ref #6536

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1217,7 +1217,9 @@ def supports_getitem(value: nodes.NodeNG, node: nodes.NodeNG) -> bool:
     if isinstance(value, nodes.ClassDef):
         if _supports_protocol_method(value, CLASS_GETITEM_METHOD):
             return True
-        if subscriptable_with_postponed_evaluation_enabled(node):
+        if is_postponed_evaluation_enabled(node) and is_node_in_type_annotation_context(
+            node
+        ):
             return True
     return _supports_protocol(value, _supports_getitem_protocol)
 
@@ -1405,20 +1407,14 @@ def is_class_subscriptable_pep585_with_postponed_evaluation_enabled(
     warnings.warn(
         "'is_class_subscriptable_pep585_with_postponed_evaluation_enabled' has been "
         "deprecated and will be removed in pylint 3.0. "
-        "Use 'subscriptable_with_postponed_evaluation_enabled' instead.",
+        "Use 'is_postponed_evaluation_enabled(node) and "
+        "is_node_in_type_annotation_context(node)' instead.",
         DeprecationWarning,
     )
     return (
         is_postponed_evaluation_enabled(node)
         and value.qname() in SUBSCRIPTABLE_CLASSES_PEP585
         and is_node_in_type_annotation_context(node)
-    )
-
-
-def subscriptable_with_postponed_evaluation_enabled(node: nodes.NodeNG) -> bool:
-    """Check if class can be subscriptable in type annotation context."""
-    return is_postponed_evaluation_enabled(node) and is_node_in_type_annotation_context(
-        node
     )
 
 


### PR DESCRIPTION
## Description
Update documentation and remove `utils.subscriptable_with_postponed_evaluation_enabled` added in #6536.

The helper function is just one more function call and with that specific name can't really be used anywhere else. Much better to just call the two functions directly. Which is already done elsewhere anyway. The helper has only been included in `2.14.0b1`, so I think it's ok to remove without deprecation.
```py
if is_postponed_evaluation_enabled(node) and is_node_in_type_annotation_context(node):
    ...
```