### PR TITLE
Ignore no-member checks on Mock functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,14 +1,19 @@
 ------------------
+
 Pylint's ChangeLog
 ------------------
 
-
 What's New in Pylint 2.14.0?
 ============================
+
 Release date: TBA
 
 ..
   Put new features here and also in 'doc/whatsnew/2.14.rst'
+
+* Fix false positive ``no-member`` checks when using ``unittest.mock.Mock`` functions.
+
+  Closes #2821
 
 * We have improved our recognition of inline disable and enable comments. It is
   now possible to disable ``bad-option-value`` inline  (as long as you disable it before
@@ -95,7 +100,7 @@ Release date: TBA
 * All ``Interface`` classes in ``pylint.interfaces`` have been deprecated. You can subclass
   the respective normal classes to get the same behaviour. The ``__implements__`` functionality
   was based on a rejected PEP from 2001:
-  https://peps.python.org/pep-0245/
+  <https://peps.python.org/pep-0245/>
 
   Closes #2287
 
@@ -313,11 +318,10 @@ Release date: TBA
   Insert your changelog randomly, it will reduce merge conflicts
   (Ie. not necessarily at the end)
 
-
 What's New in Pylint 2.13.9?
 ============================
-Release date: TBA
 
+Release date: TBA
 
 * Fix false positives for ``no-name-in-module`` and ``import-error`` for ``numpy.distutils`` and ``pydantic``.
 
@@ -335,9 +339,9 @@ Release date: TBA
 
   Closes #6539
 
-
 What's New in Pylint 2.13.8?
 ============================
+
 Release date: 2022-05-02
 
 * Fix a false positive for ``undefined-loop-variable`` for a variable used in a lambda
@@ -369,18 +373,18 @@ Release date: 2022-05-02
 
   Closes #3979
 
-
 What's New in Pylint 2.13.7?
 ============================
+
 Release date: 2022-04-20
 
 * Fix a crash caused by using the new config from 2.14.0 in 2.13.x code.
 
   Closes #6408
 
-
 What's New in Pylint 2.13.6?
 ============================
+
 Release date: 2022-04-20
 
 * Fix a crash in the ``unsupported-membership-test`` checker when assigning
@@ -404,9 +408,9 @@ Release date: 2022-04-20
 
   Closes #6301
 
-
 What's New in Pylint 2.13.5?
 ============================
+
 Release date: 2022-04-06
 
 * Fix false positive regression in 2.13.0 for ``used-before-assignment`` for
@@ -442,12 +446,11 @@ Release date: 2022-04-06
 
   Closes #5931
 
-
 * Fix a false negative for ``subclassed-final-class`` when a set of other messages were disabled.
-
 
 What's New in Pylint 2.13.4?
 ============================
+
 Release date: 2022-03-31
 
 * Fix false positive regression in 2.13.0 for ``used-before-assignment`` for
@@ -464,16 +467,15 @@ Release date: 2022-03-31
 
   Closes #6027
 
-
 * Fix crash for ``unneccessary-ellipsis`` checker when an ellipsis is used inside of a container or a lambda expression.
 
   Closes #6036
   Closes #6037
   Closes #6048
 
-
 What's New in Pylint 2.13.3?
 ============================
+
 Release date: 2022-03-29
 
 * Fix false positive for ``unnecessary-ellipsis`` when using an ellipsis as a default argument.
@@ -489,9 +491,9 @@ Release date: 2022-03-29
 
   Closes #5769
 
-
 What's New in Pylint 2.13.2?
 ============================
+
 Release date: 2022-03-27
 
 * Fix crash when subclassing a ``namedtuple``.
@@ -512,9 +514,9 @@ Release date: 2022-03-27
 
   Refer to #5987
 
-
 What's New in Pylint 2.13.1?
 ============================
+
 Release date: 2022-03-26
 
 * Fix a regression in 2.13.0 where ``used-before-assignment`` was emitted for
@@ -545,9 +547,9 @@ Release date: 2022-03-26
 * Don't emit ``broken-noreturn`` and ``broken-collections-callable`` errors
   inside ``if TYPE_CHECKING`` blocks.
 
-
 What's New in Pylint 2.13.0?
 ============================
+
 Release date: 2022-03-24
 
 * Add missing dunder methods to ``unexpected-special-method-signature`` check.
@@ -636,7 +638,7 @@ Release date: 2022-03-24
   Ref #2366
 
 * Added several checkers to deal with unicode security issues
-  (see `Trojan Sources <https://trojansource.codes/>`_ and
+  (see `Trojan Sources <https://trojansource.codes/>`_and
   `PEP 672 <https://peps.python.org/pep-0672/>`_ for details) that also
   concern the readability of the code. In detail the following checks were added:
 
@@ -828,7 +830,7 @@ Release date: 2022-03-24
 
 * By default, pylint does no longer take files starting with ``.#`` into account. Those are
   considered ``Emacs file locks``. See
-  https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html.
+  <https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html>.
   This behavior can be reverted by redefining the ``ignore-patterns`` option.
 
   Closes #367
@@ -1012,11 +1014,11 @@ Release date: 2022-03-24
 
   * Added new check ``broken-noreturn`` to detect broken uses of ``typing.NoReturn``
     if ``py-version`` is set to Python ``3.7.1`` or below.
-    https://bugs.python.org/issue34921
+    <https://bugs.python.org/issue34921>
 
   * Added new check ``broken-collections-callable`` to detect broken uses of ``collections.abc.Callable``
     if ``py-version`` is set to Python ``3.9.1`` or below.
-    https://bugs.python.org/issue42965
+    <https://bugs.python.org/issue42965>
 
 * The ``testutils`` for unittests now accept ``end_lineno`` and ``end_column``. Tests
   without these will trigger a ``DeprecationWarning``.
@@ -1079,9 +1081,9 @@ Release date: 2022-03-24
 
   Closes #4756
 
-
 What's New in Pylint 2.12.2?
 ============================
+
 Release date: 2021-11-25
 
 * Fixed a false positive for ``unused-import`` where everything
@@ -1125,18 +1127,18 @@ Release date: 2021-11-25
 
   Closes #5316
 
-
 What's New in Pylint 2.12.1?
 ============================
+
 Release date: 2021-11-25
 
 * Require Python ``3.6.2`` to run pylint.
 
   Closes #5065
 
-
 What's New in Pylint 2.12.0?
 ============================
+
 Release date: 2021-11-24
 
 * Upgrade astroid to 2.9.0
@@ -1440,18 +1442,18 @@ Release date: 2021-11-24
   * Fix false-negative for ``deprecated-typing-alias`` and ``consider-using-alias``
     with ``typing.Type`` + ``typing.Callable``.
 
-
 What's New in Pylint 2.11.1?
 ============================
+
 Release date: 2021-09-16
 
 * ``unspecified-encoding`` now checks the encoding of ``pathlib.Path()`` correctly
 
   Closes #5017
 
-
 What's New in Pylint 2.11.0?
 ============================
+
 Release date: 2021-09-16
 
 * The python3 porting mode checker and it's ``py3k`` option were removed. You can still find it in older pylint
@@ -1463,7 +1465,6 @@ Release date: 2021-09-16
   Emitted when using an in-place defined ``list`` or ``tuple`` to do a membership test. ``sets`` are better optimized for that.
 
   Closes #4776
-
 
 * Added ``py-version`` config key (if ``[MASTER]`` section). Used for version dependent checks.
   Will default to whatever Python version pylint is executed with.
@@ -1484,7 +1485,7 @@ Release date: 2021-09-16
 
   Closes #4751
 
-* https is now preferred in the documentation and http://pylint.pycqa.org correctly redirect to https://pylint.pycqa.org
+* https is now preferred in the documentation and <http://pylint.pycqa.org> correctly redirect to <https://pylint.pycqa.org>
 
   Closes #3802
 
@@ -1551,9 +1552,9 @@ Release date: 2021-09-16
 
 * The ``invalid-name`` message is now more detailed when using multiple naming style regexes.
 
-
 What's New in Pylint 2.10.2?
 ============================
+
 Release date: 2021-08-21
 
 * We now use platformdirs instead of appdirs since the latter is not maintained.
@@ -1565,19 +1566,18 @@ Release date: 2021-08-21
 
   Closes #4891
 
-
-
 What's New in Pylint 2.10.1?
 ============================
+
 Release date: 2021-08-20
 
 * pylint does not crash when PYLINT_HOME does not exist.
 
   Closes #4883
 
-
 What's New in Pylint 2.10.0?
 ============================
+
 Release date: 2021-08-20
 
 * pyreverse: add option to produce colored output.
@@ -1732,9 +1732,9 @@ Release date: 2021-08-20
 
 * Improve error message for invalid-metaclass when the node is an Instance.
 
-
 What's New in Pylint 2.9.6?
 ===========================
+
 Release date: 2021-07-28
 
 * Fix a false positive ``undefined-variable`` when variable name in decoration
@@ -1742,9 +1742,9 @@ Release date: 2021-07-28
 
   Closes #3791
 
-
 What's New in Pylint 2.9.5?
 ===========================
+
 Release date: 2021-07-21
 
 * Fix a crash when there would be a 'TypeError object does not support
@@ -1761,9 +1761,9 @@ Release date: 2021-07-21
 
   Closes #4692
 
-
 What's New in Pylint 2.9.4?
 ===========================
+
 Release date: 2021-07-20
 
 * Added ``time.clock`` to deprecated functions/methods for python 3.3
@@ -1845,11 +1845,10 @@ Release date: 2021-07-20
 
   Closes #4723
 
-
 What's New in Pylint 2.9.3?
 ===========================
-Release date: 2021-07-01
 
+Release date: 2021-07-01
 
 * Fix a crash that happened when analysing empty function with docstring
   in the ``similarity`` checker.
@@ -1859,9 +1858,9 @@ Release date: 2021-07-01
 * The ``similarity`` checker no longer add three trailing whitespaces for
   empty lines in its report.
 
-
 What's New in Pylint 2.9.2?
 ===========================
+
 Release date: 2021-07-01
 
 * Fix a crash that happened when analysing code using ``type(self)`` to access
@@ -1879,9 +1878,9 @@ Release date: 2021-07-01
 
   Closes #4630
 
-
 What's New in Pylint 2.9.1?
 ===========================
+
 Release date: 2021-06-30
 
 * Upgrade astroid to 2.6.2
@@ -1889,9 +1888,9 @@ Release date: 2021-06-30
   Closes #4631
   Closes #4633
 
-
 What's New in Pylint 2.9.0?
 ===========================
+
 Release date: 2021-06-29
 
 * Python 3.10 is now supported.
@@ -2083,16 +2082,16 @@ Release date: 2021-06-29
 
   Closes #4603
 
-
 What's New in Pylint 2.8.3?
 ===========================
+
 Release date: 2021-05-31
 
 * Astroid has been pinned to 2.5.6 for the 2.8 branch see #4527.
 
-
 What's New in Pylint 2.8.2?
 ===========================
+
 Release date: 2021-04-26
 
 * Keep ``__pkginfo__.numversion`` a tuple to avoid breaking pylint-django.
@@ -2108,9 +2107,9 @@ Release date: 2021-04-26
 
 Closes #4388
 
-
 What's New in Pylint 2.8.1?
 ===========================
+
 Release date: 2021-04-25
 
 * Add numversion back (temporarily) in ``__pkginfo__`` because it broke Pylama and revert the unnecessary
@@ -2118,9 +2117,9 @@ Release date: 2021-04-25
 
   Closes #4399
 
-
 What's New in Pylint 2.8.0?
 ===========================
+
 Release date: 2021-04-24
 
 * New refactoring message ``consider-using-with``. This message is emitted if resource-allocating functions or methods of the
@@ -2150,7 +2149,7 @@ Release date: 2021-04-24
 * The packaging is now done via setuptools exclusively. ``doc``, ``tests``, ``man``, ``elisp`` and ``Changelog`` are
   not packaged anymore - reducing the size of the package by 75%.
 
-* Debian packaging is now  (officially) done in https://salsa.debian.org/python-team/packages/pylint.
+* Debian packaging is now  (officially) done in <https://salsa.debian.org/python-team/packages/pylint>.
 
 * The 'doc' extra-require has been removed.
 
@@ -2232,11 +2231,10 @@ Release date: 2021-04-24
 
 * Improve check for invalid PEP 585 syntax as default function arguments
 
-
 What's New in Pylint 2.7.4?
 ===========================
-Release date: 2021-03-30
 
+Release date: 2021-03-30
 
 * Fix a problem with disabled msgid not being ignored
 
@@ -2246,9 +2244,9 @@ Release date: 2021-03-30
 
   Closes #4264
 
-
 What's New in Pylint 2.7.3?
 ===========================
+
 Release date: 2021-03-29
 
 * Introduce logic for checking deprecated attributes in DeprecationMixin.
@@ -2324,9 +2322,9 @@ Release date: 2021-03-29
 
   Closes #4252
 
-
 What's New in Pylint 2.7.2?
 ===========================
+
 Release date: 2021-02-28
 
 * Fix False Positive on ``Enum.__members__.items()``, ``Enum.__members__.values``, and ``Enum.__members__.keys``
@@ -2338,9 +2336,9 @@ Release date: 2021-02-28
 
 * Workflow and packaging improvements
 
-
 What's New in Pylint 2.7.1?
 ===========================
+
 Release date: 2021-02-23
 
 * Expose ``UnittestLinter`` in pylint.testutils
@@ -2349,9 +2347,9 @@ Release date: 2021-02-23
 
   Closes #4119
 
-
 What's New in Pylint 2.7.0?
 ===========================
+
 Release date: 2021-02-21
 
 * Introduce DeprecationMixin for reusable deprecation checks.
@@ -2531,18 +2529,18 @@ Release date: 2021-02-21
 
 * Add Github Actions to replace Travis and AppVeyor in the future
 
-
 What's New in Pylint 2.6.1?
 ===========================
+
 Release date: 2021-02-16
 
 * Astroid version has been set as < 2.5
 
   Close #4093
 
-
 What's New in Pylint 2.6.0?
 ===========================
+
 Release date: 2020-08-20
 
 * Fix various scope-related bugs in ``undefined-variable`` checker
@@ -2597,9 +2595,9 @@ Release date: 2020-08-20
 
   Close #3564
 
-
 What's New in Pylint 2.5.3?
 ===========================
+
 Release date: 2020-06-8
 
 * Fix a regression where disable comments that have checker names with numbers in them are not parsed correctly
@@ -2618,7 +2616,7 @@ Release date: 2020-06-8
 
   Close #3604
 
-* In a TOML configuration file, it's now possible to use rich (non-string) types, such as list, integer or boolean instead of strings. For example, one can now define a *list* of message identifiers to enable like this::
+* In a TOML configuration file, it's now possible to use rich (non-string) types, such as list, integer or boolean instead of strings. For example, one can now define a _list_ of message identifiers to enable like this::
 
     enable = [
         "use-symbolic-message-instead",
@@ -2635,18 +2633,18 @@ Release date: 2020-06-8
 
   Close #3646
 
-
 What's New in Pylint 2.5.2?
 ===========================
+
 Release date: 2020-05-05
 
 * ``pylint.Run`` accepts ``do_exit`` as a deprecated parameter
 
   Close #3590
 
-
 What's New in Pylint 2.5.1?
 ===========================
+
 Release date: 2020-05-05
 
 * Fix a crash in ``method-hidden`` lookup for unknown base classes
@@ -2671,9 +2669,9 @@ Release date: 2020-05-05
 
   Close #3528
 
-
 What's New in Pylint 2.5.0?
 ===========================
+
 Release date: 2020-04-27
 
 * Fix a false negative for ``undefined-variable`` when using class attribute in comprehension.
@@ -2835,7 +2833,7 @@ Release date: 2020-04-27
 
   Close #3178
 
-* ``Ellipsis` is exempted from ``multiple-statements`` for function overloads.
+* ``Ellipsis` is exempted from``multiple-statements`` for function overloads.
 
   Close #3224
 
@@ -2951,9 +2949,9 @@ Release date: 2020-04-27
 
   Close #3361
 
-
 What's New in Pylint 2.4.4?
 ===========================
+
 Release date: 2019-11-13
 
 * Exempt all the names found in type annotations from ``unused-import``
@@ -2968,9 +2966,9 @@ Release date: 2019-11-13
 
   Close #3191
 
-
 What's New in Pylint 2.4.3?
 ===========================
+
 Release date: 2019-10-18
 
 * Fix an issue with ``unnecessary-comprehension`` in comprehensions with additional repacking of elements.
@@ -3002,11 +3000,10 @@ Release date: 2019-10-18
 
   Close #3170
 
-
 What's New in Pylint 2.4.2?
 ===========================
-Release date: 2019-09-30
 
+Release date: 2019-09-30
 
 * ``ignored-modules`` can skip submodules. Close #3135
 
@@ -3030,16 +3027,14 @@ Release date: 2019-09-30
 
   Close #3028
 
-
 What's New in Pylint 2.4.1?
 ===========================
-Release date: 2019-09-25
 
+Release date: 2019-09-25
 
 * Exempt type checking definitions defined in both clauses of a type checking guard
 
   Close #3127
-
 
 * Exempt type checking definitions inside the type check guard
 
@@ -3053,9 +3048,9 @@ Release date: 2019-09-25
 
 * Require astroid >= 2.3 to avoid any compatibility issues.
 
-
 What's New in Pylint 2.4.0?
 ===========================
+
 Release date: 2019-09-24
 
 * New check: ``import-outside-toplevel``
@@ -3336,9 +3331,9 @@ must rename the associated identification.
 
 * Added ``--list-msgs-enabled`` command to list all enabled and disabled messages given the current RC file and command line arguments.
 
-
 What's New in Pylint 2.3.0?
 ===========================
+
 Release date: 2019-02-27
 
 * Protect against ``NonDeducibleTypeHierarchy`` when calling semi-private ``is_subtype``
@@ -3475,9 +3470,9 @@ Release date: 2019-02-27
 
 * Minor improvements to the help text for a few options.
 
-
 What's New in Pylint 2.2.2?
 ===========================
+
 Release date: 2018-11-28
 
 * Change the ``logging-format-style`` to use name identifier instead of their
@@ -3490,26 +3485,25 @@ Release date: 2018-11-28
 
   Closes #2614
 
-
 What's New in Pylint 2.2.1?
 ===========================
+
 Release date: 2018-11-27
 
 * Fix a crash caused by ``implicit-str-concat-in-sequence`` and multi-bytes characters.
 
   Closes #2610
 
-
 What's New in Pylint 2.2?
 =========================
 
 Release date: 2018-11-25
 
-   * Consider ``range()`` objects for ``undefined-loop-variable`` leaking from iteration.
+* Consider ``range()`` objects for ``undefined-loop-variable`` leaking from iteration.
 
      Close #2533
 
-   * ``deprecated-method`` can use the attribute name for identifying a deprecated method
+* ``deprecated-method`` can use the attribute name for identifying a deprecated method
 
      Previously we were using the fully qualified name, which we still do, but the fully
      qualified name for some ``unittest`` deprecated aliases leads to a generic
@@ -3519,17 +3513,17 @@ Release date: 2018-11-25
      Close #1653
      Close #1946
 
-   * Fix compatibility with changes to stdlib tokenizer.
+* Fix compatibility with changes to stdlib tokenizer.
 
-   * ``pylint`` is less eager to consume the whole line for pragmas
+* ``pylint`` is less eager to consume the whole line for pragmas
 
      Close #2485
 
-   * Obtain the correct number of CPUs for virtualized or containerized environments.
+* Obtain the correct number of CPUs for virtualized or containerized environments.
 
      Close #2519
 
-   * Change ``unbalanced-tuple-unpacking`` back to a warning.
+* Change ``unbalanced-tuple-unpacking`` back to a warning.
 
      It used to be a warning until a couple of years ago, after it was promoted to
      an error. But the check might be suggesting the wrong thing in some cases,
@@ -3539,101 +3533,101 @@ Release date: 2018-11-25
 
      Close #2522
 
-   * Remove ``enumerate`` usage suggestion when defining ``__iter__`` (C0200)
+* Remove ``enumerate`` usage suggestion when defining ``__iter__`` (C0200)
 
      Close #2477
 
-   * Emit ``too-many-starred-assignment`` only when the number of Starred nodes is per assignment elements
+* Emit ``too-many-starred-assignment`` only when the number of Starred nodes is per assignment elements
 
      Close #2513
 
-   * ``try-except-raise`` checker now handles multilevel inheritance hirerachy for exceptions correctly.
+* ``try-except-raise`` checker now handles multilevel inheritance hirerachy for exceptions correctly.
 
      Close #2484
 
-   * Add a new check, ``simplifiable-if-expression`` for expressions like ``True if cond else False``.
+* Add a new check, ``simplifiable-if-expression`` for expressions like ``True if cond else False``.
 
      Close #2487
 
-   * ``too-few-public-methods`` is not reported for ``typing.NamedTuple``
+* ``too-few-public-methods`` is not reported for ``typing.NamedTuple``
 
      Close #2459
 
-   * ```too-few-public-methods`` is not reported for dataclasses created with options.
+* ```too-few-public-methods`` is not reported for dataclasses created with options.
 
      Close #2488
 
-   * Remove wrong modules from 'bad-python3-import'.
+* Remove wrong modules from 'bad-python3-import'.
 
      Close #2453
 
-   * The ``json`` reporter prints an empty list when no messages are emitted
+* The ``json`` reporter prints an empty list when no messages are emitted
 
      Close #2446
 
-   * Add a new check, ``duplicate-string-formatting-argument``
+* Add a new check, ``duplicate-string-formatting-argument``
 
      This new check is emitted whenever a duplicate string formatting argument
      is found.
 
      Close #497
 
-   * ``assignment-from-no-return`` is not emitted for coroutines.
+* ``assignment-from-no-return`` is not emitted for coroutines.
 
      Close #1715
 
-   * Report format string type mismatches.
+* Report format string type mismatches.
 
-   * ``consider-using-ternary`` and ``simplified-boolean-expression`` no longer emit for sequence based checks
+* ``consider-using-ternary`` and ``simplified-boolean-expression`` no longer emit for sequence based checks
 
      Close #2473
 
-   * Handle ``AstroidSyntaxError`` when trying to import a module.
+* Handle ``AstroidSyntaxError`` when trying to import a module.
 
      Close #2313
 
-   * Allow ``__module__`` to be redefined at a class level. Close #2451
+* Allow ``__module__`` to be redefined at a class level. Close #2451
 
-   * ``pylint`` used to emit an ``unused-variable`` error if unused import was found in the function. Now instead of
+* ``pylint`` used to emit an ``unused-variable`` error if unused import was found in the function. Now instead of
      ``unused-variable``, ``unused-import`` is emitted.
 
      Close #2421
 
-   * Handle asyncio.coroutine when looking for ``not-an-iterable`` check.
+* Handle asyncio.coroutine when looking for ``not-an-iterable`` check.
 
      Close #996
 
-   * The ``locally-enabled`` check is gone.
+* The ``locally-enabled`` check is gone.
 
      Close #2442
 
-   * Infer decorated methods when looking for method-hidden
+* Infer decorated methods when looking for method-hidden
 
      Close #2369
 
-   * Pick the latest value from the inferred values when looking for ``raising-non-exception``
+* Pick the latest value from the inferred values when looking for ``raising-non-exception``
 
      Close #2431
 
-   * Extend the TYPE_CHECKING guard to TYPE_CHECKING name as well, not just the attribute
+* Extend the TYPE_CHECKING guard to TYPE_CHECKING name as well, not just the attribute
 
      Close #2411
 
-   * Ignore import x.y.z as z cases for checker ``useless-import-alias``.
+* Ignore import x.y.z as z cases for checker ``useless-import-alias``.
 
      Close #2309
 
-   * Fix false positive ``undefined-variable`` and ``used-before-assignment`` with nonlocal keyword usage.
+* Fix false positive ``undefined-variable`` and ``used-before-assignment`` with nonlocal keyword usage.
 
      Close #2049
 
-   * Stop ``protected-access`` exception for missing class attributes
+* Stop ``protected-access`` exception for missing class attributes
 
-   * Don't emit ``assignment-from-no-return`` for decorated function nodes
+* Don't emit ``assignment-from-no-return`` for decorated function nodes
 
      Close #2385
 
-   * ``unnecessary-pass`` is now also emitted when a function or class contains only docstring and pass statement.
+* ``unnecessary-pass`` is now also emitted when a function or class contains only docstring and pass statement.
 
       In Python, stubbed functions often have a body that contains just a single ``pass`` statement,
       indicating that the function doesn't do anything. However, a stubbed function can also have just a
@@ -3641,81 +3635,81 @@ Release date: 2018-11-25
 
       Close #2208
 
-   * ``duplicate-argument-name`` is emitted for more than one duplicate argument per function
+* ``duplicate-argument-name`` is emitted for more than one duplicate argument per function
 
       Close #1712
 
-   * Allow double indentation levels for more distinguishable indentations
+* Allow double indentation levels for more distinguishable indentations
 
      Close #741
 
-   * Consider tuples in exception handler for ``try-except-raise``.
+* Consider tuples in exception handler for ``try-except-raise``.
      Close #2389
 
-   * Fix astroid.ClassDef check in checkers.utils.is_subclass_of
+* Fix astroid.ClassDef check in checkers.utils.is_subclass_of
 
-   * Fix wildcard imports being ignored by the import checker
+* Fix wildcard imports being ignored by the import checker
 
-   * Fix external/internal distinction being broken in the import graph
+* Fix external/internal distinction being broken in the import graph
 
-   * Fix wildcard import check not skipping ``__init__.py``
+* Fix wildcard import check not skipping ``__init__.py``
 
      Close #2430
 
-   * Add new option to logging checker, ``logging_format_style``
+* Add new option to logging checker, ``logging_format_style``
 
-   * Fix --ignore-imports to understand multi-line imports
+* Fix --ignore-imports to understand multi-line imports
 
      Close #1422
      Close #2019
 
-   * Add a new check 'implicit-str-concat-in-sequence' to spot string concatenation inside lists, sets & tuples.
+* Add a new check 'implicit-str-concat-in-sequence' to spot string concatenation inside lists, sets & tuples.
 
-   * ``literal-comparison`` is now emitted for 0 and 1 literals.
-
+* ``literal-comparison`` is now emitted for 0 and 1 literals.
 
 What's New in Pylint 2.1.1?
 ===========================
+
 Release date: 2018-08-07
 
-   * fix pylint crash due to ``misplaced-format-function`` not correctly handling class attribute.
+* fix pylint crash due to ``misplaced-format-function`` not correctly handling class attribute.
      Close #2384
 
-   * Do not emit \*-builtin for Python 3 builtin checks when the builtin is used inside a try-except
+* Do not emit \*-builtin for Python 3 builtin checks when the builtin is used inside a try-except
 
      Close PyCQA/pylint#2228
 
-   * ``simplifiable-if-statement`` not emitted when dealing with subscripts
-
+* ``simplifiable-if-statement`` not emitted when dealing with subscripts
 
 What's New in Pylint 2.1?
 =========================
 
 Release date: 2018-08-01
-   * ``trailing-comma-tuple`` gets emitted for ``yield`` statements as well.
+
+* ``trailing-comma-tuple`` gets emitted for ``yield`` statements as well.
 
       Close #2363
 
-   * Get only the arguments of the scope function for ``redefined-argument-from-local``
+* Get only the arguments of the scope function for ``redefined-argument-from-local``
 
      Close #2364
 
-   * Add a check ``misplaced-format-function`` which is emitted if format function is used on
+* Add a check ``misplaced-format-function`` which is emitted if format function is used on
      non str object.
 
      Close #2200
 
-   * ``chain.from_iterable`` no longer emits `dict-{}-not-iterating` when dealing with dict values and keys
+* ``chain.from_iterable`` no longer emits `dict-{}-not-iterating` when dealing with dict values and keys
 
-   * Demote the ``try-except-raise`` message from an error to a warning (E0705 -> W0706)
+* Demote the ``try-except-raise`` message from an error to a warning (E0705 -> W0706)
 
       Close #2323
 
-   * Correctly handle the new name of the Python implementation of the ``abc`` module.
+* Correctly handle the new name of the Python implementation of the ``abc`` module.
 
      Close PyCQA/astroid#2288
 
-    * Modules with ``__getattr__`` are exempted by default from ``no-member``
+  * Modules with ``__getattr__`` are exempted by default from ``no-member``
 
       There's no easy way to figure out if a module has a particular member when
       the said module uses ``__getattr__``, which is a new addition to Python 3.7.
@@ -3724,49 +3718,48 @@ Release date: 2018-08-01
 
       Close #2331
 
-    * Fix a false positive ``invalid name`` message when method or attribute name is longer then 30 characters.
+  * Fix a false positive ``invalid name`` message when method or attribute name is longer then 30 characters.
 
       Close #2047
 
-    * Include the type of the next branch in ``no-else-return``
+  * Include the type of the next branch in ``no-else-return``
 
       Close #2295
 
-    * Fix inconsistent behaviour for bad-continuation on first line of file
+  * Fix inconsistent behaviour for bad-continuation on first line of file
 
       Close #2281
 
-     * Fix not being able to disable certain messages on the last line through
+  * Fix not being able to disable certain messages on the last line through
        the global disable option
 
        Close #2278
 
-    * Don't emit ``useless-return`` when we have a single statement that is the return itself
+  * Don't emit ``useless-return`` when we have a single statement that is the return itself
 
       We still want to be explicit when a function is supposed to return
       an optional value; even though ``pass`` could still work, it's not explicit
       enough and the function might look like it's missing an implementation.
       Close #2300
 
-   * Fix false-positive undefined-variable for self referential class name in lamdbas
+* Fix false-positive undefined-variable for self referential class name in lamdbas
 
       Close #704
 
-    * Don't crash when ``pylint`` is unable to infer the value of an argument to ``next()``
+  * Don't crash when ``pylint`` is unable to infer the value of an argument to ``next()``
 
       Close #2316
 
-    * Don't emit ``not-an-iterable`` when dealing with async iterators.
+  * Don't emit ``not-an-iterable`` when dealing with async iterators.
 
       But do emit it when using the usual iteration protocol against
       async iterators.
 
       Close #2311
 
-   * Can specify a default docstring type for when the check cannot guess the type
+* Can specify a default docstring type for when the check cannot guess the type
 
       Close #1169
-
 
 What's New in Pylint 2.0?
 =========================
@@ -4159,7 +4152,6 @@ Release date: 2018-07-15
 
       Closes #1164
 
-
 What's New in Pylint 1.9?
 =========================
 
@@ -4197,13 +4189,12 @@ Release date: 2018-05-15
 
       Close #1997
 
-
 What's New in Pylint 1.8.1?
 ===========================
+
 Release date: 2017-12-15
 
     * Wrong version number in __pkginfo__.
-
 
 What's New in Pylint 1.8?
 =========================
@@ -4389,9 +4380,9 @@ Release date: 2017-12-15
       message for lines that follow.
       Close #1742
 
-
 What's New in Pylint 1.7.1?
 ===========================
+
 Release date: 2017-04-17
 
     * Fix a false positive which occurred when an exception was reraised
@@ -4403,7 +4394,6 @@ Release date: 2017-04-17
       The check was improved by verifying for non-terminating newlines, which
       should exempt function calls and function definitions from the check
       Close #1424
-
 
 What's New in Pylint 1.7?
 =========================
@@ -4725,18 +4715,18 @@ Release date: 2017-04-13
 
       Fixes #59
 
-
 What's new in Pylint 1.6.3?
 ===========================
+
 Release date: 2016-07-18
 
     * Do not crash when inferring uninferable exception types for docparams extension
 
       Close #998
 
-
 What's new in Pylint 1.6.2?
 ===========================
+
 Release date: 2016-07-15
 
     * Do not crash when printing the help of options with default regular expressions
@@ -4747,16 +4737,16 @@ Release date: 2016-07-15
 
       Close #991
 
-
 What's new in Pylint 1.6.1?
 ===========================
+
 Release date: 2016-07-07
 
     * Use environment markers for supporting conditional dependencies.
 
-
 What's New in Pylint 1.6.0?
 ===========================
+
 Release date: 2016-07-03
 
     * Added a new extension, ``pylint.extensions.mccabe``, for warning
@@ -4844,11 +4834,10 @@ Release date: 2016-07-03
 
       Close #769.
 
-
 What's New in Pylint 1.5.5?
 ===========================
-Release date: 2016-03-21
 
+Release date: 2016-03-21
 
     * Let visit_importfrom from Python 3 porting checker be called when everything is disabled
 
@@ -4879,11 +4868,10 @@ Release date: 2016-03-21
 
       Closes issue #826
 
-
 What's New in Pylint 1.5.4?
 ===========================
-Release date: 2016-01-15
 
+Release date: 2016-01-15
 
     * Merge StringMethodChecker with StringFormatChecker. This fixes a
       bug where disabling all the messages and enabling only a handful of
@@ -4892,9 +4880,9 @@ Release date: 2016-01-15
 
     * Don't apply unneeded-not over sets.
 
-
 What's New in Pylint 1.5.3?
 ===========================
+
 Release date: 2016-01-11
 
     * Handle the import fallback idiom with regard to wrong-import-order.
@@ -4938,9 +4926,9 @@ Release date: 2016-01-11
 
       Closes issue #749.
 
-
 What's New in Pylint 1.5.2?
 ===========================
+
 Release date: 2015-12-21
 
     * Don't crash if graphviz is not installed, instead emit a
@@ -4960,11 +4948,10 @@ Release date: 2015-12-21
 
       Closes issue #714.
 
-
 What's New in Pylint 1.5.1?
 ===========================
-Release date: 2015-12-02
 
+Release date: 2015-12-02
 
     * Fix a crash which occurred when old visit methods are encountered
       in plugin modules. Closes issue #711.
@@ -4985,11 +4972,10 @@ Release date: 2015-12-02
       of modules with the same name as the package itself.
       Closes issues #708 and #706.
 
-
 What's New in Pylint 1.5.0?
 ===========================
-Release date: 2015-11-29
 
+Release date: 2015-11-29
 
     * Added multiple warnings related to imports. 'wrong-import-order'
       is emitted when PEP 8 recommendations regarding imports are not
@@ -5398,12 +5384,10 @@ Release date: 2015-11-29
 
       Closes issue #675.
 
-
-
 What's New in Pylint 1.4.3?
 ===========================
-Release date: 2015-03-14
 
+Release date: 2015-03-14
 
     * Remove three warnings: star-args, abstract-class-little-used,
       abstract-class-not-used. These warnings don't add any real value
@@ -5420,9 +5404,9 @@ Release date: 2015-03-14
       and this exhibit a problem, because the visit_binop method stops being
       called (in the optimized AST it will be a Const node).
 
-
 What's New in Pylint 1.4.2?
 ===========================
+
 Release date: 2015-03-11
 
     * Don't require a docstring for empty modules. Closes issue #261.
@@ -5475,9 +5459,9 @@ Release date: 2015-03-11
       fixes the leaks of error messages from the Python 3 checker when
       the errors mode was activated. Closes issue #437.
 
-
 What's New in Pylint 1.4.1?
 ===========================
+
 Release date: 2015-01-16
 
     * Look only in the current function's scope for bad-super-call.
@@ -5520,11 +5504,10 @@ Release date: 2015-01-16
     * Fix a crash which occurred when using multiple jobs and the files
       given as argument didn't exist at all.
 
-
 What's New in Pylint 1.4.0?
 ============================
-Release date: 2014-11-23
 
+Release date: 2014-11-23
 
     * Added new options for controlling the loading of C extensions.
       By default, only C extensions from the stdlib will be loaded
@@ -5722,10 +5705,9 @@ Release date: 2014-11-23
     * Add 'implicit-map-evaluation' to Python 3 porting checker, emitted
       when encountering the use of map builtin, without explicit evaluation.
 
-
-
 What's New in Pylint 1.3.0?
 ===========================
+
 Release date: 2014-07-26
 
     * Allow hanging continued indentation for implicitly concatenated
@@ -5807,9 +5789,9 @@ Release date: 2014-07-26
     * Don't emit 'missing-docstring' when the actual docstring uses ``.format``.
       Closes issue #281.
 
-
 What's New in Pylint 1.2.1?
 ===========================
+
 Release date: 2014-04-30
 
     * Restore the ability to specify the init-hook option via the
@@ -5838,9 +5820,9 @@ Release date: 2014-04-30
     * Add 'indexing-exception' warning, which detects that indexing
       an exception occurs in Python 2 (behaviour removed in Python 3).
 
-
 What's New in Pylint 1.2.0?
 ===========================
+
 Release date: 2014-04-18
 
     * Pass the current python paths to pylint process when invoked via
@@ -5933,9 +5915,9 @@ Release date: 2014-04-18
 
     * Do not attempt to analyze non python file, e.g. .so file (#122)
 
-
 What's New in Pylint 1.1.0?
 ===========================
+
 Release date: 2013-12-22
 
     * Add new check for use of deprecated pragma directives "pylint:disable-msg"
@@ -5995,9 +5977,9 @@ Release date: 2013-12-22
 
     * Fix issue #55 (false-positive trailing-whitespace on Windows)
 
-
 What's New in Pylint 1.0.0?
 ===========================
+
 Release date: 2013-08-06
 
     * Add check for the use of 'exec' function
@@ -6105,9 +6087,9 @@ Release date: 2013-08-06
     * bitbucket #3: remove string module from the default list of deprecated
       modules
 
-
 What's New in Pylint 0.28.0?
 ============================
+
 Release date: 2013-04-25
 
     * bitbucket #1: fix "dictionary changed size during iteration" crash
@@ -6139,9 +6121,9 @@ Release date: 2013-04-25
 
     * Improve the description for E1124[redundant-keyword-arg]
 
-
 What's New in Pylint 0.27.0?
 ============================
+
 Release date: 2013-02-26
 
     * #20693: replace pylint.el by Ian Eure version (patch by J.Kotta)
@@ -6203,9 +6185,9 @@ Release date: 2013-02-26
     * Add hooks for import path setup and move pylint's sys.path
       modifications into them. (patch by Torsten Marek)
 
-
 What's New in Pylint 0.26.0?
 ============================
+
 Release date: 2012-10-05
 
     * #106534: add --ignore-imports option to code similarity checking
@@ -6244,9 +6226,9 @@ Release date: 2012-10-05
     * stop including tests files in distribution, they causes crash when
       installed with python3 (#72022, #82417, #76910)
 
-
 What's New in Pylint 0.25.2?
 ============================
+
 Release date: 2012-07-17
 
     * #93591: Correctly emit warnings about clobbered variable names when an
@@ -6277,9 +6259,9 @@ Release date: 2012-07-17
 
     * fix potential crashes with utils.safe_infer raising InferenceError
 
-
 What's New in Pylint 0.25.1?
 ============================
+
 Release date: 2011-12-08
 
     * #81078: Warn if names in  exception handlers clobber overwrite
@@ -6294,9 +6276,9 @@ Release date: 2011-12-08
     * #9188, #4024: Do not trigger W0631 if a loop variable is assigned
       in the else branch of a for loop.
 
-
 What's New in Pylint 0.25.0?
 ============================
+
 Release date: 2011-10-7
 
     * #74742: make allowed name for first argument of class method configurable
@@ -6317,9 +6299,9 @@ Release date: 2011-10-7
 
     * #73941: HTML report messages table is badly rendered
 
-
 What's New in Pylint 0.24.0?
 ============================
+
 Release date: 2011-07-18
 
     * #69738: add regular expressions support for "generated-members"
@@ -6343,9 +6325,9 @@ Release date: 2011-07-18
 
     * #22273: Fix --ignore option documentation to match reality
 
-
 What's New in Pylint 0.23.0?
 ============================
+
 Release date: 2011-01-11
 
     * documentation update, add manpages
@@ -6363,16 +6345,16 @@ Release date: 2011-01-11
     * don't emit W0221 or W0222 when methods as variable arguments (e.g. \*arg
       and/or \*\*args). Patch submitted by Charles Duffy.
 
-
 What's New in Pylint 0.22.0?
 ============================
+
 Release date: 2010-11-15
 
     * python versions: minimal python3.x support; drop python < 2.5 support
 
-
 What's New in Pylint 0.21.4?
 ============================
+
 Release date: 2010-10-27
 
     * fix #48066: pylint crashes when redirecting output containing non-ascii characters
@@ -6381,18 +6363,18 @@ Release date: 2010-10-27
 
     * update documentation
 
-
 What's New in Pylint 0.21.3?
 ============================
+
 Release date: 2010-09-28
 
     * restored python 2.3 compatibility. Along with logilab-astng
       0.21.3 and logilab-common 0.52, this will much probably be the
       latest release supporting python < 2.5.
 
-
 What's New in Pylint 0.21.2?
 ============================
+
 Release date: 2010-08-26
 
     * fix #36193: import checker raise exception on cyclic import
@@ -6401,9 +6383,9 @@ Release date: 2010-08-26
 
     * some documentation cleanups
 
-
 What's New in Pylint 0.21.1?
 ============================
+
 Release date: 2010-06-04
 
     * fix #28962: pylint crash with new options, due to missing stats data while
@@ -6411,9 +6393,9 @@ Release date: 2010-06-04
 
     * updated man page to 0.21 or greater command line usage (fix debian #582494)
 
-
 What's New in Pylint 0.21.0?
 ============================
+
 Release date: 2010-05-11
 
     * command line updated (closes #9774, #9787, #9992, #22962):
@@ -6444,10 +6426,9 @@ Release date: 2010-05-11
 
     * fix #20067: AttributeError: 'NoneType' object has no attribute 'name' with with
 
-
-
 What's New in Pylint 0.20.0?
 ============================
+
 Release date: 2010-03-01
 
     * fix #19498: fix windows batch file
@@ -6476,9 +6457,9 @@ Release date: 2010-03-01
 
     * remove --cache-size option
 
-
 What's New in Pylint 0.19.0?
 ============================
+
 Release date: 2009-12-18
 
     * implement #18947, #5561: checker for function arguments
@@ -6510,9 +6491,9 @@ Release date: 2009-12-18
 
     * #5821 added a utility function to run pylint in another process (patch provide by Vincent Ferotin)
 
-
 What's New in Pylint 0.18.0?
 ============================
+
 Release date: 2009-03-25
 
     * tests ok with python 2.4, 2.5, 2.6. 2.3 not tested
@@ -6537,9 +6518,9 @@ Release date: 2009-03-25
 
     * integration of Yuen Ho Wong's patches on Emacs lisp files
 
-
 What's New in Pylint 0.17.0?
 ============================
+
 Release date: 2009-03-19
 
     * semicolon check : move W0601 to W0301
@@ -6548,9 +6529,9 @@ Release date: 2009-03-19
 
     * astng 0.18 compatibility: support for _ast module modifies interfaces
 
-
 What's New in Pylint 0.16.0?
 ============================
+
 Release date: 2009-01-28
 
     * change [en|dis]able-msg-cat options: only accept message categories
@@ -6585,9 +6566,9 @@ Release date: 2009-01-28
 
     * fix #6954
 
-
 What's New in Pylint 0.15.2?
 ============================
+
 Release date: 2008-10-13
 
     * fix #5672: W0706 weirdness ( W0706 removed )
@@ -6598,9 +6579,9 @@ Release date: 2008-10-13
 
     * fix #6040: pytest doesn't run test/func_test.py
 
-
 What's New in Pylint 0.15.1?
 ============================
+
 Release date: 2008-09-15
 
     * fix #4910: default values are missing in manpage
@@ -6609,9 +6590,9 @@ Release date: 2008-09-15
 
     * fix #5993: epylint should work with python 2.3
 
-
 What's New in Pylint 0.15.0?
 ============================
+
 Release date: 2008-09-10
 
     * include pyreverse package and class diagram generation
@@ -6630,9 +6611,9 @@ Release date: 2008-09-10
 
     * Flymake integration: added bin/epylint and elisp/pylint-flymake.el
 
-
 What's New in Pylint 0.14.0?
 ============================
+
 Release date: 2008-01-14
 
     * fix #3733: Messages (dis)appear depending on order of file names
@@ -6649,9 +6630,9 @@ Release date: 2008-01-14
     * new ignored-class option on typecheck checker allowing to skip members
       checking based on class name (patch provided by Thomas W Barr)
 
-
 What's New in Pylint 0.13.2?
 ============================
+
 Release date: 2007-06-07
 
     * fix disable-checker option so that it won't accidentally enable the
@@ -6659,19 +6640,17 @@ Release date: 2007-06-07
 
     * added note about the gedit plugin into documentation
 
-
-
 What's New in Pylint 0.13.1?
 ============================
+
 Release date: 2007-03-02
 
     * fix some unexplained 0.13.0 packaging issue which led to a bunch of
       files missing from the distribution
 
-
-
 What's New in Pylint 0.13.0?
 ============================
+
 Release date: 2007-02-28
 
     * new RPython (Restricted Python) checker for PyPy fellow or people
@@ -6715,9 +6694,9 @@ Release date: 2007-02-28
     * fix #3259: when a message is explicitly enabled, check the checker
       emitting it is enabled
 
-
 What's New in Pylint 0.12.2?
 ============================
+
 Release date: 2006-11-23
 
     * fix #3143: W0233 bug w/ YES objects
@@ -6737,9 +6716,9 @@ Release date: 2006-11-23
 
     * fixed some format checker false positives
 
-
 What's New in Pylint 0.12.1?
 ============================
+
 Release date: 2006-09-25
 
     * fixed python >= 2.4 format false positive with multiple lines statement
@@ -6750,9 +6729,9 @@ Release date: 2006-09-25
 
     * stop requiring __revision__
 
-
 What's New in Pylint 0.12.0?
 ============================
+
 Release date: 2006-08-10
 
     * usability changes:
@@ -6785,9 +6764,9 @@ Release date: 2006-08-10
 
     * fix cr/lf pb when generating the rc file on windows platforms
 
-
 What's New in Pylint 0.11.0?
 ============================
+
 Release date: 2006-04-19
 
     * fix crash caused by the exceptions checker in some case
@@ -6805,9 +6784,9 @@ Release date: 2006-04-19
     * included patch from Benjamin Niemann to allow block level
       enabling/disabling of messages
 
-
 What's New in Pylint 0.10.0?
 ============================
+
 Release date: 2006-03-06
 
     * WARNING, this release include some configuration changes (see below),
@@ -6864,9 +6843,9 @@ Release date: 2006-03-06
 
     * fixed some R0201 (method could be a function) false positive
 
-
 What's New in Pylint 0.9.0?
 ============================
+
 Release date: 2006-01-10
 
     * a lot of updates to follow astng 0.14 API changes, so install
@@ -6914,9 +6893,9 @@ Release date: 2006-01-10
 
     * misc lint style fixes
 
-
 What's New in Pylint 0.8.1?
 ============================
+
 Release date: 2005-11-07
 
     * fix "deprecated module" false positive when the code imports a
@@ -6931,9 +6910,9 @@ Release date: 2005-11-07
     * fix "explicit return in __init__" false positive when return is
       actually in an inner function (close #10075)
 
-
 What's New in Pylint 0.8.0?
 ============================
+
 Release date: 2005-10-21
 
     * check names imported from a module exists in the module (E0611),
@@ -6972,9 +6951,9 @@ Release date: 2005-10-21
 
     * fix --rcfile handling (support for --rcfile=file, close #9590)
 
-
 What's New in Pylint 0.7.0?
 ============================
+
 Release date: 2005-05-27
 
     * WARNING: pylint is no longer a logilab subpackage. Users may have to
@@ -6996,9 +6975,9 @@ Release date: 2005-05-27
 
     * fix possible false positive for W0201
 
-
 What's New in Pylint 0.6.4?
 ===========================
+
 Release date: 2005-04-14
 
     * allow to parse files without extension when a path is given on the
@@ -7026,9 +7005,9 @@ Release date: 2005-04-14
 
     * packaged (generated...) man page
 
-
 What's New in Pylint 0.6.3?
 ===========================
+
 Release date: 2005-02-24
 
     * fix scope problem which may cause false positive and true negative
@@ -7037,9 +7016,9 @@ Release date: 2005-02-24
     * fix problem with some options such as disable-msg causing error when
       they are coming from the configuration file
 
-
 What's New in Pylint 0.6.2?
 ============================
+
 Release date: 2005-02-16
 
     * fix false positive on E0201 ("access to undefined member") with
@@ -7059,9 +7038,9 @@ Release date: 2005-02-16
 
     * new raw checker example in the examples/ directory
 
-
 What's New in Pylint 0.6.1?
 ===========================
+
 Release date: 2005-02-04
 
     * new --rcfile option to specify the configuration file without the
@@ -7073,9 +7052,9 @@ Release date: 2005-02-04
     * some fixes to handle fixes in common 0.9.1 (should however still working
       with common 0.9.0, even if upgrade is recommended)
 
-
 What's New in Pylint 0.6.0?
 ===========================
+
 Release date: 2005-01-20
 
     * refix pylint Emacs mode
@@ -7104,9 +7083,9 @@ Release date: 2005-01-20
 
     * improved tests coverage
 
-
 What's New in Pylint 0.5.0?
 ===========================
+
 Release date: 2004-10-19
 
     * avoid importing analyzed modules !
@@ -7126,18 +7105,18 @@ Release date: 2004-10-19
 
     * fix bug with total / undocumented number of methods
 
-
 What's New in Pylint 0.4.2?
 ===========================
+
 Release date: 2004-07-08
 
     * fix pylint Emacs mode
 
     * fix classes checkers to handler twisted interfaces
 
-
 What's New in Pylint 0.4.1?
 ===========================
+
 Release date: 2004-05-14
 
     * fix the setup.py script to allow bdist_winst (well, the generated
@@ -7148,9 +7127,9 @@ Release date: 2004-05-14
 
     * fix stupid crash bug with bad method names
 
-
 What's New in Pylint 0.4.0?
 ===========================
+
 Release date: 2004-05-10
 
     * fix file path with --parsable
@@ -7181,9 +7160,9 @@ Release date: 2004-05-10
 
     * use logilab.common.ureports to layout reports
 
-
 What's New in Pylint 0.3.3?
 ===========================
+
 Release date: 2004-02-17
 
     * added a parsable text output, used when the --parsable option is
@@ -7204,10 +7183,9 @@ Release date: 2004-02-17
     * provide scripts for unix and windows to wrap the minimal pylint tk
       gui
 
-
-
 What's New in Pylint 0.3.2?
 ===========================
+
 Release date: 2003-12-23
 
     * html-escape messages in the HTML reporter (bug reported by Juergen
@@ -7219,10 +7197,9 @@ Release date: 2003-12-23
 
     * fixed typos in some messages
 
-
-
 What's New in Pylint 0.3.1?
 ===========================
+
 Release date: 2003-12-05
 
     * bug fix in format and classes checkers
@@ -7231,10 +7208,9 @@ Release date: 2003-12-05
 
     * provide a simple tk gui, essentially useful for windows users
 
-
-
 What's New in Pylint 0.3.0?
 ===========================
+
 Release date: 2003-11-20
 
     * new exceptions checker, checking for string exception and empty
@@ -7294,10 +7270,9 @@ Release date: 2003-11-20
     * do not print redefinition warning for function/class/method defined
       in mutually exclusive branches
 
-
-
 What's New in Pylint 0.2.1?
 ===========================
+
 Release date: 2003-10-10
 
     * added some documentation, fixed some typos
@@ -7321,9 +7296,9 @@ Release date: 2003-10-10
 
     * fix format checker
 
-
 What's New in Pylint 0.2.0?
 ===========================
+
 Release date: 2003-09-12
 
     * new source encoding / FIXME checker (pep 263)
@@ -7338,25 +7313,25 @@ Release date: 2003-09-12
 
     * easy functional test infrastructure
 
-
 What's New in Pylint 0.1.2?
 ===========================
+
 Release date: 2003-06-18
 
     * bug fix release
 
     * remove dependency to pyreverse
 
-
 What's New in Pylint 0.1.1?
 ===========================
+
 Release date: 2003-06-01
 
     * much more functionalities !
 
-
 What's New in Pylint 0.1?
 ===========================
+
 Release date: 2003-05-19
 
     * initial release

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -126,6 +126,10 @@ Extensions
 Other Changes
 =============
 
+* Fix false positive ``no-member`` checks when using ``unittest.mock.Mock`` functions.
+
+  Closes #2821
+
 * Started ignoring underscore as a local variable for ``too-many-locals``.
 
   Closes #6488

--- a/script/.contributors_aliases.json
+++ b/script/.contributors_aliases.json
@@ -210,6 +210,10 @@
     "mails": ["celnazli@bitdefender.com", "cezar.elnazli2@gmail.com"],
     "name": "Cezar Elnazli"
   },
+  "chris.read@gmail.com": {
+    "mails": ["chris.read@gmail.com"],
+    "name": "Chris Read"
+  },
   "cmin@ropython.org": {
     "mails": ["cmin@ropython.org"],
     "name": "Cosmin Poieană"

--- a/tests/functional/n/no/no_member_mocks.py
+++ b/tests/functional/n/no/no_member_mocks.py
@@ -1,0 +1,24 @@
+""" Test that Mock objects don't raise a no-member. See issue #2821 """
+
+# pylint: disable=missing-function-docstring
+from unittest.mock import Mock
+
+
+def real_no_member():
+    exc = BaseException()
+    exc.no_member()  # [no-member]
+
+
+def mock_function_override():
+    bigquery = Mock()
+
+    def get_table(ds_table):
+        return ds_table
+
+    bigquery.get_table = get_table
+
+
+def mock_function_return_value():
+    bigquery = Mock()
+    destination_table = bigquery.get_table.return_value
+    destination_table.num_rows = 0

--- a/tests/functional/n/no/no_member_mocks.txt
+++ b/tests/functional/n/no/no_member_mocks.txt
@@ -1,0 +1,1 @@
+no-member:9:4:9:17:real_no_member:"Instance of 'BaseException' has no 'no_member' member":INFERENCE


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fix false positive ``no-member`` checks when using ``unittest.mock.Mock`` functions.

Closes #2821
