### PR TITLE
Fix `no-member` in type annotations with future import

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -321,6 +321,11 @@ Release date: TBA
 * Update ranges for ``using-constant-test`` and ``missing-parentheses-for-call-in-test``
   error messages.
 
+* Don't emit ``no-member`` inside type annotations with
+  ``from __future__ import annotations``.
+
+  Closes #6594
+
 ..
   Insert your changelog randomly, it will reduce merge conflicts
   (Ie. not necessarily at the end)

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -266,6 +266,11 @@ Other Changes
 * Update ranges for ``using-constant-test`` and ``missing-parentheses-for-call-in-test``
   error messages.
 
+* Don't emit ``no-member`` inside type annotations with
+  ``from __future__ import annotations``.
+
+  Closes #6594
+
 Deprecations
 ============
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -34,6 +34,7 @@ from pylint.checkers.utils import (
     is_inside_abstract_class,
     is_iterable,
     is_mapping,
+    is_node_in_type_annotation_context,
     is_overload_stub,
     is_postponed_evaluation_enabled,
     is_super,
@@ -1036,6 +1037,11 @@ accessed. Python regular expressions are accepted.",
             pattern.match(name)
             for name in (node.attrname, node.as_string())
             for pattern in self._compiled_generated_members
+        ):
+            return
+
+        if is_postponed_evaluation_enabled(node) and is_node_in_type_annotation_context(
+            node
         ):
             return
 

--- a/tests/functional/g/generated_members.py
+++ b/tests/functional/g/generated_members.py
@@ -1,6 +1,6 @@
 """Test the generated-members config option."""
 # pylint: disable=pointless-statement, invalid-name, useless-object-inheritance
-from __future__ import print_function
+from __future__ import annotations
 from astroid import nodes
 from pylint import checkers
 
@@ -18,3 +18,11 @@ session = Klass()
 SESSION = Klass()
 session.rollback()
 SESSION.rollback()
+
+
+# https://github.com/PyCQA/pylint/issues/6594
+# Don't emit no-member inside type annotations
+# with PEP 563 'from __future__ import annotations'
+print(Klass.X)  # [no-member]
+var: "Klass.X"
+var2: Klass.X

--- a/tests/functional/g/generated_members.txt
+++ b/tests/functional/g/generated_members.txt
@@ -1,1 +1,2 @@
 no-member:13:6:13:18::Instance of 'Klass' has no 'spam' member:INFERENCE
+no-member:26:6:26:13::Class 'Klass' has no 'X' member:INFERENCE


### PR DESCRIPTION
## Description
Don't emit ``no-member`` inside type annotations with ``from __future__ import annotations``.

With PEP 563, annotations are stored as strings and thus not executed. This can cause false-positives if attributes are used which don't exist in the version used to run pylint.
```py
# pylint: disable=missing-docstring,unused-argument
from __future__ import annotations

import ast
import sys

if sys.version_info >= (3, 10):
    def func(node: ast.Match) -> None:  # no-member
        ...
```

If Python 3.8 is used, pylint would currently emit a `no-member` error for `ast.Match` (which was added in `3.10`).
By excluding type annotations with `from __future__ import annotations`, the behavior will be similar to normal string annotations (which don't emit an error).
```py
def func(node: "ast.Match") -> None:
    ...
```

Closes #6594
