### PR TITLE
Fix homepage link

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,14 +30,12 @@ classifiers =
     Topic :: Software Development :: Testing
 keywords = static code analysis linter python lint
 project_urls =
-    Homepage = https://pylint.pycqa.org/
+    Docs: User Guide = https://pylint.pycqa.org/en/latest/
     Source Code = https://github.com/PyCQA/pylint
-    What's New = https://pylint.pycqa.org/en/latest/whatsnew/
+    What's New = https://pylint.pycqa.org/en/latest/whatsnew/2/
     Bug Tracker = https://github.com/PyCQA/pylint/issues
     Discord Server = https://discord.com/invite/Egy6P8AMB5
-    Docs: User Guide = https://pylint.pycqa.org/en/latest/
-    Docs: Contributing = https://pylint.pycqa.org/en/latest/development_guide/contribute.html
-    Docs: Technical Reference = https://pylint.pycqa.org/en/latest/technical_reference/index.html
+    Docs: Contributer Guide = https://pylint.pycqa.org/en/latest/development_guide/contributor_guide/index.html
 
 [options]
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
     Topic :: Software Development :: Testing
 keywords = static code analysis linter python lint
 project_urls =
-    Homepage = https://www.pylint.org/
+    Homepage = https://pylint.pycqa.org/
     Source Code = https://github.com/PyCQA/pylint
     What's New = https://pylint.pycqa.org/en/latest/whatsnew/
     Bug Tracker = https://github.com/PyCQA/pylint/issues


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Add an entry to the change log describing the change in
  `doc/whatsnew/2/2.15/index.rst` (or ``doc/whatsnew/2/2.14/full.rst``
   if the change needs backporting in 2.14). If necessary you can write
   details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The "Homepage" link at https://pypi.org/project/pylint/ points to https://www.pylint.org/ which is down:

<img width="684" alt="image" src="https://user-images.githubusercontent.com/1324225/174968064-6cd2978d-a5d4-4994-b184-c048f8fe012c.png">

Instead, link to the docs page at https://pylint.pycqa.org/.
