### PR TITLE
Emit `used-before-assignment` when calling nested functions before assignment

### DIFF
--- a/doc/whatsnew/2/2.15/index.rst
+++ b/doc/whatsnew/2/2.15/index.rst
@@ -46,6 +46,10 @@ False negatives fixed
 
   Closes #5653
 
+* Emit ``used-before-assignment`` when calling nested functions before assignment.
+
+  Closes #6812
+
 
 Other bug fixes
 ===============

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -204,11 +204,12 @@ def _detect_global_scope(node, frame, defframe):
         return False
     if isinstance(frame, nodes.FunctionDef):
         # If the parent of the current node is a
-        # function, then it can be under its scope
-        # (defined in, which doesn't concern us) or
+        # function, then it can be under its scope (defined in); or
         # the `->` part of annotations. The same goes
         # for annotations of function arguments, they'll have
         # their parent the Arguments node.
+        if frame.parent_of(defframe):
+            return node.lineno < defframe.lineno
         if not isinstance(node.parent, (nodes.FunctionDef, nodes.Arguments)):
             return False
     elif any(

--- a/tests/functional/u/used/used_before_assignment.py
+++ b/tests/functional/u/used/used_before_assignment.py
@@ -6,3 +6,10 @@ __revision__ = None
 MSG = "hello %s" % MSG  # [used-before-assignment]
 
 MSG2 = "hello %s" % MSG2  # [used-before-assignment]
+
+def outer():
+    inner()  # [used-before-assignment]
+    def inner():
+        pass
+
+outer()

--- a/tests/functional/u/used/used_before_assignment.txt
+++ b/tests/functional/u/used/used_before_assignment.txt
@@ -1,2 +1,3 @@
 used-before-assignment:6:19:6:22::Using variable 'MSG' before assignment:HIGH
 used-before-assignment:8:20:8:24::Using variable 'MSG2' before assignment:HIGH
+used-before-assignment:11:4:11:9:outer:Using variable 'inner' before assignment:HIGH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Closes #6812
