### PR TITLE
Normalize path before checking if path should be ignored

### DIFF
--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -5,6 +5,11 @@ What's New in Pylint 2.14.4?
 ----------------------------
 Release date: TBA
 
+* Fixed an issue where scanning `.` directory recursively with ``--ignore-path=^path/to/dir`` is not
+  ignoring the `path/to/dir` directory.
+
+  Closes #6964
+
 * Fixed regression that didn't allow quoted ``init-hooks`` in option files.
 
   Closes #7006

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -52,6 +52,7 @@ def _is_ignored_file(
     ignore_list_re: list[Pattern[str]],
     ignore_list_paths_re: list[Pattern[str]],
 ) -> bool:
+    element = os.path.normpath(element)
     basename = os.path.basename(element)
     return (
         basename in ignore_list

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1330,7 +1330,7 @@ class TestRunTC:
                     code=0,
                 )
 
-    def test_ignore_path_recursive_current_dir(self) ->None:
+    def test_ignore_path_recursive_current_dir(self) -> None:
         """Tests that path is normalized before checked that is ignored. Github bug #6964"""
         with _test_sys_path():
             # pytest is including directory HERE/regrtest_data to sys.path which causes

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1331,7 +1331,7 @@ class TestRunTC:
                 )
 
     def test_ignore_path_recursive_current_dir(self) -> None:
-        """Tests that path is normalized before checked that is ignored. Github bug #6964"""
+        """Tests that path is normalized before checked that is ignored. GitHub issue #6964"""
         with _test_sys_path():
             # pytest is including directory HERE/regrtest_data to sys.path which causes
             # astroid to believe that directory is a package.

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1330,6 +1330,27 @@ class TestRunTC:
                     code=0,
                 )
 
+    def test_ignore_path_recursive_current_dir(self):
+        """Tests that path is normalized before checked that is ignored. Github bug #6964"""
+        with _test_sys_path():
+            # pytest is including directory HERE/regrtest_data to sys.path which causes
+            # astroid to believe that directory is a package.
+            sys.path = [
+                path
+                for path in sys.path
+                if not os.path.basename(path) == "regrtest_data"
+            ]
+            with _test_cwd():
+                os.chdir(join(HERE, "regrtest_data", "directory"))
+                self._runtest(
+                    [
+                        ".",
+                        "--recursive=y",
+                        "--ignore-paths=^ignored_subdirectory/.*",
+                    ],
+                    code=0,
+                )
+
     def test_regression_recursive_current_dir(self):
         with _test_sys_path():
             # pytest is including directory HERE/regrtest_data to sys.path which causes

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1330,7 +1330,7 @@ class TestRunTC:
                     code=0,
                 )
 
-    def test_ignore_path_recursive_current_dir(self):
+    def test_ignore_path_recursive_current_dir(self) ->None:
         """Tests that path is normalized before checked that is ignored. Github bug #6964"""
         with _test_sys_path():
             # pytest is including directory HERE/regrtest_data to sys.path which causes


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Add an entry to the change log describing the change in
  `doc/whatsnew/2/2.15/index.rst` (or ``doc/whatsnew/2/2.14/full.rst``
   if the change needs backporting in 2.14). If necessary you can write
   details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Description

Path should be normalized before checking if it should be ignored. E.g. paths
* ./some/path
* some/path
* some//path
Are the same path. All paths are normalized before checking so creating ignore regex is more straightforward.

See https://docs.python.org/3/library/os.path.html#os.path.normpath for details.

Closes #6964
