### PR TITLE
[empty_comment] fix checker name in code and docs

### DIFF
--- a/doc/user_guide/checkers/extensions.rst
+++ b/doc/user_guide/checkers/extensions.rst
@@ -290,6 +290,20 @@ Else If Used checker Messages
   does not contain statements that would be unrelated to it.
 
 
+.. _pylint.extensions.empty_comment:
+
+Empty Comment checker
+~~~~~~~~~~~~~~~~~~~~~
+
+This checker is provided by ``pylint.extensions.empty_comment``.
+Verbatim name of the checker is ``empty-comment``.
+
+Empty Comment checker Messages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:empty-comment (R2044): *Line with empty comment*
+  Used when a # symbol appears on a line not followed by an actual comment
+
+
 .. _pylint.extensions.eq_without_hash:
 
 Eq-Without-Hash checker
@@ -578,20 +592,6 @@ Redefined-Loop-Name checker Messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 :redefined-loop-name (W2901): *Redefining %r from loop (line %s)*
   Used when a loop variable is overwritten in the loop body.
-
-
-.. _pylint.extensions.empty_comment:
-
-Refactoring checker
-~~~~~~~~~~~~~~~~~~~
-
-This checker is provided by ``pylint.extensions.empty_comment``.
-Verbatim name of the checker is ``refactoring``.
-
-Refactoring checker Messages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-:empty-comment (R2044): *Line with empty comment*
-  Used when a # symbol appears on a line not followed by an actual comment
 
 
 .. _pylint.extensions.set_membership:

--- a/pylint/extensions/empty_comment.py
+++ b/pylint/extensions/empty_comment.py
@@ -41,7 +41,7 @@ def comment_part_of_string(line: bytes, comment_idx: int) -> bool:
 
 class CommentChecker(BaseRawFileChecker):
 
-    name = "refactoring"
+    name = "empty-comment"
     msgs = {
         "R2044": (
             "Line with empty comment",

--- a/tests/message/unittest_message_id_store.py
+++ b/tests/message/unittest_message_id_store.py
@@ -127,7 +127,7 @@ def test_exclusivity_of_msgids() -> None:
         "07": ("exceptions", "broad_try_clause", "overlap-except"),
         "12": ("design", "logging"),
         "17": ("async", "refactoring"),
-        "20": ("compare-to-zero", "refactoring"),
+        "20": ("compare-to-zero", "empty-comment"),
     }
 
     for msgid, definition in runner.linter.msgs_store._messages_definitions.items():


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Description

Seemingly copypaste artifacts from the refactoring checker.