### PR TITLE
Store namespaces respective to directories

### DIFF
--- a/.pyenchant_pylint_custom_dict.txt
+++ b/.pyenchant_pylint_custom_dict.txt
@@ -21,6 +21,7 @@ async
 asynccontextmanager
 attr
 attrib
+backport
 BaseChecker
 basename
 behaviour

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -42,7 +42,7 @@ from pylint.config.option_parser import OptionParser
 from pylint.config.options_provider_mixin import OptionsProviderMixIn
 from pylint.config.utils import _convert_option_to_argument, _parse_rich_type_value
 from pylint.constants import MAIN_CHECKER_NAME
-from pylint.typing import OptionDict
+from pylint.typing import DirectoryNamespaceDict, OptionDict
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -66,6 +66,14 @@ class _ArgumentsManager:
         self._config = argparse.Namespace()
         """Namespace for all options."""
 
+        self._base_config = self._config
+        """Fall back Namespace object created during initialization.
+
+        This is necessary for the per-directory configuration support. Whenever we
+        fail to match a file with a directory we fall back to the Namespace object
+        created during initialization.
+        """
+
         self._arg_parser = argparse.ArgumentParser(
             prog=prog,
             usage=usage or "%(prog)s [options]",
@@ -81,6 +89,9 @@ class _ArgumentsManager:
 
         self._option_dicts: dict[str, OptionDict] = {}
         """All option dictionaries that have been registered."""
+
+        self._directory_namespaces: DirectoryNamespaceDict = {}
+        """Mapping of directories and their respective namespace objects."""
 
         # TODO: 3.0: Remove deprecated attributes introduced to keep API
         # parity with optparse. Until '_maxlevel'

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -106,6 +106,9 @@ def _config_initialization(
 
     linter._parse_error_mode()
 
+    # Link the base Namespace object on the current directory
+    linter._directory_namespaces[Path(".").resolve()] = (linter.config, {})
+
     # parsed_args_list should now only be a list of files/directories to lint.
     # All other options have been removed from the list.
     return parsed_args_list

--- a/pylint/lint/utils.py
+++ b/pylint/lint/utils.py
@@ -99,3 +99,16 @@ def fix_import_path(args: Sequence[str]) -> Iterator[None]:
         yield
     finally:
         sys.path[:] = original
+
+
+def _is_relative_to(self: Path, *other: Path) -> bool:
+    """Checks if self is relative to other.
+
+    Backport of pathlib.Path.is_relative_to for Python <3.9
+    TODO: py39: Remove this backport and use stdlib function.
+    """
+    try:
+        self.relative_to(*other)
+        return True
+    except ValueError:
+        return False

--- a/pylint/typing.py
+++ b/pylint/typing.py
@@ -6,7 +6,9 @@
 
 from __future__ import annotations
 
+import argparse
 import sys
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -127,3 +129,5 @@ MessageDefinitionTuple = Union[
     Tuple[str, str, str],
     Tuple[str, str, str, ExtraMessageOptions],
 ]
+# Mypy doesn't support recursive types (yet), see https://github.com/python/mypy/issues/731
+DirectoryNamespaceDict = Dict[Path, Tuple[argparse.Namespace, "DirectoryNamespaceDict"]]  # type: ignore[misc]

--- a/tests/config/test_per_directory_config.py
+++ b/tests/config/test_per_directory_config.py
@@ -8,17 +8,17 @@ from pathlib import Path
 from pylint.lint import Run
 
 
-def test_fall_back_on_base_config() -> None:
+def test_fall_back_on_base_config(tmpdir: LocalPath) -> None:
     """Test that we correctly fall back on the base config."""
     # A file under the current dir should fall back to the highest level
     # For pylint this is ./pylintrc
+     test_file = tmpdir /  "test.py"
     runner = Run([__name__], exit=False)
     assert id(runner.linter.config) == id(runner.linter._base_config)
 
     # When the file is a directory that does not have any of its parents in
     # linter._directory_namespaces it should default to the base config
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(Path(tmpdir) / "test.py", "w", encoding="utf-8") as f:
-            f.write("1")
-        Run([str(Path(tmpdir) / "test.py")], exit=False)
-        assert id(runner.linter.config) == id(runner.linter._base_config)
+    with open(test_file, "w", encoding="utf-8") as f:
+        f.write("1")
+    Run([str(test_file)], exit=False)
+    assert id(runner.linter.config) == id(runner.linter._base_config)

--- a/tests/config/test_per_directory_config.py
+++ b/tests/config/test_per_directory_config.py
@@ -1,0 +1,24 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+import tempfile
+from pathlib import Path
+
+from pylint.lint import Run
+
+
+def test_fall_back_on_base_config() -> None:
+    """Test that we correctly fall back on the base config."""
+    # A file under the current dir should fall back to the highest level
+    # For pylint this is ./pylintrc
+    runner = Run([__name__], exit=False)
+    assert id(runner.linter.config) == id(runner.linter._base_config)
+
+    # When the file is a directory that does not have any of its parents in
+    # linter._directory_namespaces it should default to the base config
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(Path(tmpdir) / "test.py", "w", encoding="utf-8") as f:
+            f.write("1")
+        Run([str(Path(tmpdir) / "test.py")], exit=False)
+        assert id(runner.linter.config) == id(runner.linter._base_config)

--- a/tests/config/test_per_directory_config.py
+++ b/tests/config/test_per_directory_config.py
@@ -3,6 +3,8 @@
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
 
+from py._path.local import LocalPath  # type: ignore[import]
+
 from pylint.lint import Run
 
 

--- a/tests/config/test_per_directory_config.py
+++ b/tests/config/test_per_directory_config.py
@@ -2,8 +2,6 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
-import tempfile
-from pathlib import Path
 
 from pylint.lint import Run
 
@@ -12,7 +10,7 @@ def test_fall_back_on_base_config(tmpdir: LocalPath) -> None:
     """Test that we correctly fall back on the base config."""
     # A file under the current dir should fall back to the highest level
     # For pylint this is ./pylintrc
-    test_file = tmpdir /  "test.py"
+    test_file = tmpdir / "test.py"
     runner = Run([__name__], exit=False)
     assert id(runner.linter.config) == id(runner.linter._base_config)
 

--- a/tests/config/test_per_directory_config.py
+++ b/tests/config/test_per_directory_config.py
@@ -12,7 +12,7 @@ def test_fall_back_on_base_config(tmpdir: LocalPath) -> None:
     """Test that we correctly fall back on the base config."""
     # A file under the current dir should fall back to the highest level
     # For pylint this is ./pylintrc
-     test_file = tmpdir /  "test.py"
+    test_file = tmpdir /  "test.py"
     runner = Run([__name__], exit=False)
     assert id(runner.linter.config) == id(runner.linter._base_config)
 


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This is a first step towards `per-directory-config` as I think they make the most sense:
1) Create a basic `Namespace`
2) Iterate over all `files_or_modules` and see if we can create additional `Namespaces` for subdirectories
3) Look up the correct `Namespace` before checking a file

This is a basic implementation of 3 which allows storing the information that should be gathered in step 2.