### PR TITLE
[primer] Truncate comments that are too long for github

### DIFF
--- a/tests/primer/primer_tool.py
+++ b/tests/primer/primer_tool.py
@@ -269,8 +269,8 @@ class Primer:
         )
         if len(comment) >= MAX_GITHUB_COMMENT_LENGTH:
             truncation_information = (
-                f"* This comment was truncated because github allow"
-                f"{MAX_GITHUB_COMMENT_LENGTH} characters in comment."
+                f"*This comment was truncated because GitHub allows only"
+                f"{MAX_GITHUB_COMMENT_LENGTH} characters in a comment.*"
             )
             max_len = (
                 MAX_GITHUB_COMMENT_LENGTH

--- a/tests/primer/primer_tool.py
+++ b/tests/primer/primer_tool.py
@@ -280,7 +280,7 @@ class Primer:
                 - len(hash_information)
                 - len(truncation_information)
             )
-            comment = f"{comment[:max_len - 5]}...\n{truncation_information}"
+            comment = f"{comment[:max_len - 10]}...\n\n{truncation_information}\n\n"
         comment += hash_information
         with open(PRIMER_DIRECTORY / "comment.txt", "w", encoding="utf-8") as f:
             f.write(comment)

--- a/tests/primer/primer_tool.py
+++ b/tests/primer/primer_tool.py
@@ -270,7 +270,7 @@ class Primer:
         hash_information = (
             f"*This comment was generated for commit {self.config.commit}*"
         )
-        if len(comment) >= MAX_GITHUB_COMMENT_LENGTH:
+        if len(comment) + len(hash_information) >= MAX_GITHUB_COMMENT_LENGTH:
             truncation_information = (
                 f"*This comment was truncated because GitHub allows only"
                 f"{MAX_GITHUB_COMMENT_LENGTH} characters in a comment.*"
@@ -280,10 +280,8 @@ class Primer:
                 - len(hash_information)
                 - len(truncation_information)
             )
-            comment = comment[:max_len] + truncation_information
-
+            comment = f"{comment[:max_len - 5]}...\n{truncation_information}"
         comment += hash_information
-
         with open(PRIMER_DIRECTORY / "comment.txt", "w", encoding="utf-8") as f:
             f.write(comment)
 

--- a/tests/primer/primer_tool.py
+++ b/tests/primer/primer_tool.py
@@ -259,10 +259,13 @@ class Primer:
                 comment += "\n</details>\n\n"
 
         if comment == "":
-            comment = "🤖 According to the primer, this change has **no effect** on the checked open source code. 🤖🎉"
+            comment = (
+                "🤖 According to the primer, this change has **no effect** on the"
+                " checked open source code. 🤖🎉\n\n"
+            )
         else:
             comment = (
-                "🤖 **Effect of this PR on checked open source code:** 🤖\n\n" + comment
+                f"🤖 **Effect of this PR on checked open source code:** 🤖\n\n{comment}"
             )
         hash_information = (
             f"*This comment was generated for commit {self.config.commit}*"


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description


Refs https://github.com/PyCQA/pylint/actions/runs/2465775611
