### PR TITLE
Add concurrency to primer

### DIFF
--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -17,6 +17,10 @@ on:
       - "!.github/workflows/primer_comment.yaml"
       - "!tests/primer/packages_to_prime.json"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CACHE_VERSION: 1
 


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Based on tips by original `mypy` primer author over at https://github.com/hauntsaninja/mypy_primer/issues/29.

I considered adding `pre-commit` as a non-triggering actor like they do, but that doesn't work with concurrency. The `pre-commit` commit would trigger the concurrency so then no run would succeed.