### PR TITLE
Fix ``unexpected-special-method-signature`` false positive 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,10 @@ Release date: TBA
 
   Closes #6076
 
+* Fix ``unexpected-special-method-signature`` false positive for ``__init_subclass__`` methods with one or more arguments.
+
+  Closes #6644
+
 * Started ignoring underscore as a local variable for ``too-many-locals``.
 
   Closes #6488

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -273,6 +273,11 @@ Other Changes
 
   Closes #6594
 
+* Fix ``unexpected-special-method-signature`` false positive for ``__init_subclass__`` methods with one or more arguments.
+
+  Closes #6644
+
+
 Deprecations
 ============
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -69,7 +69,7 @@ KEYS_METHOD = "keys"
 #          although it's best to implement it in order to accept
 #          all of them.
 _SPECIAL_METHODS_PARAMS = {
-    None: ("__new__", "__init__", "__call__"),
+    None: ("__new__", "__init__", "__call__", "__init_subclass__"),
     0: (
         "__del__",
         "__repr__",
@@ -107,7 +107,6 @@ _SPECIAL_METHODS_PARAMS = {
         "__anext__",
         "__fspath__",
         "__subclasses__",
-        "__init_subclass__",
     ),
     1: (
         "__format__",

--- a/tests/functional/u/unexpected_special_method_signature.py
+++ b/tests/functional/u/unexpected_special_method_signature.py
@@ -33,9 +33,6 @@ class Invalid(object):
     def __subclasses__(self, blabla):  # [unexpected-special-method-signature]
         pass
 
-    @classmethod
-    def __init_subclass__(cls, blabla):  # [unexpected-special-method-signature]
-        pass
 
 class FirstBadContextManager(object):
     def __enter__(self):
@@ -106,6 +103,10 @@ class Valid(object):
     def __getitem__(index):
         pass
 
+    @classmethod
+    def __init_subclass__(cls, blabla):
+        pass
+
 
 class FirstGoodContextManager(object):
     def __enter__(self):
@@ -124,3 +125,14 @@ class ThirdGoodContextManager(object):
         return self
     def __exit__(self, exc_type, *args):
         pass
+
+
+# unexpected-special-method-signature
+# https://github.com/PyCQA/pylint/issues/6644
+class Philosopher:
+    def __init_subclass__(cls, default_name, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.default_name = default_name
+
+class AustralianPhilosopher(Philosopher, default_name="Bruce"):
+    pass

--- a/tests/functional/u/unexpected_special_method_signature.txt
+++ b/tests/functional/u/unexpected_special_method_signature.txt
@@ -7,12 +7,11 @@ unexpected-special-method-signature:23:4:23:20:Invalid.__deepcopy__:The special 
 no-method-argument:26:4:26:16:Invalid.__iter__:Method has no argument:UNDEFINED
 unexpected-special-method-signature:30:4:30:19:Invalid.__getattr__:The special method '__getattr__' expects 1 param(s), 2 were given:UNDEFINED
 unexpected-special-method-signature:33:4:33:22:Invalid.__subclasses__:The special method '__subclasses__' expects 0 param(s), 1 was given:UNDEFINED
-unexpected-special-method-signature:37:4:37:25:Invalid.__init_subclass__:The special method '__init_subclass__' expects 0 param(s), 1 was given:UNDEFINED
-unexpected-special-method-signature:43:4:43:16:FirstBadContextManager.__exit__:The special method '__exit__' expects 3 param(s), 1 was given:UNDEFINED
-unexpected-special-method-signature:49:4:49:16:SecondBadContextManager.__exit__:The special method '__exit__' expects 3 param(s), 4 were given:UNDEFINED
-unexpected-special-method-signature:57:4:57:16:ThirdBadContextManager.__exit__:The special method '__exit__' expects 3 param(s), 4 were given:UNDEFINED
-unexpected-special-method-signature:63:4:63:17:Async.__aiter__:The special method '__aiter__' expects 0 param(s), 1 was given:UNDEFINED
-unexpected-special-method-signature:65:4:65:17:Async.__anext__:The special method '__anext__' expects 0 param(s), 2 were given:UNDEFINED
-unexpected-special-method-signature:67:4:67:17:Async.__await__:The special method '__await__' expects 0 param(s), 1 was given:UNDEFINED
-unexpected-special-method-signature:69:4:69:18:Async.__aenter__:The special method '__aenter__' expects 0 param(s), 1 was given:UNDEFINED
-unexpected-special-method-signature:71:4:71:17:Async.__aexit__:The special method '__aexit__' expects 3 param(s), 0 was given:UNDEFINED
+unexpected-special-method-signature:40:4:40:16:FirstBadContextManager.__exit__:The special method '__exit__' expects 3 param(s), 1 was given:UNDEFINED
+unexpected-special-method-signature:46:4:46:16:SecondBadContextManager.__exit__:The special method '__exit__' expects 3 param(s), 4 were given:UNDEFINED
+unexpected-special-method-signature:54:4:54:16:ThirdBadContextManager.__exit__:The special method '__exit__' expects 3 param(s), 4 were given:UNDEFINED
+unexpected-special-method-signature:60:4:60:17:Async.__aiter__:The special method '__aiter__' expects 0 param(s), 1 was given:UNDEFINED
+unexpected-special-method-signature:62:4:62:17:Async.__anext__:The special method '__anext__' expects 0 param(s), 2 were given:UNDEFINED
+unexpected-special-method-signature:64:4:64:17:Async.__await__:The special method '__await__' expects 0 param(s), 1 was given:UNDEFINED
+unexpected-special-method-signature:66:4:66:18:Async.__aenter__:The special method '__aenter__' expects 0 param(s), 1 was given:UNDEFINED
+unexpected-special-method-signature:68:4:68:17:Async.__aexit__:The special method '__aexit__' expects 3 param(s), 0 was given:UNDEFINED


### PR DESCRIPTION
Fix ``unexpected-special-method-signature`` false positive for ``__init_subclass__`` methods with one or more arguments.
The method can accept arguments.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #6644
