### PR TITLE
[consider-using-in] Suggest set instead of tuple for membership

### DIFF
--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1267,6 +1267,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             "consider-using-in",
             node=node,
             args=(common_variable, maybe_not, values_string),
+            confidence=HIGH,
         )
 
     def _check_chained_comparison(self, node):

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -321,7 +321,8 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             "and increases readability compared to for-loop iteration.",
         ),
         "R1714": (
-            'Consider merging these comparisons with "in" to %r',
+            "Consider merging these comparisons with 'in' by using '%s %sin (%s)'."
+            " Use a set instead if elements are hashable.",
             "consider-using-in",
             "To check if a variable is equal to one of many values,"
             'combine the values into a tuple and check if the variable is contained "in" it '
@@ -1258,13 +1259,15 @@ class RefactoringChecker(checkers.BaseTokenChecker):
 
         # Gather information for the suggestion
         common_variable = sorted(list(common_variables))[0]
-        comprehension = "in" if node.op == "or" else "not in"
         values = list(collections.OrderedDict.fromkeys(values))
         values.remove(common_variable)
         values_string = ", ".join(values) if len(values) != 1 else values[0] + ","
-        suggestion = f"{common_variable} {comprehension} ({values_string})"
-
-        self.add_message("consider-using-in", node=node, args=(suggestion,))
+        maybe_not = "" if node.op == "or" else "not "
+        self.add_message(
+            "consider-using-in",
+            node=node,
+            args=(common_variable, maybe_not, values_string),
+        )
 
     def _check_chained_comparison(self, node):
         """Check if there is any chained comparison in the expression.

--- a/tests/functional/c/consider/consider_using_in.txt
+++ b/tests/functional/c/consider/consider_using_in.txt
@@ -1,14 +1,14 @@
-consider-using-in:10:0:10:24::Consider merging these comparisons with 'in' by using 'value in (1,)'. Use a set instead if elements are hashable.:UNDEFINED
-consider-using-in:11:0:11:24::Consider merging these comparisons with 'in' by using 'value in (1, 2)'. Use a set instead if elements are hashable.:UNDEFINED
-consider-using-in:12:0:12:36::Consider merging these comparisons with 'in' by using 'value in ('value',)'. Use a set instead if elements are hashable.:UNDEFINED
-consider-using-in:13:0:13:34::Consider merging these comparisons with 'in' by using 'value in (1, undef_value)'. Use a set instead if elements are hashable.:UNDEFINED
-consider-using-in:14:0:14:38::Consider merging these comparisons with 'in' by using 'value in (1, 2, 3)'. Use a set instead if elements are hashable.:UNDEFINED
-consider-using-in:15:0:15:26::Consider merging these comparisons with 'in' by using 'value in ('2', 1)'. Use a set instead if elements are hashable.:UNDEFINED
-consider-using-in:16:0:16:24::Consider merging these comparisons with 'in' by using 'value in (1, 2)'. Use a set instead if elements are hashable.:UNDEFINED
-consider-using-in:17:0:17:24::Consider merging these comparisons with 'in' by using 'value in (1, 2)'. Use a set instead if elements are hashable.:UNDEFINED
-consider-using-in:18:0:18:29::Consider merging these comparisons with 'in' by using 'value in (1, a_list)'. Use a set instead if elements are hashable.:UNDEFINED
-consider-using-in:19:0:19:51::Consider merging these comparisons with 'in' by using 'value in (a_set, a_list, a_str)'. Use a set instead if elements are hashable.:UNDEFINED
-consider-using-in:20:0:20:25::Consider merging these comparisons with 'in' by using 'value not in (1, 2)'. Use a set instead if elements are hashable.:UNDEFINED
-consider-using-in:21:0:21:36::Consider merging these comparisons with 'in' by using 'value1 in (value2,)'. Use a set instead if elements are hashable.:UNDEFINED
-consider-using-in:22:0:22:35::Consider merging these comparisons with 'in' by using 'a_list in ([1, 2, 3], [])'. Use a set instead if elements are hashable.:UNDEFINED
-consider-using-in:53:0:53:28::Consider merging these comparisons with 'in' by using 'A.value in (1, 2)'. Use a set instead if elements are hashable.:UNDEFINED
+consider-using-in:10:0:10:24::Consider merging these comparisons with 'in' by using 'value in (1,)'. Use a set instead if elements are hashable.:HIGH
+consider-using-in:11:0:11:24::Consider merging these comparisons with 'in' by using 'value in (1, 2)'. Use a set instead if elements are hashable.:HIGH
+consider-using-in:12:0:12:36::Consider merging these comparisons with 'in' by using 'value in ('value',)'. Use a set instead if elements are hashable.:HIGH
+consider-using-in:13:0:13:34::Consider merging these comparisons with 'in' by using 'value in (1, undef_value)'. Use a set instead if elements are hashable.:HIGH
+consider-using-in:14:0:14:38::Consider merging these comparisons with 'in' by using 'value in (1, 2, 3)'. Use a set instead if elements are hashable.:HIGH
+consider-using-in:15:0:15:26::Consider merging these comparisons with 'in' by using 'value in ('2', 1)'. Use a set instead if elements are hashable.:HIGH
+consider-using-in:16:0:16:24::Consider merging these comparisons with 'in' by using 'value in (1, 2)'. Use a set instead if elements are hashable.:HIGH
+consider-using-in:17:0:17:24::Consider merging these comparisons with 'in' by using 'value in (1, 2)'. Use a set instead if elements are hashable.:HIGH
+consider-using-in:18:0:18:29::Consider merging these comparisons with 'in' by using 'value in (1, a_list)'. Use a set instead if elements are hashable.:HIGH
+consider-using-in:19:0:19:51::Consider merging these comparisons with 'in' by using 'value in (a_set, a_list, a_str)'. Use a set instead if elements are hashable.:HIGH
+consider-using-in:20:0:20:25::Consider merging these comparisons with 'in' by using 'value not in (1, 2)'. Use a set instead if elements are hashable.:HIGH
+consider-using-in:21:0:21:36::Consider merging these comparisons with 'in' by using 'value1 in (value2,)'. Use a set instead if elements are hashable.:HIGH
+consider-using-in:22:0:22:35::Consider merging these comparisons with 'in' by using 'a_list in ([1, 2, 3], [])'. Use a set instead if elements are hashable.:HIGH
+consider-using-in:53:0:53:28::Consider merging these comparisons with 'in' by using 'A.value in (1, 2)'. Use a set instead if elements are hashable.:HIGH

--- a/tests/functional/c/consider/consider_using_in.txt
+++ b/tests/functional/c/consider/consider_using_in.txt
@@ -1,14 +1,14 @@
-consider-using-in:10:0:10:24::"Consider merging these comparisons with ""in"" to 'value in (1,)'":UNDEFINED
-consider-using-in:11:0:11:24::"Consider merging these comparisons with ""in"" to 'value in (1, 2)'":UNDEFINED
-consider-using-in:12:0:12:36::"Consider merging these comparisons with ""in"" to ""value in ('value',)""":UNDEFINED
-consider-using-in:13:0:13:34::"Consider merging these comparisons with ""in"" to 'value in (1, undef_value)'":UNDEFINED
-consider-using-in:14:0:14:38::"Consider merging these comparisons with ""in"" to 'value in (1, 2, 3)'":UNDEFINED
-consider-using-in:15:0:15:26::"Consider merging these comparisons with ""in"" to ""value in ('2', 1)""":UNDEFINED
-consider-using-in:16:0:16:24::"Consider merging these comparisons with ""in"" to 'value in (1, 2)'":UNDEFINED
-consider-using-in:17:0:17:24::"Consider merging these comparisons with ""in"" to 'value in (1, 2)'":UNDEFINED
-consider-using-in:18:0:18:29::"Consider merging these comparisons with ""in"" to 'value in (1, a_list)'":UNDEFINED
-consider-using-in:19:0:19:51::"Consider merging these comparisons with ""in"" to 'value in (a_set, a_list, a_str)'":UNDEFINED
-consider-using-in:20:0:20:25::"Consider merging these comparisons with ""in"" to 'value not in (1, 2)'":UNDEFINED
-consider-using-in:21:0:21:36::"Consider merging these comparisons with ""in"" to 'value1 in (value2,)'":UNDEFINED
-consider-using-in:22:0:22:35::"Consider merging these comparisons with ""in"" to 'a_list in ([1, 2, 3], [])'":UNDEFINED
-consider-using-in:53:0:53:28::"Consider merging these comparisons with ""in"" to 'A.value in (1, 2)'":UNDEFINED
+consider-using-in:10:0:10:24::Consider merging these comparisons with 'in' by using 'value in (1,)'. Use a set instead if elements are hashable.:UNDEFINED
+consider-using-in:11:0:11:24::Consider merging these comparisons with 'in' by using 'value in (1, 2)'. Use a set instead if elements are hashable.:UNDEFINED
+consider-using-in:12:0:12:36::Consider merging these comparisons with 'in' by using 'value in ('value',)'. Use a set instead if elements are hashable.:UNDEFINED
+consider-using-in:13:0:13:34::Consider merging these comparisons with 'in' by using 'value in (1, undef_value)'. Use a set instead if elements are hashable.:UNDEFINED
+consider-using-in:14:0:14:38::Consider merging these comparisons with 'in' by using 'value in (1, 2, 3)'. Use a set instead if elements are hashable.:UNDEFINED
+consider-using-in:15:0:15:26::Consider merging these comparisons with 'in' by using 'value in ('2', 1)'. Use a set instead if elements are hashable.:UNDEFINED
+consider-using-in:16:0:16:24::Consider merging these comparisons with 'in' by using 'value in (1, 2)'. Use a set instead if elements are hashable.:UNDEFINED
+consider-using-in:17:0:17:24::Consider merging these comparisons with 'in' by using 'value in (1, 2)'. Use a set instead if elements are hashable.:UNDEFINED
+consider-using-in:18:0:18:29::Consider merging these comparisons with 'in' by using 'value in (1, a_list)'. Use a set instead if elements are hashable.:UNDEFINED
+consider-using-in:19:0:19:51::Consider merging these comparisons with 'in' by using 'value in (a_set, a_list, a_str)'. Use a set instead if elements are hashable.:UNDEFINED
+consider-using-in:20:0:20:25::Consider merging these comparisons with 'in' by using 'value not in (1, 2)'. Use a set instead if elements are hashable.:UNDEFINED
+consider-using-in:21:0:21:36::Consider merging these comparisons with 'in' by using 'value1 in (value2,)'. Use a set instead if elements are hashable.:UNDEFINED
+consider-using-in:22:0:22:35::Consider merging these comparisons with 'in' by using 'a_list in ([1, 2, 3], [])'. Use a set instead if elements are hashable.:UNDEFINED
+consider-using-in:53:0:53:28::Consider merging these comparisons with 'in' by using 'A.value in (1, 2)'. Use a set instead if elements are hashable.:UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Set are more performant for membership tests, we have another checks for this, we may as well suggest the right test from the start. Follow-up to #6635 
