### PR TITLE
[bad-option-value] Use the right confidence and refactor message

### DIFF
--- a/pylint/lint/message_state_handler.py
+++ b/pylint/lint/message_state_handler.py
@@ -17,6 +17,7 @@ from pylint.constants import (
     MSG_TYPES,
     MSG_TYPES_LONG,
 )
+from pylint.interfaces import HIGH
 from pylint.message import MessageDefinition
 from pylint.typing import ManagedMessage
 from pylint.utils.pragma_parser import (
@@ -411,9 +412,11 @@ class _MessageStateHandler:
                         try:
                             meth(msgid, "module", l_start)
                         except exceptions.UnknownMessageError:
-                            msg = f"{pragma_repr.action}. Don't recognize message {msgid}."
                             self.linter.add_message(
-                                "bad-option-value", args=msg, line=start[0]
+                                "bad-option-value",
+                                args=(pragma_repr.action, msgid),
+                                line=start[0],
+                                confidence=HIGH,
                             )
             except UnRecognizedOptionError as err:
                 self.linter.add_message(

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -192,7 +192,7 @@ MSGS: dict[str, MessageDefinitionTuple] = {
     "E0012": (
         "Bad option value for '%s', expected a valid pylint message and got '%s'",
         "bad-option-value",
-        "Used when a bad value for an inline option is encountered.",
+        "Used when a bad value for an option is encountered.",
         {"scope": WarningScope.LINE},
     ),
     "E0013": (

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -29,6 +29,7 @@ from pylint.constants import (
     MSG_TYPES_STATUS,
     WarningScope,
 )
+from pylint.interfaces import HIGH
 from pylint.lint.base_options import _make_linter_options
 from pylint.lint.caching import load_results, save_results
 from pylint.lint.expand_modules import _is_ignored_file, expand_modules
@@ -189,7 +190,7 @@ MSGS: dict[str, MessageDefinitionTuple] = {
         {"scope": WarningScope.LINE},
     ),
     "E0012": (
-        "Bad option value for %s",
+        "Bad option value for '%s', expected a valid pylint message and got '%s'",
         "bad-option-value",
         "Used when a bad value for an inline option is encountered.",
         {"scope": WarningScope.LINE},
@@ -1206,6 +1207,10 @@ class PyLinter(
             self.linter.set_current_module(modname)
             values = self._stashed_bad_option_value_messages[modname]
             for option_string, msg_id in values:
-                msg = f"{option_string}. Don't recognize message {msg_id}."
-                self.add_message("bad-option-value", args=msg, line=0)
+                self.add_message(
+                    "bad-option-value",
+                    args=(option_string, msg_id),
+                    line=0,
+                    confidence=HIGH,
+                )
         self._stashed_bad_option_value_messages = collections.defaultdict(list)

--- a/tests/config/functional/ini/pylintrc_with_deleted_message.2.out
+++ b/tests/config/functional/ini/pylintrc_with_deleted_message.2.out
@@ -1,4 +1,4 @@
 ************* Module {abspath}
-{relpath}:1:0: E0012: Bad option value for --disable. Don't recognize message buffer-builtin. (bad-option-value)
-{relpath}:1:0: E0012: Bad option value for --enable. Don't recognize message useless-option-value. (bad-option-value)
-{relpath}:1:0: E0012: Bad option value for --enable. Don't recognize message cmp-builtin. (bad-option-value)
+{relpath}:1:0: E0012: Bad option value for '--disable', expected a valid pylint message and got 'buffer-builtin' (bad-option-value)
+{relpath}:1:0: E0012: Bad option value for '--enable', expected a valid pylint message and got 'useless-option-value' (bad-option-value)
+{relpath}:1:0: E0012: Bad option value for '--enable', expected a valid pylint message and got 'cmp-builtin' (bad-option-value)

--- a/tests/config/functional/ini/pylintrc_with_missing_comma.2.out
+++ b/tests/config/functional/ini/pylintrc_with_missing_comma.2.out
@@ -1,3 +1,3 @@
 ************* Module {abspath}
-{relpath}:1:0: E0012: Bad option value for --disable. Don't recognize message logging-not-lazylogging-format-interpolation. (bad-option-value)
-{relpath}:1:0: E0012: Bad option value for --enable. Don't recognize message locally-disabledsuppressed-message. (bad-option-value)
+{relpath}:1:0: E0012: Bad option value for '--disable', expected a valid pylint message and got 'logging-not-lazylogging-format-interpolation' (bad-option-value)
+{relpath}:1:0: E0012: Bad option value for '--enable', expected a valid pylint message and got 'locally-disabledsuppressed-message' (bad-option-value)

--- a/tests/config/functional/setup_cfg/do_not_read_other_tools_configuration/setup.2.out
+++ b/tests/config/functional/setup_cfg/do_not_read_other_tools_configuration/setup.2.out
@@ -1,2 +1,2 @@
 ************* Module {abspath}
-{relpath}:1:0: E0012: Bad option value for --enable. Don't recognize message useless-supression. (bad-option-value)
+{relpath}:1:0: E0012: Bad option value for '--enable', expected a valid pylint message and got 'useless-supression' (bad-option-value)

--- a/tests/config/functional/toml/issue_3122/toml_with_missing_comma.2.out
+++ b/tests/config/functional/toml/issue_3122/toml_with_missing_comma.2.out
@@ -1,3 +1,3 @@
 ************* Module {abspath}
-{relpath}:1:0: E0012: Bad option value for --disable. Don't recognize message logging-not-lazylogging-format-interpolation. (bad-option-value)
-{relpath}:1:0: E0012: Bad option value for --enable. Don't recognize message locally-disabledsuppressed-message. (bad-option-value)
+{relpath}:1:0: E0012: Bad option value for '--disable', expected a valid pylint message and got 'logging-not-lazylogging-format-interpolation' (bad-option-value)
+{relpath}:1:0: E0012: Bad option value for '--enable', expected a valid pylint message and got 'locally-disabledsuppressed-message' (bad-option-value)

--- a/tests/config/functional/toml/unknown_msgid/enable_unknown_msgid.2.out
+++ b/tests/config/functional/toml/unknown_msgid/enable_unknown_msgid.2.out
@@ -1,3 +1,3 @@
 ************* Module {abspath}
-{relpath}:1:0: E0012: Bad option value for --disable. Don't recognize message logging-not-layzy. (bad-option-value)
-{relpath}:1:0: E0012: Bad option value for --enable. Don't recognize message C00000. (bad-option-value)
+{relpath}:1:0: E0012: Bad option value for '--disable', expected a valid pylint message and got 'logging-not-layzy' (bad-option-value)
+{relpath}:1:0: E0012: Bad option value for '--enable', expected a valid pylint message and got 'C00000' (bad-option-value)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -60,7 +60,7 @@ def test_unknown_message_id(capsys: CaptureFixture) -> None:
     """Check that we correctly raise a message on an unknown id."""
     Run([str(EMPTY_MODULE), "--disable=12345"], exit=False)
     output = capsys.readouterr()
-    assert "Command line:1:0: E0012: Bad option value for --disable." in output.out
+    assert "Command line:1:0: E0012: Bad option value for '--disable'" in output.out
 
 
 def test_unknown_option_name(capsys: CaptureFixture) -> None:

--- a/tests/functional/b/bad_option_value.py
+++ b/tests/functional/b/bad_option_value.py
@@ -19,3 +19,8 @@
 # pylint:enable=no-space-after-comma  # [bad-option-value]
 # enable with deleted msgid
 # pylint:enable=W1622  # [bad-option-value]
+
+# Standard disable with deleted old name symbol of deleted message
+# pylint: disable=no-space-after-operator  # [bad-option-value]
+# Standard disable with deleted old name msgid of deleted message
+# pylint: disable=C0323  # [bad-option-value]

--- a/tests/functional/b/bad_option_value.txt
+++ b/tests/functional/b/bad_option_value.txt
@@ -1,9 +1,11 @@
-bad-option-value:4:0:None:None::Bad option value for disable. Don't recognize message C05048.:UNDEFINED
-bad-option-value:6:0:None:None::Bad option value for disable. Don't recognize message execfile-builtin.:UNDEFINED
-bad-option-value:8:0:None:None::Bad option value for disable. Don't recognize message W1656.:UNDEFINED
-bad-option-value:10:0:None:None::Bad option value for disable-next. Don't recognize message R78948.:UNDEFINED
-bad-option-value:12:0:None:None::Bad option value for disable-next. Don't recognize message deprecated-types-field.:UNDEFINED
-bad-option-value:14:0:None:None::Bad option value for disable-next. Don't recognize message W1634.:UNDEFINED
-bad-option-value:17:0:None:None::Bad option value for enable. Don't recognize message W04044.:UNDEFINED
-bad-option-value:19:0:None:None::Bad option value for enable. Don't recognize message no-space-after-comma.:UNDEFINED
-bad-option-value:21:0:None:None::Bad option value for enable. Don't recognize message W1622.:UNDEFINED
+bad-option-value:4:0:None:None::Bad option value for 'disable', expected a valid pylint message and got 'C05048':HIGH
+bad-option-value:6:0:None:None::Bad option value for 'disable', expected a valid pylint message and got 'execfile-builtin':HIGH
+bad-option-value:8:0:None:None::Bad option value for 'disable', expected a valid pylint message and got 'W1656':HIGH
+bad-option-value:10:0:None:None::Bad option value for 'disable-next', expected a valid pylint message and got 'R78948':HIGH
+bad-option-value:12:0:None:None::Bad option value for 'disable-next', expected a valid pylint message and got 'deprecated-types-field':HIGH
+bad-option-value:14:0:None:None::Bad option value for 'disable-next', expected a valid pylint message and got 'W1634':HIGH
+bad-option-value:17:0:None:None::Bad option value for 'enable', expected a valid pylint message and got 'W04044':HIGH
+bad-option-value:19:0:None:None::Bad option value for 'enable', expected a valid pylint message and got 'no-space-after-comma':HIGH
+bad-option-value:21:0:None:None::Bad option value for 'enable', expected a valid pylint message and got 'W1622':HIGH
+bad-option-value:24:0:None:None::Bad option value for 'disable', expected a valid pylint message and got 'no-space-after-operator':HIGH
+bad-option-value:26:0:None:None::Bad option value for 'disable', expected a valid pylint message and got 'C0323':HIGH

--- a/tests/functional/b/bad_option_value_disable.txt
+++ b/tests/functional/b/bad_option_value_disable.txt
@@ -1,2 +1,2 @@
-bad-option-value:10:0:None:None::Bad option value for disable. Don't recognize message a-removed-option.:UNDEFINED
-bad-option-value:13:0:None:None::Bad option value for disable. Don't recognize message a-removed-option.:UNDEFINED
+bad-option-value:10:0:None:None::Bad option value for 'disable', expected a valid pylint message and got 'a-removed-option':HIGH
+bad-option-value:13:0:None:None::Bad option value for 'disable', expected a valid pylint message and got 'a-removed-option':HIGH

--- a/tests/functional/u/use/use_symbolic_message_instead.txt
+++ b/tests/functional/u/use/use_symbolic_message_instead.txt
@@ -1,4 +1,4 @@
-bad-option-value:1:0:None:None::Bad option value for disable. Don't recognize message T1234.:UNDEFINED
+bad-option-value:1:0:None:None::Bad option value for 'disable', expected a valid pylint message and got 'T1234':HIGH
 use-symbolic-message-instead:1:0:None:None::"'C0111' is cryptic: use '# pylint: disable=missing-docstring' instead":UNDEFINED
 use-symbolic-message-instead:1:0:None:None::"'R0903' is cryptic: use '# pylint: disable=too-few-public-methods' instead":UNDEFINED
 use-symbolic-message-instead:2:0:None:None::"'c0111' is cryptic: use '# pylint: enable=missing-docstring' instead":UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

All the refactoring and betterment done during #6824 so we only have the new message in the final MR. Follow-up to https://github.com/PyCQA/pylint/pull/6826
