### PR TITLE
[deleted messages] Refactor the constant to be able to give a reason

### DIFF
--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -203,9 +203,8 @@ def _enable_all_extensions(run: Run, value: str | None) -> None:
 PREPROCESSABLE_OPTIONS: dict[
     str, tuple[bool, Callable[[Run, str | None], None], int]
 ] = {  # pylint: disable=consider-using-namedtuple-or-dataclass
-    # pylint: disable=wrong-spelling-in-comment
     # Argparse by default allows abbreviations. It behaves differently
-    # if you turn this off, so we also turn it on. We mimick this
+    # if you turn this off, so we also turn it on. We mimic this
     # by allowing some abbreviations or incorrect spelling here.
     # The integer at the end of the tuple indicates how many letters
     # should match, include the '-'. 0 indicates a full match.

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -9,7 +9,6 @@ import pathlib
 import platform
 import sys
 from datetime import datetime
-from typing import NamedTuple
 
 import astroid
 import platformdirs
@@ -81,118 +80,6 @@ HUMAN_READABLE_TYPES = {
     "inlinevar": "inline iteration",
     "typevar": "type variable",
 }
-
-
-class DeletedMessage(NamedTuple):
-    msgid: str
-    symbol: str
-    old_names: list[tuple[str, str]] = []
-
-
-DELETED_MSGID_PREFIXES: list[int] = []
-
-DELETED_MESSAGES = [
-    # Everything until the next comment is from the
-    # PY3K+ checker, see https://github.com/PyCQA/pylint/pull/4942
-    DeletedMessage("W1601", "apply-builtin"),
-    DeletedMessage("E1601", "print-statement"),
-    DeletedMessage("E1602", "parameter-unpacking"),
-    DeletedMessage(
-        "E1603", "unpacking-in-except", [("W0712", "old-unpacking-in-except")]
-    ),
-    DeletedMessage("E1604", "old-raise-syntax", [("W0121", "old-old-raise-syntax")]),
-    DeletedMessage("E1605", "backtick", [("W0333", "old-backtick")]),
-    DeletedMessage("E1609", "import-star-module-level"),
-    DeletedMessage("W1601", "apply-builtin"),
-    DeletedMessage("W1602", "basestring-builtin"),
-    DeletedMessage("W1603", "buffer-builtin"),
-    DeletedMessage("W1604", "cmp-builtin"),
-    DeletedMessage("W1605", "coerce-builtin"),
-    DeletedMessage("W1606", "execfile-builtin"),
-    DeletedMessage("W1607", "file-builtin"),
-    DeletedMessage("W1608", "long-builtin"),
-    DeletedMessage("W1609", "raw_input-builtin"),
-    DeletedMessage("W1610", "reduce-builtin"),
-    DeletedMessage("W1611", "standarderror-builtin"),
-    DeletedMessage("W1612", "unicode-builtin"),
-    DeletedMessage("W1613", "xrange-builtin"),
-    DeletedMessage("W1614", "coerce-method"),
-    DeletedMessage("W1615", "delslice-method"),
-    DeletedMessage("W1616", "getslice-method"),
-    DeletedMessage("W1617", "setslice-method"),
-    DeletedMessage("W1618", "no-absolute-import"),
-    DeletedMessage("W1619", "old-division"),
-    DeletedMessage("W1620", "dict-iter-method"),
-    DeletedMessage("W1621", "dict-view-method"),
-    DeletedMessage("W1622", "next-method-called"),
-    DeletedMessage("W1623", "metaclass-assignment"),
-    DeletedMessage(
-        "W1624", "indexing-exception", [("W0713", "old-indexing-exception")]
-    ),
-    DeletedMessage("W1625", "raising-string", [("W0701", "old-raising-string")]),
-    DeletedMessage("W1626", "reload-builtin"),
-    DeletedMessage("W1627", "oct-method"),
-    DeletedMessage("W1628", "hex-method"),
-    DeletedMessage("W1629", "nonzero-method"),
-    DeletedMessage("W1630", "cmp-method"),
-    DeletedMessage("W1632", "input-builtin"),
-    DeletedMessage("W1633", "round-builtin"),
-    DeletedMessage("W1634", "intern-builtin"),
-    DeletedMessage("W1635", "unichr-builtin"),
-    DeletedMessage(
-        "W1636", "map-builtin-not-iterating", [("W1631", "implicit-map-evaluation")]
-    ),
-    DeletedMessage("W1637", "zip-builtin-not-iterating"),
-    DeletedMessage("W1638", "range-builtin-not-iterating"),
-    DeletedMessage("W1639", "filter-builtin-not-iterating"),
-    DeletedMessage("W1640", "using-cmp-argument"),
-    DeletedMessage("W1642", "div-method"),
-    DeletedMessage("W1643", "idiv-method"),
-    DeletedMessage("W1644", "rdiv-method"),
-    DeletedMessage("W1645", "exception-message-attribute"),
-    DeletedMessage("W1646", "invalid-str-codec"),
-    DeletedMessage("W1647", "sys-max-int"),
-    DeletedMessage("W1648", "bad-python3-import"),
-    DeletedMessage("W1649", "deprecated-string-function"),
-    DeletedMessage("W1650", "deprecated-str-translate-call"),
-    DeletedMessage("W1651", "deprecated-itertools-function"),
-    DeletedMessage("W1652", "deprecated-types-field"),
-    DeletedMessage("W1653", "next-method-defined"),
-    DeletedMessage("W1654", "dict-items-not-iterating"),
-    DeletedMessage("W1655", "dict-keys-not-iterating"),
-    DeletedMessage("W1656", "dict-values-not-iterating"),
-    DeletedMessage("W1657", "deprecated-operator-function"),
-    DeletedMessage("W1658", "deprecated-urllib-function"),
-    DeletedMessage("W1659", "xreadlines-attribute"),
-    DeletedMessage("W1660", "deprecated-sys-function"),
-    DeletedMessage("W1661", "exception-escape"),
-    DeletedMessage("W1662", "comprehension-escape"),
-    # https://github.com/PyCQA/pylint/pull/3578
-    DeletedMessage("W0312", "mixed-indentation"),
-    # https://github.com/PyCQA/pylint/pull/3577
-    DeletedMessage(
-        "C0326",
-        "bad-whitespace",
-        [
-            ("C0323", "no-space-after-operator"),
-            ("C0324", "no-space-after-comma"),
-            ("C0322", "no-space-before-operator"),
-        ],
-    ),
-    # https://github.com/PyCQA/pylint/pull/3571
-    DeletedMessage("C0330", "bad-continuation"),
-    # No PR
-    DeletedMessage("R0921", "abstract-class-not-used"),
-    # https://github.com/PyCQA/pylint/pull/3577
-    DeletedMessage("C0326", "bad-whitespace"),
-    # Pylint 1.4.3
-    DeletedMessage("W0142", "star-args"),
-    # https://github.com/PyCQA/pylint/issues/2409
-    DeletedMessage("W0232", "no-init"),
-    # https://github.com/PyCQA/pylint/pull/6421
-    DeletedMessage("W0111", "assign-to-new-keyword"),
-]
-
 
 # ignore some messages when emitting useless-suppression:
 # - cyclic-import: can show false positives due to incomplete context

--- a/pylint/exceptions.py
+++ b/pylint/exceptions.py
@@ -13,6 +13,17 @@ class UnknownMessageError(Exception):
     """Raised when an unregistered message id is encountered."""
 
 
+class DeletedMessageError(UnknownMessageError):
+    """Raised when a message id or symbol that was deleted from pylint is
+    encountered.
+    """
+
+    def __init__(self, msgid_or_symbol: str, removal_explanation: str):
+        super().__init__(
+            f"'{msgid_or_symbol}' was removed from pylint, see {removal_explanation}."
+        )
+
+
 class EmptyReportError(Exception):
     """Raised when a report is empty and so should not be displayed."""
 

--- a/pylint/message/_deleted_message_ids.py
+++ b/pylint/message/_deleted_message_ids.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
 from typing import NamedTuple
 
 
@@ -123,3 +124,23 @@ DELETED_MESSAGES_IDS = {
         DeletedMessage("W0111", "assign-to-new-keyword"),
     ],
 }
+
+
+@lru_cache(maxsize=None)
+def is_deleted_symbol(symbol: str) -> str | None:
+    """Return the explanation for removal if the message was removed."""
+    for explanation, deleted_messages in DELETED_MESSAGES_IDS.items():
+        for deleted_message in deleted_messages:
+            if symbol == deleted_message.symbol:
+                return explanation
+    return None
+
+
+@lru_cache(maxsize=None)
+def is_deleted_msgid(msgid: str) -> str | None:
+    """Return the explanation for removal if the message was removed."""
+    for explanation, deleted_messages in DELETED_MESSAGES_IDS.items():
+        for deleted_message in deleted_messages:
+            if msgid == deleted_message.msgid:
+                return explanation
+    return None

--- a/pylint/message/_deleted_message_ids.py
+++ b/pylint/message/_deleted_message_ids.py
@@ -1,0 +1,125 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class DeletedMessage(NamedTuple):
+    msgid: str
+    symbol: str
+    old_names: list[tuple[str, str]] = []
+
+
+DELETED_MSGID_PREFIXES: list[int] = []
+
+DELETED_MESSAGES_IDS = {
+    # Everything until the next comment is from the PY3K+ checker
+    "https://github.com/PyCQA/pylint/pull/4942": [
+        DeletedMessage("W1601", "apply-builtin"),
+        DeletedMessage("E1601", "print-statement"),
+        DeletedMessage("E1602", "parameter-unpacking"),
+        DeletedMessage(
+            "E1603", "unpacking-in-except", [("W0712", "old-unpacking-in-except")]
+        ),
+        DeletedMessage(
+            "E1604", "old-raise-syntax", [("W0121", "old-old-raise-syntax")]
+        ),
+        DeletedMessage("E1605", "backtick", [("W0333", "old-backtick")]),
+        DeletedMessage("E1609", "import-star-module-level"),
+        DeletedMessage("W1601", "apply-builtin"),
+        DeletedMessage("W1602", "basestring-builtin"),
+        DeletedMessage("W1603", "buffer-builtin"),
+        DeletedMessage("W1604", "cmp-builtin"),
+        DeletedMessage("W1605", "coerce-builtin"),
+        DeletedMessage("W1606", "execfile-builtin"),
+        DeletedMessage("W1607", "file-builtin"),
+        DeletedMessage("W1608", "long-builtin"),
+        DeletedMessage("W1609", "raw_input-builtin"),
+        DeletedMessage("W1610", "reduce-builtin"),
+        DeletedMessage("W1611", "standarderror-builtin"),
+        DeletedMessage("W1612", "unicode-builtin"),
+        DeletedMessage("W1613", "xrange-builtin"),
+        DeletedMessage("W1614", "coerce-method"),
+        DeletedMessage("W1615", "delslice-method"),
+        DeletedMessage("W1616", "getslice-method"),
+        DeletedMessage("W1617", "setslice-method"),
+        DeletedMessage("W1618", "no-absolute-import"),
+        DeletedMessage("W1619", "old-division"),
+        DeletedMessage("W1620", "dict-iter-method"),
+        DeletedMessage("W1621", "dict-view-method"),
+        DeletedMessage("W1622", "next-method-called"),
+        DeletedMessage("W1623", "metaclass-assignment"),
+        DeletedMessage(
+            "W1624", "indexing-exception", [("W0713", "old-indexing-exception")]
+        ),
+        DeletedMessage("W1625", "raising-string", [("W0701", "old-raising-string")]),
+        DeletedMessage("W1626", "reload-builtin"),
+        DeletedMessage("W1627", "oct-method"),
+        DeletedMessage("W1628", "hex-method"),
+        DeletedMessage("W1629", "nonzero-method"),
+        DeletedMessage("W1630", "cmp-method"),
+        DeletedMessage("W1632", "input-builtin"),
+        DeletedMessage("W1633", "round-builtin"),
+        DeletedMessage("W1634", "intern-builtin"),
+        DeletedMessage("W1635", "unichr-builtin"),
+        DeletedMessage(
+            "W1636", "map-builtin-not-iterating", [("W1631", "implicit-map-evaluation")]
+        ),
+        DeletedMessage("W1637", "zip-builtin-not-iterating"),
+        DeletedMessage("W1638", "range-builtin-not-iterating"),
+        DeletedMessage("W1639", "filter-builtin-not-iterating"),
+        DeletedMessage("W1640", "using-cmp-argument"),
+        DeletedMessage("W1642", "div-method"),
+        DeletedMessage("W1643", "idiv-method"),
+        DeletedMessage("W1644", "rdiv-method"),
+        DeletedMessage("W1645", "exception-message-attribute"),
+        DeletedMessage("W1646", "invalid-str-codec"),
+        DeletedMessage("W1647", "sys-max-int"),
+        DeletedMessage("W1648", "bad-python3-import"),
+        DeletedMessage("W1649", "deprecated-string-function"),
+        DeletedMessage("W1650", "deprecated-str-translate-call"),
+        DeletedMessage("W1651", "deprecated-itertools-function"),
+        DeletedMessage("W1652", "deprecated-types-field"),
+        DeletedMessage("W1653", "next-method-defined"),
+        DeletedMessage("W1654", "dict-items-not-iterating"),
+        DeletedMessage("W1655", "dict-keys-not-iterating"),
+        DeletedMessage("W1656", "dict-values-not-iterating"),
+        DeletedMessage("W1657", "deprecated-operator-function"),
+        DeletedMessage("W1658", "deprecated-urllib-function"),
+        DeletedMessage("W1659", "xreadlines-attribute"),
+        DeletedMessage("W1660", "deprecated-sys-function"),
+        DeletedMessage("W1661", "exception-escape"),
+        DeletedMessage("W1662", "comprehension-escape"),
+    ],
+    "https://github.com/PyCQA/pylint/pull/3578": [
+        DeletedMessage("W0312", "mixed-indentation"),
+    ],
+    "https://github.com/PyCQA/pylint/pull/3577": [
+        DeletedMessage(
+            "C0326",
+            "bad-whitespace",
+            [
+                ("C0323", "no-space-after-operator"),
+                ("C0324", "no-space-after-comma"),
+                ("C0322", "no-space-before-operator"),
+            ],
+        ),
+    ],
+    "https://github.com/PyCQA/pylint/pull/3571": [
+        DeletedMessage("C0330", "bad-continuation")
+    ],
+    "https://pylint.pycqa.org/en/latest/whatsnew/1/1.4.html#what-s-new-in-pylint-1-4-3": [
+        DeletedMessage("R0921", "abstract-class-not-used"),
+        DeletedMessage("R0922", "abstract-class-little-used"),
+        DeletedMessage("W0142", "star-args"),
+    ],
+    "https://github.com/PyCQA/pylint/issues/2409": [
+        DeletedMessage("W0232", "no-init"),
+    ],
+    "https://github.com/PyCQA/pylint/pull/6421": [
+        DeletedMessage("W0111", "assign-to-new-keyword"),
+    ],
+}

--- a/script/get_unused_message_id_category.py
+++ b/script/get_unused_message_id_category.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from pylint.checkers import initialize as initialize_checkers
 from pylint.extensions import initialize as initialize_extensions
 from pylint.lint.pylinter import PyLinter
-from pylint.message.deleted_message_ids import _DELETED_MSGID_PREFIXES
+from pylint.message._deleted_message_ids import DELETED_MSGID_PREFIXES
 
 
 def register_all_checkers_and_plugins(linter: PyLinter) -> None:
@@ -21,7 +21,7 @@ def register_all_checkers_and_plugins(linter: PyLinter) -> None:
 def get_next_code_category(message_ids: list[str]) -> int:
     categories = sorted({int(i[:2]) for i in message_ids})
     # We add the prefixes for deleted checkers
-    categories += _DELETED_MSGID_PREFIXES
+    categories += DELETED_MSGID_PREFIXES
     for i in categories:
         if i + 1 not in categories:
             return i + 1

--- a/script/get_unused_message_id_category.py
+++ b/script/get_unused_message_id_category.py
@@ -6,9 +6,9 @@
 from __future__ import annotations
 
 from pylint.checkers import initialize as initialize_checkers
-from pylint.constants import DELETED_MSGID_PREFIXES
 from pylint.extensions import initialize as initialize_extensions
 from pylint.lint.pylinter import PyLinter
+from pylint.message.deleted_message_ids import _DELETED_MSGID_PREFIXES
 
 
 def register_all_checkers_and_plugins(linter: PyLinter) -> None:
@@ -21,7 +21,7 @@ def register_all_checkers_and_plugins(linter: PyLinter) -> None:
 def get_next_code_category(message_ids: list[str]) -> int:
     categories = sorted({int(i[:2]) for i in message_ids})
     # We add the prefixes for deleted checkers
-    categories += DELETED_MSGID_PREFIXES
+    categories += _DELETED_MSGID_PREFIXES
     for i in categories:
         if i + 1 not in categories:
             return i + 1

--- a/tests/config/functional/ini/pylintrc_with_deleted_message.2.out
+++ b/tests/config/functional/ini/pylintrc_with_deleted_message.2.out
@@ -1,0 +1,4 @@
+************* Module {abspath}
+{relpath}:1:0: E0012: Bad option value for --disable. Don't recognize message buffer-builtin. (bad-option-value)
+{relpath}:1:0: E0012: Bad option value for --enable. Don't recognize message useless-option-value. (bad-option-value)
+{relpath}:1:0: E0012: Bad option value for --enable. Don't recognize message cmp-builtin. (bad-option-value)

--- a/tests/config/functional/ini/pylintrc_with_deleted_message.ini
+++ b/tests/config/functional/ini/pylintrc_with_deleted_message.ini
@@ -1,0 +1,7 @@
+# Check that we raise an informational when a deleted messages exists in a .pylintrc file
+# See https://github.com/PyCQA/pylint/issues/6794
+[messages control]
+disable = logging-not-lazy, buffer-builtin
+enable = useless-option-value, locally-disabled, cmp-builtin
+jobs = 10
+reports = yes

--- a/tests/config/functional/ini/pylintrc_with_deleted_message.result.json
+++ b/tests/config/functional/ini/pylintrc_with_deleted_message.result.json
@@ -1,0 +1,12 @@
+{
+  "functional_append": {
+    "disable": ["logging-not-lazy"],
+    "enable": ["locally-disabled"]
+  },
+  "functional_remove": {
+    "disable": ["locally-disabled"],
+    "enable": ["logging-not-lazy"]
+  },
+  "jobs": 10,
+  "reports": true
+}

--- a/tests/functional/b/bad_option_value.py
+++ b/tests/functional/b/bad_option_value.py
@@ -1,4 +1,21 @@
+"""Check unknown or deleted option. """
+
+# Standard disable with unknown value
+# pylint: disable=C05048  # [bad-option-value]
+# Standard disable with deleted symbol
+# pylint: disable=execfile-builtin  # [bad-option-value]
+# Standard disable with deleted msgid
+# pylint: disable=W1656  # [bad-option-value]
+# disable-next with unknown value
+# pylint: disable-next=R78948  # [bad-option-value]
+# disable-next with deleted symbol
+# pylint: disable-next=deprecated-types-field  # [bad-option-value]
+# disable-next with deleted msgid
+# pylint: disable-next=W1634  # [bad-option-value]
+
+# enable with unknown value
 # pylint:enable=W04044  # [bad-option-value]
-"""check unknown option
-"""
-__revision__ = 1
+# enable with deleted symbol
+# pylint:enable=no-space-after-comma  # [bad-option-value]
+# enable with deleted msgid
+# pylint:enable=W1622  # [bad-option-value]

--- a/tests/functional/b/bad_option_value.txt
+++ b/tests/functional/b/bad_option_value.txt
@@ -1,1 +1,9 @@
-bad-option-value:1:0:None:None::Bad option value for enable. Don't recognize message W04044.:UNDEFINED
+bad-option-value:4:0:None:None::Bad option value for disable. Don't recognize message C05048.:UNDEFINED
+bad-option-value:6:0:None:None::Bad option value for disable. Don't recognize message execfile-builtin.:UNDEFINED
+bad-option-value:8:0:None:None::Bad option value for disable. Don't recognize message W1656.:UNDEFINED
+bad-option-value:10:0:None:None::Bad option value for disable-next. Don't recognize message R78948.:UNDEFINED
+bad-option-value:12:0:None:None::Bad option value for disable-next. Don't recognize message deprecated-types-field.:UNDEFINED
+bad-option-value:14:0:None:None::Bad option value for disable-next. Don't recognize message W1634.:UNDEFINED
+bad-option-value:17:0:None:None::Bad option value for enable. Don't recognize message W04044.:UNDEFINED
+bad-option-value:19:0:None:None::Bad option value for enable. Don't recognize message no-space-after-comma.:UNDEFINED
+bad-option-value:21:0:None:None::Bad option value for enable. Don't recognize message W1622.:UNDEFINED

--- a/tests/message/test_no_removed_msgid_or_symbol_used.py
+++ b/tests/message/test_no_removed_msgid_or_symbol_used.py
@@ -3,7 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
 from pylint.lint import PyLinter
-from pylint.message.deleted_message_ids import _DELETED_MESSAGES_IDS
+from pylint.message._deleted_message_ids import DELETED_MESSAGES_IDS
 
 
 def test_no_removed_msgid_or_symbol_used(linter: PyLinter) -> None:
@@ -12,7 +12,7 @@ def test_no_removed_msgid_or_symbol_used(linter: PyLinter) -> None:
     This could cause occasional bugs, but more importantly confusion and inconsistencies
     when searching for old msgids online. See https://github.com/PyCQA/pylint/issues/5729
     """
-    for deleted_messages in _DELETED_MESSAGES_IDS.values():
+    for deleted_messages in DELETED_MESSAGES_IDS.values():
         for msgid, symbol, old_names in deleted_messages:
             linter.msgs_store.message_id_store.register_message_definition(
                 msgid, symbol, old_names

--- a/tests/message/test_no_removed_msgid_or_symbol_used.py
+++ b/tests/message/test_no_removed_msgid_or_symbol_used.py
@@ -2,8 +2,8 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
-from pylint.constants import DELETED_MESSAGES
 from pylint.lint import PyLinter
+from pylint.message.deleted_message_ids import _DELETED_MESSAGES_IDS
 
 
 def test_no_removed_msgid_or_symbol_used(linter: PyLinter) -> None:
@@ -12,7 +12,8 @@ def test_no_removed_msgid_or_symbol_used(linter: PyLinter) -> None:
     This could cause occasional bugs, but more importantly confusion and inconsistencies
     when searching for old msgids online. See https://github.com/PyCQA/pylint/issues/5729
     """
-    for msgid, symbol, old_names in DELETED_MESSAGES:
-        linter.msgs_store.message_id_store.register_message_definition(
-            msgid, symbol, old_names
-        )
+    for deleted_messages in _DELETED_MESSAGES_IDS.values():
+        for msgid, symbol, old_names in deleted_messages:
+            linter.msgs_store.message_id_store.register_message_definition(
+                msgid, symbol, old_names
+            )


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Refactor prior to #6824 in order to be able to give a reason for why the message was deleted, and better overall organization as deleted messages are not public and specific to ``pylint.messages``.
