### PR TITLE
Add ``pylint-config`` command

### DIFF
--- a/pylint/__init__.py
+++ b/pylint/__init__.py
@@ -27,6 +27,16 @@ def run_pylint(argv: Sequence[str] | None = None) -> None:
         sys.exit(1)
 
 
+def _run_pylint_config(argv: Sequence[str] | None = None) -> None:
+    """Run pylint-config.
+
+    argv can be a sequence of strings normally supplied as arguments on the command line
+    """
+    from pylint.lint.run import _PylintConfigRun
+
+    _PylintConfigRun(argv or sys.argv[1:])
+
+
 def run_epylint(argv: Sequence[str] | None = None) -> NoReturn:
     """Run epylint.
 

--- a/pylint/config/_pylint_config/__init__.py
+++ b/pylint/config/_pylint_config/__init__.py
@@ -7,4 +7,5 @@
 Everything in this module is private.
 """
 
+from pylint.config._pylint_config.main import _handle_pylint_config_commands  # noqa
 from pylint.config._pylint_config.setup import _register_generate_config_options  # noqa

--- a/pylint/config/_pylint_config/__init__.py
+++ b/pylint/config/_pylint_config/__init__.py
@@ -1,0 +1,10 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Everything related to the 'pylint-config' command.
+
+Everything in this module is private.
+"""
+
+from pylint.config._pylint_config.setup import _register_generate_config_options  # noqa

--- a/pylint/config/_pylint_config/generate_command.py
+++ b/pylint/config/_pylint_config/generate_command.py
@@ -1,0 +1,40 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Everything related to the 'pylint-config generate' command."""
+
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING
+
+from pylint.config._pylint_config import utils
+from pylint.config._pylint_config.help_message import get_subparser_help
+
+if TYPE_CHECKING:
+    from pylint.lint.pylinter import PyLinter
+
+
+def generate_interactive_config(linter: PyLinter) -> None:
+    print("Starting interactive pylint configuration generation")
+
+    format_type = utils.get_and_validate_format()
+
+    if format_type == "toml":
+        linter._generate_config_file()
+    else:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            linter.generate_config(skipsections=("Commands",))
+
+
+def handle_generate_command(linter: PyLinter) -> int:
+    """Handle 'pylint-config generate'."""
+    # Interactively generate a pylint configuration
+    if linter.config.interactive:
+        generate_interactive_config(linter)
+        return 0
+    print(get_subparser_help(linter, "generate"))
+    return 32

--- a/pylint/config/_pylint_config/help_message.py
+++ b/pylint/config/_pylint_config/help_message.py
@@ -1,0 +1,59 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Everything related to the 'pylint-config -h' command and subcommands."""
+
+
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pylint.lint.pylinter import PyLinter
+
+
+def get_subparser_help(linter: PyLinter, command: str) -> str:
+    """Get the help message for one of the subcommands."""
+    # Make sure subparsers are initialized properly
+    assert linter._arg_parser._subparsers
+    subparser_action = linter._arg_parser._subparsers._group_actions[0]
+    assert isinstance(subparser_action, argparse._SubParsersAction)
+
+    for name, subparser in subparser_action.choices.items():
+        assert isinstance(subparser, argparse.ArgumentParser)
+        if name == command:
+            # Remove last character which is an extra new line
+            return subparser.format_help()[:-1]
+    return ""  # pragma: no cover
+
+
+def get_help(parser: argparse.ArgumentParser) -> str:
+    """Get the help message for the main 'pylint-config' command.
+
+    Taken from argparse.ArgumentParser.format_help.
+    """
+    formatter = parser._get_formatter()
+
+    # usage
+    formatter.add_usage(
+        parser.usage, parser._actions, parser._mutually_exclusive_groups
+    )
+
+    # description
+    formatter.add_text(parser.description)
+
+    # positionals, optionals and user-defined groups
+    for action_group in parser._action_groups:
+        if action_group.title == "Subcommands":
+            formatter.start_section(action_group.title)
+            formatter.add_text(action_group.description)
+            formatter.add_arguments(action_group._group_actions)
+            formatter.end_section()
+
+    # epilog
+    formatter.add_text(parser.epilog)
+
+    # determine help from format above
+    return formatter.format_help()

--- a/pylint/config/_pylint_config/main.py
+++ b/pylint/config/_pylint_config/main.py
@@ -1,0 +1,25 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Everything related to the 'pylint-config' command."""
+
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pylint.config._pylint_config.generate_command import handle_generate_command
+from pylint.config._pylint_config.help_message import get_help
+
+if TYPE_CHECKING:
+    from pylint.lint.pylinter import PyLinter
+
+
+def _handle_pylint_config_commands(linter: PyLinter) -> int:
+    """Handle whichever command is passed to 'pylint-config'."""
+    if linter.config.config_subcommand == "generate":
+        return handle_generate_command(linter)
+
+    print(get_help(linter._arg_parser))
+    return 32

--- a/pylint/config/_pylint_config/setup.py
+++ b/pylint/config/_pylint_config/setup.py
@@ -1,0 +1,49 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Everything related to the setup of the 'pylint-config' command."""
+
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from typing import Any
+
+from pylint.config._pylint_config.help_message import get_help
+from pylint.config.callback_actions import _AccessParserAction
+
+
+class _HelpAction(_AccessParserAction):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: str | Sequence[Any] | None,
+        option_string: str | None = "--help",
+    ) -> None:
+        get_help(self.parser)
+
+
+def _register_generate_config_options(parser: argparse.ArgumentParser) -> None:
+    """Registers the necessary arguments on the parser."""
+    parser.prog = "pylint-config"
+    # Overwrite the help command
+    parser.add_argument(
+        "-h",
+        "--help",
+        action=_HelpAction,
+        default=argparse.SUPPRESS,
+        help="show this help message and exit",
+        parser=parser,
+    )
+
+    # We use subparsers to create various subcommands under 'pylint-config'
+    subparsers = parser.add_subparsers(dest="config_subcommand", title="Subcommands")
+
+    # Add the generate command
+    generate_parser = subparsers.add_parser(
+        "generate", help="Generate a pylint configuration"
+    )
+    generate_parser.add_argument("--interactive", action="store_true")

--- a/pylint/config/_pylint_config/utils.py
+++ b/pylint/config/_pylint_config/utils.py
@@ -1,0 +1,33 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Utils for the 'pylint-config' command."""
+
+
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+
+SUPPORTED_FORMATS = {"t", "toml", "i", "ini"}
+
+
+def get_and_validate_format() -> Literal["toml", "ini"]:
+    """Make sure that the output format is either .toml or .ini."""
+    # pylint: disable-next=bad-builtin
+    format_type = input(
+        "Please choose the format of configuration, (T)oml or (I)ni (.cfg): "
+    ).lower()
+
+    if format_type not in SUPPORTED_FORMATS:
+        raise ValueError(
+            f"Format should be one of {', '.join(i.capitalize() for i in sorted(SUPPORTED_FORMATS))}"
+        )
+
+    if format_type.startswith("t"):
+        return "toml"
+    return "ini"

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -433,7 +433,12 @@ class _ArgumentsManager:
                 continue
 
             options = []
-            for opt in group._group_actions:
+            option_actions = [
+                i
+                for i in group._group_actions
+                if not isinstance(i, argparse._SubParsersAction)
+            ]
+            for opt in option_actions:
                 if "--help" in opt.option_strings:
                     continue
 
@@ -675,9 +680,12 @@ class _ArgumentsManager:
                 continue
 
             group_table = tomlkit.table()
-            for action in sorted(
-                group._group_actions, key=lambda x: x.option_strings[0][2:]
-            ):
+            option_actions = [
+                i
+                for i in group._group_actions
+                if not isinstance(i, argparse._SubParsersAction)
+            ]
+            for action in sorted(option_actions, key=lambda x: x.option_strings[0][2:]):
                 optname = action.option_strings[0][2:]
 
                 # We skip old name options that don't have their own optdict

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -9,7 +9,7 @@ import sys
 import warnings
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from pylint import config
 from pylint.config.config_initialization import _config_initialization
@@ -88,6 +88,11 @@ class Run:
 group are mutually exclusive.",
         ),
     )
+    _is_pylint_config: ClassVar[bool] = False
+    """Boolean whether or not this is a 'pylint-config' run.
+
+    Used by _PylintConfigRun to make the 'pylint-config' command work.
+    """
 
     def __init__(
         self,
@@ -193,3 +198,13 @@ group are mutually exclusive.",
                     sys.exit(self.linter.msg_status or 1)
             else:
                 sys.exit(self.linter.msg_status)
+
+
+class _PylintConfigRun(Run):
+    """A private wrapper for the 'pylint-config' command."""
+
+    _is_pylint_config: ClassVar[bool] = True
+    """Boolean whether or not this is a 'pylint-config' run.
+
+    Used by _PylintConfigRun to make the 'pylint-config' command work.
+    """

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -13,6 +13,7 @@ from typing import Any, ClassVar
 
 from pylint import config
 from pylint.config._pylint_config import (
+    _handle_pylint_config_commands,
     _register_generate_config_options,
 )
 from pylint.config.config_initialization import _config_initialization
@@ -148,6 +149,17 @@ group are mutually exclusive.",
         args = _config_initialization(
             linter, args, reporter, config_file=self._rcfile, verbose_mode=self.verbose
         )
+
+        # Handle the 'pylint-config' command
+        if self._is_pylint_config:
+            warnings.warn(
+                "NOTE: The 'pylint-config' command is experimental and usage can change",
+                UserWarning,
+            )
+            code = _handle_pylint_config_commands(linter)
+            if exit:
+                sys.exit(code)
+            return
 
         # Display help messages if there are no files to lint
         if not args:

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -12,6 +12,9 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 from pylint import config
+from pylint.config._pylint_config import (
+    _register_generate_config_options,
+)
 from pylint.config.config_initialization import _config_initialization
 from pylint.config.exceptions import ArgumentPreprocessingError
 from pylint.config.utils import _preprocess_options
@@ -136,6 +139,11 @@ group are mutually exclusive.",
 
         linter.disable("I")
         linter.enable("c-extension-no-member")
+
+        # Register the options needed for 'pylint-config'
+        # By not registering them by default they don't show up in the normal usage message
+        if self._is_pylint_config:
+            _register_generate_config_options(linter._arg_parser)
 
         args = _config_initialization(
             linter, args, reporter, config_file=self._rcfile, verbose_mode=self.verbose

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ include =
 [options.entry_points]
 console_scripts =
     pylint = pylint:run_pylint
+    pylint-config = pylint:_run_pylint_config
     epylint = pylint:run_epylint
     pyreverse = pylint:run_pyreverse
     symilar = pylint:run_symilar

--- a/tests/config/pylint_config/test_pylint_config_generate.py
+++ b/tests/config/pylint_config/test_pylint_config_generate.py
@@ -1,0 +1,69 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Test for the 'pylint-config generate' command."""
+
+
+import warnings
+
+import pytest
+from pytest import CaptureFixture, MonkeyPatch
+
+from pylint.lint.run import _PylintConfigRun as Run
+
+
+def test_generate_interactive_exitcode(monkeypatch: MonkeyPatch) -> None:
+    """Check that we exit correctly based on different parameters."""
+    # Monkeypatch everything we don't want to check in this test
+    monkeypatch.setattr(
+        "pylint.config._pylint_config.utils.get_and_validate_format", lambda: "toml"
+    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="NOTE:.*", category=UserWarning)
+        with pytest.raises(SystemExit) as ex:
+            Run(["generate", "--interactive"])
+        assert ex.value.code == 0
+
+        Run(["generate", "--interactive"], exit=False)
+
+
+def test_format_of_output(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    """Check that we output the correct format."""
+    # Set the answers needed for the input() calls
+    answers = iter(["T", "toml", "TOML", "I", "INI", "TOMLINI"])
+    monkeypatch.setattr("builtins.input", lambda x: next(answers))
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="NOTE:.*", category=UserWarning)
+        # Check 'T'
+        Run(["generate", "--interactive"], exit=False)
+        captured = capsys.readouterr()
+        assert "[tool.pylint.main]" in captured.out
+
+        # Check 'toml'
+        Run(["generate", "--interactive"], exit=False)
+        captured = capsys.readouterr()
+        assert "[tool.pylint.main]" in captured.out
+
+        # Check 'TOML'
+        Run(["generate", "--interactive"], exit=False)
+        captured = capsys.readouterr()
+        assert "[tool.pylint.main]" in captured.out
+
+        # Check 'I'
+        Run(["generate", "--interactive"], exit=False)
+        captured = capsys.readouterr()
+        assert "[MAIN]" in captured.out
+
+        # Check 'INI'
+        Run(["generate", "--interactive"], exit=False)
+        captured = capsys.readouterr()
+        assert "[MAIN]" in captured.out
+
+        # Check 'TOMLINI'
+        with pytest.raises(ValueError, match="Format should be one.*"):
+            Run(["generate", "--interactive"], exit=False)

--- a/tests/config/pylint_config/test_pylint_config_help.py
+++ b/tests/config/pylint_config/test_pylint_config_help.py
@@ -1,0 +1,44 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Test for the 'pylint-config generate' command."""
+
+
+import warnings
+
+import pytest
+from pytest import CaptureFixture
+
+from pylint.lint.run import _PylintConfigRun as Run
+
+
+def test_pylint_config_main_messages(capsys: CaptureFixture[str]) -> None:
+    """Check that the help messages are displayed correctly."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="NOTE:.*", category=UserWarning)
+        Run([], exit=False)
+        captured = capsys.readouterr()
+        assert captured.out.startswith("usage: pylint-config [options]")
+        assert "--interactive" not in captured.out
+
+        Run(["-h"], exit=False)
+        captured_two = capsys.readouterr()
+        assert captured_two.out == captured.out
+
+        with pytest.raises(SystemExit):
+            Run(["generate", "-h"])
+        captured = capsys.readouterr()
+        assert captured.out.startswith("usage: pylint-config [options] generate")
+        assert "--interactive" in captured.out
+
+        with pytest.raises(SystemExit) as ex:
+            Run(["generate"])
+        captured_two = capsys.readouterr()
+        assert captured_two.out == captured.out
+        # This gets auto-raised by argparse to be 0.
+        assert ex.value.code == 32
+
+        with pytest.raises(SystemExit) as ex:
+            Run(["-h"])
+        assert ex.value.code == 32

--- a/tests/config/pylint_config/test_run_pylint_config.py
+++ b/tests/config/pylint_config/test_run_pylint_config.py
@@ -1,0 +1,24 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Test for the 'pylint-config generate' command."""
+
+
+import warnings
+
+import pytest
+from pytest import CaptureFixture
+
+from pylint import _run_pylint_config
+
+
+def test_invocation_of_pylint_config(capsys: CaptureFixture[str]) -> None:
+    """Check that the help messages are displayed correctly."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="NOTE:.*", category=UserWarning)
+        with pytest.raises(SystemExit) as ex:
+            _run_pylint_config()
+        captured = capsys.readouterr()
+        assert captured.err.startswith("usage: pylint-config [options]")
+        assert ex.value.code == 2


### PR DESCRIPTION
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Ref https://github.com/PyCQA/pylint/pull/6578 and https://github.com/PyCQA/pylint/issues/971.

This adds a number of new commands:
- `pylint-config`, Shows help message for the new command
- `pylint-config -h/--help`, idem.
- `pylint-config generate`, Shows help message for the subparser
- `pylint-config generate -h/--help`, idem.
- `pylint-config generate --interactive`, Starts interactive process of generating a configuration file

Everything is behind a `UserWarning` that indicates that all of this is experimental to give us some freedom to play around with this.

The way it works is that when `pylint-config` is used on the CLI a `Run` instance is initiated with a flag which indicates that we are in `pylint-config`. This then registers some additional options, which is necessary for these options not to show up in the default configuration.
Then if we find that flag we short-circuit just before we would start checking files and go into the `pylint-config` handler.

Everything related to `pylint-config` is included in `pylint/config/_pylint_config`. That should avoid any issues with private/public API we are having in other parts of our code.

Let me know what you think!

_Commits are sort of separated by topic but not really.._