### PR TITLE
[doc] Move the naming-style documentation to invalid-name doc

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,6 +62,7 @@ redirects: dict[str, str] = {
     "messages/messages_list": "../user_guide/messages/messages_overview.html",
     "user_guide/message-control": "messages/message_control.html",
     "technical_reference/c_extensions": "../user_guide/messages/error/no-member.html",
+    "user_guide/configuration/naming-styles": "../user_guide/messages/convention/invalid-name.html",
     "development/testing": "tests/index.html",
 }
 

--- a/doc/data/messages/i/invalid-name/bad.py
+++ b/doc/data/messages/i/invalid-name/bad.py
@@ -1,0 +1,8 @@
+class cat:  # [invalid-name]
+
+    def Meow(self, NUMBER_OF_MEOW):  # [invalid-name, invalid-name]
+        print("Meow" * NUMBER_OF_MEOW)
+        return NUMBER_OF_MEOW
+
+
+Cat = cat().Meow(42)  # [invalid-name]

--- a/doc/data/messages/i/invalid-name/details.rst
+++ b/doc/data/messages/i/invalid-name/details.rst
@@ -1,12 +1,3 @@
-.. -*- coding: utf-8 -*-
-
-===============
- Naming styles
-===============
-
-Introduction
-~~~~~~~~~~~~
-
 Pylint recognizes a number of different name types internally. With a few
 exceptions, the type of the name is governed by the location the assignment to a
 name is found in, and not the type of object assigned.

--- a/doc/data/messages/i/invalid-name/good.py
+++ b/doc/data/messages/i/invalid-name/good.py
@@ -1,0 +1,8 @@
+class Cat:
+
+    def meow(self, number_of_meow):
+        print("Meow" * number_of_meow)
+        return number_of_meow
+
+
+CAT = Cat().meow(42)

--- a/doc/user_guide/options.rst
+++ b/doc/user_guide/options.rst
@@ -7,4 +7,3 @@ Configuration
    :titlesonly:
 
    configuration/all-options
-   configuration/naming-styles


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

Same reasoning than for #6659. This is the most searched message in the documentation too, by far with double the hit of other messages, see https://github.com/PyCQA/pylint/issues/5953#issuecomment-1134172901.
