### PR TITLE
Fix a crash in the ``docparams`` extension when raising the result of a function

### DIFF
--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -94,6 +94,8 @@ Release date: TBA
 
   Closes #6372
 
+* Fixed a crash in the ``docparams`` extension involving raising the result of a function.
+
 * Fixed failure to enable ``deprecated-module`` after a ``disable=all``
   by making ``ImportsChecker`` solely responsible for emitting ``deprecated-module`` instead
   of sharing responsibility with ``StdlibChecker``. (This could have led to double messages.)

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -135,6 +135,8 @@ def possible_exc_types(node: nodes.NodeNG) -> set[nodes.ClassDef]:
             exceptions = [target]
         elif isinstance(target, nodes.FunctionDef):
             for ret in target.nodes_of_class(nodes.Return):
+                if ret.value is None:
+                    continue
                 if ret.frame(future=True) != target:
                     # return from inner function - ignore it
                     continue

--- a/tests/extensions/test_check_docs_utils.py
+++ b/tests/extensions/test_check_docs_utils.py
@@ -139,3 +139,14 @@ def test_exception(raise_node, expected):
     for node in found_nodes:
         assert isinstance(node, astroid.nodes.ClassDef)
     assert {node.name for node in found_nodes} == expected
+
+
+def test_possible_exc_types_raising_potential_none() -> None:
+    raise_node = astroid.extract_node(
+        """
+    def a():
+        return
+    raise a()  #@
+    """
+    )
+    assert utils.possible_exc_types(raise_node) == set()


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Fixes issue discovered by new primer!
