### PR TITLE
Fix the use of abbreviations for preprocessable options on the CLI

### DIFF
--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -13,6 +13,10 @@ Release date: TBA
 
   Closes #6802
 
+* Fixed the use of abbreviations for some special options on the command line.
+
+  Closes #6810
+
 
 What's New in Pylint 2.14.0?
 ----------------------------

--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -203,6 +203,7 @@ def _enable_all_extensions(run: Run, value: str | None) -> None:
 PREPROCESSABLE_OPTIONS: dict[
     str, tuple[bool, Callable[[Run, str | None], None], int]
 ] = {  # pylint: disable=consider-using-namedtuple-or-dataclass
+    # pylint: disable=wrong-spelling-in-comment
     # Argparse by default allows abbreviations. It behaves differently
     # if you turn this off, so we also turn it on. We mimick this
     # by allowing some abbreviations or incorrect spelling here.
@@ -223,6 +224,7 @@ PREPROCESSABLE_OPTIONS: dict[
     # Clashes with --enable
     "--enable-all-extensions": (False, _enable_all_extensions, 9),
 }
+# pylint: enable=wrong-spelling-in-comment
 
 
 def _preprocess_options(run: Run, args: Sequence[str]) -> list[str]:

--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -201,15 +201,27 @@ def _enable_all_extensions(run: Run, value: str | None) -> None:
 
 
 PREPROCESSABLE_OPTIONS: dict[
-    str, tuple[bool, Callable[[Run, str | None], None]]
+    str, tuple[bool, Callable[[Run, str | None], None], int]
 ] = {  # pylint: disable=consider-using-namedtuple-or-dataclass
-    "--init-hook": (True, _init_hook),
-    "--rcfile": (True, _set_rcfile),
-    "--output": (True, _set_output),
-    "--load-plugins": (True, _add_plugins),
-    "--verbose": (False, _set_verbose_mode),
-    "-v": (False, _set_verbose_mode),
-    "--enable-all-extensions": (False, _enable_all_extensions),
+    # Argparse by default allows abbreviations. It behaves differently
+    # if you turn this off, so we also turn it on. We mimick this
+    # by allowing some abbreviations or incorrect spelling here.
+    # The integer at the end of the tuple indicates how many letters
+    # should match, include the '-'. 0 indicates a full match.
+    #
+    # Clashes with --init-(import)
+    "--init-hook": (True, _init_hook, 8),
+    # Clashes with --r(ecursive)
+    "--rcfile": (True, _set_rcfile, 4),
+    # Clashes with --output(-format)
+    "--output": (True, _set_output, 0),
+    # Clashes with --lo(ng-help)
+    "--load-plugins": (True, _add_plugins, 5),
+    # Clashes with --v(ariable-rgx)
+    "--verbose": (False, _set_verbose_mode, 4),
+    "-v": (False, _set_verbose_mode, 2),
+    # Clashes with --enable
+    "--enable-all-extensions": (False, _enable_all_extensions, 9),
 }
 
 
@@ -230,12 +242,21 @@ def _preprocess_options(run: Run, args: Sequence[str]) -> list[str]:
         except ValueError:
             option, value = argument, None
 
-        if option not in PREPROCESSABLE_OPTIONS:
+        matched_option = None
+        for option_name, data in PREPROCESSABLE_OPTIONS.items():
+            to_match = data[2]
+            if to_match == 0:
+                if option == option_name:
+                    matched_option = option_name
+            elif option.startswith(option_name[:to_match]):
+                matched_option = option_name
+
+        if matched_option is None:
             processed_args.append(argument)
             i += 1
             continue
 
-        takearg, cb = PREPROCESSABLE_OPTIONS[option]
+        takearg, cb, _ = PREPROCESSABLE_OPTIONS[matched_option]
 
         if takearg and value is None:
             i += 1

--- a/tests/config/test_find_default_config_files.py
+++ b/tests/config/test_find_default_config_files.py
@@ -176,6 +176,7 @@ def test_verbose_abbreviation(capsys: CaptureFixture) -> None:
             with pytest.raises(SystemExit):
                 Run(["--ve"])
             out = capsys.readouterr()
+            # This output only exists when launched in verbose mode
             assert "No config file found, using default configuration" in out.err
 
 

--- a/tests/config/test_find_default_config_files.py
+++ b/tests/config/test_find_default_config_files.py
@@ -165,6 +165,20 @@ def test_verbose_output_no_config(capsys: CaptureFixture) -> None:
             assert "No config file found, using default configuration" in out.err
 
 
+@pytest.mark.usefixtures("pop_pylintrc")
+def test_verbose_abbreviation(capsys: CaptureFixture) -> None:
+    """Test that we correctly handle an abbreviated pre-processable option."""
+    with tempdir() as chroot:
+        with fake_home():
+            chroot_path = Path(chroot)
+            testutils.create_files(["a/b/c/d/__init__.py"])
+            os.chdir(chroot_path / "a/b/c")
+            with pytest.raises(SystemExit):
+                Run(["--ve"])
+            out = capsys.readouterr()
+            assert "No config file found, using default configuration" in out.err
+
+
 @pytest.mark.parametrize(
     "content,expected",
     [


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #6810.

This might need to be updated when we add new options, but a new option that clashes with the current length of these preprocessable options will error out anyway. So it's immediately clear that something needs to be updated.

