### PR TITLE
Fail "new primer" runs on fatal errors, like "old primer"

### DIFF
--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -97,7 +97,7 @@ jobs:
           . venv/bin/activate
           pip install -e .
           python tests/primer/primer_tool.py run --type=main 2>warnings.txt
-          WARNINGS=$(<warnings.txt)
+          WARNINGS=$(head -c 65000 < warnings.txt)
       - name: Emit Actions warnings for python warnings
         run: |
           if [[ $WARNINGS ]]

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -98,8 +98,6 @@ jobs:
           pip install -e .
           python tests/primer/primer_tool.py run --type=main 2>warnings.txt
           WARNINGS=$(head -c 65000 < warnings.txt)
-      - name: Emit Actions warnings for python warnings
-        run: |
           if [[ $WARNINGS ]]
           then echo "::warning ::$WARNINGS"
           fi

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -96,7 +96,13 @@ jobs:
         run: |
           . venv/bin/activate
           pip install -e .
-          python tests/primer/primer_tool.py run --type=main
+          python tests/primer/primer_tool.py run --type=main 2>warnings.txt
+          WARNINGS=$(<warnings.txt)
+      - name: Emit Actions warnings for python warnings
+        run: |
+          if [[ $WARNINGS ]]
+          then echo "::warning ::$WARNINGS"
+          fi
       - name: Upload output
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -169,8 +169,6 @@ jobs:
           pip install -e .
           python tests/primer/primer_tool.py run --type=pr 2>warnings.txt
           WARNINGS=$(<warnings.txt)
-      - name: Emit Actions warnings for python warnings
-        run: |
           if [[ $WARNINGS ]]
           then echo "::warning ::$WARNINGS"
           fi

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -167,7 +167,13 @@ jobs:
         run: |
           . venv/bin/activate
           pip install -e .
-          python tests/primer/primer_tool.py run --type=pr
+          python tests/primer/primer_tool.py run --type=pr 2>warnings.txt
+          WARNINGS=$(<warnings.txt)
+      - name: Emit Actions warnings for python warnings
+        run: |
+          if [[ $WARNINGS ]]
+          then echo "::warning ::$WARNINGS"
+          fi
       - name: Upload output of PR
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -168,7 +168,7 @@ jobs:
           . venv/bin/activate
           pip install -e .
           python tests/primer/primer_tool.py run --type=pr 2>warnings.txt
-          WARNINGS=$(<warnings.txt)
+          WARNINGS=$(head -c 65000 < warnings.txt)
           if [[ $WARNINGS ]]
           then echo "::warning ::$WARNINGS"
           fi

--- a/tests/primer/primer_tool.py
+++ b/tests/primer/primer_tool.py
@@ -260,7 +260,7 @@ class Primer:
             arguments += [f"--rcfile={data.pylintrc_relpath}"]
         output = StringIO()
         reporter = JSONReporter(output)
-        Run(arguments, reporter=reporter, do_exit=False)
+        Run(arguments, reporter=reporter, exit=False)
         return json.loads(output.getvalue())
 
     @staticmethod

--- a/tests/primer/primer_tool.py
+++ b/tests/primer/primer_tool.py
@@ -133,11 +133,10 @@ class Primer:
             json.dump(packages, f)
 
         # Fail loudly (and fail CI pipelines) if any fatal errors are found,
-        # unless they are astroid-errors, in which case just warn sotto voce.
+        # unless they are astroid-errors, in which case just warn.
         # This is to avoid introducing a dependency on bleeding-edge astroid
-        # for pylint CI pipelines generally, even though we do use astroid main
-        # to catch vanilla (non-crash) behavior changes in pylint PRs so that
-        # the contributor is alerted to it in a comment.
+        # for pylint CI pipelines generally, even though we want to use astroid main
+        # for the purpose of diffing emitted messages and generating PR comments.
         messages = list(chain.from_iterable(packages.values()))
         astroid_errors = [msg for msg in messages if msg["symbol"] == "astroid-error"]
         other_fatal_msgs = [

--- a/tests/primer/primer_tool.py
+++ b/tests/primer/primer_tool.py
@@ -145,7 +145,7 @@ class Primer:
             if msg["type"] == "fatal" and msg["symbol"] != "astroid-error"
         ]
         if astroid_errors:
-            warnings.warn(f"Fatal errors traced to astroid:\n{astroid_errors}")
+            warnings.warn(f"Fatal errors traced to astroid:  {astroid_errors}")
         assert not other_fatal_msgs, other_fatal_msgs
 
     def _handle_compare_command(self) -> None:

--- a/tests/profile/test_profile_against_externals.py
+++ b/tests/profile/test_profile_against_externals.py
@@ -46,7 +46,7 @@ def test_run(tmp_path, name, git_repo):
     filepaths = _get_py_files(scanpath=str(checkoutdir))
     print(f"Have {len(filepaths)} files")
 
-    runner = Run(filepaths, reporter=Reporter(), do_exit=False)
+    runner = Run(filepaths, reporter=Reporter(), exit=False)
 
     print(
         f"Had {len(filepaths)} files with {len(runner.linter.reporter.messages)} messages"


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
The old primer did one thing very well -- it failed CI jobs when encountering `fatal` errors during the linting of open source packages, whether caused in new pylint or astroid PRs, or when adding new packages to the primer, or when third-party packages pushed new changes.

The new primer needs some analogous functionality -- something beyond the message differ. If some fatal errors "sneak in" (we merge a PR without noticing the change, or we believe it to be related to a different PR, or incompatible PRs are merged, or we add a package, or third-party maintainers publish new commits), we don't want `n` fatal errors on main to silently match `n` fatal errors on a PR and for the comment-bot to stay quiet about it. We want a failure.

I persuaded (💪🏻 😅 🙏🏻 📈 )  us into running the primer on bleeding-edge astroid, and from the feedback that we want to be careful not to introduce a dependency in pylint's CI on bleeding-edge astroid with respect to failing jobs (because that is more significant than simply the contents of a bot's comments on a PR), I filter those out here and just issue a warning instead.