### PR TITLE
Emit `used-before-assignment` for self-referencing assignments under if conditions

### DIFF
--- a/doc/whatsnew/2/2.15/index.rst
+++ b/doc/whatsnew/2/2.15/index.rst
@@ -46,6 +46,10 @@ False negatives fixed
 
   Closes #5653
 
+* Emit ``used-before-assignment`` for self-referencing assignments under if conditions.
+
+  Closes #6643
+
 
 Other bug fixes
 ===============

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -361,7 +361,7 @@ def is_defined_before(var_node: nodes.Name) -> bool:
             return True
         if isinstance(defnode, nodes.Nonlocal):
             return True
-        # defnode and var_node on the same line
+        # `defnode` and `var_node` on the same line
         for defnode_anc in defnode.node_ancestors():
             if defnode_anc.lineno != var_node.lineno:
                 continue

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -288,8 +288,7 @@ def is_defined_in_scope(
     varname: str,
     scope: nodes.NodeNG,
 ) -> bool:
-    return bool(defnode_in_scope(var_node, varname, scope))
-
+    return defnode_in_scope(var_node, varname, scope) is not None
 
 def defnode_in_scope(
     var_node: nodes.NodeNG,

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -290,6 +290,7 @@ def is_defined_in_scope(
 ) -> bool:
     return defnode_in_scope(var_node, varname, scope) is not None
 
+
 def defnode_in_scope(
     var_node: nodes.NodeNG,
     varname: str,

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -344,11 +344,9 @@ def is_defined_before(var_node: nodes.Name) -> bool:
 
     Verify that the variable node is defined by a parent node
     (e.g. if or with) earlier than `var_node`, or is defined by a
-    (list, set, dict, or generator comprehension, lambda),
-    or is a nonlocal, or is defined
-    in a previous sibling node on the same line
-    (statement_defining ; statement_using)
-    (statement_block: statement_using).
+    (list, set, dict, or generator comprehension, lambda)
+    or in a previous sibling node on the same line
+    (statement_defining ; statement_using).
     """
     varname = var_node.name
     for parent in var_node.node_ancestors():
@@ -359,8 +357,6 @@ def is_defined_before(var_node: nodes.Name) -> bool:
         if isinstance(defnode_scope, COMP_NODE_TYPES + (nodes.Lambda,)):
             return True
         if defnode.lineno < var_node.lineno:
-            return True
-        if isinstance(defnode, nodes.Nonlocal):
             return True
         # `defnode` and `var_node` on the same line
         for defnode_anc in defnode.node_ancestors():
@@ -376,10 +372,6 @@ def is_defined_before(var_node: nodes.Name) -> bool:
                     nodes.TryFinally,
                     nodes.ExceptHandler,
                 ),
-            ):
-                return True
-            if isinstance(defnode_anc, nodes.If) and not (
-                defnode_anc.test is var_node or defnode_anc.test.parent_of(var_node)
             ):
                 return True
     # possibly multiple statements on the same line using semicolon separator

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -288,26 +288,32 @@ def is_defined_in_scope(
     varname: str,
     scope: nodes.NodeNG,
 ) -> bool:
+    return bool(defnode_in_scope(var_node, varname, scope))
+
+
+def defnode_in_scope(
+    var_node: nodes.NodeNG,
+    varname: str,
+    scope: nodes.NodeNG,
+) -> nodes.NodeNG | None:
     if isinstance(scope, nodes.If):
         for node in scope.body:
-            if (
-                isinstance(node, nodes.Assign)
-                and any(
-                    isinstance(target, nodes.AssignName) and target.name == varname
-                    for target in node.targets
-                )
-            ) or (isinstance(node, nodes.Nonlocal) and varname in node.names):
-                return True
+            if isinstance(node, nodes.Nonlocal) and varname in node.names:
+                return node
+            if isinstance(node, nodes.Assign):
+                for target in node.targets:
+                    if isinstance(target, nodes.AssignName) and target.name == varname:
+                        return target
     elif isinstance(scope, (COMP_NODE_TYPES, nodes.For)):
         for ass_node in scope.nodes_of_class(nodes.AssignName):
             if ass_node.name == varname:
-                return True
+                return ass_node
     elif isinstance(scope, nodes.With):
         for expr, ids in scope.items:
             if expr.parent_of(var_node):
                 break
             if ids and isinstance(ids, nodes.AssignName) and ids.name == varname:
-                return True
+                return ids
     elif isinstance(scope, (nodes.Lambda, nodes.FunctionDef)):
         if scope.args.is_argument(varname):
             # If the name is found inside a default value
@@ -317,32 +323,65 @@ def is_defined_in_scope(
                 try:
                     scope.args.default_value(varname)
                     scope = scope.parent
-                    is_defined_in_scope(var_node, varname, scope)
+                    defnode = defnode_in_scope(var_node, varname, scope)
                 except astroid.NoDefault:
                     pass
-            return True
+                else:
+                    return defnode
+            return scope
         if getattr(scope, "name", None) == varname:
-            return True
+            return scope
     elif isinstance(scope, nodes.ExceptHandler):
         if isinstance(scope.name, nodes.AssignName):
             ass_node = scope.name
             if ass_node.name == varname:
-                return True
-    return False
+                return ass_node
+    return None
 
 
 def is_defined_before(var_node: nodes.Name) -> bool:
     """Check if the given variable node is defined before.
 
     Verify that the variable node is defined by a parent node
-    (list, set, dict, or generator comprehension, lambda)
-    or in a previous sibling node on the same line
-    (statement_defining ; statement_using).
+    (e.g. if or with) earlier than `var_node`, or is defined by a
+    (list, set, dict, or generator comprehension, lambda),
+    or is a nonlocal, or is defined
+    in a previous sibling node on the same line
+    (statement_defining ; statement_using)
+    (statement_block: statement_using).
     """
     varname = var_node.name
     for parent in var_node.node_ancestors():
-        if is_defined_in_scope(var_node, varname, parent):
+        defnode = defnode_in_scope(var_node, varname, parent)
+        if defnode is None:
+            continue
+        defnode_scope = defnode.scope()
+        if isinstance(defnode_scope, COMP_NODE_TYPES + (nodes.Lambda,)):
             return True
+        if defnode.lineno < var_node.lineno:
+            return True
+        if isinstance(defnode, nodes.Nonlocal):
+            return True
+        # defnode and var_node on the same line
+        for defnode_anc in defnode.node_ancestors():
+            if defnode_anc.lineno != var_node.lineno:
+                continue
+            if isinstance(
+                defnode_anc,
+                (
+                    nodes.For,
+                    nodes.While,
+                    nodes.With,
+                    nodes.TryExcept,
+                    nodes.TryFinally,
+                    nodes.ExceptHandler,
+                ),
+            ):
+                return True
+            if isinstance(defnode_anc, nodes.If) and not (
+                defnode_anc.test is var_node or defnode_anc.test.parent_of(var_node)
+            ):
+                return True
     # possibly multiple statements on the same line using semicolon separator
     stmt = var_node.statement(future=True)
     _node = stmt.previous_sibling()

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1977,8 +1977,9 @@ class VariablesChecker(BaseChecker):
                     # (b := b)
                     # Otherwise, safe if used after assignment:
                     # (b := 2) and b
-                    maybe_before_assign = any(
-                        anc is defnode.value for anc in node.node_ancestors()
+                    maybe_before_assign = (
+                        defnode.value is node
+                        or any(anc is defnode.value for anc in node.node_ancestors())
                     )
 
             # Look for type checking definitions inside a type checking guard.

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1977,9 +1977,8 @@ class VariablesChecker(BaseChecker):
                     # (b := b)
                     # Otherwise, safe if used after assignment:
                     # (b := 2) and b
-                    maybe_before_assign = (
-                        defnode.value is node
-                        or any(anc is defnode.value for anc in node.node_ancestors())
+                    maybe_before_assign = defnode.value is node or any(
+                        anc is defnode.value for anc in node.node_ancestors()
                     )
 
             # Look for type checking definitions inside a type checking guard.

--- a/tests/functional/u/undefined/undefined_variable_py38.py
+++ b/tests/functional/u/undefined/undefined_variable_py38.py
@@ -175,3 +175,8 @@ def expression_in_ternary_operator_inside_container_tuple():
 def expression_in_ternary_operator_inside_container_wrong_position():
     """2-element list where named expression comes too late"""
     return [val3, val3 if (val3 := 'something') else 'anything']  # [used-before-assignment]
+
+
+# Self-referencing
+if (z := z):  # [used-before-assignment]
+    z = z + 1

--- a/tests/functional/u/undefined/undefined_variable_py38.txt
+++ b/tests/functional/u/undefined/undefined_variable_py38.txt
@@ -7,3 +7,4 @@ undefined-variable:105:6:105:19::Undefined variable 'else_assign_2':INFERENCE
 used-before-assignment:140:10:140:16:type_annotation_used_improperly_after_comprehension:Using variable 'my_int' before assignment:HIGH
 used-before-assignment:147:10:147:16:type_annotation_used_improperly_after_comprehension_2:Using variable 'my_int' before assignment:HIGH
 used-before-assignment:177:12:177:16:expression_in_ternary_operator_inside_container_wrong_position:Using variable 'val3' before assignment:HIGH
+used-before-assignment:181:9:181:10::Using variable 'z' before assignment:HIGH

--- a/tests/functional/u/used/used_before_assignment_conditional.py
+++ b/tests/functional/u/used/used_before_assignment_conditional.py
@@ -4,6 +4,3 @@ if 1 + 1 == 2:
 
 if y:  # [used-before-assignment]
     y = y + 1
-
-if (z := z):  # [used-before-assignment]
-    z = z + 1

--- a/tests/functional/u/used/used_before_assignment_conditional.py
+++ b/tests/functional/u/used/used_before_assignment_conditional.py
@@ -1,0 +1,9 @@
+"""used-before-assignment cases involving IF conditions"""
+if 1 + 1 == 2:
+    x = x + 1  # [used-before-assignment]
+
+if y:  # [used-before-assignment]
+    y = y + 1
+
+if (z := z):  # [used-before-assignment]
+    z = z + 1

--- a/tests/functional/u/used/used_before_assignment_conditional.txt
+++ b/tests/functional/u/used/used_before_assignment_conditional.txt
@@ -1,3 +1,2 @@
 used-before-assignment:3:8:3:9::Using variable 'x' before assignment:HIGH
 used-before-assignment:5:3:5:4::Using variable 'y' before assignment:HIGH
-used-before-assignment:8:9:8:10::Using variable 'z' before assignment:HIGH

--- a/tests/functional/u/used/used_before_assignment_conditional.txt
+++ b/tests/functional/u/used/used_before_assignment_conditional.txt
@@ -1,0 +1,3 @@
+used-before-assignment:3:8:3:9::Using variable 'x' before assignment:HIGH
+used-before-assignment:5:3:5:4::Using variable 'y' before assignment:HIGH
+used-before-assignment:8:9:8:10::Using variable 'z' before assignment:HIGH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Self-referencing assignments under if statements were getting a free pass.

Closes #6643
