### PR TITLE
Add documentation examples for `invalid-format-index`

### DIFF
--- a/doc/data/messages/i/invalid-format-index/bad.py
+++ b/doc/data/messages/i/invalid-format-index/bad.py
@@ -1,0 +1,1 @@
+print('{a[1]}'.format(a=[0]))  # [invalid-format-index]

--- a/doc/data/messages/i/invalid-format-index/bad.py
+++ b/doc/data/messages/i/invalid-format-index/bad.py
@@ -1,1 +1,2 @@
-print('{a[1]}'.format(a=[0]))  # [invalid-format-index]
+not_enough_fruits = ["apple"]
+print('The second fruit is a {fruits[1]}'.format(fruits=not_enough_fruits))  # [invalid-format-index]

--- a/doc/data/messages/i/invalid-format-index/details.rst
+++ b/doc/data/messages/i/invalid-format-index/details.rst
@@ -1,1 +1,0 @@
-You can help us make the doc better `by contributing <https://github.com/PyCQA/pylint/issues/5953>`_ !

--- a/doc/data/messages/i/invalid-format-index/good.py
+++ b/doc/data/messages/i/invalid-format-index/good.py
@@ -1,2 +1,2 @@
 enough_fruits = ["apple", "banana"]
-print('The second fruit is a {fruits[1]}'.format(fruits=enough_fruits))  # [invalid-format-index]
+print('The second fruit is a {fruits[1]}'.format(fruits=enough_fruits))

--- a/doc/data/messages/i/invalid-format-index/good.py
+++ b/doc/data/messages/i/invalid-format-index/good.py
@@ -1,1 +1,1 @@
-# This is a placeholder for correct code for this message.
+print('{a[1]}'.format(a=[0, 1]))

--- a/doc/data/messages/i/invalid-format-index/good.py
+++ b/doc/data/messages/i/invalid-format-index/good.py
@@ -1,1 +1,2 @@
-print('{a[1]}'.format(a=[0, 1]))
+enough_fruits = ["apple", "banana"]
+print('The second fruit is a {fruits[1]}'.format(fruits=enough_fruits))  # [invalid-format-index]


### PR DESCRIPTION
Co-authored-by: Vladyslav Krylasov <vladyslav.krylasov@gmail.com>

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [✓] Write a good description on what the PR does.
- [ ] Add an entry to the change log describing the change in
  `doc/whatsnew/2/2.15/index.rst` (or ``doc/whatsnew/2/2.14/full.rst``
   if the change needs backporting in 2.14). If necessary you can write
   details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description
Add documentation examples for `invalid-format-index`

<!-- If this PR references an issue without fixing it: -->

Refs #5953

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->
