### PR TITLE
Add typing to `pylint.pyreverse.inspector`

### DIFF
--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -6,12 +6,13 @@
 
 Try to resolve definitions (namespace) dictionary, relationship...
 """
+
 from __future__ import annotations
 
 import collections
 import os
 import traceback
-from collections.abc import Iterator
+from collections.abc import Generator
 from typing import Any, Callable, Optional
 
 import astroid
@@ -44,7 +45,7 @@ def interfaces(
     node: nodes.ClassDef,
     herited: bool = True,
     handler_func: Callable[[nodes.NodeNG | Any], bool] = _iface_hdlr,
-) -> Iterator[Any] | None:
+) -> Generator[Any, None, None]:
     """Return an iterator on interfaces implemented by the given class node."""
     try:
         implements = astroid.bases.Instance(node).getattr("__implements__")[0]

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import collections
 import os
 import traceback
-from collections.abc import Callable, Iterator
-from typing import Any, Optional
+from collections.abc import Iterator
+from typing import Any, Callable, Optional
 
 import astroid
 from astroid import nodes

--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import itertools
 import os
+from collections.abc import Iterable
 
 from astroid import modutils, nodes
 
@@ -56,7 +57,7 @@ class DiagramWriter:
         )
         self.used_colors: dict[str, str] = {}
 
-    def write(self, diadefs):
+    def write(self, diadefs: Iterable[ClassDiagram | PackageDiagram]) -> None:
         """Write files for <project> according to <diadefs>."""
         for diagram in diadefs:
             basename = diagram.title.strip().replace(" ", "_")
@@ -64,10 +65,10 @@ class DiagramWriter:
             if os.path.exists(self.config.output_directory):
                 file_name = os.path.join(self.config.output_directory, file_name)
             self.set_printer(file_name, basename)
-            if diagram.TYPE == "class":
-                self.write_classes(diagram)
-            else:
+            if isinstance(diagram, PackageDiagram):
                 self.write_packages(diagram)
+            else:
+                self.write_classes(diagram)
             self.save()
 
     def write_packages(self, diagram: PackageDiagram) -> None:


### PR DESCRIPTION
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Add remaining typing to `inspector.py`.
This was the last untyped module.
After this change I can take a look at the refactoring TODOs we found.

Especially the parts of `inspector.py` that deal with interfaces and implementation links can be removed in my opinion, as their behaviour is based on the `__implements__` attribute which is not a standard Python feature and the corresponding PEP 245 is rejected. Plus, `pylint`'s codebase itself does not use it any more.
Those are also the only places in this module where I used `Any`.

