### PR TITLE
Remove unnecessary base class and dead code in `pylint.pyreverse.utils`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -177,6 +177,10 @@ Release date: TBA
 
   Ref #5392
 
+* ``pylint.pyreverse.ASTWalker`` has been removed, as it was only used internally by a single child class.
+
+  Ref #6712
+
 * ``interfaces.implements`` has been deprecated and will be removed in 3.0. Please use standard inheritance
   patterns instead of ``__implements__``.
 

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -281,6 +281,10 @@ Other Changes
 
   Closes #6644
 
+* ``pylint.pyreverse.ASTWalker`` has been removed, as it was only used internally by a single child class.
+
+  Ref #6712
+
 
 Deprecations
 ============


### PR DESCRIPTION
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
Ref #6582 
Closes the first bullet point from the list:
`ASTWalker` and `LocalsVisitor` were apparently moved from `astroid.utils` to `pylint.pyreverse.utils` some years ago.
Maybe originally there were also other subclasses of `ASTWalker`, but at least in `pyreverse` that is not the case.

Thus we can remove `ASTWalker` and some of the unused code in there and directly put the remaining stuff in `LocalsVisitor`.

Some remarks, as the diff is a bit hard to read imo:

* `handler` was always `self` -> removed `handler` and replaced references with `self`
* `walk` and `leave` were never called -> removed
