### PR TITLE
Add support of sharing message in multiple checkers. Fix DeprecatedChecker example

### DIFF
--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -260,8 +260,7 @@ def _write_single_shared_message_page(
     category_dir: Path, messages: List[MessageData]
 ) -> None:
     message = messages[0]
-    messages_file = os.path.join(category_dir, f"{message.name}.rst")
-    with open(messages_file, "w", encoding="utf-8") as stream:
+    with open(category_dir / f"{message.name}.rst", "w", encoding="utf-8") as stream:
         stream.write(_generate_single_message_body(message))
         checker_urls = ", ".join(
             [
@@ -273,8 +272,7 @@ def _write_single_shared_message_page(
 
 
 def _write_single_message_page(category_dir: Path, message: MessageData) -> None:
-    messages_file = os.path.join(category_dir, f"{message.name}.rst")
-    with open(messages_file, "w", encoding="utf-8") as stream:
+    with open(category_dir / f"{message.name}.rst", "w", encoding="utf-8") as stream:
         stream.write(_generate_single_message_body(message))
         checker_url = _generate_checker_url(message)
         stream.write(f"Created by the `{message.checker} <{checker_url}>`__ checker.")

--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -135,11 +135,6 @@ def _get_all_messages(
         ((checker, msg) for msg in checker.messages)
         for checker in linter.get_checkers()
     )
-    shared_msg_ids = set(
-        chain.from_iterable(
-            [checker.shared_message_ids for checker in linter.get_checkers()]
-        )
-    )
 
     for checker, message in checker_message_mapping:
         message_data_path = (
@@ -164,7 +159,7 @@ def _get_all_messages(
             related,
             checker_module.__name__,
             checker_module.__file__,
-            message.msgid in shared_msg_ids,
+            message.shared,
         )
         msg_type = MSG_TYPES_DOC[message.msgid[0]]
         messages_dict[msg_type].append(message_data)

--- a/examples/deprecation_checker.py
+++ b/examples/deprecation_checker.py
@@ -43,7 +43,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from pylint.checkers import BaseChecker, DeprecatedMixin
-from pylint.checkers.deprecated import DEPRECATED_MSGS
 
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
@@ -59,7 +58,7 @@ class DeprecationChecker(DeprecatedMixin, BaseChecker):
 
     # The name defines a custom section of the config for this checker.
     name = "deprecated"
-    msgs = DEPRECATED_MSGS
+    msgs = DeprecatedMixin.DEPRECATED_MSGS
 
     def deprecated_methods(self) -> set[str]:
         """Callback method called by DeprecatedMixin for every method/function found in the code.

--- a/examples/deprecation_checker.py
+++ b/examples/deprecation_checker.py
@@ -44,11 +44,6 @@ from typing import TYPE_CHECKING
 
 from pylint.checkers import BaseChecker, DeprecatedMixin
 
-from pylint.checkers.deprecated import (
-    DEPRECATED_ARGUMENT_MESSAGE,
-    DEPRECATED_METHOD_MESSAGE,
-)
-
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
@@ -56,7 +51,7 @@ if TYPE_CHECKING:
 class DeprecationChecker(DeprecatedMixin, BaseChecker):
     """Class implementing deprecation checker."""
 
-    # DeprecationMixin class is Mixin class implementing logic for searching deprecated methods and functions.
+    # DeprecatedMixin class is Mixin class implementing logic for searching deprecated methods and functions.
     # The list of deprecated methods/functions is defined by implementing class via deprecated_methods callback.
     # DeprecatedMixin class is overriding attributes of BaseChecker hence must be specified *before* BaseChecker
     # in list of base classes.
@@ -65,7 +60,10 @@ class DeprecationChecker(DeprecatedMixin, BaseChecker):
     name = "deprecated"
 
     # Register messages emitted by the checker.
-    msgs = {**DEPRECATED_METHOD_MESSAGE, **DEPRECATED_ARGUMENT_MESSAGE}
+    msgs = {
+        **DeprecatedMixin.DEPRECATED_METHOD_MESSAGE,
+        **DeprecatedMixin.DEPRECATED_ARGUMENT_MESSAGE,
+    }
 
     def deprecated_methods(self) -> set[str]:
         """Callback method called by DeprecatedMixin for every method/function found in the code.

--- a/examples/deprecation_checker.py
+++ b/examples/deprecation_checker.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from pylint.checkers import BaseChecker, DeprecatedMixin
+from pylint.checkers.deprecated import DEPRECATED_MSGS
 
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
@@ -58,6 +59,7 @@ class DeprecationChecker(DeprecatedMixin, BaseChecker):
 
     # The name defines a custom section of the config for this checker.
     name = "deprecated"
+    msgs = DEPRECATED_MSGS
 
     def deprecated_methods(self) -> set[str]:
         """Callback method called by DeprecatedMixin for every method/function found in the code.

--- a/examples/deprecation_checker.py
+++ b/examples/deprecation_checker.py
@@ -44,6 +44,11 @@ from typing import TYPE_CHECKING
 
 from pylint.checkers import BaseChecker, DeprecatedMixin
 
+from pylint.checkers.deprecated import (
+    DEPRECATED_ARGUMENT_MESSAGE,
+    DEPRECATED_METHOD_MESSAGE,
+)
+
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
@@ -58,6 +63,9 @@ class DeprecationChecker(DeprecatedMixin, BaseChecker):
 
     # The name defines a custom section of the config for this checker.
     name = "deprecated"
+
+    # Register messages emitted by the checker.
+    msgs = {**DEPRECATED_METHOD_MESSAGE, **DEPRECATED_ARGUMENT_MESSAGE}
 
     def deprecated_methods(self) -> set[str]:
         """Callback method called by DeprecatedMixin for every method/function found in the code.

--- a/examples/deprecation_checker.py
+++ b/examples/deprecation_checker.py
@@ -58,7 +58,6 @@ class DeprecationChecker(DeprecatedMixin, BaseChecker):
 
     # The name defines a custom section of the config for this checker.
     name = "deprecated"
-    msgs = DeprecatedMixin.DEPRECATED_MSGS
 
     def deprecated_methods(self) -> set[str]:
         """Callback method called by DeprecatedMixin for every method/function found in the code.

--- a/examples/deprecation_checker.py
+++ b/examples/deprecation_checker.py
@@ -52,7 +52,7 @@ class DeprecationChecker(DeprecatedMixin, BaseChecker):
     """Class implementing deprecation checker."""
 
     # DeprecatedMixin class is Mixin class implementing logic for searching deprecated methods and functions.
-    # The list of deprecated methods/functions is defined by implementing class via deprecated_methods callback.
+    # The list of deprecated methods/functions is defined by the implementing class via deprecated_methods callback.
     # DeprecatedMixin class is overriding attributes of BaseChecker hence must be specified *before* BaseChecker
     # in list of base classes.
 

--- a/pylint/checkers/__init__.py
+++ b/pylint/checkers/__init__.py
@@ -50,7 +50,14 @@ from pylint.checkers.base_checker import (
     BaseRawFileChecker,
     BaseTokenChecker,
 )
-from pylint.checkers.deprecated import DeprecatedMixin
+from pylint.checkers.deprecated import (
+    DeprecatedMixin,
+    DEPRECATED_MODULE_MESSAGE,
+    DEPRECATED_METHOD_MESSAGE,
+    DEPRECATED_ARGUMENT_MESSAGE,
+    DEPRECATED_CLASS_MESSAGE,
+    DEPRECATED_DECORATOR_MESSAGE,
+)
 from pylint.checkers.mapreduce_checker import MapReduceMixin
 from pylint.utils import LinterStats, diff_string, register_plugins
 

--- a/pylint/checkers/__init__.py
+++ b/pylint/checkers/__init__.py
@@ -50,14 +50,7 @@ from pylint.checkers.base_checker import (
     BaseRawFileChecker,
     BaseTokenChecker,
 )
-from pylint.checkers.deprecated import (
-    DeprecatedMixin,
-    DEPRECATED_MODULE_MESSAGE,
-    DEPRECATED_METHOD_MESSAGE,
-    DEPRECATED_ARGUMENT_MESSAGE,
-    DEPRECATED_CLASS_MESSAGE,
-    DEPRECATED_DECORATOR_MESSAGE,
-)
+from pylint.checkers.deprecated import DeprecatedMixin
 from pylint.checkers.mapreduce_checker import MapReduceMixin
 from pylint.utils import LinterStats, diff_string, register_plugins
 

--- a/pylint/checkers/__init__.py
+++ b/pylint/checkers/__init__.py
@@ -50,7 +50,14 @@ from pylint.checkers.base_checker import (
     BaseRawFileChecker,
     BaseTokenChecker,
 )
-from pylint.checkers.deprecated import DeprecatedMixin
+from pylint.checkers.deprecated import (
+    DEPRECATED_ARGUMENT_MESSAGE,
+    DEPRECATED_CLASS_MESSAGE,
+    DEPRECATED_DECORATOR_MESSAGE,
+    DEPRECATED_METHOD_MESSAGE,
+    DEPRECATED_MODULE_MESSAGE,
+    DeprecatedMixin,
+)
 from pylint.checkers.mapreduce_checker import MapReduceMixin
 from pylint.utils import LinterStats, diff_string, register_plugins
 

--- a/pylint/checkers/__init__.py
+++ b/pylint/checkers/__init__.py
@@ -50,14 +50,7 @@ from pylint.checkers.base_checker import (
     BaseRawFileChecker,
     BaseTokenChecker,
 )
-from pylint.checkers.deprecated import (
-    DEPRECATED_ARGUMENT_MESSAGE,
-    DEPRECATED_CLASS_MESSAGE,
-    DEPRECATED_DECORATOR_MESSAGE,
-    DEPRECATED_METHOD_MESSAGE,
-    DEPRECATED_MODULE_MESSAGE,
-    DeprecatedMixin,
-)
+from pylint.checkers.deprecated import DeprecatedMixin
 from pylint.checkers.mapreduce_checker import MapReduceMixin
 from pylint.utils import LinterStats, diff_string, register_plugins
 

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -47,7 +47,7 @@ class BaseChecker(_ArgumentsProvider):
     enabled: bool = True
     # Set of messages allowed to be reused in multiple checkers.
     # Hence, the Message ID does not need to match Checker ID.
-    shared_message_ids: set[str] = {}
+    shared_message_ids: set[str] = set()
 
     def __init__(self, linter: PyLinter) -> None:
         """Checker instances should have the linter as argument."""

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -45,9 +45,6 @@ class BaseChecker(_ArgumentsProvider):
     reports: tuple[tuple[str, str, ReportsCallable], ...] = ()
     # mark this checker as enabled or not.
     enabled: bool = True
-    # Set of messages allowed to be reused in multiple checkers.
-    # Hence, the Message ID does not need to match Checker ID.
-    shared_message_ids: set[str] = set()
 
     def __init__(self, linter: PyLinter) -> None:
         """Checker instances should have the linter as argument."""
@@ -177,7 +174,7 @@ class BaseChecker(_ArgumentsProvider):
         checker_id = None
         existing_ids = []
         for message in self.messages:
-            if message.msgid in self.shared_message_ids:
+            if message.shared:
                 continue
             if checker_id is not None and checker_id != message.msgid[1:3]:
                 error_msg = "Inconsistent checker part in message id "
@@ -222,7 +219,7 @@ class BaseChecker(_ArgumentsProvider):
 """
             raise InvalidMessageError(error_msg)
         options.setdefault("scope", default_scope)
-        return MessageDefinition(self, msgid, msg, descr, symbol, **options)
+        return MessageDefinition(self, msgid, msg, descr, symbol, options)
 
     @property
     def messages(self) -> list[MessageDefinition]:

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -45,6 +45,9 @@ class BaseChecker(_ArgumentsProvider):
     reports: tuple[tuple[str, str, ReportsCallable], ...] = ()
     # mark this checker as enabled or not.
     enabled: bool = True
+    # Set of messages allowed to be reused in multiple checkers.
+    # Hence, the Message ID does not need to match Checker ID.
+    shared_message_ids: set[str] = {}
 
     def __init__(self, linter: PyLinter) -> None:
         """Checker instances should have the linter as argument."""
@@ -174,6 +177,8 @@ class BaseChecker(_ArgumentsProvider):
         checker_id = None
         existing_ids = []
         for message in self.messages:
+            if message.msgid in self.shared_message_ids:
+                continue
             if checker_id is not None and checker_id != message.msgid[1:3]:
                 error_msg = "Inconsistent checker part in message id "
                 error_msg += f"'{message.msgid}' (expected 'x{checker_id}xx' "

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -219,7 +219,7 @@ class BaseChecker(_ArgumentsProvider):
 """
             raise InvalidMessageError(error_msg)
         options.setdefault("scope", default_scope)
-        return MessageDefinition(self, msgid, msg, descr, symbol, options)
+        return MessageDefinition(self, msgid, msg, descr, symbol, **options)
 
     @property
     def messages(self) -> list[MessageDefinition]:

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -174,6 +174,8 @@ class BaseChecker(_ArgumentsProvider):
         checker_id = None
         existing_ids = []
         for message in self.messages:
+            # Id's for shared messages such as the 'deprecated-*' messages
+            # can be inconsistent with their checker id.
             if message.shared:
                 continue
             if checker_id is not None and checker_id != message.msgid[1:3]:

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -52,6 +52,7 @@ MSGS: dict[str, MessageDefinitionTuple] = {
     ),
 }
 
+
 class DeprecatedMixin(BaseChecker):
 
     shared_message_ids: set[str] = set(MSGS.keys())

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -55,6 +55,7 @@ DEPRECATED_IMPORT_MSGS: dict[str, MessageDefinitionTuple] = {
     ),
 }
 
+
 class DeprecatedMixin(BaseChecker):
     """A mixin implementing logic for checking deprecated symbols.
 

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -24,39 +24,39 @@ ACCEPTABLE_NODES = (
     nodes.ClassDef,
 )
 
+MSGS: dict[str, MessageDefinitionTuple] = {
+    "W0402": (
+        "Deprecated module %r",
+        "deprecated-module",
+        "A module marked as deprecated is imported.",
+    ),
+    "W1505": (
+        "Using deprecated method %s()",
+        "deprecated-method",
+        "The method is marked as deprecated and will be removed in the future.",
+    ),
+    "W1511": (
+        "Using deprecated argument %s of method %s()",
+        "deprecated-argument",
+        "The argument is marked as deprecated and will be removed in the future.",
+    ),
+    "W1512": (
+        "Using deprecated class %s of module %s",
+        "deprecated-class",
+        "The class is marked as deprecated and will be removed in the future.",
+    ),
+    "W1513": (
+        "Using deprecated decorator %s()",
+        "deprecated-decorator",
+        "The decorator is marked as deprecated and will be removed in the future.",
+    ),
+}
 
 class DeprecatedMixin(BaseChecker):
 
-    DEPRECATED_IMPORT_MSGS: dict[str, MessageDefinitionTuple] = {
-        "W0402": (
-            "Deprecated module %r",
-            "deprecated-module",
-            "A module marked as deprecated is imported.",
-        ),
-    }
+    shared_message_ids: set[str] = set(MSGS.keys())
 
-    DEPRECATED_MSGS: dict[str, MessageDefinitionTuple] = {
-        "W1505": (
-            "Using deprecated method %s()",
-            "deprecated-method",
-            "The method is marked as deprecated and will be removed in the future.",
-        ),
-        "W1511": (
-            "Using deprecated argument %s of method %s()",
-            "deprecated-argument",
-            "The argument is marked as deprecated and will be removed in the future.",
-        ),
-        "W1512": (
-            "Using deprecated class %s of module %s",
-            "deprecated-class",
-            "The class is marked as deprecated and will be removed in the future.",
-        ),
-        "W1513": (
-            "Using deprecated decorator %s()",
-            "deprecated-decorator",
-            "The decorator is marked as deprecated and will be removed in the future.",
-        ),
-    }
+    msgs: dict[str, MessageDefinitionTuple] = MSGS
 
     """A mixin implementing logic for checking deprecated symbols.
 

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -25,30 +25,35 @@ ACCEPTABLE_NODES = (
 )
 
 MSGS: dict[str, MessageDefinitionTuple] = {
-    "W0402": (
+    "W4901": (
         "Deprecated module %r",
         "deprecated-module",
         "A module marked as deprecated is imported.",
+        {"old_names": [("W0402", "old-deprecated-module")]},
     ),
-    "W1505": (
+    "W4902": (
         "Using deprecated method %s()",
         "deprecated-method",
         "The method is marked as deprecated and will be removed in the future.",
+        {"old_names": [("W1505", "old-deprecated-method")]},
     ),
-    "W1511": (
+    "W4903": (
         "Using deprecated argument %s of method %s()",
         "deprecated-argument",
         "The argument is marked as deprecated and will be removed in the future.",
+        {"old_names": [("W1511", "old-deprecated-argument")]},
     ),
-    "W1512": (
+    "W4904": (
         "Using deprecated class %s of module %s",
         "deprecated-class",
         "The class is marked as deprecated and will be removed in the future.",
+        {"old_names": [("W1512", "old-deprecated-class")]},
     ),
-    "W1513": (
+    "W4905": (
         "Using deprecated decorator %s()",
         "deprecated-decorator",
         "The decorator is marked as deprecated and will be removed in the future.",
+        {"old_names": [("W1513", "old-deprecated-decorator")]},
     ),
 }
 

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -24,39 +24,40 @@ ACCEPTABLE_NODES = (
     nodes.ClassDef,
 )
 
-DEPRECATED_MSGS: dict[str, MessageDefinitionTuple] = {
-    "W1505": (
-        "Using deprecated method %s()",
-        "deprecated-method",
-        "The method is marked as deprecated and will be removed in the future.",
-    ),
-    "W1511": (
-        "Using deprecated argument %s of method %s()",
-        "deprecated-argument",
-        "The argument is marked as deprecated and will be removed in the future.",
-    ),
-    "W1512": (
-        "Using deprecated class %s of module %s",
-        "deprecated-class",
-        "The class is marked as deprecated and will be removed in the future.",
-    ),
-    "W1513": (
-        "Using deprecated decorator %s()",
-        "deprecated-decorator",
-        "The decorator is marked as deprecated and will be removed in the future.",
-    ),
-}
-
-DEPRECATED_IMPORT_MSGS: dict[str, MessageDefinitionTuple] = {
-    "W0402": (
-        "Deprecated module %r",
-        "deprecated-module",
-        "A module marked as deprecated is imported.",
-    ),
-}
-
-
 class DeprecatedMixin(BaseChecker):
+
+    DEPRECATED_IMPORT_MSGS: dict[str, MessageDefinitionTuple] = {
+        "W0402": (
+            "Deprecated module %r",
+            "deprecated-module",
+            "A module marked as deprecated is imported.",
+        ),
+    }
+
+    DEPRECATED_MSGS: dict[str, MessageDefinitionTuple] = {
+        "W1505": (
+            "Using deprecated method %s()",
+            "deprecated-method",
+            "The method is marked as deprecated and will be removed in the future.",
+        ),
+        "W1511": (
+            "Using deprecated argument %s of method %s()",
+            "deprecated-argument",
+            "The argument is marked as deprecated and will be removed in the future.",
+        ),
+        "W1512": (
+            "Using deprecated class %s of module %s",
+            "deprecated-class",
+            "The class is marked as deprecated and will be removed in the future.",
+        ),
+        "W1513": (
+            "Using deprecated decorator %s()",
+            "deprecated-decorator",
+            "The decorator is marked as deprecated and will be removed in the future.",
+        ),
+    }
+
+
     """A mixin implementing logic for checking deprecated symbols.
 
     A class implementing mixin must define "deprecated-method" Message.

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -24,57 +24,57 @@ ACCEPTABLE_NODES = (
     nodes.ClassDef,
 )
 
-DEPRECATED_MODULE_MESSAGE: dict[str, MessageDefinitionTuple] = {
-    "W4901": (
-        "Deprecated module %r",
-        "deprecated-module",
-        "A module marked as deprecated is imported.",
-        {"old_names": [("W0402", "old-deprecated-module")], "shared": True},
-    ),
-}
-
-DEPRECATED_METHOD_MESSAGE: dict[str, MessageDefinitionTuple] = {
-    "W4902": (
-        "Using deprecated method %s()",
-        "deprecated-method",
-        "The method is marked as deprecated and will be removed in the future.",
-        {"old_names": [("W1505", "old-deprecated-method")], "shared": True},
-    ),
-}
-
-DEPRECATED_ARGUMENT_MESSAGE: dict[str, MessageDefinitionTuple] = {
-    "W4903": (
-        "Using deprecated argument %s of method %s()",
-        "deprecated-argument",
-        "The argument is marked as deprecated and will be removed in the future.",
-        {"old_names": [("W1511", "old-deprecated-argument")], "shared": True},
-    ),
-}
-
-DEPRECATED_CLASS_MESSAGE: dict[str, MessageDefinitionTuple] = {
-    "W4904": (
-        "Using deprecated class %s of module %s",
-        "deprecated-class",
-        "The class is marked as deprecated and will be removed in the future.",
-        {"old_names": [("W1512", "old-deprecated-class")], "shared": True},
-    ),
-}
-
-DEPRECATED_DECORATOR_MESSAGE: dict[str, MessageDefinitionTuple] = {
-    "W4905": (
-        "Using deprecated decorator %s()",
-        "deprecated-decorator",
-        "The decorator is marked as deprecated and will be removed in the future.",
-        {"old_names": [("W1513", "old-deprecated-decorator")], "shared": True},
-    ),
-}
-
 
 class DeprecatedMixin(BaseChecker):
     """A mixin implementing logic for checking deprecated symbols.
 
     A class implementing mixin must define "deprecated-method" Message.
     """
+
+    DEPRECATED_MODULE_MESSAGE: dict[str, MessageDefinitionTuple] = {
+        "W4901": (
+            "Deprecated module %r",
+            "deprecated-module",
+            "A module marked as deprecated is imported.",
+            {"old_names": [("W0402", "old-deprecated-module")], "shared": True},
+        ),
+    }
+
+    DEPRECATED_METHOD_MESSAGE: dict[str, MessageDefinitionTuple] = {
+        "W4902": (
+            "Using deprecated method %s()",
+            "deprecated-method",
+            "The method is marked as deprecated and will be removed in the future.",
+            {"old_names": [("W1505", "old-deprecated-method")], "shared": True},
+        ),
+    }
+
+    DEPRECATED_ARGUMENT_MESSAGE: dict[str, MessageDefinitionTuple] = {
+        "W4903": (
+            "Using deprecated argument %s of method %s()",
+            "deprecated-argument",
+            "The argument is marked as deprecated and will be removed in the future.",
+            {"old_names": [("W1511", "old-deprecated-argument")], "shared": True},
+        ),
+    }
+
+    DEPRECATED_CLASS_MESSAGE: dict[str, MessageDefinitionTuple] = {
+        "W4904": (
+            "Using deprecated class %s of module %s",
+            "deprecated-class",
+            "The class is marked as deprecated and will be removed in the future.",
+            {"old_names": [("W1512", "old-deprecated-class")], "shared": True},
+        ),
+    }
+
+    DEPRECATED_DECORATOR_MESSAGE: dict[str, MessageDefinitionTuple] = {
+        "W4905": (
+            "Using deprecated decorator %s()",
+            "deprecated-decorator",
+            "The decorator is marked as deprecated and will be removed in the future.",
+            {"old_names": [("W1513", "old-deprecated-decorator")], "shared": True},
+        ),
+    }
 
     @utils.only_required_for_messages(
         "deprecated-method",

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -24,32 +24,43 @@ ACCEPTABLE_NODES = (
     nodes.ClassDef,
 )
 
-# pylint: disable-next=consider-using-namedtuple-or-dataclass
-MSGS: dict[str, MessageDefinitionTuple] = {
+DEPRECATED_MODULE_MESSAGE: dict[str, MessageDefinitionTuple] = {
     "W4901": (
         "Deprecated module %r",
         "deprecated-module",
         "A module marked as deprecated is imported.",
         {"old_names": [("W0402", "old-deprecated-module")]},
     ),
+}
+
+DEPRECATED_METHOD_MESSAGE: dict[str, MessageDefinitionTuple] = {
     "W4902": (
         "Using deprecated method %s()",
         "deprecated-method",
         "The method is marked as deprecated and will be removed in the future.",
         {"old_names": [("W1505", "old-deprecated-method")]},
     ),
+}
+
+DEPRECATED_ARGUMENT_MESSAGE: dict[str, MessageDefinitionTuple] = {
     "W4903": (
         "Using deprecated argument %s of method %s()",
         "deprecated-argument",
         "The argument is marked as deprecated and will be removed in the future.",
         {"old_names": [("W1511", "old-deprecated-argument")]},
     ),
+}
+
+DEPRECATED_CLASS_MESSAGE: dict[str, MessageDefinitionTuple] = {
     "W4904": (
         "Using deprecated class %s of module %s",
         "deprecated-class",
         "The class is marked as deprecated and will be removed in the future.",
         {"old_names": [("W1512", "old-deprecated-class")]},
     ),
+}
+
+DEPRECATED_DECORATOR_MESSAGE: dict[str, MessageDefinitionTuple] = {
     "W4905": (
         "Using deprecated decorator %s()",
         "deprecated-decorator",
@@ -61,9 +72,7 @@ MSGS: dict[str, MessageDefinitionTuple] = {
 
 class DeprecatedMixin(BaseChecker):
 
-    shared_message_ids: set[str] = set(MSGS.keys())
-
-    msgs: dict[str, MessageDefinitionTuple] = MSGS
+    shared_message_ids: set[str] = {"W4901", "W4902", "W4903", "W4904", "W4905"}
 
     """A mixin implementing logic for checking deprecated symbols.
 

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -29,7 +29,7 @@ DEPRECATED_MODULE_MESSAGE: dict[str, MessageDefinitionTuple] = {
         "Deprecated module %r",
         "deprecated-module",
         "A module marked as deprecated is imported.",
-        {"old_names": [("W0402", "old-deprecated-module")]},
+        {"old_names": [("W0402", "old-deprecated-module")], "shared": True},
     ),
 }
 
@@ -38,7 +38,7 @@ DEPRECATED_METHOD_MESSAGE: dict[str, MessageDefinitionTuple] = {
         "Using deprecated method %s()",
         "deprecated-method",
         "The method is marked as deprecated and will be removed in the future.",
-        {"old_names": [("W1505", "old-deprecated-method")]},
+        {"old_names": [("W1505", "old-deprecated-method")], "shared": True},
     ),
 }
 
@@ -47,7 +47,7 @@ DEPRECATED_ARGUMENT_MESSAGE: dict[str, MessageDefinitionTuple] = {
         "Using deprecated argument %s of method %s()",
         "deprecated-argument",
         "The argument is marked as deprecated and will be removed in the future.",
-        {"old_names": [("W1511", "old-deprecated-argument")]},
+        {"old_names": [("W1511", "old-deprecated-argument")], "shared": True},
     ),
 }
 
@@ -56,7 +56,7 @@ DEPRECATED_CLASS_MESSAGE: dict[str, MessageDefinitionTuple] = {
         "Using deprecated class %s of module %s",
         "deprecated-class",
         "The class is marked as deprecated and will be removed in the future.",
-        {"old_names": [("W1512", "old-deprecated-class")]},
+        {"old_names": [("W1512", "old-deprecated-class")], "shared": True},
     ),
 }
 
@@ -65,15 +65,12 @@ DEPRECATED_DECORATOR_MESSAGE: dict[str, MessageDefinitionTuple] = {
         "Using deprecated decorator %s()",
         "deprecated-decorator",
         "The decorator is marked as deprecated and will be removed in the future.",
-        {"old_names": [("W1513", "old-deprecated-decorator")]},
+        {"old_names": [("W1513", "old-deprecated-decorator")], "shared": True},
     ),
 }
 
 
 class DeprecatedMixin(BaseChecker):
-
-    shared_message_ids: set[str] = {"W4901", "W4902", "W4903", "W4904", "W4905"}
-
     """A mixin implementing logic for checking deprecated symbols.
 
     A class implementing mixin must define "deprecated-method" Message.

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -24,6 +24,7 @@ ACCEPTABLE_NODES = (
     nodes.ClassDef,
 )
 
+# pylint: disable-next=consider-using-namedtuple-or-dataclass
 MSGS: dict[str, MessageDefinitionTuple] = {
     "W4901": (
         "Deprecated module %r",

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -24,6 +24,7 @@ ACCEPTABLE_NODES = (
     nodes.ClassDef,
 )
 
+
 class DeprecatedMixin(BaseChecker):
 
     DEPRECATED_IMPORT_MSGS: dict[str, MessageDefinitionTuple] = {
@@ -56,7 +57,6 @@ class DeprecatedMixin(BaseChecker):
             "The decorator is marked as deprecated and will be removed in the future.",
         ),
     }
-
 
     """A mixin implementing logic for checking deprecated symbols.
 

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -24,40 +24,42 @@ ACCEPTABLE_NODES = (
     nodes.ClassDef,
 )
 
+DEPRECATED_MSGS: dict[str, MessageDefinitionTuple] = {
+    "W1505": (
+        "Using deprecated method %s()",
+        "deprecated-method",
+        "The method is marked as deprecated and will be removed in the future.",
+    ),
+    "W1511": (
+        "Using deprecated argument %s of method %s()",
+        "deprecated-argument",
+        "The argument is marked as deprecated and will be removed in the future.",
+    ),
+    "W1512": (
+        "Using deprecated class %s of module %s",
+        "deprecated-class",
+        "The class is marked as deprecated and will be removed in the future.",
+    ),
+    "W1513": (
+        "Using deprecated decorator %s()",
+        "deprecated-decorator",
+        "The decorator is marked as deprecated and will be removed in the future.",
+    ),
+}
+
+DEPRECATED_IMPORT_MSGS: dict[str, MessageDefinitionTuple] = {
+    "W0402": (
+        "Deprecated module %r",
+        "deprecated-module",
+        "A module marked as deprecated is imported.",
+    ),
+}
 
 class DeprecatedMixin(BaseChecker):
     """A mixin implementing logic for checking deprecated symbols.
 
     A class implementing mixin must define "deprecated-method" Message.
     """
-
-    msgs: dict[str, MessageDefinitionTuple] = {
-        "W1505": (
-            "Using deprecated method %s()",
-            "deprecated-method",
-            "The method is marked as deprecated and will be removed in the future.",
-        ),
-        "W1511": (
-            "Using deprecated argument %s of method %s()",
-            "deprecated-argument",
-            "The argument is marked as deprecated and will be removed in the future.",
-        ),
-        "W0402": (
-            "Deprecated module %r",
-            "deprecated-module",
-            "A module marked as deprecated is imported.",
-        ),
-        "W1512": (
-            "Using deprecated class %s of module %s",
-            "deprecated-class",
-            "The class is marked as deprecated and will be removed in the future.",
-        ),
-        "W1513": (
-            "Using deprecated decorator %s()",
-            "deprecated-decorator",
-            "The decorator is marked as deprecated and will be removed in the future.",
-        ),
-    }
 
     @utils.only_required_for_messages(
         "deprecated-method",

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -197,7 +197,6 @@ def _make_graph(
 # the import checker itself ###################################################
 
 MSGS: dict[str, MessageDefinitionTuple] = {
-    **DeprecatedMixin.DEPRECATED_IMPORT_MSGS,
     "E0401": (
         "Unable to import %s",
         "import-error",
@@ -302,7 +301,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
     """
 
     name = "imports"
-    msgs = MSGS
+    msgs = {**DeprecatedMixin.msgs, **MSGS}
     default_deprecated_modules = ()
 
     options = (

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -16,7 +16,6 @@ import astroid
 from astroid import nodes
 
 from pylint.checkers import BaseChecker, DeprecatedMixin
-from pylint.checkers.deprecated import DEPRECATED_MODULE_MESSAGE
 from pylint.checkers.utils import (
     get_import_name,
     is_from_fallback_block,
@@ -302,7 +301,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
     """
 
     name = "imports"
-    msgs = {**DEPRECATED_MODULE_MESSAGE, **MSGS}
+    msgs = {**DeprecatedMixin.DEPRECATED_MODULE_MESSAGE, **MSGS}
     default_deprecated_modules = ()
 
     options = (

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -16,7 +16,6 @@ import astroid
 from astroid import nodes
 
 from pylint.checkers import BaseChecker, DeprecatedMixin
-from pylint.checkers.deprecated import DEPRECATED_IMPORT_MSGS
 from pylint.checkers.utils import (
     get_import_name,
     is_from_fallback_block,
@@ -198,7 +197,7 @@ def _make_graph(
 # the import checker itself ###################################################
 
 MSGS: dict[str, MessageDefinitionTuple] = {
-    **DEPRECATED_IMPORT_MSGS,
+    **DeprecatedMixin.DEPRECATED_IMPORT_MSGS,
     "E0401": (
         "Unable to import %s",
         "import-error",

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -16,6 +16,7 @@ import astroid
 from astroid import nodes
 
 from pylint.checkers import BaseChecker, DeprecatedMixin
+from pylint.checkers.deprecated import DEPRECATED_IMPORT_MSGS
 from pylint.checkers.utils import (
     get_import_name,
     is_from_fallback_block,
@@ -197,7 +198,7 @@ def _make_graph(
 # the import checker itself ###################################################
 
 MSGS: dict[str, MessageDefinitionTuple] = {
-    **{k: v for k, v in DeprecatedMixin.msgs.items() if k[1:3] == "04"},
+    **DEPRECATED_IMPORT_MSGS,
     "E0401": (
         "Unable to import %s",
         "import-error",

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -15,7 +15,8 @@ from typing import TYPE_CHECKING, Any
 import astroid
 from astroid import nodes
 
-from pylint.checkers import DEPRECATED_MODULE_MESSAGE, BaseChecker, DeprecatedMixin
+from pylint.checkers import BaseChecker, DeprecatedMixin
+from pylint.checkers.deprecated import DEPRECATED_MODULE_MESSAGE
 from pylint.checkers.utils import (
     get_import_name,
     is_from_fallback_block,

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 import astroid
 from astroid import nodes
 
-from pylint.checkers import BaseChecker, DeprecatedMixin
+from pylint.checkers import DEPRECATED_MODULE_MESSAGE, BaseChecker, DeprecatedMixin
 from pylint.checkers.utils import (
     get_import_name,
     is_from_fallback_block,
@@ -301,7 +301,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
     """
 
     name = "imports"
-    msgs = {**DeprecatedMixin.msgs, **MSGS}
+    msgs = {**DEPRECATED_MODULE_MESSAGE, **MSGS}
     default_deprecated_modules = ()
 
     options = (

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -14,7 +14,15 @@ import astroid
 from astroid import nodes
 
 from pylint import interfaces
-from pylint.checkers import BaseChecker, DeprecatedMixin, utils
+from pylint.checkers import (
+    DEPRECATED_ARGUMENT_MESSAGE,
+    DEPRECATED_CLASS_MESSAGE,
+    DEPRECATED_DECORATOR_MESSAGE,
+    DEPRECATED_METHOD_MESSAGE,
+    BaseChecker,
+    DeprecatedMixin,
+    utils,
+)
 from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
@@ -334,7 +342,10 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
     name = "stdlib"
 
     msgs: dict[str, MessageDefinitionTuple] = {
-        **DeprecatedMixin.msgs,
+        **DEPRECATED_METHOD_MESSAGE,
+        **DEPRECATED_ARGUMENT_MESSAGE,
+        **DEPRECATED_CLASS_MESSAGE,
+        **DEPRECATED_DECORATOR_MESSAGE,
         "W1501": (
             '"%s" is not a valid mode for open.',
             "bad-open-mode",

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -14,14 +14,12 @@ import astroid
 from astroid import nodes
 
 from pylint import interfaces
-from pylint.checkers import (
+from pylint.checkers import BaseChecker, DeprecatedMixin, utils
+from pylint.checkers.deprecated import (
     DEPRECATED_ARGUMENT_MESSAGE,
     DEPRECATED_CLASS_MESSAGE,
     DEPRECATED_DECORATOR_MESSAGE,
     DEPRECATED_METHOD_MESSAGE,
-    BaseChecker,
-    DeprecatedMixin,
-    utils,
 )
 from pylint.typing import MessageDefinitionTuple
 

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -334,7 +334,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
     name = "stdlib"
 
     msgs: dict[str, MessageDefinitionTuple] = {
-        **DeprecatedMixin.DEPRECATED_MSGS,
+        **DeprecatedMixin.msgs,
         "W1501": (
             '"%s" is not a valid mode for open.',
             "bad-open-mode",

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -15,6 +15,7 @@ from astroid import nodes
 
 from pylint import interfaces
 from pylint.checkers import BaseChecker, DeprecatedMixin, utils
+from pylint.checkers.deprecated import DEPRECATED_MSGS
 
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
@@ -333,7 +334,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
     name = "stdlib"
 
     msgs = {
-        **{k: v for k, v in DeprecatedMixin.msgs.items() if k[1:3] == "15"},
+        **DEPRECATED_MSGS,
         "W1501": (
             '"%s" is not a valid mode for open.',
             "bad-open-mode",

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -16,6 +16,7 @@ from astroid import nodes
 from pylint import interfaces
 from pylint.checkers import BaseChecker, DeprecatedMixin, utils
 from pylint.checkers.deprecated import DEPRECATED_MSGS
+from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
@@ -333,7 +334,7 @@ def _check_mode_str(mode):
 class StdlibChecker(DeprecatedMixin, BaseChecker):
     name = "stdlib"
 
-    msgs = {
+    msgs: dict[str, MessageDefinitionTuple] = {
         **DEPRECATED_MSGS,
         "W1501": (
             '"%s" is not a valid mode for open.',

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -15,7 +15,6 @@ from astroid import nodes
 
 from pylint import interfaces
 from pylint.checkers import BaseChecker, DeprecatedMixin, utils
-from pylint.checkers.deprecated import DEPRECATED_MSGS
 from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
@@ -335,7 +334,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
     name = "stdlib"
 
     msgs: dict[str, MessageDefinitionTuple] = {
-        **DEPRECATED_MSGS,
+        **DeprecatedMixin.DEPRECATED_MSGS,
         "W1501": (
             '"%s" is not a valid mode for open.',
             "bad-open-mode",

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -15,12 +15,6 @@ from astroid import nodes
 
 from pylint import interfaces
 from pylint.checkers import BaseChecker, DeprecatedMixin, utils
-from pylint.checkers.deprecated import (
-    DEPRECATED_ARGUMENT_MESSAGE,
-    DEPRECATED_CLASS_MESSAGE,
-    DEPRECATED_DECORATOR_MESSAGE,
-    DEPRECATED_METHOD_MESSAGE,
-)
 from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
@@ -340,10 +334,10 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
     name = "stdlib"
 
     msgs: dict[str, MessageDefinitionTuple] = {
-        **DEPRECATED_METHOD_MESSAGE,
-        **DEPRECATED_ARGUMENT_MESSAGE,
-        **DEPRECATED_CLASS_MESSAGE,
-        **DEPRECATED_DECORATOR_MESSAGE,
+        **DeprecatedMixin.DEPRECATED_METHOD_MESSAGE,
+        **DeprecatedMixin.DEPRECATED_ARGUMENT_MESSAGE,
+        **DeprecatedMixin.DEPRECATED_CLASS_MESSAGE,
+        **DeprecatedMixin.DEPRECATED_DECORATOR_MESSAGE,
         "W1501": (
             '"%s" is not a valid mode for open.',
             "bad-open-mode",

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -11,7 +11,6 @@ from astroid import nodes
 
 from pylint.constants import _SCOPE_EXEMPT, MSG_TYPES, WarningScope
 from pylint.exceptions import InvalidMessageError
-from pylint.typing import ExtraMessageOptions
 from pylint.utils import normalize_text
 
 if TYPE_CHECKING:
@@ -19,6 +18,8 @@ if TYPE_CHECKING:
 
 
 class MessageDefinition:
+    # TODO: remove disable and move all extra option to single parameter.
+    # pylint: disable-next=too-many-arguments
     def __init__(
         self,
         checker: BaseChecker,
@@ -26,7 +27,11 @@ class MessageDefinition:
         msg: str,
         description: str,
         symbol: str,
-        extra_options: ExtraMessageOptions,
+        scope: str,
+        minversion: tuple[int, int] | None = None,
+        maxversion: tuple[int, int] | None = None,
+        old_names: list[tuple[str, str]] | None = None,
+        shared: bool = False,
     ) -> None:
         self.checker_name = checker.name
         self.check_msgid(msgid)
@@ -34,13 +39,13 @@ class MessageDefinition:
         self.symbol = symbol
         self.msg = msg
         self.description = description
-        self.scope: str = extra_options["scope"]
-        self.minversion: tuple[int, int] | None = extra_options.get("minversion", None)
-        self.maxversion: tuple[int, int] | None = extra_options.get("maxversion", None)
-        self.shared: bool = extra_options.get("shared", False)
+        self.scope = scope
+        self.minversion = minversion
+        self.maxversion = maxversion
+        self.shared = shared
         self.old_names: list[tuple[str, str]] = []
-        if "old_names" in extra_options:
-            for old_msgid, old_symbol in extra_options["old_names"]:
+        if old_names:
+            for old_msgid, old_symbol in old_names:
                 self.check_msgid(old_msgid)
                 self.old_names.append(
                     (old_msgid, old_symbol),

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
 
 
 class MessageDefinition:
-    # TODO: remove disable and move all extra option to single parameter.
     # pylint: disable-next=too-many-arguments
     def __init__(
         self,

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -11,6 +11,7 @@ from astroid import nodes
 
 from pylint.constants import _SCOPE_EXEMPT, MSG_TYPES, WarningScope
 from pylint.exceptions import InvalidMessageError
+from pylint.typing import ExtraMessageOptions
 from pylint.utils import normalize_text
 
 if TYPE_CHECKING:
@@ -25,10 +26,7 @@ class MessageDefinition:
         msg: str,
         description: str,
         symbol: str,
-        scope: str,
-        minversion: tuple[int, int] | None = None,
-        maxversion: tuple[int, int] | None = None,
-        old_names: list[tuple[str, str]] | None = None,
+        extra_options: ExtraMessageOptions,
     ) -> None:
         self.checker_name = checker.name
         self.check_msgid(msgid)
@@ -36,12 +34,13 @@ class MessageDefinition:
         self.symbol = symbol
         self.msg = msg
         self.description = description
-        self.scope = scope
-        self.minversion = minversion
-        self.maxversion = maxversion
+        self.scope: str = extra_options["scope"]
+        self.minversion: tuple[int, int] | None = extra_options.get("minversion", None)
+        self.maxversion: tuple[int, int] | None = extra_options.get("maxversion", None)
+        self.shared: bool = extra_options.get("shared", False)
         self.old_names: list[tuple[str, str]] = []
-        if old_names:
-            for old_msgid, old_symbol in old_names:
+        if "old_names" in extra_options:
+            for old_msgid, old_symbol in extra_options["old_names"]:
                 self.check_msgid(old_msgid)
                 self.old_names.append(
                     (old_msgid, old_symbol),

--- a/pylint/typing.py
+++ b/pylint/typing.py
@@ -121,6 +121,7 @@ class ExtraMessageOptions(TypedDict, total=False):
     old_names: list[tuple[str, str]]
     maxversion: tuple[int, int]
     minversion: tuple[int, int]
+    shared: bool
 
 
 MessageDefinitionTuple = Union[

--- a/tests/message/unittest_message_definition.py
+++ b/tests/message/unittest_message_definition.py
@@ -12,7 +12,6 @@ from pylint.constants import WarningScope
 from pylint.exceptions import InvalidMessageError
 from pylint.lint.pylinter import PyLinter
 from pylint.message import MessageDefinition
-from pylint.typing import ExtraMessageOptions
 
 
 @pytest.mark.parametrize(
@@ -65,14 +64,15 @@ class TestMessagesDefinition:
 
     @staticmethod
     def get_message_definition() -> MessageDefinition:
-        extra_msg_options: ExtraMessageOptions = {"scope": WarningScope.NODE}
         return MessageDefinition(
             FalseChecker(),
             "W1234",
             "message",
             "description",
             "msg-symbol",
-            extra_msg_options,
+            WarningScope.NODE,
+            minversion=None,
+            maxversion=None,
         )
 
     def test_may_be_emitted(self) -> None:

--- a/tests/message/unittest_message_definition.py
+++ b/tests/message/unittest_message_definition.py
@@ -12,6 +12,7 @@ from pylint.constants import WarningScope
 from pylint.exceptions import InvalidMessageError
 from pylint.lint.pylinter import PyLinter
 from pylint.message import MessageDefinition
+from pylint.typing import ExtraMessageOptions
 
 
 @pytest.mark.parametrize(
@@ -64,15 +65,14 @@ class TestMessagesDefinition:
 
     @staticmethod
     def get_message_definition() -> MessageDefinition:
-        kwargs = {"minversion": None, "maxversion": None}
+        extra_msg_options: ExtraMessageOptions = {"scope": WarningScope.NODE}
         return MessageDefinition(
             FalseChecker(),
             "W1234",
             "message",
             "description",
             "msg-symbol",
-            WarningScope.NODE,
-            **kwargs,
+            extra_msg_options,
         )
 
     def test_may_be_emitted(self) -> None:

--- a/tests/message/unittest_message_definition.py
+++ b/tests/message/unittest_message_definition.py
@@ -71,8 +71,6 @@ class TestMessagesDefinition:
             "description",
             "msg-symbol",
             WarningScope.NODE,
-            minversion=None,
-            maxversion=None,
         )
 
     def test_may_be_emitted(self) -> None:

--- a/tests/message/unittest_message_id_store.py
+++ b/tests/message/unittest_message_id_store.py
@@ -131,6 +131,8 @@ def test_exclusivity_of_msgids() -> None:
     }
 
     for msgid, definition in runner.linter.msgs_store._messages_definitions.items():
+        if definition.shared:
+            continue
         if msgid[1:3] in checker_id_pairs:
             assert (
                 definition.checker_name in checker_id_pairs[msgid[1:3]]

--- a/tests/pyreverse/functional/class_diagrams/colorized_output/colorized.puml
+++ b/tests/pyreverse/functional/class_diagrams/colorized_output/colorized.puml
@@ -23,7 +23,7 @@ class "ExceptionsChecker" as pylint.checkers.exceptions.ExceptionsChecker #aquam
   visit_tryexcept(node: nodes.TryExcept) -> None
 }
 class "StdlibChecker" as pylint.checkers.stdlib.StdlibChecker #aquamarine {
-  msgs
+  msgs : dict[str, MessageDefinitionTuple]
   name : str
   deprecated_arguments(method: str)
   deprecated_classes(module: str)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Add a ChangeLog entry describing what your PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [ ] Write a good description on what the PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

This PR move message definitions from `msgs` attribute of DeprecatecMixin to separate class attributes. `msgs` attribute cannot be used directly anyway because it mixes two different message classes: `W15XX` and `W04XX`.

Closes #6656
