### PR TITLE
Emit `modified-iterating-{list|dict|set}` when iterating literals or using `del`

### DIFF
--- a/doc/whatsnew/2/2.15/index.rst
+++ b/doc/whatsnew/2/2.15/index.rst
@@ -31,6 +31,11 @@ False positives fixed
 False negatives fixed
 =====================
 
+* Emit ``modified-iterating-list`` and analogous messages for dicts and sets when iterating
+  literals, or when using the ``del`` keyword.
+
+  Closes #6648
+
 
 Other bug fixes
 ===============

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -12,7 +12,7 @@ import numbers
 import re
 import string
 import warnings
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from functools import lru_cache, partial
 from re import Match
 from typing import TYPE_CHECKING, Callable, TypeVar
@@ -1792,3 +1792,15 @@ def in_for_else_branch(parent: nodes.NodeNG, stmt: nodes.Statement) -> bool:
     return isinstance(parent, nodes.For) and any(
         else_stmt.parent_of(stmt) or else_stmt == stmt for else_stmt in parent.orelse
     )
+
+
+def find_assigned_names_recursive(
+    target: nodes.AssignName | nodes.BaseContainer,
+) -> Iterator[str]:
+    """Yield the names of assignment targets, accounting for nested ones."""
+    if isinstance(target, nodes.AssignName):
+        if target.name is not None:
+            yield target.name
+    elif isinstance(target, nodes.BaseContainer):
+        for elt in target.elts:
+            yield from find_assigned_names_recursive(elt)

--- a/tests/functional/m/modified_iterating.py
+++ b/tests/functional/m/modified_iterating.py
@@ -47,6 +47,18 @@ for l in item_list:
         item_set.remove(4)  # [modified-iterating-set]
     item_list.remove(1)  # [modified-iterating-list]
 
+for item in [1, 2, 3]:
+    del item  # [modified-iterating-list]
+
+for inner_first, inner_second in [[1, 2], [1, 2]]:
+    del inner_second  # [modified-iterating-list]
+
+for k in my_dict:
+    del k  # [modified-iterating-dict]
+
+for element in item_set:
+    del element  # [modified-iterating-set]
+
 # Check for nested for loops and changes to iterators
 for l in item_list:
     item_list.append(1)  # [modified-iterating-list]

--- a/tests/functional/m/modified_iterating.txt
+++ b/tests/functional/m/modified_iterating.txt
@@ -5,6 +5,10 @@ modified-iterating-set:39:4:39:27::Iterated set 'item_set' is being modified ins
 modified-iterating-list:46:8:46:27::Iterated list 'item_list' is being modified inside for loop body, consider iterating through a copy of it instead.:INFERENCE
 modified-iterating-set:47:8:47:26::Iterated set 'item_set' is being modified inside for loop body, iterate through a copy of it instead.:INFERENCE
 modified-iterating-list:48:4:48:23::Iterated list 'item_list' is being modified inside for loop body, consider iterating through a copy of it instead.:INFERENCE
-modified-iterating-list:52:4:52:23::Iterated list 'item_list' is being modified inside for loop body, consider iterating through a copy of it instead.:INFERENCE
-modified-iterating-list:55:12:55:31::Iterated list 'item_list' is being modified inside for loop body, consider iterating through a copy of it instead.:INFERENCE
-modified-iterating-list:57:16:57:35::Iterated list 'item_list' is being modified inside for loop body, consider iterating through a copy of it instead.:INFERENCE
+modified-iterating-list:51:4:51:12::Iterated list 'list' is being modified inside for loop body, consider iterating through a copy of it instead.:INFERENCE
+modified-iterating-list:54:4:54:20::Iterated list 'list' is being modified inside for loop body, consider iterating through a copy of it instead.:INFERENCE
+modified-iterating-dict:57:4:57:9::Iterated dict 'my_dict' is being modified inside for loop body, iterate through a copy of it instead.:INFERENCE
+modified-iterating-set:60:4:60:15::Iterated set 'item_set' is being modified inside for loop body, iterate through a copy of it instead.:INFERENCE
+modified-iterating-list:64:4:64:23::Iterated list 'item_list' is being modified inside for loop body, consider iterating through a copy of it instead.:INFERENCE
+modified-iterating-list:67:12:67:31::Iterated list 'item_list' is being modified inside for loop body, consider iterating through a copy of it instead.:INFERENCE
+modified-iterating-list:69:16:69:35::Iterated list 'item_list' is being modified inside for loop body, consider iterating through a copy of it instead.:INFERENCE


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Closes #6648
Solves an additional false negative: the check wasn't emitted when iterating literals.