### PR TITLE
[primer] Refactor the primer to use 'pylint.message.Message'

### DIFF
--- a/pylint/testutils/_primer/primer_command.py
+++ b/pylint/testutils/_primer/primer_command.py
@@ -7,11 +7,12 @@ from __future__ import annotations
 import abc
 import argparse
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List
 
+from pylint.message import Message
 from pylint.testutils._primer import PackageToLint
 
-PackageMessages = Dict[str, List[Dict[str, Union[str, int]]]]
+PackageMessages = Dict[str, List[Message]]
 
 
 class PrimerCommand:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

<!-- If this PR references an issue without fixing it: -->

Refs #6984, blocked by #7077
