### PR TITLE
[primer] stop overwriting `--rcfile`

### DIFF
--- a/tests/primer/primer_tool.py
+++ b/tests/primer/primer_tool.py
@@ -292,8 +292,6 @@ class Primer:
         # TODO: Find a way to allow cyclic-import and compare output correctly
         disables = ["--disable=duplicate-code,cyclic-import"]
         arguments = data.pylint_args + enables + disables
-        if data.pylintrc_relpath:
-            arguments += [f"--rcfile={data.pylintrc_relpath}"]
         output = StringIO()
         reporter = JSONReporter(output)
         Run(arguments, reporter=reporter, exit=False)

--- a/tests/primer/primer_tool.py
+++ b/tests/primer/primer_tool.py
@@ -273,7 +273,7 @@ class Primer:
         if len(comment) + len(hash_information) >= MAX_GITHUB_COMMENT_LENGTH:
             truncation_information = (
                 f"*This comment was truncated because GitHub allows only"
-                f"{MAX_GITHUB_COMMENT_LENGTH} characters in a comment.*"
+                f" {MAX_GITHUB_COMMENT_LENGTH} characters in a comment.*"
             )
             max_len = (
                 MAX_GITHUB_COMMENT_LENGTH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
~Move everything into the new primer and increase the timeout on the `main` job. (3.7 is about 2x as slow as 3.10)
Follow up to #6761 and #6753.~

Never mind, we will have to discuss that separately.
