### PR TITLE
Remove duplicate of the documentation in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,12 +92,13 @@ Contributing
 ------------
 
 We welcome all contributions, doc, code, checking issues for duplicate or telling us
-that we can close them, confirming that it's still an issue, creating issues because
-you found a bug or want a feature... everything helps !
+that we can close them, confirming that it's still an issue, `creating issues because
+you found a bug or want a feature`_... everything helps !
 
 Please follow the `code of conduct`_ and check `the contribution documentation`_ if you want to
 make a code contribution.
 
+.. _creating issues because you found a bug or want a feature: https://pylint.pycqa.org/en/latest/contact.html#bug-reports-feedback
 .. _code of conduct: https://github.com/Pierre-Sassoulas/pylint/blob/main/CODE_OF_CONDUCT.md
 .. _the contribution documentation: https://pylint.pycqa.org/en/latest/development_guide/contribute.html
 
@@ -126,6 +127,10 @@ The icon files are licensed under the `CC BY-SA 4.0 <https://creativecommons.org
 
 Support
 -------
+
+Please check `the contact information`_ in the documentation.
+
+.. _`the contact information`: https://pylint.pycqa.org/en/latest/contact.html
 
 .. list-table::
    :widths: 10 100

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,9 @@ Pylint
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/ambv/black
 
+.. image:: https://img.shields.io/badge/linting-pylint-yellowgreen
+    :target: https://github.com/PyCQA/pylint
+
 .. image:: https://results.pre-commit.ci/badge/github/PyCQA/pylint/main.svg
    :target: https://results.pre-commit.ci/latest/github/PyCQA/pylint/main
    :alt: pre-commit.ci status
@@ -25,25 +28,6 @@ Pylint
 .. |tideliftlogo| image:: https://raw.githubusercontent.com/PyCQA/pylint/main/doc/media/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White.png
    :width: 200
    :alt: Tidelift
-
-.. list-table::
-   :widths: 10 100
-
-   * - |tideliftlogo|
-     - Professional support for pylint is available as part of the `Tidelift
-       Subscription`_.  Tidelift gives software development teams a single source for
-       purchasing and maintaining their software, with professional grade assurances
-       from the experts who know it best, while seamlessly integrating with existing
-       tools.
-
-.. _Tidelift Subscription: https://tidelift.com/subscription/pkg/pypi-pylint?utm_source=pypi-pylint&utm_medium=referral&utm_campaign=readme
-
-Documentation
-=============
-
-Please check `the full documentation`_.
-
-.. _`the full documentation`: https://pylint.pycqa.org/
 
 What is pylint ?
 ================
@@ -73,67 +57,50 @@ re-evaluate and re-enable messages as your priorities evolve.
 
 Pylint ships with three additional tools:
 
-- :ref:`pyreverse <pyreverse>` (standalone tool that generates package and class diagrams.)
-- :ref:`symilar <symilar>`  (duplicate code finder that is also integrated in pylint)
-- :ref:`epylint <pylint_in_flymake>` (Emacs and Flymake compatible Pylint)
+- pyreverse_ (standalone tool that generates package and class diagrams.)
+- symilar_  (duplicate code finder that is also integrated in pylint)
+- epylint_ (Emacs and Flymake compatible Pylint)
+
+.. Enf of do not modify this without also modifying doc/index.rst
+
+.. _pyreverse: https://pylint.pycqa.org/en/latest/pyreverse.html
+.. _symilar: https://pylint.pycqa.org/en/latest/symilar.html
+.. _epylint: https://pylint.pycqa.org/en/latest/user_guide/ide_integration/flymake-emacs.html
 
 Install
 -------
 
-Pylint can be simply installed by running::
+.. Do not modify anything here, modify doc/user_guide/installation.rst instead
+
+For command line use, pylint is installed with::
 
     pip install pylint
 
-If you are using Python 3.7.2+, upgrade to get full support for your version::
+It can also be integrated in most editors or IDE. More information can be found
+`in the documentation`_.
 
-    pip install pylint --upgrade
+.. _in the documentation: https://pylint.pycqa.org/en/latest/user_guide/installation.html
 
-If you want to install from a source distribution, extract the tarball and run
-the following command ::
+Documentation
+=============
 
-    python setup.py install
+Please check `the full documentation`_.
 
+.. _`the full documentation`: https://pylint.pycqa.org/
 
-Do make sure to do the same for astroid, which is used internally by pylint.
+Contributing
+------------
 
-For debian and rpm packages, use your usual tools according to your Linux distribution.
+We welcome all contributions, doc, code, checking issues for duplicate or telling us
+that we can close them, confirming that it's still an issue, creating issues because
+you found a bug or want a feature... everything helps !
 
-More information about installation and available distribution format
-can be found here_.
+Please follow the `code of conduct`_ and check `the contribution documentation`_ if you want to
+make a code contribution.
 
-Testing
--------
+.. _code of conduct: https://github.com/Pierre-Sassoulas/pylint/blob/main/CODE_OF_CONDUCT.md
+.. _the contribution documentation: https://pylint.pycqa.org/en/latest/development_guide/contribute.html
 
-You should be able to install our tests dependencies with::
-
-    pip install -r requirements_test.txt
-
-You can then use pytest_ directly. If you want to run tests on a specific portion of the
-code with pytest_ and your local python version::
-
-    # ( pip install pytest-cov )
-    python3 -m pytest
-    # Everything in tests/message with coverage for the relevant code:
-    python3 -m pytest tests/message/ --cov=pylint.message
-    coverage html
-    # Only the functional test "missing_kwoa_py3":
-    python3 -m pytest "tests/test_functional.py::test_functional[missing_kwoa_py3]"
-
-You can also *optionally* install tox_. To run the test suite for a particular
-Python version, with tox you can do::
-
-    tox -e py39
-
-To run individual tests with ``tox``, you can do::
-
-    tox -e py37 -- -k name_of_the_test
-
-If you're testing new changes in astroid you need to clone astroid_ and install
-with an editable installation as follows::
-
-    git clone https://github.com/PyCQA/astroid.git
-    cd astroid
-    python3 -m pip install -e .
 
 Show your usage
 -----------------
@@ -143,27 +110,9 @@ You can place this badge in your README to let others know your project uses pyl
     .. image:: https://img.shields.io/badge/linting-pylint-yellowgreen
         :target: https://github.com/PyCQA/pylint
 
-Use the badge in your project's README.md (or any other Markdown file)::
+See how in `the badge documentation`_.
 
-    [![linting: pylint](https://img.shields.io/badge/linting-pylint-yellowgreen)](https://github.com/PyCQA/pylint)
-
-Use the badge in your project's README.rst (or any other rst file)::
-
-    .. image:: https://img.shields.io/badge/linting-pylint-yellowgreen
-        :target: https://github.com/PyCQA/pylint
-
-
-If you use GitHub Actions, and one of your CI workflows begins with "name: pylint", you
-can use GitHub's `workflow status badges <https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name>`_
-to show an up-to-date indication of whether pushes to your default branch pass pylint.
-For more detailed information, check the documentation.
-
-.. _here: https://pylint.pycqa.org/en/latest/user_guide/installation.html
-.. _tox: https://tox.readthedocs.io/en/latest/
-.. _pytest: https://docs.pytest.org/en/latest/
-.. _pytest-benchmark: https://pytest-benchmark.readthedocs.io/en/latest/index.html
-.. _pytest-cov: https://pypi.org/project/pytest-cov/
-.. _astroid: https://github.com/PyCQA/astroid
+.. _the badge documentation: https://pylint.pycqa.org/en/latest/user_guide/badge.html
 
 License
 -------
@@ -174,3 +123,18 @@ The icon files are licensed under the `CC BY-SA 4.0 <https://creativecommons.org
 
 - `doc/logo.png <https://raw.githubusercontent.com/PyCQA/pylint/main/doc/logo.png>`_
 - `doc/logo.svg <https://raw.githubusercontent.com/PyCQA/pylint/main/doc/logo.svg>`_
+
+Support
+-------
+
+.. list-table::
+   :widths: 10 100
+
+   * - |tideliftlogo|
+     - Professional support for pylint is available as part of the `Tidelift
+       Subscription`_.  Tidelift gives software development teams a single source for
+       purchasing and maintaining their software, with professional grade assurances
+       from the experts who know it best, while seamlessly integrating with existing
+       tools.
+
+.. _Tidelift Subscription: https://tidelift.com/subscription/pkg/pypi-pylint?utm_source=pypi-pylint&utm_medium=referral&utm_campaign=readme

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@
    :target: https://results.pre-commit.ci/latest/github/PyCQA/pylint/main
    :alt: pre-commit.ci status
 
-What is Pylint ?
+What is Pylint?
 ================
 
 Pylint is a `static code analyser`_ for Python 2 or 3. The latest version supports Python
@@ -44,15 +44,15 @@ will know that ``argparse.error(...)`` is in fact a logging call and not an argp
 .. _`code smells`: https://martinfowler.com/bliki/CodeSmell.html
 
 Pylint is highly configurable and permits to write plugins in order to add your
-own checks (for example for an internal libraries or internal rule). Pylint has an
-ecosystem of existing plugins for popular framework among them `pylint-django`_ or
+own checks (for example, for internal libraries or an internal rule). Pylint has an
+ecosystem of existing plugins for popular frameworks such as `pylint-django`_ or
 `pylint-i18n`_.
 
 .. _`pylint-django`: https://github.com/PyCQA/pylint-django
 .. _`pylint-i18n`: https://github.com/amandasaurus/python-pylint-i18n
 
 Pylint isn't smarter than you: it may warn you about things that you have
-conscientiously done or checks for some things that you don't care about.
+conscientiously done or check for some things that you don't care about.
 During adoption, especially in a legacy project where pylint was never enforced,
 it's best to start with the ``--errors-only`` flag, then disable
 convention and refactor message with ``--disable=C,R`` and progressively
@@ -71,7 +71,7 @@ Pylint ships with three additional tools:
 Projects that you might want to use alongside pylint include flake8_ (faster and simpler checks
 with very few false positives), mypy_, pyright_ or pyre_ (typing checks), bandit_ (security
 oriented checks), black_ and isort_ (auto-formatting), autoflake_ (automated removal of
-unused import or variable), pyupgrade_ (automated upgrade to newer python syntax) and
+unused imports or variables), pyupgrade_ (automated upgrade to newer python syntax) and
 pydocstringformatter_ (automated pep257).
 
 .. _flake8: https://gitlab.com/pycqa/flake8/
@@ -92,7 +92,7 @@ For command line use, pylint is installed with::
 
     pip install pylint
 
-It can also be integrated in most editors or IDE. More information can be found
+It can also be integrated in most editors or IDEs. More information can be found
 `in the documentation`_.
 
 .. _in the documentation: https://pylint.pycqa.org/en/latest/user_guide/installation.html
@@ -100,9 +100,9 @@ It can also be integrated in most editors or IDE. More information can be found
 Contributing
 ------------
 
-We welcome all contributions, doc, code, checking issues for duplicate or telling us
-that we can close them, confirming that it's still an issue, `creating issues because
-you found a bug or want a feature`_... everything helps !
+We welcome all forms of contributions such as updates for documentation, new code, checking issues for duplicates or telling us
+that we can close them, confirming that issues still exist, `creating issues because
+you found a bug or want a feature`_, etc. Everything is much appreciated!
 
 Please follow the `code of conduct`_ and check `the Contributor Guides`_ if you want to
 make a code contribution.
@@ -120,7 +120,7 @@ You can place this badge in your README to let others know your project uses pyl
     .. image:: https://img.shields.io/badge/linting-pylint-yellowgreen
         :target: https://github.com/PyCQA/pylint
 
-See how in `the badge documentation`_.
+Learn how to add a badge to your documentation in the `the badge documentation`_.
 
 .. _the badge documentation: https://pylint.pycqa.org/en/latest/user_guide/badge.html
 

--- a/README.rst
+++ b/README.rst
@@ -35,31 +35,21 @@ Pylint is a `static code analyser`_ for Python 2 or 3. The latest version suppor
 
 .. _`static code analyser`: https://en.wikipedia.org/wiki/Static_code_analysis
 
-Pylint analyses your code without actually running it. It checks for errors, enforces a coding
-standard, looks for `code smells`_, and can make suggestions about how the code could be refactored.
+Pylint analyses your code without actually running it. It checks for errors, enforces a
+coding standard, looks for `code smells`_, and can make suggestions about how the code
+could be refactored. Pylint can infer actual values from your code using its internal
+code representation (astroid). If your code is ``import logging as argparse``, Pylint
+will know that ``argparse.error(...)`` is in fact a logging call and not an argparse call.
 
 .. _`code smells`: https://martinfowler.com/bliki/CodeSmell.html
 
-Projects that you might want to use alongside pylint include flake8_ (faster and simpler checks
-with very few false positives), mypy_, pyright_ or pyre_ (typing checks), bandit_ (security
-oriented checks), black_ and isort_ (auto-formatting), autoflake_ (automated removal of
-unused import or variable), pyupgrade_ (automated upgrade to newer python syntax) and
-pydocstringformatter_ (automated pep257).
+Pylint is highly configurable and permits to write plugins in order to add your
+own checks (for example for an internal libraries or internal rule). Pylint has an
+ecosystem of existing plugins for popular framework among them `pylint-django`_ or
+`pylint-i18n`_.
 
-.. _flake8: https://gitlab.com/pycqa/flake8/
-.. _bandit: https://github.com/PyCQA/bandit
-.. _mypy: https://github.com/python/mypy
-.. _pyright: https://github.com/microsoft/pyright
-.. _pyre: https://github.com/facebook/pyre-check
-.. _black: https://github.com/psf/black
-.. _autoflake: https://github.com/myint/autoflake
-.. _pyupgrade: https://github.com/asottile/pyupgrade
-.. _pydocstringformatter: https://github.com/DanielNoord/pydocstringformatter
-.. _isort: https://pycqa.github.io/isort/
-
-Pylint can infer actual values from your code using its internal code representation (astroid).
-If your code is ``import logging as argparse``, Pylint will know that ``argparse.error(...)``
-is in fact a logging call and not an argparse call.
+.. _`pylint-django`: https://github.com/PyCQA/pylint-django
+.. _`pylint-i18n`: https://github.com/amandasaurus/python-pylint-i18n
 
 Pylint isn't smarter than you: it may warn you about things that you have
 conscientiously done or checks for some things that you don't care about.
@@ -77,6 +67,23 @@ Pylint ships with three additional tools:
 .. _pyreverse: https://pylint.pycqa.org/en/latest/pyreverse.html
 .. _symilar: https://pylint.pycqa.org/en/latest/symilar.html
 .. _epylint: https://pylint.pycqa.org/en/latest/user_guide/ide_integration/flymake-emacs.html
+
+Projects that you might want to use alongside pylint include flake8_ (faster and simpler checks
+with very few false positives), mypy_, pyright_ or pyre_ (typing checks), bandit_ (security
+oriented checks), black_ and isort_ (auto-formatting), autoflake_ (automated removal of
+unused import or variable), pyupgrade_ (automated upgrade to newer python syntax) and
+pydocstringformatter_ (automated pep257).
+
+.. _flake8: https://gitlab.com/pycqa/flake8/
+.. _bandit: https://github.com/PyCQA/bandit
+.. _mypy: https://github.com/python/mypy
+.. _pyright: https://github.com/microsoft/pyright
+.. _pyre: https://github.com/facebook/pyre-check
+.. _black: https://github.com/psf/black
+.. _autoflake: https://github.com/myint/autoflake
+.. _pyupgrade: https://github.com/asottile/pyupgrade
+.. _pydocstringformatter: https://github.com/DanielNoord/pydocstringformatter
+.. _isort: https://pycqa.github.io/isort/
 
 Install
 -------

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,7 @@
-Pylint
-======
+`Pylint`_
+=========
+
+.. _`Pylint`: https://pylint.pycqa.org/
 
 .. image:: https://github.com/PyCQA/pylint/actions/workflows/tests.yaml/badge.svg?branch=main
     :target: https://github.com/PyCQA/pylint/actions
@@ -25,14 +27,8 @@ Pylint
    :target: https://results.pre-commit.ci/latest/github/PyCQA/pylint/main
    :alt: pre-commit.ci status
 
-.. |tideliftlogo| image:: https://raw.githubusercontent.com/PyCQA/pylint/main/doc/media/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White.png
-   :width: 200
-   :alt: Tidelift
-
-What is pylint ?
+What is Pylint ?
 ================
-
-.. Do not modify this without also modifying doc/index.rst
 
 Pylint is a `static code analyser`_ for Python 2 or 3. The latest version supports Python
 3.7.2 and above.
@@ -43,6 +39,23 @@ Pylint analyses your code without actually running it. It checks for errors, enf
 standard, looks for `code smells`_, and can make suggestions about how the code could be refactored.
 
 .. _`code smells`: https://martinfowler.com/bliki/CodeSmell.html
+
+Projects that you might want to use alongside pylint include flake8_ (faster and simpler checks
+with very few false positives), mypy_, pyright_ or pyre_ (typing checks), bandit_ (security
+oriented checks), black_ and isort_ (auto-formatting), autoflake_ (automated removal of
+unused import or variable), pyupgrade_ (automated upgrade to newer python syntax) and
+pydocstringformatter_ (automated pep257).
+
+.. _flake8: https://gitlab.com/pycqa/flake8/
+.. _bandit: https://github.com/PyCQA/bandit
+.. _mypy: https://github.com/python/mypy
+.. _pyright: https://github.com/microsoft/pyright
+.. _pyre: https://github.com/facebook/pyre-check
+.. _black: https://github.com/psf/black
+.. _autoflake: https://github.com/myint/autoflake
+.. _pyupgrade: https://github.com/asottile/pyupgrade
+.. _pydocstringformatter: https://github.com/DanielNoord/pydocstringformatter
+.. _isort: https://pycqa.github.io/isort/
 
 Pylint can infer actual values from your code using its internal code representation (astroid).
 If your code is ``import logging as argparse``, Pylint will know that ``argparse.error(...)``
@@ -61,16 +74,12 @@ Pylint ships with three additional tools:
 - symilar_  (duplicate code finder that is also integrated in pylint)
 - epylint_ (Emacs and Flymake compatible Pylint)
 
-.. Enf of do not modify this without also modifying doc/index.rst
-
 .. _pyreverse: https://pylint.pycqa.org/en/latest/pyreverse.html
 .. _symilar: https://pylint.pycqa.org/en/latest/symilar.html
 .. _epylint: https://pylint.pycqa.org/en/latest/user_guide/ide_integration/flymake-emacs.html
 
 Install
 -------
-
-.. Do not modify anything here, modify doc/user_guide/installation.rst instead
 
 For command line use, pylint is installed with::
 
@@ -81,13 +90,6 @@ It can also be integrated in most editors or IDE. More information can be found
 
 .. _in the documentation: https://pylint.pycqa.org/en/latest/user_guide/installation.html
 
-Documentation
-=============
-
-Please check `the full documentation`_.
-
-.. _`the full documentation`: https://pylint.pycqa.org/
-
 Contributing
 ------------
 
@@ -95,12 +97,12 @@ We welcome all contributions, doc, code, checking issues for duplicate or tellin
 that we can close them, confirming that it's still an issue, `creating issues because
 you found a bug or want a feature`_... everything helps !
 
-Please follow the `code of conduct`_ and check `the contribution documentation`_ if you want to
+Please follow the `code of conduct`_ and check `the Contributor Guides`_ if you want to
 make a code contribution.
 
 .. _creating issues because you found a bug or want a feature: https://pylint.pycqa.org/en/latest/contact.html#bug-reports-feedback
 .. _code of conduct: https://github.com/Pierre-Sassoulas/pylint/blob/main/CODE_OF_CONDUCT.md
-.. _the contribution documentation: https://pylint.pycqa.org/en/latest/development_guide/contribute.html
+.. _the Contributor Guides: https://pylint.pycqa.org/en/latest/development_guide/contribute.html
 
 
 Show your usage
@@ -128,9 +130,13 @@ The icon files are licensed under the `CC BY-SA 4.0 <https://creativecommons.org
 Support
 -------
 
-Please check `the contact information`_ in the documentation.
+Please check `the contact information`_.
 
 .. _`the contact information`: https://pylint.pycqa.org/en/latest/contact.html
+
+.. |tideliftlogo| image:: https://raw.githubusercontent.com/PyCQA/pylint/main/doc/media/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White.png
+   :width: 200
+   :alt: Tidelift
 
 .. list-table::
    :widths: 10 100

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,11 @@
-
-README for Pylint - https://pylint.pycqa.org/
-=============================================
+Pylint
+======
 
 .. image:: https://github.com/PyCQA/pylint/actions/workflows/tests.yaml/badge.svg?branch=main
     :target: https://github.com/PyCQA/pylint/actions
 
 .. image:: https://coveralls.io/repos/github/PyCQA/pylint/badge.svg?branch=main
     :target: https://coveralls.io/github/PyCQA/pylint?branch=main
-
 
 .. image:: https://img.shields.io/pypi/v/pylint.svg
     :alt: Pypi Package version
@@ -40,32 +38,44 @@ README for Pylint - https://pylint.pycqa.org/
 
 .. _Tidelift Subscription: https://tidelift.com/subscription/pkg/pypi-pylint?utm_source=pypi-pylint&utm_medium=referral&utm_campaign=readme
 
+Documentation
+=============
 
-======
-Pylint
-======
+Please check `the full documentation`_.
 
-**It's not just a linter that annoys you!**
+.. _`the full documentation`: https://pylint.pycqa.org/
 
-Pylint is a Python static code analysis tool which looks for programming errors,
-helps enforcing a coding standard, sniffs for code smells and offers simple refactoring
-suggestions.
+What is pylint ?
+================
 
-It's highly configurable, having special pragmas to control its errors and warnings
-from within your code, as well as from an extensive configuration file.
-It is also possible to write your own plugins for adding your own checks or for
-extending pylint in one way or another.
+.. Do not modify this without also modifying doc/index.rst
 
-It's a free software distributed under the GNU General Public Licence unless
-otherwise specified.
+Pylint is a `static code analyser`_ for Python 2 or 3. The latest version supports Python
+3.7.2 and above.
 
-Development is hosted on GitHub: https://github.com/PyCQA/pylint/
+.. _`static code analyser`: https://en.wikipedia.org/wiki/Static_code_analysis
 
-You can use the code-quality@python.org mailing list to discuss about
-Pylint. Subscribe at https://mail.python.org/mailman/listinfo/code-quality/
-or read the archives at https://mail.python.org/pipermail/code-quality/
+Pylint analyses your code without actually running it. It checks for errors, enforces a coding
+standard, looks for `code smells`_, and can make suggestions about how the code could be refactored.
 
-Pull requests are amazing and most welcome.
+.. _`code smells`: https://martinfowler.com/bliki/CodeSmell.html
+
+Pylint can infer actual values from your code using its internal code representation (astroid).
+If your code is ``import logging as argparse``, Pylint will know that ``argparse.error(...)``
+is in fact a logging call and not an argparse call.
+
+Pylint isn't smarter than you: it may warn you about things that you have
+conscientiously done or checks for some things that you don't care about.
+During adoption, especially in a legacy project where pylint was never enforced,
+it's best to start with the ``--errors-only`` flag, then disable
+convention and refactor message with ``--disable=C,R`` and progressively
+re-evaluate and re-enable messages as your priorities evolve.
+
+Pylint ships with three additional tools:
+
+- :ref:`pyreverse <pyreverse>` (standalone tool that generates package and class diagrams.)
+- :ref:`symilar <symilar>`  (duplicate code finder that is also integrated in pylint)
+- :ref:`epylint <pylint_in_flymake>` (Emacs and Flymake compatible Pylint)
 
 Install
 -------
@@ -90,18 +100,6 @@ For debian and rpm packages, use your usual tools according to your Linux distri
 
 More information about installation and available distribution format
 can be found here_.
-
-Documentation
--------------
-
-The documentation lives at https://pylint.pycqa.org/.
-
-Pylint is shipped with following additional commands:
-
-* pyreverse: an UML diagram generator
-* symilar: an independent similarities checker
-* epylint: Emacs and Flymake compatible Pylint
-
 
 Testing
 -------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,6 +62,7 @@ redirects: dict[str, str] = {
     "messages/messages_list": "../user_guide/messages/messages_overview.html",
     "user_guide/message-control": "messages/message_control.html",
     "technical_reference/c_extensions": "../user_guide/c_extensions.html",
+    "development/testing": "tests/index.html",
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/development_guide/contribute.rst
+++ b/doc/development_guide/contribute.rst
@@ -4,8 +4,6 @@
  Contributing
 ==============
 
-Pull requests are amazing and most welcome !
-
 .. _repository:
 
 Repository

--- a/doc/development_guide/contribute.rst
+++ b/doc/development_guide/contribute.rst
@@ -4,6 +4,8 @@
  Contributing
 ==============
 
+Pull requests are amazing and most welcome !
+
 .. _repository:
 
 Repository

--- a/doc/development_guide/index.rst
+++ b/doc/development_guide/index.rst
@@ -1,4 +1,3 @@
-
 Development
 ===========
 
@@ -7,6 +6,6 @@ Development
    :titlesonly:
 
    contribute
-   testing
+   tests/index
    api/index
    profiling

--- a/doc/development_guide/tests/index.rst
+++ b/doc/development_guide/tests/index.rst
@@ -1,0 +1,18 @@
+.. _testing:
+
+=======
+Testing
+=======
+
+.. _test_your_code:
+
+Pylint is very well tested and has a high code coverage. New contributions are not accepted
+unless they include tests.
+
+.. toctree::
+   :maxdepth: 3
+   :titlesonly:
+
+   install
+   launching_test
+   writting_test

--- a/doc/development_guide/tests/install.rst
+++ b/doc/development_guide/tests/install.rst
@@ -1,0 +1,25 @@
+Installation
+============
+
+Before you start testing your code, you need to install your source-code package locally.
+Suppose you have cloned pylint into a directory, say ``my-pylint``.
+To set up your environment for testing, open a terminal and run::
+
+    cd my-pylint
+    pip install -r requirements_test_min.txt
+
+This ensures your testing environment is similar to Pylint's testing environment on GitHub.
+
+If you're testing new changes in astroid you need to clone astroid_ and install
+with an editable installation as follows::
+
+    git clone https://github.com/PyCQA/astroid.git
+    cd astroid
+    python3 -m pip install -e .
+
+If you want to check the coverage locally, consider using `pytest-cov`_::
+
+    python3 -m pip install pytest-cov
+
+.. _pytest-cov: https://pypi.org/project/pytest-cov/
+.. _astroid: https://github.com/pycqa/astroid

--- a/doc/development_guide/tests/launching_test.rst
+++ b/doc/development_guide/tests/launching_test.rst
@@ -1,0 +1,82 @@
+Launching tests
+===============
+
+pytest
+------
+
+Since we use pytest_ to run the tests, you can also use it on its own.
+We do recommend using the tox_ command though::
+
+    pytest pylint -k test_functional
+
+You can use pytest_ directly. If you want to run tests on a specific portion of the
+code with pytest_ and your local python version::
+
+    python3 -m pytest
+
+
+Everything in tests/message with coverage for the relevant code (require `pytest-cov`_)::
+
+    python3 -m pytest tests/message/ --cov=pylint.message
+    coverage html
+
+Only the functional test "missing_kwoa_py3"::
+
+    python3 -m pytest "tests/test_functional.py::test_functional[missing_kwoa_py3]"
+
+tox
+---
+
+You can also *optionally* install tox_ and run our tests using the tox_ package, as in::
+
+    python -m tox
+    python -m tox -epy38 # for Python 3.8 suite only
+    python -m tox -epylint # for running Pylint over Pylint's codebase
+    python -m tox -eformatting # for running formatting checks over Pylint's codebase
+
+It's usually a good idea to run tox_ with ``--recreate``. This flag tells tox_ to re-download
+all dependencies before running the tests. This can be important when a new version of
+astroid_ or any of the other dependencies has been published::
+
+    python -m tox --recreate # The entire tox environment will be recreated
+    python -m tox --recreate -e py310 # The python 3.10 tox environment will be recreated
+
+
+To run only a specific test suite, use a pattern for the test filename
+(**without** the ``.py`` extension), as in::
+
+    python -m tox -e py310 -- -k test_functional
+    python -m tox -e py310 -- -k  \*func\*
+    python -m tox --recreate -e py310 -- -k test_functional # With recreation of the environment
+
+
+.. _primer_tests:
+
+Primer tests
+------------
+
+Pylint also uses what we refer to as ``primer`` tests. These are tests that are run automatically
+in our Continuous Integration and check whether any changes in Pylint lead to crashes or fatal errors
+on the ``stdlib`` and a selection of external repositories.
+
+To run the ``primer`` tests you can add either ``--primer-stdlib`` or ``--primer-external`` to the
+pytest_ command. If you want to only run the ``primer`` you can add either of their marks, for example::
+
+    pytest -m primer_stdlib --primer-stdlib
+
+The external ``primer`` has been split up in two marks to speed up our Continuous Integration. You can run
+either of the two batches or run them both::
+
+    pytest -m primer_external_batch_one --primer-external # Runs batch one
+    pytest -m primer_external_batch_two --primer-external # Runs batch two
+    pytest -m "primer_external_batch_one or primer_external_batch_two" --primer-external # Runs both batches
+
+The list of repositories is created on the basis of three criteria: 1) projects need to use a diverse
+range of language features, 2) projects need to be well maintained and 3) projects should not have a codebase
+that is too repetitive. This guarantees a good balance between speed of our CI and finding potential bugs.
+
+You can find the latest list of repositories and any relevant code for these tests in the ``tests/primer``
+directory.
+
+.. _pytest-cov: https://pypi.org/project/pytest-cov/
+.. _astroid: https://github.com/pycqa/astroid

--- a/doc/development_guide/tests/writting_test.rst
+++ b/doc/development_guide/tests/writting_test.rst
@@ -1,65 +1,38 @@
-.. -*- coding: utf-8 -*-
-.. _testing:
+.. _writing_tests:
 
-==============
- Testing
-==============
+Writing tests
+=============
 
-.. _test_your_code:
+Pylint uses three types of tests: unittests, functional tests and primer tests.
 
-Test your code!
+- :ref:`unittests <writing_unittests>` can be found in ``pylint/tests``. Unless you're working on pylint's
+  internal you're probably not going to have to write any.
+- :ref:`Global functional tests <writing_functional_tests>`  can be found in the ``pylint/tests/functional``. They are
+  mainly used to test whether Pylint emits the correct messages.
+- :ref:`Configuration's functional tests <writing_config_functional_tests>`  can be found in the
+  ``pylint/tests/config/functional``. They are used to test Pylint's configuration loading.
+- :ref:`Primer tests <primer_tests>` you can suggest a new external repository to check but there's nothing to do
+  most of the time.
+
+.. _writing_unittests:
+
+Unittest tests
+--------------
+
+Most other tests reside in the '/pylint/test' directory. These unittests can be used to test
+almost all functionality within Pylint. A good step before writing any new unittests is to look
+at some tests that test a similar funcitionality. This can often help write new tests.
+
+If your new test requires any additional files you can put those in the
+``/pylint/test/regrtest_data`` directory. This is the directory we use to store any data needed for
+the unittests.
+
+
+
+.. _writing_functional_tests:
+
+Functional tests
 ----------------
-
-Pylint is very well tested and has a high code coverage. New contributions are not accepted
-unless they include tests.
-
-Before you start testing your code, you need to install your source-code package locally.
-Suppose you have cloned pylint into a directory, say ``my-pylint``.
-To set up your environment for testing, open a terminal and run:
-
-    cd my-pylint
-    pip install -r requirements_test_min.txt
-
-This ensures your testing environment is similar to Pylint's testing environment on GitHub.
-
-Pylint uses two types of tests: unittests and functional tests.
-
-  - The unittests can be found in the ``/pylint/test`` directory and they can
-    be used for testing almost anything Pylint related.
-
-  - The functional tests can be found in the ``/pylint/test/functional`` directory. They are
-    mainly used to test whether Pylint emits the correct messages.
-
-Before writing a new test it is often a good idea to ensure that your change isn't
-breaking a current test. You can run our tests using the tox_ package, as in::
-
-    python -m tox
-    python -m tox -epy38 # for Python 3.8 suite only
-    python -m tox -epylint # for running Pylint over Pylint's codebase
-    python -m tox -eformatting # for running formatting checks over Pylint's codebase
-
-It's usually a good idea to run tox_ with ``--recreate``. This flag tells tox_ to redownload
-all dependencies before running the tests. This can be important when a new version of
-astroid_ or any of the other dependencies has been published::
-
-    python -m tox --recreate # The entire tox environment will be recreated
-    python -m tox --recreate -e py310 # The python 3.10 tox environment will be recreated
-
-
-To run only a specific test suite, use a pattern for the test filename
-(**without** the ``.py`` extension), as in::
-
-    python -m tox -e py310 -- -k test_functional
-    python -m tox -e py310 -- -k  \*func\*
-    python -m tox --recreate -e py310 -- -k test_functional # With recreation of the environment
-
-Since we use pytest_ to run the tests, you can also use it on its own.
-We do recommend using the tox_ command though::
-
-    pytest pylint -k test_functional
-
-Writing functional tests
-------------------------
 
 These are residing under ``/pylint/test/functional`` and they are formed of multiple
 components. First, each Python file is considered to be a test case and it
@@ -123,20 +96,11 @@ on the the current output by appending ``--update-functional-output`` to the com
 
     python tests/test_functional.py --update-functional-output -k "test_functional[len_checks]"
 
-Writing unittest tests
-------------------------
 
-Most other tests reside in the '/pylint/test' directory. These unittests can be used to test
-almost all functionality within Pylint. A good step before writing any new unittests is to look
-at some tests that test a similar funcitionality. This can often help write new tests.
+.. _writing_config_functional_tests:
 
-If your new test requires any additional files you can put those in the
-``/pylint/test/regrtest_data`` directory. This is the directory we use to store any data needed for
-the unittests.
-
-
-Writing functional tests for configurations
--------------------------------------------
+Functional tests for configurations
+-----------------------------------
 
 To test the different ways to configure Pylint there is also a small functional test framework
 for configuration files. These tests can be found in the '/pylint/test/config' directory.
@@ -168,32 +132,8 @@ and should exit with exit code 2 the ``.out`` file should be named ``bad_configu
 The content of the ``.out`` file should have a similar pattern as a normal Pylint output. Note that the
 module name should be ``{abspath}`` and the file name ``{relpath}``.
 
-Primer tests
--------------------------------------------
-
-Pylint also uses what we refer to as ``primer`` tests. These are tests that are run automatically
-in our Continuous Integration and check whether any changes in Pylint lead to crashes or fatal errors
-on the ``stdlib`` and a selection of external repositories.
-
-To run the ``primer`` tests you can add either ``--primer-stdlib`` or ``--primer-external`` to the
-pytest_ command. If you want to only run the ``primer`` you can add either of their marks, for example::
-
-    pytest -m primer_stdlib --primer-stdlib
-
-The external ``primer`` has been split up in two marks to speed up our Continuous Integration. You can run
-either of the two batches or run them both::
-
-    pytest -m primer_external_batch_one --primer-external # Runs batch one
-    pytest -m primer_external_batch_two --primer-external # Runs batch two
-    pytest -m "primer_external_batch_one or primer_external_batch_two" --primer-external # Runs both batches
-
-The list of repositories is created on the basis of three criteria: 1) projects need to use a diverse
-range of language features, 2) projects need to be well maintained and 3) projects should not have a codebase
-that is too repetitive. This guarantees a good balance between speed of our CI and finding potential bugs.
-
-You can find the latest list of repositories and any relevant code for these tests in the ``tests/primer``
-directory.
 
 .. _tox: https://tox.wiki/en/latest/
 .. _pytest: https://docs.pytest.org/en/latest/
+.. _pytest-cov: https://pypi.org/project/pytest-cov/
 .. _astroid: https://github.com/pycqa/astroid

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,49 +1,5 @@
-Pylint documentation
-====================
 
-Pylint is a `static code analyser`_ for Python 2 or 3. The latest version supports Python
-3.7.2 and above.
-
-.. _`static code analyser`: https://en.wikipedia.org/wiki/Static_code_analysis
-
-Pylint analyses your code without actually running it. It checks for errors, enforces a coding
-standard, looks for `code smells`_, and can make suggestions about how the code could be refactored.
-
-.. _`code smells`: https://martinfowler.com/bliki/CodeSmell.html
-
-Projects that you might want to use alongside pylint include flake8_ (faster and simpler checks
-with very few false positives), mypy_, pyright_ or pyre_ (typing checks), bandit_ (security
-oriented checks), black_ and isort_ (auto-formatting), autoflake_ (automated removal of
-unused import or variable), pyupgrade_ (automated upgrade to newer python syntax) and
-pydocstringformatter_ (automated pep257).
-
-.. _flake8: https://gitlab.com/pycqa/flake8/
-.. _bandit: https://github.com/PyCQA/bandit
-.. _mypy: https://github.com/python/mypy
-.. _pyright: https://github.com/microsoft/pyright
-.. _pyre: https://github.com/facebook/pyre-check
-.. _black: https://github.com/psf/black
-.. _autoflake: https://github.com/myint/autoflake
-.. _pyupgrade: https://github.com/asottile/pyupgrade
-.. _pydocstringformatter: https://github.com/DanielNoord/pydocstringformatter
-.. _isort: https://pycqa.github.io/isort/
-
-Pylint can infer actual values from your code using its internal code representation (astroid).
-If your code is ``import logging as argparse``, Pylint will know that ``argparse.error(...)``
-is in fact a logging call and not an argparse call.
-
-Pylint isn't smarter than you: it may warn you about things that you have
-conscientiously done or checks for some things that you don't care about.
-During adoption, especially in a legacy project where pylint was never enforced,
-it's best to start with the ``--errors-only`` flag, then disable
-convention and refactor message with ``--disable=C,R`` and progressively
-re-evaluate and re-enable messages as your priorities evolve.
-
-Pylint ships with three additional tools:
-
-- :ref:`pyreverse <pyreverse>` (standalone tool that generates package and class diagrams.)
-- :ref:`symilar <symilar>`  (duplicate code finder that is also integrated in pylint)
-- :ref:`epylint <pylint_in_flymake>` (Emacs and Flymake compatible Pylint)
+.. include:: ../README.rst
 
 .. toctree::
    :titlesonly:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,8 +4,12 @@ Pylint documentation
 Pylint is a `static code analyser`_ for Python 2 or 3. The latest version supports Python
 3.7.2 and above.
 
+.. _`static code analyser`: https://en.wikipedia.org/wiki/Static_code_analysis
+
 Pylint analyses your code without actually running it. It checks for errors, enforces a coding
 standard, looks for `code smells`_, and can make suggestions about how the code could be refactored.
+
+.. _`code smells`: https://martinfowler.com/bliki/CodeSmell.html
 
 Projects that you might want to use alongside pylint include flake8_ (faster and simpler checks
 with very few false positives), mypy_, pyright_ or pyre_ (typing checks), bandit_ (security
@@ -23,8 +27,6 @@ pydocstringformatter_ (automated pep257).
 .. _pyupgrade: https://github.com/asottile/pyupgrade
 .. _pydocstringformatter: https://github.com/DanielNoord/pydocstringformatter
 .. _isort: https://pycqa.github.io/isort/
-.. _`static code analyser`: https://en.wikipedia.org/wiki/Static_code_analysis
-.. _`code smells`: https://martinfowler.com/bliki/CodeSmell.html
 
 Pylint can infer actual values from your code using its internal code representation (astroid).
 If your code is ``import logging as argparse``, Pylint will know that ``argparse.error(...)``
@@ -37,11 +39,11 @@ it's best to start with the ``--errors-only`` flag, then disable
 convention and refactor message with ``--disable=C,R`` and progressively
 re-evaluate and re-enable messages as your priorities evolve.
 
-
-Pylint ships with two additional tools:
+Pylint ships with three additional tools:
 
 - :ref:`pyreverse <pyreverse>` (standalone tool that generates package and class diagrams.)
 - :ref:`symilar <symilar>`  (duplicate code finder that is also integrated in pylint)
+- :ref:`epylint <pylint_in_flymake>` (Emacs and Flymake compatible Pylint)
 
 .. toctree::
    :titlesonly:

--- a/doc/user_guide/badge.rst
+++ b/doc/user_guide/badge.rst
@@ -1,0 +1,25 @@
+
+.. _badge:
+
+Show your usage
+---------------
+
+You can place this badge in your README to let others know your project uses pylint.
+
+    .. image:: https://img.shields.io/badge/linting-pylint-yellowgreen
+        :target: https://github.com/PyCQA/pylint
+
+Use the badge in your project's README.md (or any other Markdown file)::
+
+    [![linting: pylint](https://img.shields.io/badge/linting-pylint-yellowgreen)](https://github.com/PyCQA/pylint)
+
+Use the badge in your project's README.rst (or any other rst file)::
+
+    .. image:: https://img.shields.io/badge/linting-pylint-yellowgreen
+        :target: https://github.com/PyCQA/pylint
+
+
+If you use GitHub Actions, and one of your CI workflows begins with "name: pylint", you
+can use GitHub's `workflow status badges <https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name>`_
+to show an up-to-date indication of whether pushes to your default branch pass pylint.
+For more detailed information, check the documentation.

--- a/doc/user_guide/index.rst
+++ b/doc/user_guide/index.rst
@@ -8,7 +8,7 @@ User Guide
 
    installation
    run
-   output  
+   output
    c_extensions
    messages/index
    options

--- a/doc/user_guide/index.rst
+++ b/doc/user_guide/index.rst
@@ -14,3 +14,4 @@ User Guide
    options
    ide_integration/ide-integration
    pre-commit-integration
+   badge


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

This duplicate only what is strictly necessary in the readme.rst and factorize the remainder and reorganize the testing documentation that was duplicated and contradictory between readme/doc.
