### PR TITLE
Warn users who want to be warned about failing comment workflows

### DIFF
--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -24,6 +24,10 @@ jobs:
     name: Run
     runs-on: ubuntu-latest
     steps:
+      - name: Skip if PR run failed
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        run: exit 1
+      - run: echo 'The triggering workflow passed'
       - uses: actions/setup-node@v3
         with:
           node-version: 16
@@ -138,3 +142,10 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           leave_visible: 1
           issue_number: ${{ steps.post-comment.outputs.result }}
+      - name: Warn about failure
+        if: ${{ failure() }}
+        run: |
+          echo "🤖 **Comment workflow failed**. 🤖" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Please investigate:" >> $GITHUB_STEP_SUMMARY
+          echo "@DanielNoord" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -24,10 +24,6 @@ jobs:
     name: Run
     runs-on: ubuntu-latest
     steps:
-      - name: Skip if PR run failed
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        run: exit 1
-      - run: echo 'The triggering workflow passed'
       - uses: actions/setup-node@v3
         with:
           node-version: 16


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Since Comment workflows fail silently expect for PR creators we can easily miss whenever there are issues in that pipeline.
This makes it so that I will be tagged in any failing workflows which is quite handy.

See [this](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary) and [this](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/)