### PR TITLE
Reraise failures in astroid as `AstroidError`

### DIFF
--- a/doc/whatsnew/2/2.14/summary.rst
+++ b/doc/whatsnew/2/2.14/summary.rst
@@ -141,6 +141,10 @@ Other Changes
 
   Closes #4301
 
+* We made a greater effort to reraise failures stemming from the ``astroid``
+  library as ``AstroidError``, with the effect that pylint emits ``astroid-error``
+  rather than merely ``fatal``. Regardless, please report any such issues you encounter!
+
 * We have improved our recognition of inline disable and enable comments. It is
   now possible to disable ``bad-option-value`` inline (as long as you disable it before
   the bad option value is raised, i.e. ``disable=bad-option-value,bad-message`` not ``disable=bad-message,bad-option-value`` ) as well as certain other

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -771,7 +771,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             message = f"Cannot import {modname!r} due to syntax error {str(exc.error)!r}"  # pylint: disable=no-member; false positive
             self.add_message("syntax-error", line=importnode.lineno, args=message)
 
-        except astroid.AstroidBuildingException:
+        except astroid.AstroidBuildingError:
             if not self.linter.is_message_enabled("import-error"):
                 return None
             if _ignore_import_failure(importnode, modname, self._ignored_modules):
@@ -784,6 +784,8 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
 
             dotted_modname = get_import_name(importnode, modname)
             self.add_message("import-error", args=repr(dotted_modname), node=importnode)
+        except Exception as e:  # pragma: no cover
+            raise astroid.AstroidError from e
         return None
 
     def _add_imported_module(

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -21,6 +21,7 @@ import _string
 import astroid.objects
 from astroid import TooManyLevelsError, nodes
 from astroid.context import InferenceContext
+from astroid.exceptions import AstroidError
 
 from pylint.constants import TYPING_TYPE_CHECKS_GUARDS
 
@@ -1259,6 +1260,8 @@ def safe_infer(
         value = next(infer_gen)
     except astroid.InferenceError:
         return None
+    except Exception as e:  # pragma: no cover
+        raise AstroidError from e
 
     if value is not astroid.Uninferable:
         inferred_types.add(_get_python_type_of_node(value))
@@ -1280,6 +1283,8 @@ def safe_infer(
         return None  # There is some kind of ambiguity
     except StopIteration:
         return value
+    except Exception as e:  # pragma: no cover
+        raise AstroidError from e
     return value if len(inferred_types) <= 1 else None
 
 
@@ -1291,6 +1296,8 @@ def infer_all(
         return list(node.infer(context=context))
     except astroid.InferenceError:
         return []
+    except Exception as e:  # pragma: no cover
+        raise AstroidError from e
 
 
 def has_known_bases(

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -695,6 +695,7 @@ class PyLinter(
         :param callable check_astroid_module: callable checking an AST taking the following arguments
         - ast: AST of the module
         :param FileItem file: data about the file
+        :raises AstroidError: for any failures stemming from astroid
         """
         self.set_current_module(file.name, file.filepath)
         # get the module representation
@@ -708,7 +709,10 @@ class PyLinter(
         # fix the current file (if the source file was not available or
         # if it's actually a c extension)
         self.current_file = ast_node.file
-        check_astroid_module(ast_node)
+        try:
+            check_astroid_module(ast_node)
+        except Exception as e:  # pragma: no cover
+            raise astroid.AstroidError from e
         # warn about spurious inline messages handling
         spurious_messages = self.file_state.iter_spurious_suppression_messages(
             self.msgs_store


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] If it's a new feature, or an important bug fix, add a What's New entry in
      ``doc/whatsnew/2/2.14/summary.rst`` otherwise in ``doc/whatsnew/2/2.14/full.rst``.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Not 100% bullet-proof, but we're making an effort not to fail primer jobs if the failures stem from astroid and just warn about them instead. There could be little places all over the codebase that import little helpers, but these are the big ones.

Ref https://github.com/PyCQA/pylint/pull/6746#issuecomment-1141266169