### PR TITLE
Fix false negative for `nonlocal-without-binding`.

### DIFF
--- a/doc/whatsnew/2/2.15/index.rst
+++ b/doc/whatsnew/2/2.15/index.rst
@@ -65,6 +65,10 @@ False negatives fixed
 
   Closes #6643
 
+* Emit ``nonlocal-without-binding`` when a nonlocal name has been assigned at a later point in the same scope. 
+
+  Closes #6883
+
 * Rename ``unhashable-dict-key`` to ``unhashable-member`` and emit when creating sets and dicts,
   not just when accessing dicts.
 

--- a/pylint/checkers/base/basic_error_checker.py
+++ b/pylint/checkers/base/basic_error_checker.py
@@ -404,7 +404,10 @@ class BasicErrorChecker(_BasicChecker):
                 self.add_message("nonlocal-without-binding", args=(name,), node=node)
                 return
 
-            if name not in current_scope.locals:
+            # Search for `name` in the parent scope if:
+            #  `current_scope` is the same scope in which the `nonlocal` name is declared
+            #  or `name` is not in `current_scope.locals`.
+            if current_scope is node.scope() or name not in current_scope.locals:
                 current_scope = current_scope.parent.scope()
                 continue
 

--- a/tests/functional/n/nonlocal_without_binding.py
+++ b/tests/functional/n/nonlocal_without_binding.py
@@ -2,30 +2,45 @@
 # pylint: disable=missing-docstring,invalid-name,unused-variable, useless-object-inheritance
 # pylint: disable=too-few-public-methods
 
+
 def test():
     def parent():
         a = 42
+
         def stuff():
             nonlocal a
 
     c = 24
+
     def parent2():
         a = 42
+
         def stuff():
             def other_stuff():
                 nonlocal a
                 nonlocal c
 
+
 b = 42
+
+
 def func():
     def other_func():
         nonlocal b  # [nonlocal-without-binding]
 
+    # Case where `nonlocal-without-binding` was not emitted when
+    # the nonlocal name was assigned later in the same scope.
+    # https://github.com/PyCQA/pylint/issues/6883
+    def other_func2():
+        nonlocal c  # [nonlocal-without-binding]
+        c = 1
+
+
 class SomeClass(object):
-    nonlocal x # [nonlocal-without-binding]
+    nonlocal x  # [nonlocal-without-binding]
 
     def func(self):
-        nonlocal some_attr # [nonlocal-without-binding]
+        nonlocal some_attr  # [nonlocal-without-binding]
 
 
 def func2():

--- a/tests/functional/n/nonlocal_without_binding.txt
+++ b/tests/functional/n/nonlocal_without_binding.txt
@@ -1,3 +1,4 @@
-nonlocal-without-binding:22:8:22:18:func.other_func:nonlocal name b found without binding:UNDEFINED
-nonlocal-without-binding:25:4:25:14:SomeClass:nonlocal name x found without binding:UNDEFINED
-nonlocal-without-binding:28:8:28:26:SomeClass.func:nonlocal name some_attr found without binding:UNDEFINED
+nonlocal-without-binding:29:8:29:18:func.other_func:nonlocal name b found without binding:UNDEFINED
+nonlocal-without-binding:35:8:35:18:func.other_func2:nonlocal name c found without binding:UNDEFINED
+nonlocal-without-binding:40:4:40:14:SomeClass:nonlocal name x found without binding:UNDEFINED
+nonlocal-without-binding:43:8:43:26:SomeClass.func:nonlocal name some_attr found without binding:UNDEFINED


### PR DESCRIPTION
It was not emitted when the `nonlocal` name is assigned later on in the same scope.

Closes #6883

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Add an entry to the change log describing the change in
  `doc/whatsnew/2/2.15/index.rst` (or ``doc/whatsnew/2/2.14/full.rst``
   if the change needs backporting in 2.14). If necessary you can write
   details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

Refs #XXXX

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #XXXX
