### PR TITLE
Search for successful instead of completed runs on ``main`` for primer

### DIFF
--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -96,7 +96,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: ".github/workflows/primer_run_main.yaml",
-              status: "completed"
+              status: "success"
             });
             const lastRunMain = runs.data.workflow_runs.reduce(function(prev, current) {
                 return (prev.run_number > current.run_number) ? prev : current


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Fixes run failures such as those seen in https://github.com/PyCQA/pylint/pull/6898.

Because skipped runs are also counted as `completed` we don't get the correct run whenever an initial run on `main` is skipped but the new one hasn't yet finished. See https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs