### PR TITLE
Rename clashing import name in one test case

### DIFF
--- a/tests/functional/r/regression/regression_4680.py
+++ b/tests/functional/r/regression/regression_4680.py
@@ -1,9 +1,9 @@
 # pylint: disable=missing-docstring,too-few-public-methods
 
-import pkg.sub  # [import-error]
+import foo.sub  # [import-error]
 
 
-class Failed(metaclass=pkg.sub.Metaclass):
+class Failed(metaclass=foo.sub.Metaclass):
     pass
 
 
@@ -11,8 +11,8 @@ class FailedTwo(metaclass=ab.ABCMeta):  # [undefined-variable]
     pass
 
 
-class FailedThree(metaclass=pkg.sob.Metaclass):
+class FailedThree(metaclass=foo.sob.Metaclass):
     pass
 
 
-assert pkg.sub.value is None
+assert foo.sub.value is None

--- a/tests/functional/r/regression/regression_4680.txt
+++ b/tests/functional/r/regression/regression_4680.txt
@@ -1,2 +1,2 @@
-import-error:3:0:3:14::Unable to import 'pkg.sub':UNDEFINED
+import-error:3:0:3:14::Unable to import 'foo.sub':UNDEFINED
 undefined-variable:10:0:10:15:FailedTwo:Undefined variable 'ab':UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Add an entry to the change log describing the change in
  `doc/whatsnew/2/2.15/index.rst` (or ``doc/whatsnew/2/2.14/full.rst``
   if the change needs backporting in 2.14). If necessary you can write
   details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

On Solaris (both Oracle and OpenIndiana), `import pkg` actually find something because pkg is our OS package manager. This results in pylint warnings in **regression_4680** test being very different. Would it be possible to rename it to something non clashing? It seems that foo package doesn't exist, but if it does, I am happy to change it to anything else ;).
