### PR TITLE
Makes functional tests auto-update works even if the current output is wrong

### DIFF
--- a/doc/whatsnew/2/2.15/index.rst
+++ b/doc/whatsnew/2/2.15/index.rst
@@ -61,3 +61,9 @@ Internal changes
 * ``pylint.testutils.primer`` is now a private API.
 
   Refs #6905
+
+* Fixed an issue where it was impossible to update functional tests output when the existing
+  output was impossible to parse. Instead of raising an error we raise a warning message and
+  let the functional test fail with a default value.
+
+  Closes #6891

--- a/doc/whatsnew/2/2.15/index.rst
+++ b/doc/whatsnew/2/2.15/index.rst
@@ -66,4 +66,4 @@ Internal changes
   output was impossible to parse. Instead of raising an error we raise a warning message and
   let the functional test fail with a default value.
 
-  Closes #6891
+  Refs #6891

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -33,44 +33,6 @@ class MessageTest(NamedTuple):
     """
 
 
-class MalformedOutputLineException(Exception):
-    def __init__(
-        self,
-        row: Sequence[str] | str,
-        exception: Exception,
-    ) -> None:
-        example = "msg-symbolic-name:42:27:MyClass.my_function:The message"
-        other_example = "msg-symbolic-name:7:42::The message"
-        expected = [
-            "symbol",
-            "line",
-            "column",
-            "end_line",
-            "end_column",
-            "MyClass.myFunction, (or '')",
-            "Message",
-            "confidence",
-        ]
-        reconstructed_row = ""
-        i = 0
-        try:
-            for i, column in enumerate(row):
-                reconstructed_row += f"\t{expected[i]}='{column}' ?\n"
-            for missing in expected[i + 1 :]:
-                reconstructed_row += f"\t{missing}= Nothing provided !\n"
-        except IndexError:
-            pass
-        raw = ":".join(row)
-        msg = f"""\
-{exception}
-
-Expected '{example}' or '{other_example}' but we got '{raw}':
-{reconstructed_row}
-
-Try updating it with: 'python tests/test_functional.py {UPDATE_OPTION}'"""
-        super().__init__(msg)
-
-
 class OutputLine(NamedTuple):
     symbol: str
     lineno: int
@@ -127,6 +89,7 @@ class OutputLine(NamedTuple):
         """
         if isinstance(row, str):
             row = row.split(",")
+        # noinspection PyBroadException
         try:
             column = cls._get_column(row[2])
             if len(row) == 5:
@@ -170,8 +133,14 @@ class OutputLine(NamedTuple):
                     row[7],
                 )
             raise IndexError
-        except Exception as e:
-            raise MalformedOutputLineException(row, e) from e
+        except Exception:  # pylint: disable=broad-except
+            warnings.warn(
+                "Expected 'msg-symbolic-name:42:27:MyClass.my_function:The message:"
+                f"CONFIDENCE' but we got '{':'.join(row)}'. Try updating the expected"
+                f" output with:\npython tests/test_functional.py {UPDATE_OPTION}",
+                UserWarning,
+            )
+            return cls("", 0, 0, None, None, "", "", "")
 
     def to_csv(self) -> tuple[str, str, str, str, str, str, str, str]:
         """Convert an OutputLine to a tuple of string to be written by a

--- a/tests/testutils/test_output_line.py
+++ b/tests/testutils/test_output_line.py
@@ -13,7 +13,7 @@ import pytest
 from pylint.constants import PY38_PLUS
 from pylint.interfaces import HIGH, INFERENCE, Confidence
 from pylint.message import Message
-from pylint.testutils.output_line import MalformedOutputLineException, OutputLine
+from pylint.testutils.output_line import OutputLine
 from pylint.typing import MessageLocationTuple
 
 
@@ -127,20 +127,20 @@ def test_output_line_to_csv(confidence: Confidence, message: Callable) -> None:
 def test_output_line_from_csv_error() -> None:
     """Test that errors are correctly raised for incorrect OutputLine's."""
     # Test a csv-string which does not have a number for line and column
-    with pytest.raises(
-        MalformedOutputLineException,
+    with pytest.warns(
+        UserWarning,
         match="msg-symbolic-name:42:27:MyClass.my_function:The message",
     ):
         OutputLine.from_csv("'missing-docstring', 'line', 'column', 'obj', 'msg'", True)
     # Test a tuple which does not have a number for line and column
-    with pytest.raises(
-        MalformedOutputLineException, match="symbol='missing-docstring' ?"
+    with pytest.warns(
+        UserWarning, match="we got 'missing-docstring:line:column:obj:msg'"
     ):
         csv = ("missing-docstring", "line", "column", "obj", "msg")
         OutputLine.from_csv(csv, True)
     # Test a csv-string that is too long
-    with pytest.raises(
-        MalformedOutputLineException,
+    with pytest.warns(
+        UserWarning,
         match="msg-symbolic-name:42:27:MyClass.my_function:The message",
     ):
         OutputLine.from_csv(


### PR DESCRIPTION


<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Add an entry to the change log describing the change in
  `doc/whatsnew/2/2.15/index.rst` (or ``doc/whatsnew/2/2.14/full.rst``
   if the change needs backporting in 2.14). If necessary you can write
   details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
Previously if an exception was raised during parsing we re-raised an explanation.
Most of the time I just want to regenerate the output from the current pylint's
output. It's what the exception suggested but it's impossible to do as the error
is also raised when updating, so you had to empty the file.
