### PR TITLE
Treat `--errors-only` as a disable, not a paired enable/disable

### DIFF
--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -34,6 +34,11 @@ Release date: TBA
 * Fixed a false positive for ``used-before-assignment`` when a try block returns
   but an except handler defines a name via type annotation.
 
+* ``--errors-only`` no longer enables previously disabled messages. It was acting as
+  "emit *all* and only error messages" without being clearly documented that way.
+
+  Closes #6811
+
 
 What's New in Pylint 2.14.1?
 ----------------------------

--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -34,6 +34,11 @@ Release date: TBA
 * Fixed a false positive for ``used-before-assignment`` when a try block returns
   but an except handler defines a name via type annotation.
 
+* ``--errors-only`` no longer explicitly enables non-error messages. This led to the unexpected
+  behavior of cancelling out prior disables.
+
+  Closes #6811
+
 
 What's New in Pylint 2.14.1?
 ----------------------------

--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -34,8 +34,7 @@ Release date: TBA
 * Fixed a false positive for ``used-before-assignment`` when a try block returns
   but an except handler defines a name via type annotation.
 
-* ``--errors-only`` no longer explicitly enables non-error messages. This led to the unexpected
-  behavior of cancelling out prior disables.
+* ``--errors-only`` no longer unexpectedly enables previously disabled messages.
 
   Closes #6811
 

--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -34,10 +34,6 @@ Release date: TBA
 * Fixed a false positive for ``used-before-assignment`` when a try block returns
   but an except handler defines a name via type annotation.
 
-* ``--errors-only`` no longer unexpectedly enables previously disabled messages.
-
-  Closes #6811
-
 
 What's New in Pylint 2.14.1?
 ----------------------------

--- a/doc/whatsnew/2/2.15/index.rst
+++ b/doc/whatsnew/2/2.15/index.rst
@@ -54,6 +54,11 @@ Other bug fixes
 Other Changes
 =============
 
+* ``--errors-only`` no longer unexpectedly enables previously disabled messages. It was
+  acting as "emit *all* and only error messages" without being clearly documented that way.
+
+  Closes #6811
+
 
 Internal changes
 ================

--- a/doc/whatsnew/2/2.15/index.rst
+++ b/doc/whatsnew/2/2.15/index.rst
@@ -54,11 +54,6 @@ Other bug fixes
 Other Changes
 =============
 
-* ``--errors-only`` no longer unexpectedly enables previously disabled messages. It was
-  acting as "emit *all* and only error messages" without being clearly documented that way.
-
-  Closes #6811
-
 
 Internal changes
 ================

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -529,9 +529,9 @@ def _make_run_options(self: Run) -> Options:
                 "action": _ErrorsOnlyModeAction,
                 "kwargs": {"Run": self},
                 "short": "E",
-                "help": "In error mode, checkers without error messages are "
-                "disabled and for others, only the ERROR messages are "
-                "displayed, and no reports are done by default.",
+                "help": "In error mode, messages with a category besides "
+                "ERROR or FATAL are suppressed, and no reports are done by default. "
+                "Error mode is compatible with disabling specific errors. ",
                 "hide_from_config_file": True,
             },
         ),

--- a/pylint/lint/message_state_handler.py
+++ b/pylint/lint/message_state_handler.py
@@ -227,14 +227,11 @@ class _MessageStateHandler:
         self._register_by_id_managed_msg(msgid, line, is_disabled=False)
 
     def disable_noerror_messages(self) -> None:
-        for msgcat, msgids in self.linter.msgs_store._msgs_by_category.items():
-            # enable only messages with 'error' severity and above ('fatal')
+        """Disable message categories other than `error` and `fatal`."""
+        for msgcat in self.linter.msgs_store._msgs_by_category:
             if msgcat in {"E", "F"}:
-                for msgid in msgids:
-                    self.enable(msgid)
-            else:
-                for msgid in msgids:
-                    self.disable(msgid)
+                continue
+            self.disable(msgcat)
 
     def list_messages_enabled(self) -> None:
         emittable, non_emittable = self.linter.msgs_store.find_emittable_messages()

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1520,6 +1520,16 @@ class TestCallbackOptions:
             assert run.linter._error_mode
 
     @staticmethod
+    def test_errors_only_functions_as_disable() -> None:
+        """--errors-only functions as a shortcut for --disable=W,C,R,I;
+        it no longer enables any messages."""
+        run = Run(
+            [str(UNNECESSARY_LAMBDA), "--disable=import-error", "--errors-only"],
+            do_exit=False,
+        )
+        assert not run.linter.is_message_enabled("import-error")
+
+    @staticmethod
     def test_verbose() -> None:
         """Test the --verbose flag."""
         with pytest.raises(SystemExit):


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Closes #6811

Now, `--errors-only` is interpreted as a disable of non-error/fatal messages, not a paired disable of non-errors and enable of every error. Prevents canceling out prior disables. (In other words, it was acting as "enable all and only errors", not "disable non-errors").
