### PR TITLE
Improve packaging [PEP 517 + 621]

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-ignore =
-    E203, W503, # Incompatible with black see https://github.com/ambv/black/issues/315
-    E501, # Lot of lines too long right now
-
-max-line-length=88
-max-complexity=39

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,12 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Install requirements
         run: |
-          python -m pip install -U pip twine wheel
-          python -m pip install -U "setuptools>=56.0.0"
+          # Remove dist, build, and pylint.egg-info
+          # when building locally for testing!
+          python -m pip install twine build
       - name: Build distributions
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
       - name: Upload to PyPI
         if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: copyright-notice
         args: ["--notice=script/copyright.txt", "--enforce-all"]
-        exclude: tests(/\w*)*/functional/|tests/input|doc/data/messages|examples/|setup.py|tests(/\w*)*data/
+        exclude: tests(/\w*)*/functional/|tests/input|doc/data/messages|examples/|tests(/\w*)*data/
         types: [python]
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.34.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: copyright-notice
         args: ["--notice=script/copyright.txt", "--enforce-all"]
-        exclude: tests(/\w*)*/functional/|tests/input|doc/data/messages|examples/|tests(/\w*)*data/
+        exclude: tests(/\w*)*/functional/|tests/input|doc/data/messages|examples/|setup.py|tests(/\w*)*data/
         types: [python]
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.34.0

--- a/.pyenchant_pylint_custom_dict.txt
+++ b/.pyenchant_pylint_custom_dict.txt
@@ -76,6 +76,7 @@ deepcopy
 defframe
 defstmts
 deleter
+dependabot
 deque
 destructured
 destructuring

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM python:3.10.0-alpine3.15
 
 COPY ./ /tmp/build
 WORKDIR /tmp/build
-RUN python setup.py install && rm -rf /tmp/build
+RUN python -m pip install . && rm -rf /tmp/build
 
 ENTRYPOINT ["pylint"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include README.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,13 +1,1 @@
 include README.rst
-recursive-exclude pylint *.rst
-prune .github
-prune doc
-prune elisp
-prune examples
-prune tests
-prune script
-exclude .*
-exclude Dockerfile
-exclude pylintrc
-exclude requirements_*.txt
-exclude tox.ini

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include README.rst
 recursive-exclude pylint *.rst
 prune .github
 prune doc
@@ -7,7 +8,6 @@ prune tests
 prune script
 exclude .*
 exclude Dockerfile
-exclude README.rst
 exclude pylintrc
 exclude requirements_*.txt
 exclude tox.ini

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme      = "README.rst"
 authors     = [
     {name = "Python Code Quality Authority", email = "code-quality@python.org"}
 ]
-keywords    = ["static", "code", "analysis", "linter", "python", "lint"]
+keywords    = ["static code analysis", "linter", "python", "lint"]
 classifiers = [
     "Development Status :: 6 - Mature",
     "Environment :: Console",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools~=62.6", "wheel~=0.37.1"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,79 @@
 [build-system]
 requires = ["setuptools~=62.6", "wheel~=0.37.1"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name        = "pylint"
+license     = {text = "GPL-2.0-or-later"}
+description = "python code static checker"
+readme      = "README.rst"
+authors     = [
+    {name = "Python Code Quality Authority", email = "code-quality@python.org"}
+]
+keywords    = ["static", "code", "analysis", "linter", "python", "lint"]
+classifiers = [
+    "Development Status :: 6 - Mature",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "Topic :: Software Development :: Debuggers",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Software Development :: Testing",
+]
+requires-python = ">=3.7.2"
+dependencies    = [
+    "dill>=0.2",
+    "platformdirs>=2.2.0",
+    # Also upgrade requirements_test_min.txt if you are bumping astroid.
+    # Pinned to dev of next minor update to allow editable installs,
+    # see https://github.com/PyCQA/astroid/issues/1341
+    "astroid>=2.11.6,<=2.12.0-dev0",
+    "isort>=4.2.5,<6",
+    "mccabe>=0.6,<0.8",
+    "tomli>=1.1.0;python_version<'3.11'",
+    "tomlkit>=0.10.1",
+    "colorama>=0.4.5;sys_platform=='win32'",
+    "typing-extensions>=3.10.0;python_version<'3.10'",
+]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+testutils = ["gitpython>3"]
+spelling = ["pyenchant~=3.2"]
+
+[project.urls]
+"Docs: User Guide"  = "https://pylint.pycqa.org/en/latest/"
+"Source Code"       = "https://github.com/PyCQA/pylint"
+"What's New"        = "https://pylint.pycqa.org/en/latest/whatsnew/2/"
+"Bug Tracker"       = "https://github.com/PyCQA/pylint/issues"
+"Discord Server"    = "https://discord.com/invite/Egy6P8AMB5"
+"Docs: Contributer Guide" = "https://pylint.pycqa.org/en/latest/development_guide/contributor_guide/index.html"
+
+[project.scripts]
+pylint        = "pylint:run_pylint"
+pylint-config = "pylint:_run_pylint_config"
+epylint       = "pylint:run_epylint"
+pyreverse     = "pylint:run_pyreverse"
+symilar       = "pylint:run_symilar"
+
+[tool.setuptools]
+license-files = ["LICENSE", "CONTRIBUTORS.txt"]  # Keep in sync with setup.cfg
+
+[tool.setuptools.packages.find]
+include = ["pylint*"]
+
+[tool.setuptools.package-data]
+pylint = ["testutils/testing_pylintrc"]
+
+[tool.setuptools.dynamic]
+version = {attr = "pylint.__pkginfo__.__version__"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 # Setuptools v62.6 doesn't support editable installs with just 'pyproject.toml' (PEP 660).
 # Keep this file until it does!
+
 [metadata]
 # wheel doesn't yet read license_files from pyproject.toml - tools.setuptools
 # Keep it here until it does!

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,77 +1,11 @@
+# Setuptools v62.6 doesn't support editable installs with just 'pyproject.toml' (PEP 660).
+# Keep this file until it does!
 [metadata]
-name = pylint
-version = attr: pylint.__pkginfo__.__version__
-description = python code static checker
-long_description = file: README.rst
-long_description_content_type = text/x-rst
-author = Python Code Quality Authority
-author_email = code-quality@python.org
-license = GPL-2.0-or-later
+# wheel doesn't yet read license_files from pyproject.toml - tools.setuptools
+# Keep it here until it does!
 license_files =
     LICENSE
     CONTRIBUTORS.txt
-classifiers =
-    Development Status :: 6 - Mature
-    Environment :: Console
-    Intended Audience :: Developers
-    License :: OSI Approved :: GNU General Public License v2 (GPLv2)
-    Operating System :: OS Independent
-    Programming Language :: Python
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: Implementation :: CPython
-    Programming Language :: Python :: Implementation :: PyPy
-    Topic :: Software Development :: Debuggers
-    Topic :: Software Development :: Quality Assurance
-    Topic :: Software Development :: Testing
-keywords = static code analysis linter python lint
-project_urls =
-    Docs: User Guide = https://pylint.pycqa.org/en/latest/
-    Source Code = https://github.com/PyCQA/pylint
-    What's New = https://pylint.pycqa.org/en/latest/whatsnew/2/
-    Bug Tracker = https://github.com/PyCQA/pylint/issues
-    Discord Server = https://discord.com/invite/Egy6P8AMB5
-    Docs: Contributer Guide = https://pylint.pycqa.org/en/latest/development_guide/contributor_guide/index.html
-
-[options]
-packages = find:
-install_requires =
-    dill>=0.2
-    platformdirs>=2.2.0
-    # Also upgrade requirements_test_min.txt if you are bumping astroid.
-    # Pinned to dev of next minor update to allow editable installs,
-    # see https://github.com/PyCQA/astroid/issues/1341
-    astroid>=2.11.6,<=2.12.0-dev0
-    isort>=4.2.5,<6
-    mccabe>=0.6,<0.8
-    tomli>=1.1.0;python_version<"3.11"
-    tomlkit>=0.10.1
-    colorama>=0.4.5;sys_platform=="win32"
-    typing-extensions>=3.10.0;python_version<"3.10"
-python_requires = >=3.7.2
-
-[options.extras_require]
-testutils=gitpython>3
-spelling=pyenchant~=3.2
-
-[options.packages.find]
-include =
-    pylint*
-
-[options.entry_points]
-console_scripts =
-    pylint = pylint:run_pylint
-    pylint-config = pylint:_run_pylint_config
-    epylint = pylint:run_epylint
-    pyreverse = pylint:run_pyreverse
-    symilar = pylint:run_symilar
-
-[options.package_data]
-pylint = testutils/testing_pylintrc
 
 [aliases]
 test = pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,11 @@ known_third_party = platformdirs, astroid, sphinx, isort, pytest, mccabe, six, t
 skip_glob = tests/functional/**,tests/input/**,tests/extensions/data/**,tests/regrtest_data/**,tests/data/**,astroid/**,venv/**
 src_paths = pylint
 
+[flake8]
+# Required for flake8-typing-imports (v1.12.0)
+# The plugin doesn't yet read the value from pyproject.toml
+min_python_version = 3.7.2
+
 [mypy]
 no_implicit_optional = True
 scripts_are_modules = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,11 @@ skip_glob = tests/functional/**,tests/input/**,tests/extensions/data/**,tests/re
 src_paths = pylint
 
 [flake8]
+ignore =
+    E203, W503, # Incompatible with black see https://github.com/ambv/black/issues/315
+    E501, # Lot of lines too long right now
+max-line-length=88
+max-complexity=39
 # Required for flake8-typing-imports (v1.12.0)
 # The plugin doesn't yet read the value from pyproject.toml
 min_python_version = 3.7.2

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+# Keep file until dependabot issue is resolved
+# https://github.com/dependabot/dependabot-core/issues/4483
+
+from setuptools import setup
+
+setup()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-# Keep file until dependabot issue is resolved
-# https://github.com/dependabot/dependabot-core/issues/4483
-
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
## Description
* Use isolated build environments [PEP 517](https://peps.python.org/pep-0517/) with `python -m build` instead of deprecated `python setup.py sdist bdist_wheel`
* Move project metadata from `setup.cfg` to `pyproject.toml` [PEP 621](https://peps.python.org/pep-0621/)
* Cleanup and remove `MANIFEST.in` -> entries haven't been used.
* ~Add `README.rst` to `MANIFEST.in`. Required to be able to build the `wheel` from `sdist` and still include the readme text in the project metadata.~
* Remove `setup.py`. With recent pip versions (`>= 21.0`), no longer required for editable installs. `setup.cfg` is enough.

**Metadata diff**
```diff
-Author: Python Code Quality Authority
-Author-email: code-quality@python.org
+Author-email: Python Code Quality Authority <code-quality@python.org>
...
-Keywords: static code analysis linter python lint
+Keywords: static code analysis,linter,python,lint
```

Closes #4193