### PR TITLE
Create constant for default ignore list

### DIFF
--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -54,6 +54,8 @@ USER_HOME = os.path.expanduser("~")
 OLD_DEFAULT_PYLINT_HOME = ".pylint.d"
 DEFAULT_PYLINT_HOME = platformdirs.user_cache_dir("pylint")
 
+DEFAULT_IGNORE_LIST = ("CVS",)
+
 
 class WarningScope:
     LINE = "line-based-msg"

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -10,7 +10,7 @@ import re
 import sys
 from typing import TYPE_CHECKING
 
-from pylint import interfaces
+from pylint import constants, interfaces
 from pylint.config.callback_actions import (
     _DisableAction,
     _DoNothingAction,
@@ -44,7 +44,7 @@ def _make_linter_options(linter: PyLinter) -> Options:
                 "metavar": "<file>[,<file>...]",
                 "dest": "black_list",
                 "kwargs": {"old_names": ["black_list"]},
-                "default": ("CVS",),
+                "default": constants.DEFAULT_IGNORE_LIST,
                 "help": "Files or directories to be skipped. "
                 "They should be base names, not paths.",
             },

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Optional
 import astroid
 from astroid import nodes
 
+from pylint import constants
 from pylint.pyreverse import utils
 
 _WrapperFuncT = Callable[[Callable[[str], nodes.Module], str], Optional[nodes.Module]]
@@ -322,7 +323,7 @@ def project_from_files(
     files: list[str],
     func_wrapper: _WrapperFuncT = _astroid_wrapper,
     project_name: str = "no name",
-    black_list: tuple[str, ...] = ("CVS",),
+    black_list: tuple[str, ...] = constants.DEFAULT_IGNORE_LIST,
 ) -> Project:
     """Return a Project from a list of files or modules."""
     # build the project representation

--- a/pylint/pyreverse/main.py
+++ b/pylint/pyreverse/main.py
@@ -10,6 +10,7 @@ import sys
 from collections.abc import Sequence
 from typing import NoReturn
 
+from pylint import constants
 from pylint.config.arguments_manager import _ArgumentsManager
 from pylint.config.arguments_provider import _ArgumentsProvider
 from pylint.lint.utils import fix_import_path
@@ -175,7 +176,7 @@ OPTIONS: Options = (
             type="csv",
             metavar="<file[,file...]>",
             dest="ignore_list",
-            default=("CVS",),
+            default=constants.DEFAULT_IGNORE_LIST,
             help="Files or directories to be skipped. They should be base names, not paths.",
         ),
     ),


### PR DESCRIPTION
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Follow up to @DanielNoord's comment:
https://github.com/PyCQA/pylint/pull/6614#discussion_r872992691

The same default value for `ignore` / `black_list` was used in three different places in the code base, so we can extract a constant for it.
