### PR TITLE
[doc] Move the c-extensions documentation to no-member doc

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -61,7 +61,7 @@ redirects: dict[str, str] = {
     "messages/messages_introduction": "../user_guide/messages/index.html",
     "messages/messages_list": "../user_guide/messages/messages_overview.html",
     "user_guide/message-control": "messages/message_control.html",
-    "technical_reference/c_extensions": "../user_guide/c_extensions.html",
+    "technical_reference/c_extensions": "../user_guide/messages/error/no-member.html",
     "development/testing": "tests/index.html",
 }
 

--- a/doc/data/messages/n/no-member/bad.py
+++ b/doc/data/messages/n/no-member/bad.py
@@ -1,3 +1,11 @@
 from pathlib import Path
 
 directories = Path(".").mothers  # [no-member]
+
+
+class Cat:
+    def meow(self):
+        print("Meow")
+
+
+Cat().roar()  # [no-member]

--- a/doc/data/messages/n/no-member/bad.py
+++ b/doc/data/messages/n/no-member/bad.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+directories = Path(".").mothers  # [no-member]

--- a/doc/data/messages/n/no-member/details.rst
+++ b/doc/data/messages/n/no-member/details.rst
@@ -1,16 +1,16 @@
-If you are getting the dreaded **no-member** error, there is a possibility that
+If you are getting the dreaded ``no-member`` error, there is a possibility that
 either:
 
 - pylint found a bug in your code
-- You're launching pylint without the dependencies installed in your environment.
+- You're launching pylint without the dependencies installed in its environment.
 - pylint would need to lint a C extension module and is refraining to do so.
 
 Linting C extension modules is not supported out of the box, especially since
 pylint has no way to get an AST object out of the extension module.
 
-But **pylint** actually has a mechanism which you might use in case you
-want to analyze C extensions. **pylint** has a flag, called **extension-pkg-allow-list**
-(formerly **extension-pkg-whitelist**), through which you can tell it to
+But pylint actually has a mechanism which you might use in case you
+want to analyze C extensions. Pylint has a flag, called ``extension-pkg-allow-list``
+(formerly ``extension-pkg-whitelist``), through which you can tell it to
 import that module and to build an AST from that imported module::
 
    $ pylint --extension-pkg-allow-list=your_c_extension
@@ -19,11 +19,11 @@ Be aware though that using this flag means that extensions are loaded into the
 active Python interpreter and may run arbitrary code, which you may not want. This
 is the reason why we disable by default loading C extensions. In case you do not want
 the hassle of passing C extensions module with this flag all the time, you
-can enable **unsafe-load-any-extension** in your configuration file, which will
-build AST objects from all the C extensions that **pylint** encounters::
+can enable ``unsafe-load-any-extension`` in your configuration file, which will
+build AST objects from all the C extensions that pylint encounters::
 
    $ pylint --unsafe-load-any-extension=y
 
-Alternatively, since **pylint** emits a separate error for attributes that cannot be
-found in C extensions, **c-extension-no-member**, you can disable this error for
+Alternatively, since pylint emits a separate error for attributes that cannot be
+found in C extensions, ``c-extension-no-member``, you can disable this error for
 your project.

--- a/doc/data/messages/n/no-member/details.rst
+++ b/doc/data/messages/n/no-member/details.rst
@@ -1,9 +1,9 @@
-Pylint and C extensions
-=======================
-
 If you are getting the dreaded **no-member** error, there is a possibility that
-either **pylint** found a bug in your code or that it actually tries to lint
-a C extension module.
+either:
+
+- pylint found a bug in your code
+- You're launching pylint without the dependencies installed in your environment.
+- pylint would need to lint a C extension module and is refraining to do so.
 
 Linting C extension modules is not supported out of the box, especially since
 pylint has no way to get an AST object out of the extension module.

--- a/doc/data/messages/n/no-member/good.py
+++ b/doc/data/messages/n/no-member/good.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+directories = Path(".").parents

--- a/doc/data/messages/n/no-member/good.py
+++ b/doc/data/messages/n/no-member/good.py
@@ -1,3 +1,11 @@
 from pathlib import Path
 
 directories = Path(".").parents
+
+
+class Cat:
+    def meow(self):
+        print("Meow")
+
+
+Cat().meow()

--- a/doc/user_guide/index.rst
+++ b/doc/user_guide/index.rst
@@ -9,7 +9,6 @@ User Guide
    installation
    run
    output
-   c_extensions
    messages/index
    options
    ide_integration/ide-integration


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

When the original documentation was created the full list of message did not exists, so this piece of documentation was always a little out of place.
