### PR TITLE
Fix broken links in primer comments by stripping ".git"

### DIFF
--- a/tests/primer/primer_tool.py
+++ b/tests/primer/primer_tool.py
@@ -237,7 +237,8 @@ class Primer:
                 filepath = str(message["path"]).replace(
                     str(package_data.clone_directory), ""
                 )
-                comment += f"{package_data.url}/blob/{package_data.branch}{filepath}#L{message['line']}\n"
+                without_suffix = package_data.url.strip(".git")
+                comment += f"{without_suffix}/blob/{package_data.branch}{filepath}#L{message['line']}\n"
                 count += 1
                 print(message)
             if missing_messages:

--- a/tests/primer/primer_tool.py
+++ b/tests/primer/primer_tool.py
@@ -237,7 +237,7 @@ class Primer:
                 filepath = str(message["path"]).replace(
                     str(package_data.clone_directory), ""
                 )
-                without_suffix = package_data.url.strip(".git")
+                without_suffix = package_data.url.rsplit(".git")[0]
                 comment += f"{without_suffix}/blob/{package_data.branch}{filepath}#L{message['line']}\n"
                 count += 1
                 print(message)


### PR DESCRIPTION
Second time I noticed broken URLs with ".git" in them, so better to fix at the source! Ref #6733