### PR TITLE
Add no-dict-direct-access checker

### DIFF
--- a/doc/whatsnew/2/2.15/index.rst
+++ b/doc/whatsnew/2/2.15/index.rst
@@ -15,7 +15,6 @@ Summary -- Release highlights
 New checkers
 ============
 
-
 Removed checkers
 ================
 
@@ -23,6 +22,10 @@ Removed checkers
 Extensions
 ==========
 
+* ``NoDictSubscriptChecker``
+
+    * Added optional extension ``no-dict-subscript`` to emit messages when the ``[]`` operator is used
+      to access a dictionary value.
 
 False positives fixed
 =====================

--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -10,9 +10,9 @@ import re
 import tokenize
 from typing import TYPE_CHECKING
 
-from astroid import Assign, Dict, nodes
+from astroid import nodes
 
-from pylint.checkers import BaseChecker, BaseRawFileChecker, BaseTokenChecker, utils
+from pylint.checkers import BaseRawFileChecker, BaseTokenChecker
 from pylint.typing import ManagedMessage
 from pylint.utils.pragma_parser import OPTION_PO, PragmaParserError, parse_pragma
 
@@ -176,24 +176,6 @@ class EncodingChecker(BaseTokenChecker, BaseRawFileChecker):
                 )
 
 
-class NoDictDirectAccessChecker(BaseChecker):
-    name = "no-dict-direct-access"
-    msgs = {
-        "W0001": (
-            "Uses dict operator []",
-            "dict-direct-access",
-            "Used to warn when subscripting a dictionary instead of using the get() function",
-        ),
-    }
-
-    def visit_subscript(self, node: nodes.Subscript) -> None:
-        if isinstance(utils.safe_infer(node.value), Dict) and not isinstance(
-            node.parent, Assign
-        ):
-            self.add_message("dict-direct-access", node=node)
-
-
 def register(linter: PyLinter) -> None:
     linter.register_checker(EncodingChecker(linter))
     linter.register_checker(ByIdManagedMessagesChecker(linter))
-    linter.register_checker(NoDictDirectAccessChecker(linter))

--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 
 import re
 import tokenize
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
-from astroid import nodes, Dict, Assign
+from astroid import Assign, Dict, nodes
 
-from pylint.checkers import BaseRawFileChecker, BaseTokenChecker, BaseChecker, utils
+from pylint.checkers import BaseChecker, BaseRawFileChecker, BaseTokenChecker, utils
 from pylint.typing import ManagedMessage
 from pylint.utils.pragma_parser import OPTION_PO, PragmaParserError, parse_pragma
 
@@ -174,6 +174,7 @@ class EncodingChecker(BaseTokenChecker, BaseRawFileChecker):
                     args=comment_text,
                     line=comment.start[0],
                 )
+
 
 class NoDictDirectAccessChecker(BaseChecker):
     name = "no-dict-direct-access"

--- a/pylint/extensions/dictionary_subscript.py
+++ b/pylint/extensions/dictionary_subscript.py
@@ -1,0 +1,30 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Check for dictionary read-access via subscript"""
+
+from astroid import nodes, Dict, Assign
+
+from pylint.checkers import BaseChecker, utils
+from pylint.lint import PyLinter
+
+
+class NoDictSubscriptChecker(BaseChecker):
+    name = "no-dict-subscript"
+    msgs = {
+        "W0001": (
+            "Uses dict operator []",
+            "dict-subscript",
+            "Used to warn when subscripting a dictionary instead of using the get() function",
+        ),
+    }
+
+    def visit_subscript(self, node: nodes.Subscript) -> None:
+        if isinstance(utils.safe_infer(node.value), Dict) and not isinstance(
+                node.parent, Assign
+        ):
+            self.add_message("dict-subscript", node=node)
+
+def register(linter: PyLinter) -> None:
+    linter.register_checker(NoDictSubscriptChecker(linter))

--- a/pylint/extensions/dictionary_subscript.py
+++ b/pylint/extensions/dictionary_subscript.py
@@ -2,9 +2,9 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
-"""Check for dictionary read-access via subscript"""
+"""Check for dictionary read-access via subscript."""
 
-from astroid import nodes, Dict, Assign
+from astroid import Assign, Dict, nodes
 
 from pylint.checkers import BaseChecker, utils
 from pylint.lint import PyLinter
@@ -22,9 +22,10 @@ class NoDictSubscriptChecker(BaseChecker):
 
     def visit_subscript(self, node: nodes.Subscript) -> None:
         if isinstance(utils.safe_infer(node.value), Dict) and not isinstance(
-                node.parent, Assign
+            node.parent, Assign
         ):
             self.add_message("dict-subscript", node=node)
+
 
 def register(linter: PyLinter) -> None:
     linter.register_checker(NoDictSubscriptChecker(linter))

--- a/pylint/extensions/dictionary_subscript.py
+++ b/pylint/extensions/dictionary_subscript.py
@@ -13,7 +13,7 @@ from pylint.lint import PyLinter
 class NoDictSubscriptChecker(BaseChecker):
     name = "no-dict-subscript"
     msgs = {
-        "W0001": (
+        "R5701": (
             "Uses dict operator []",
             "dict-subscript",
             "Used to warn when subscripting a dictionary instead of using the get() function",

--- a/pylint/extensions/dictionary_subscript.py
+++ b/pylint/extensions/dictionary_subscript.py
@@ -14,7 +14,7 @@ class NoDictSubscriptChecker(BaseChecker):
     name = "no-dict-subscript"
     msgs = {
         "R5701": (
-            "Uses dict operator []",
+            "Using dict operator [], consider using get() instead",
             "dict-subscript",
             "Used to warn when subscripting a dictionary instead of using the get() function",
         ),

--- a/tests/functional/ext/check_dictionary_subscript/check_dictionary_subscript.py
+++ b/tests/functional/ext/check_dictionary_subscript/check_dictionary_subscript.py
@@ -1,0 +1,8 @@
+"""Checks the use of dictionary subscripts"""
+
+mydict = {"foo": 3}
+
+print(mydict["foo"])
+print(mydict.get("foo"))
+
+mydict["foo"] = 4

--- a/tests/functional/ext/check_dictionary_subscript/check_dictionary_subscript.rc
+++ b/tests/functional/ext/check_dictionary_subscript/check_dictionary_subscript.rc
@@ -1,0 +1,2 @@
+[MAIN]
+load-plugins=pylint.extensions.dictionary_subscript,

--- a/tests/functional/ext/check_dictionary_subscript/check_dictionary_subscript.txt
+++ b/tests/functional/ext/check_dictionary_subscript/check_dictionary_subscript.txt
@@ -1,0 +1,1 @@
+dict-subscript:5:6:5:19::"Using dict operator [], consider using get() instead":UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

I noticed that I rarely use direct dictionary access, as in `myfunction(foo["bar"])`, since `foo` might not contain `"bar"`. I usually go for `foo.get("bar")` (or some other default value) to be safe. I wanted a checker that checks my code for these direct dictionary subscripts and reports them. I found a few bugs that way already and thought this might fit into pylint in general.

The following will produce a message:

```python
mydict = { "foo": 3 }
print(mydict["foo"])
```

Whereas this will not:

```python
mydict = { "foo": 3 }
print(mydict.get("foo"))
```

This is also fine:

```python
mydict = {}
mydict["foo"] = 3
```

Since assignment is safe per se.