### PR TITLE
[primer] Move `django` to new primer

### DIFF
--- a/tests/primer/packages_to_lint_batch_one.json
+++ b/tests/primer/packages_to_lint_batch_one.json
@@ -1,9 +1,4 @@
 {
-  "django": {
-    "branch": "main",
-    "directories": ["django"],
-    "url": "https://github.com/django/django.git"
-  },
   "keras": {
     "branch": "master",
     "directories": ["keras"],

--- a/tests/primer/packages_to_prime.json
+++ b/tests/primer/packages_to_prime.json
@@ -10,6 +10,11 @@
     "directories": ["src/black/", "src/blackd/", "src/blib2to3/"],
     "url": "https://github.com/psf/black"
   },
+  "django": {
+    "branch": "main",
+    "directories": ["django"],
+    "url": "https://github.com/django/django"
+  },
   "flask": {
     "branch": "main",
     "directories": ["src/flask"],


### PR DESCRIPTION
Tested on my fork. With adding `django`, the 3.7 primer job takes 32m, and the 3.10 job 28m.