### PR TITLE
Primer tool: remove duplicated directory paths

### DIFF
--- a/tests/primer/primer_tool.py
+++ b/tests/primer/primer_tool.py
@@ -117,7 +117,7 @@ class Primer:
         enables = ["--enable-all-extensions", "--enable=all"]
         # Duplicate code takes too long and is relatively safe
         disables = ["--disable=duplicate-code"]
-        arguments = data.directories + data.pylint_args + enables + disables
+        arguments = data.pylint_args + enables + disables
         if data.pylintrc_relpath:
             arguments += [f"--rcfile={data.pylintrc_relpath}"]
         output = StringIO()


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`pylint_args` reads `paths_to_lint`, which reads `directories`, so adding `directories` here is both duplicative and error-prone (because it doesn't account for the path to the cloned directory): we were getting fatal errors like "unable to import module src/blackd")

In a follow-up PR I'll probably add `--fail-on=fatal`.