### PR TITLE
Add commit hash in the primer comment

### DIFF
--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Compare outputs
         run: |
           . venv/bin/activate
-          python tests/primer/primer_tool.py compare --base-file=output_${{ steps.python.outputs.python-version }}_main.txt --new-file=output_${{ steps.python.outputs.python-version }}_pr.txt
+          python tests/primer/primer_tool.py compare --commit=${{ github.event.workflow_run.head_sha }} --base-file=output_${{ steps.python.outputs.python-version }}_main.txt --new-file=output_${{ steps.python.outputs.python-version }}_pr.txt
       - name: Post comment
         id: post-comment
         uses: actions/github-script@v6

--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -111,7 +111,10 @@ jobs:
       - name: Compare outputs
         run: |
           . venv/bin/activate
-          python tests/primer/primer_tool.py compare --commit=${{ github.event.workflow_run.head_sha }} --base-file=output_${{ steps.python.outputs.python-version }}_main.txt --new-file=output_${{ steps.python.outputs.python-version }}_pr.txt
+          python tests/primer/primer_tool.py compare \
+          --commit=${{ github.event.workflow_run.head_sha }} \
+          --base-file=output_${{ steps.python.outputs.python-version }}_main.txt \
+          --new-file=output_${{ steps.python.outputs.python-version }}_pr.txt
       - name: Post comment
         id: post-comment
         uses: actions/github-script@v6

--- a/tests/primer/primer_tool.py
+++ b/tests/primer/primer_tool.py
@@ -79,6 +79,11 @@ class Primer:
             required=True,
             help="Location of output file of the new run.",
         )
+        compare_parser.add_argument(
+            "--commit",
+            required=True,
+            help="Commit hash of the PR commit being checked.",
+        )
 
         # Storing arguments
         self.config = self._argument_parser.parse_args()
@@ -253,6 +258,8 @@ class Primer:
             comment = (
                 "🤖 **Effect of this PR on checked open source code:** 🤖\n\n" + comment
             )
+
+        comment += f"*This comment was generated for commit {self.config.commit}*"
 
         with open(PRIMER_DIRECTORY / "comment.txt", "w", encoding="utf-8") as f:
             f.write(comment)


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This is something I always miss in the comments from `coveralls`. Allows you to make sure you're looking at the latest comment and are not still waiting on some workflow to finish.