### PR TITLE
Fix return type annotations in MermaidJS diagrams.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: v1.4
     hooks:
       - id: autoflake
-        exclude: &fixtures tests/functional/|tests/input|doc/data/messages|tests(/\w*)*data/
+        exclude: &fixtures tests(/\w*)*/functional/|tests/input|doc/data/messages|tests(/\w*)*data/
         args:
           - --in-place
           - --remove-all-unused-imports

--- a/ChangeLog
+++ b/ChangeLog
@@ -329,6 +329,10 @@ Release date: TBA
 
   Relates to #6612
 
+* Fix syntax for return type annotations in MermaidJS diagrams produced with ``pyreverse``.
+
+  Closes #6467
+
 * Fix bug where it writes a plain text error message to stdout, invalidating output formats.
 
   Closes #6597

--- a/doc/whatsnew/2.14.rst
+++ b/doc/whatsnew/2.14.rst
@@ -260,6 +260,10 @@ Other Changes
 
   Relates to #6612
 
+* Fix syntax for return type annotations in MermaidJS diagrams produced with ``pyreverse``.
+
+  Closes #6467
+
 * Fix bug where it writes a plain text error message to stdout, invalidating output formats.
 
   Closes #6597

--- a/pylint/pyreverse/mermaidjs_printer.py
+++ b/pylint/pyreverse/mermaidjs_printer.py
@@ -55,7 +55,7 @@ class MermaidJSPrinter(Printer):
                 args = self._get_method_arguments(func)
                 line = f"{func.name}({', '.join(args)})"
                 if func.returns:
-                    line += " -> " + get_annotation_label(func.returns)
+                    line += f" {get_annotation_label(func.returns)}"
                 body.append(line)
         name = name.split(".")[-1]
         self.emit(f"{nodetype} {name}{stereotype} {{")

--- a/tests/pyreverse/data/classes_No_Name.html
+++ b/tests/pyreverse/data/classes_No_Name.html
@@ -20,7 +20,7 @@
             my_int : Optional[int]
             my_int_2 : Optional[int]
             my_string : str
-            do_it(new_int: int) -> int
+            do_it(new_int: int) int
           }
           class Interface {
             get_value()
@@ -36,8 +36,8 @@
             relation2
             top : str
             from_value(value: int)
-            increment_value() -> None
-            transform_value(value: int) -> int
+            increment_value() None
+            transform_value(value: int) int
           }
           Specialization --|> Ancestor
           Ancestor ..|> Interface

--- a/tests/pyreverse/data/classes_No_Name.mmd
+++ b/tests/pyreverse/data/classes_No_Name.mmd
@@ -15,7 +15,7 @@ classDiagram
     my_int : Optional[int]
     my_int_2 : Optional[int]
     my_string : str
-    do_it(new_int: int) -> int
+    do_it(new_int: int) int
   }
   class Interface {
     get_value()
@@ -31,8 +31,8 @@ classDiagram
     relation2
     top : str
     from_value(value: int)
-    increment_value() -> None
-    transform_value(value: int) -> int
+    increment_value() None
+    transform_value(value: int) int
   }
   Specialization --|> Ancestor
   Ancestor ..|> Interface

--- a/tests/pyreverse/functional/class_diagrams/annotations/method_annotation.mmd
+++ b/tests/pyreverse/functional/class_diagrams/annotations/method_annotation.mmd
@@ -2,5 +2,6 @@ classDiagram
   class Monkey {
     eat(food: Banana | Coconut) None
     jump(height: Optional[int]) None
+    munch(food: Union[Leaf, Insect]) None
     scream(volume: int | None) Sound
   }

--- a/tests/pyreverse/functional/class_diagrams/annotations/method_annotation.mmd
+++ b/tests/pyreverse/functional/class_diagrams/annotations/method_annotation.mmd
@@ -1,0 +1,6 @@
+classDiagram
+  class Monkey {
+    eat(food: Banana | Coconut) None
+    jump(height: Optional[int]) None
+    scream(volume: int | None) Sound
+  }

--- a/tests/pyreverse/functional/class_diagrams/annotations/method_annotation.py
+++ b/tests/pyreverse/functional/class_diagrams/annotations/method_annotation.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+# pylint: disable-next=import-error
+from lib import Banana, Coconut, Sound  # type: ignore[import]
+
+
+class Monkey:
+    def eat(self, food: Banana | Coconut) -> None:
+        print(f"Monkey eats {food}")
+
+    def jump(self, height: int | None = 10) -> None:
+        print(f"Monkey jumps {height}")
+
+    def scream(self, volume: int | None) -> Sound:
+        if volume is None:
+            volume = 0
+        return Sound(volume)

--- a/tests/pyreverse/functional/class_diagrams/annotations/method_annotation.py
+++ b/tests/pyreverse/functional/class_diagrams/annotations/method_annotation.py
@@ -1,14 +1,19 @@
+# pylint: disable=import-error,consider-alternative-union-syntax
 from __future__ import annotations
 
-# pylint: disable-next=import-error
-from lib import Banana, Coconut, Sound  # type: ignore[import]
+from typing import Optional, Union
+
+from lib import Banana, Coconut, Insect, Leaf, Sound  # type: ignore[import]
 
 
 class Monkey:
     def eat(self, food: Banana | Coconut) -> None:
         print(f"Monkey eats {food}")
 
-    def jump(self, height: int | None = 10) -> None:
+    def munch(self, food: Union[Leaf, Insect]) -> None:
+        print(f"Monkey munches {food}")
+
+    def jump(self, height: Optional[int] = 10) -> None:
         print(f"Monkey jumps {height}")
 
     def scream(self, volume: int | None) -> Sound:


### PR DESCRIPTION
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
   and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
The ` ->` before the return type annotation is incorrect, and the return type is not shown in the final diagram.

Closes #6467 
