### PR TITLE
Avoid deprecated `self.config` access in `missing-timeout`

### DIFF
--- a/pylint/checkers/method_args.py
+++ b/pylint/checkers/method_args.py
@@ -69,7 +69,7 @@ class MethodArgsChecker(BaseChecker):
         if (
             inferred
             and not call_site.has_invalid_keywords()
-            and inferred.qname() in self.config.timeout_methods
+            and inferred.qname() in self.linter.config.timeout_methods
         ):
             keyword_arguments = [keyword.arg for keyword in node.keywords]
             keyword_arguments.extend(call_site.keyword_arguments)


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Followup to #6780 to avoid deprecation warnings.
