### PR TITLE
Avoid raising `undefined-loop-variable` twice on same line

### DIFF
--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -5,6 +5,8 @@ What's New in Pylint 2.14.2?
 ----------------------------
 Release date: TBA
 
+* Avoided raising an identical ``undefined-loop-variable`` message twice on the same line.
+
 * Don't crash if ``lint.run._query_cpu()`` is run within a Kubernetes Pod, that has only
   a fraction of a cpu core assigned. Just go with one process then.
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1484,7 +1484,6 @@ class VariablesChecker(BaseChecker):
                 node, nodes.ComprehensionScope
             ):
                 self._check_late_binding_closure(node)
-                self._loopvar_name(node)
                 return (VariableVisitConsumerAction.RETURN, None)
 
         found_nodes = current_consumer.get_next_to_consume(node)

--- a/tests/functional/u/undefined/undefined_loop_variable.py
+++ b/tests/functional/u/undefined/undefined_loop_variable.py
@@ -146,3 +146,11 @@ def use_enumerate():
     for i, num in enumerate(range(3)):
         pass
     print(i, num)
+
+
+def find_even_number(container):
+    """https://github.com/PyCQA/pylint/pull/6923#discussion_r895134495"""
+    for something in container:
+        if something % 2 == 0:
+            break
+    return something  # [undefined-loop-variable]

--- a/tests/functional/u/undefined/undefined_loop_variable.txt
+++ b/tests/functional/u/undefined/undefined_loop_variable.txt
@@ -1,3 +1,4 @@
 undefined-loop-variable:6:11:6:14:do_stuff:Using possibly undefined loop variable 'var':UNDEFINED
 undefined-loop-variable:25:7:25:11::Using possibly undefined loop variable 'var1':UNDEFINED
 undefined-loop-variable:75:11:75:14:do_stuff_with_redefined_range:Using possibly undefined loop variable 'var':UNDEFINED
+undefined-loop-variable:156:11:156:20:find_even_number:Using possibly undefined loop variable 'something':UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

See https://github.com/PyCQA/pylint/pull/6923#discussion_r895134495 for report.

This call has been here since the initial commit, but nothing fails when I remove it. Let's see what the primer says.
