### PR TITLE
Fix a crash in `unused-private-member` with chained private attributes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -79,6 +79,10 @@ Release date: TBA
 
   Closes #6372
 
+* Fixed a crash in the ``unused-private-member`` checker involving chained private attributes.
+
+  Closes #6709
+
 * Fixed failure to enable ``deprecated-module`` after a ``disable=all``
   by making ``ImportsChecker`` solely responsible for emitting ``deprecated-module`` instead
   of sharing responsibility with ``StdlibChecker``. (This could have led to double messages.)

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -165,6 +165,10 @@ Other Changes
 
   Closes #6372
 
+* Fixed a crash in the ``unused-private-member`` checker involving chained private attributes.
+
+  Closes #6709
+
 * Disable spellchecking of mypy rule names in ignore directives.
 
   Closes #5929

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1028,7 +1028,7 @@ a metaclass class method.",
                 if attribute.attrname != assign_attr.attrname:
                     continue
 
-                if isinstance(attribute.expr, nodes.Call):
+                if not isinstance(attribute.expr, nodes.Name):
                     continue
 
                 if assign_attr.expr.name in {

--- a/tests/functional/u/unused/unused_private_member.py
+++ b/tests/functional/u/unused/unused_private_member.py
@@ -344,3 +344,10 @@ class TypeSelfCallInMethod:
 
     def a(self):
         return type(self).__a
+
+
+class Item:
+    """Regression test for https://github.com/PyCQA/pylint/issues/6709"""
+    def __init__(self, parent):
+        self.__parent: Item = parent
+        self.__item = self.__parent.__item  # [unused-private-member]

--- a/tests/functional/u/unused/unused_private_member.txt
+++ b/tests/functional/u/unused/unused_private_member.txt
@@ -18,3 +18,4 @@ unused-private-member:276:4:276:31:FalsePositive4849.__unused_private_method:Unu
 unused-private-member:293:4:293:23:Pony.__init_defaults:Unused private member `Pony.__init_defaults(self)`:UNDEFINED
 unused-private-member:298:4:298:23:Pony.__get_fur_color:Unused private member `Pony.__get_fur_color(self)`:UNDEFINED
 unused-private-member:343:8:343:15:TypeSelfCallInMethod.b:Unused private member `TypeSelfCallInMethod.__a`:UNDEFINED
+unused-private-member:353:8:353:19:Item.__init__:Unused private member `Item.__item`:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Reproduced the crash in the original checker: 44eab786bb794196b36b16cb8d2b36d5fd098a49
Closes #6709
