### PR TITLE
Mix incorrect parsing of multi-line options in ``ini`` files

### DIFF
--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -21,6 +21,10 @@ Release date: TBA
 
   Closes #6818
 
+* Fixed an issue with multi-line ``init-hook`` options which did not record the line endings.
+
+  Closes #6888
+
 * Fixed a false positive for ``used-before-assignment`` when a try block returns
   but an except handler defines a name via type annotation.
 

--- a/pylint/config/config_file_parser.py
+++ b/pylint/config/config_file_parser.py
@@ -56,7 +56,6 @@ class _ConfigurationFileParser:
                 else:
                     continue
             for opt, value in parser[section].items():
-                value = value.replace("\n", "")
                 config_content[opt] = value
                 options += [f"--{opt}", value]
         return config_content, options

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -45,7 +45,7 @@ def _config_initialization(
 
     # Run init hook, if present, before loading plugins
     if "init-hook" in config_data:
-        exec(utils._unquote(config_data["init-hook"]))  # pylint: disable=exec-used
+        exec(config_data["init-hook"])  # pylint: disable=exec-used
 
     # Load plugins if specified in the config file
     if "load-plugins" in config_data:

--- a/tests/config/functional/ini/pylintrc_with_missing_comma.4.out
+++ b/tests/config/functional/ini/pylintrc_with_missing_comma.4.out
@@ -1,3 +1,4 @@
 ************* Module {abspath}
 {relpath}:1:0: W0012: Unknown option value for '--disable', expected a valid pylint message and got 'logging-not-lazylogging-format-interpolation' (unknown-option-value)
-{relpath}:1:0: W0012: Unknown option value for '--enable', expected a valid pylint message and got 'locally-disabledsuppressed-message' (unknown-option-value)
+{relpath}:1:0: W0012: Unknown option value for '--enable', expected a valid pylint message and got 'locally-disabled
+suppressed-message' (unknown-option-value)

--- a/tests/config/functional/ini/pylintrc_with_multi_line_init_hook.ini
+++ b/tests/config/functional/ini/pylintrc_with_multi_line_init_hook.ini
@@ -1,0 +1,6 @@
+# Reported in https://github.com/PyCQA/pylint/issues/6888
+[MASTER]
+init-hook=
+    try: import pylint_venv
+    except ImportError: pass
+    else: pylint_venv.inithook()


### PR DESCRIPTION
- [x] Write a good description on what the PR does.
- [x] Add an entry to the change log describing the change in
  `doc/whatsnew/2/2.15/index.rst` (or ``doc/whatsnew/2/2.14/full.rst``
   if the change needs backporting in 2.14). If necessary you can write
   details or offer examples on how the new change is supposed to work.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #6888.

We could also use an `if` statement to check whether the option is `init-hook` and and then not strip the newlines. But that introduce additional overhead, while this makes pylint faster. The fact that the rest of the test suite passes makes me think that this will be fine. We strip most options of whitespaces in other places anyway.

If this regresses after `2.14.2` we can simply add the `if` statement as desired.