### PR TITLE
Prevent `used-before-assignment` for names only defined under `except` if the `else` returns

### DIFF
--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -90,6 +90,11 @@ Release date: 2022-06-01
 
   Refs #6462
 
+* Fixed a false positive regression in 2.13 for ``used-before-assignment`` where it is safe to rely
+  on a name defined only in an ``except`` block because the ``else`` block returned.
+
+  Closes #6790
+
 * Removed the ``assign-to-new-keyword`` message as there are no new keywords in the supported Python
   versions any longer.
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -680,12 +680,16 @@ scope_type : {self._atomic.scope_type}
             if closest_except_handler.parent_of(node):
                 continue
             closest_try_except: nodes.TryExcept = closest_except_handler.parent
+            # If the try or else blocks return, assume the except blocks execute.
             try_block_returns = any(
                 isinstance(try_statement, nodes.Return)
                 for try_statement in closest_try_except.body
             )
-            # If the try block returns, assume the except blocks execute.
-            if try_block_returns:
+            else_block_returns = any(
+                isinstance(else_statement, nodes.Return)
+                for else_statement in closest_try_except.orelse
+            )
+            if try_block_returns or else_block_returns:
                 # Exception: if this node is in the final block of the other_node_statement,
                 # it will execute before returning. Assume the except statements are uncertain.
                 if (

--- a/tests/functional/u/used/used_before_assignment_else_return.py
+++ b/tests/functional/u/used/used_before_assignment_else_return.py
@@ -1,0 +1,50 @@
+"""If the else block returns, it is generally safe to rely on assignments in the except."""
+
+
+def valid():
+    """https://github.com/PyCQA/pylint/issues/6790"""
+    try:
+        pass
+    except ValueError:
+        error = True
+    else:
+        return
+
+    print(error)
+
+
+def invalid():
+    """The finally will execute before the else returns."""
+    try:
+        pass
+    except ValueError:
+        error = None
+    else:
+        return
+    finally:
+        print(error)  # [used-before-assignment]
+
+
+def invalid_2():
+    """The else does not return in every branch."""
+    try:
+        pass
+    except ValueError:
+        error = None
+    else:
+        if range(0):
+            return
+    finally:
+        print(error)  # [used-before-assignment]
+
+
+def invalid_3():
+    """Not every except defines the name."""
+    try:
+        pass
+    except ValueError:
+        error = None
+    except KeyError:
+        pass
+    finally:
+        print(error)  # [used-before-assignment]

--- a/tests/functional/u/used/used_before_assignment_else_return.txt
+++ b/tests/functional/u/used/used_before_assignment_else_return.txt
@@ -1,0 +1,3 @@
+used-before-assignment:25:14:25:19:invalid:Using variable 'error' before assignment:CONTROL_FLOW
+used-before-assignment:38:14:38:19:invalid_2:Using variable 'error' before assignment:CONTROL_FLOW
+used-before-assignment:50:14:50:19:invalid_3:Using variable 'error' before assignment:CONTROL_FLOW


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Closes #6790
