### PR TITLE
Avoid `used-before-assignment` in except handlers employing type annotations

### DIFF
--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -5,6 +5,9 @@ What's New in Pylint 2.14.2?
 ----------------------------
 Release date: TBA
 
+* Fixed a false positive for ``used-before-assignment`` when a try block returns
+  but an except handler defines a name via type annotation.
+
 
 What's New in Pylint 2.14.1?
 ----------------------------

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -726,6 +726,13 @@ scope_type : {self._atomic.scope_type}
     def _defines_name_raises_or_returns(name: str, node: nodes.NodeNG) -> bool:
         if isinstance(node, (nodes.Raise, nodes.Return)):
             return True
+        if (
+            isinstance(node, nodes.AnnAssign)
+            and node.value
+            and isinstance(node.target, nodes.AssignName)
+            and node.target.name == name
+        ):
+            return True
         if isinstance(node, nodes.Assign):
             for target in node.targets:
                 for elt in utils.get_all_elements(target):

--- a/tests/functional/u/used/used_before_assignment_except_handler_for_try_with_return.py
+++ b/tests/functional/u/used/used_before_assignment_except_handler_for_try_with_return.py
@@ -99,6 +99,16 @@ def func_ok7(var):
     print(msg)
 
 
+def func_ok8(var):
+    """Define 'msg' in one handler via type annotation."""
+    try:
+        return 1 / var.some_other_func()
+    except ZeroDivisionError:
+        # See func_invalid2() for mere annotation without value
+        msg: str = "Division by 0"
+    print(msg)
+
+
 def func_invalid1(var):
     """'msg' is not defined in one handler."""
     try:

--- a/tests/functional/u/used/used_before_assignment_except_handler_for_try_with_return.txt
+++ b/tests/functional/u/used/used_before_assignment_except_handler_for_try_with_return.txt
@@ -1,7 +1,7 @@
 used-before-assignment:16:14:16:29:function:Using variable 'failure_message' before assignment:CONTROL_FLOW
-used-before-assignment:110:10:110:13:func_invalid1:Using variable 'msg' before assignment:CONTROL_FLOW
-used-before-assignment:121:10:121:13:func_invalid2:Using variable 'msg' before assignment:CONTROL_FLOW
-used-before-assignment:140:10:140:13:func_invalid3:Using variable 'msg' before assignment:CONTROL_FLOW
-used-before-assignment:153:10:153:13:func_invalid4:Using variable 'msg' before assignment:CONTROL_FLOW
-used-before-assignment:165:10:165:13:func_invalid5:Using variable 'msg' before assignment:CONTROL_FLOW
-used-before-assignment:177:10:177:13:func_invalid6:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:120:10:120:13:func_invalid1:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:131:10:131:13:func_invalid2:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:150:10:150:13:func_invalid3:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:163:10:163:13:func_invalid4:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:175:10:175:13:func_invalid5:Using variable 'msg' before assignment:CONTROL_FLOW
+used-before-assignment:187:10:187:13:func_invalid6:Using variable 'msg' before assignment:CONTROL_FLOW


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Noticed this false positive while working on #6677.