### PR TITLE
Prevent `unused-import` for `if t.TYPE_CHECKING`

### DIFF
--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -22,6 +22,11 @@ Release date: TBA
 
   Closes #6802
 
+* Fixed false positives for ``unused-import`` when aliasing ``typing`` e.g. as ``t``
+  and guarding imports under ``t.TYPE_CHECKING``.
+
+  Closes #3846
+
 * Fixed a false positive regression in 2.13 for ``used-before-assignment`` where it is safe to rely
   on a name defined only in an ``except`` block because the ``else`` block returned.
 

--- a/tests/functional/u/unused/unused_import.py
+++ b/tests/functional/u/unused/unused_import.py
@@ -17,15 +17,18 @@ class SomeClass(object):
     SomeOtherName = SomeOtherName
 
 from never import __all__
-# pylint: disable=wrong-import-order,ungrouped-imports
+# pylint: disable=wrong-import-order,ungrouped-imports,reimported
 import typing
 from typing import TYPE_CHECKING
+import typing as t
 
 
 if typing.TYPE_CHECKING:
     import collections
 if TYPE_CHECKING:
     import itertools
+if t.TYPE_CHECKING:
+    import xml
 
 
 def get_ordered_dict() -> 'collections.OrderedDict':
@@ -65,3 +68,22 @@ class NonRegr(object):
 if TYPE_CHECKING:
     if sys.version_info >= (3, 6, 2):
         from typing import NoReturn
+
+# Pathological cases
+from io import TYPE_CHECKING  # pylint: disable=no-name-in-module
+import trace as t
+import astroid as typing
+TYPE_CHECKING = "red herring"
+
+if TYPE_CHECKING:
+    import unittest  # [unused-import]
+if t.TYPE_CHECKING:  # pylint: disable=no-member
+    import uuid  # [unused-import]
+if typing.TYPE_CHECKING:  # pylint: disable=no-member
+    import warnings  # [unused-import]
+if typing.TYPE_CHECKING_WITH_MAGIC:  # pylint: disable=no-member
+    import compileall  # [unused-import]
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import zoneinfo

--- a/tests/functional/u/unused/unused_import.txt
+++ b/tests/functional/u/unused/unused_import.txt
@@ -7,4 +7,8 @@ unused-import:9:0:9:51::Unused OrderedDict imported from collections:UNDEFINED
 unused-import:9:0:9:51::Unused deque imported from collections:UNDEFINED
 unused-import:10:0:10:22::Unused import re:UNDEFINED
 unused-import:13:0:13:40::Unused SomeOtherName imported from fake:UNDEFINED
-unused-import:45:0:45:9::Unused import os:UNDEFINED
+unused-import:48:0:48:9::Unused import os:UNDEFINED
+unused-import:79:4:79:19::Unused import unittest:UNDEFINED
+unused-import:81:4:81:15::Unused import uuid:UNDEFINED
+unused-import:83:4:83:19::Unused import warnings:UNDEFINED
+unused-import:85:4:85:21::Unused import compileall:UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Write a good description on what the PR does.
- [x] Add an entry to the change log describing the change in
  `doc/whatsnew/2/2.15/index.rst` (or ``doc/whatsnew/2/2.14/full.rst``
   if the change needs backporting in 2.14). If necessary you can write
   details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The check for `typing.TYPE_CHECKING` was not robust against importing `typing` as `t`. Nor against importing `keyboarding` as `typing`. This could lead to false positives for `unused-import`.

Follow-up: we have the following plethora of utils. Would be good to standardize and deprecate some for 2.15 (not a backport task, though):
 - is_typing_guard()
 - is_node_in_typing_guarded_import_block()
 - in_type_checking_block()  <-- **this one** edited in this PR
 

Closes #3846