### PR TITLE
typecheck/Enum: fix crash in Enum attributes check

### DIFF
--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -9,6 +9,10 @@ Release date: TBA
 
   Closes #6800
 
+* Fixed a crash when linting ``__new__()`` methods that return a call expression.
+
+  Closes #6805
+
 * Don't crash if we can't find the user's home directory.
 
   Closes #6802

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -451,10 +451,10 @@ def _emit_no_member(
             except astroid.MroError:
                 return False
             if metaclass:
-                if _enum_has_attribute(owner, node):
-                    return False
                 # Renamed in Python 3.10 to `EnumType`
-                return metaclass.qname() in {"enum.EnumMeta", "enum.EnumType"}
+                if metaclass.qname() in {"enum.EnumMeta", "enum.EnumType"}:
+                    return not _enum_has_attribute(owner, node)
+                return False
             return False
         if not has_known_bases(owner):
             return False

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -583,7 +583,7 @@ def _enum_has_attribute(
             (c.value for c in dunder_new.get_children() if isinstance(c, nodes.Return)),
             None,
         )
-        if returned_obj_name is not None:
+        if isinstance(returned_obj_name, nodes.Name):
             # Find all attribute assignments to the returned object
             enum_attributes |= _get_all_attribute_assignments(
                 dunder_new, returned_obj_name.name

--- a/tests/functional/e/enum_self_defined_member_6805.py
+++ b/tests/functional/e/enum_self_defined_member_6805.py
@@ -1,6 +1,7 @@
 """Tests for self-defined Enum members (https://github.com/PyCQA/pylint/issues/6805)"""
 # pylint: disable=missing-docstring
 # pylint: disable=too-few-public-methods
+from enum import IntEnum
 
 
 class Foo(type):
@@ -24,3 +25,19 @@ class NotEnumHasDynamicGetAttrMetaclass(metaclass=Foo):
 
 
 NotEnumHasDynamicGetAttrMetaclass().magic()
+
+
+class Day(IntEnum):
+    MONDAY = (1, "Mon")
+    TUESDAY = (2, "Tue")
+    WEDNESDAY = (3, "Wed")
+    THURSDAY = (4, "Thu")
+    FRIDAY = (5, "Fri")
+    SATURDAY = (6, "Sat")
+    SUNDAY = (7, "Sun")
+
+    def __new__(cls, value, _abbr=None):
+        return int.__new__(cls, value)
+
+
+print(Day.FRIDAY.foo)  # [no-member]

--- a/tests/functional/e/enum_self_defined_member_6805.py
+++ b/tests/functional/e/enum_self_defined_member_6805.py
@@ -1,0 +1,26 @@
+"""Tests for self-defined Enum members (https://github.com/PyCQA/pylint/issues/6805)"""
+# pylint: disable=missing-docstring
+# pylint: disable=too-few-public-methods
+
+
+class Foo(type):
+    pass
+
+
+class Parent:
+    def __new__(cls, *_args, **_kwargs):
+        return object.__new__(cls)
+
+
+class NotEnumHasDynamicGetAttrMetaclass(metaclass=Foo):
+    def __new__(cls):
+        return Parent.__new__(cls)
+
+    def __getattr__(self, item):
+        return item
+
+    def magic(self):
+        return self.dynamic
+
+
+NotEnumHasDynamicGetAttrMetaclass().magic()

--- a/tests/functional/e/enum_self_defined_member_6805.txt
+++ b/tests/functional/e/enum_self_defined_member_6805.txt
@@ -1,0 +1,1 @@
+no-member:43:6:43:20::Instance of 'FRIDAY' has no 'foo' member:INFERENCE


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fixes #6805 by:
 - only checking for Enum attributes when metaclass is an Enum metaclass
 - coping with a name not being returned in `__new__`
