### PR TITLE
Run primer on ``3.7`` and ``3.10``

### DIFF
--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -30,11 +30,11 @@ jobs:
       - run: npm install @octokit/rest
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         id: python
         uses: actions/setup-python@v3.1.2
         with:
-          python-version: 3.8
+          python-version: 3.10
 
       # Restore cached Python environment
       - name: Generate partial Python venv restore key

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.7", "3.10"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.2

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.7", "3.10"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.2


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

I think it makes most sense to run the primer on the last and least supported versions. Running it on any other doesn't really add much I think.

Besides, running on `3.7` has the additional benefit of testing the old parser (<3.8).