### PR TITLE
[doc] Fix the link to block disable in useless-import-alias related

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,9 +47,7 @@ extensions = [
 
 
 # Single file redirects are handled in this file and can be done by a pylint
-# contributor. They need to redirect from the directory of the source See:
-# I. e. messages/index.html to a/b/c.html will be messages/a/b/c.html not
-# a/b/c.html
+# contributor if no englobing full directory redirect is applied first. See:
 # https://documatt.gitlab.io/sphinx-reredirects/usage.html
 # Directory redirects are handled in ReadTheDoc admin interface and can only be done
 # by pylint maintainers at the following URL:
@@ -63,12 +61,15 @@ redirects: dict[str, str] = {
     "intro": "index.html",
     "support": "contact.html",
     "user_guide/ide-integration": "installation.html",
+    "user_guide/message-control": "user_guide/messages/message_control.html",
     "additional_commands/index": "../index.html",
-    "messages/index": "../user_guide/messages/index.html",
-    "messages/messages_introduction": "../user_guide/messages/index.html",
-    "messages/messages_list": "../user_guide/messages/messages_overview.html",
-    "user_guide/message-control": "messages/message_control.html",
 }
+for m in redirects:
+    for r in DIRECTORY_REDIRECT:
+        assert not m.startswith(r), (
+            f"Redirection will silentely fail: '{m}' start with '{r}' and "
+            "the whole directory is redirected by ReadtheDoc conf already."
+        )
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,7 +47,9 @@ extensions = [
 
 
 # Single file redirects are handled in this file and can be done by a pylint
-# contributor if no englobing full directory redirect is applied first. See:
+# contributor. They need to redirect from the directory of the source See:
+# I. e. messages/index.html to a/b/c.html will be messages/a/b/c.html not
+# a/b/c.html
 # https://documatt.gitlab.io/sphinx-reredirects/usage.html
 # Directory redirects are handled in ReadTheDoc admin interface and can only be done
 # by pylint maintainers at the following URL:
@@ -61,15 +63,12 @@ redirects: dict[str, str] = {
     "intro": "index.html",
     "support": "contact.html",
     "user_guide/ide-integration": "installation.html",
-    "user_guide/message-control": "user_guide/messages/message_control.html",
     "additional_commands/index": "../index.html",
+    "messages/index": "../user_guide/messages/index.html",
+    "messages/messages_introduction": "../user_guide/messages/index.html",
+    "messages/messages_list": "../user_guide/messages/messages_overview.html",
+    "user_guide/message-control": "messages/message_control.html",
 }
-for m in redirects:
-    for r in DIRECTORY_REDIRECT:
-        assert not m.startswith(r), (
-            f"Redirection will silentely fail: '{m}' start with '{r}' and "
-            "the whole directory is redirected by ReadtheDoc conf already."
-        )
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/doc/data/messages/u/useless-import-alias/related.rst
+++ b/doc/data/messages/u/useless-import-alias/related.rst
@@ -1,3 +1,3 @@
 - `PEP 8, Import Guideline <https://peps.python.org/pep-0008/#imports>`_
-- `Pylint block-disable <block_disables>`_
+- :ref:`Pylint block-disable <messages-control:Block disables>`_
 - `mypy --no-implicit-reexport <https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport>`_

--- a/doc/data/messages/u/useless-import-alias/related.rst
+++ b/doc/data/messages/u/useless-import-alias/related.rst
@@ -1,3 +1,3 @@
 - `PEP 8, Import Guideline <https://peps.python.org/pep-0008/#imports>`_
-- :ref:`Pylint block-disable <block_disables>`_
+- :ref:`Pylint block-disable <block_disables>`
 - `mypy --no-implicit-reexport <https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport>`_

--- a/doc/data/messages/u/useless-import-alias/related.rst
+++ b/doc/data/messages/u/useless-import-alias/related.rst
@@ -1,3 +1,3 @@
 - `PEP 8, Import Guideline <https://peps.python.org/pep-0008/#imports>`_
-- :ref:`Pylint block-disable <messages-control:Block disables>`_
+- :ref:`Pylint block-disable <block_disables>`_
 - `mypy --no-implicit-reexport <https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport>`_

--- a/doc/data/messages/u/useless-import-alias/related.rst
+++ b/doc/data/messages/u/useless-import-alias/related.rst
@@ -1,3 +1,3 @@
 - `PEP 8, Import Guideline <https://peps.python.org/pep-0008/#imports>`_
-- `Pylint block-disable <https://pylint.pycqa.org/en/latest/user_guide/message-control.html#block-disables>`_
+- `Pylint block-disable <block_disables>`_
 - `mypy --no-implicit-reexport <https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport>`_

--- a/doc/user_guide/messages/message_control.rst
+++ b/doc/user_guide/messages/message_control.rst
@@ -23,6 +23,7 @@ In order to control messages, ``pylint`` accepts the following values:
 
 * All the checks with ``all``
 
+.. _block_disables:
 
 Block disables
 --------------


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Apparently the redirect in #6628 is not perfect.