### PR TITLE
Add setup.py back to fix dependabot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: copyright-notice
         args: ["--notice=script/copyright.txt", "--enforce-all"]
-        exclude: tests(/\w*)*/functional/|tests/input|doc/data/messages|examples/|tests(/\w*)*data/
+        exclude: tests(/\w*)*/functional/|tests/input|doc/data/messages|examples/|setup.py|tests(/\w*)*data/
         types: [python]
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.34.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+# Keep file until dependabot issue is resolved
+# https://github.com/dependabot/dependabot-core/issues/4483
+
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
## Description
Followup to https://github.com/PyCQA/pylint/pull/7076#issuecomment-1169308238
Turns out `setup.py` is required for dependabot. At least for now.

/CC: @DanielNoord