### PR TITLE
doc(fail-under): improve description

### DIFF
--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -78,7 +78,7 @@ Standard Checkers
 
 --fail-under
 """"""""""""
-*Specify a score threshold to be exceeded before program exits with error.*
+*Specify a score threshold under which the program will exit with error.*
 
 **Default:**  ``10``
 

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -34,7 +34,7 @@ extension-pkg-whitelist=
 # specified are enabled, while categories only check already-enabled messages.
 fail-on=
 
-# Specify a score threshold to be exceeded before program exits with error.
+# Specify a score threshold under which the program will exit with error.
 fail-under=10
 
 # Interpret the stdin as a python script, whose filename needs to be passed as

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -24,7 +24,7 @@
 # specified are enabled, while categories only check already-enabled messages.
 # fail-on =
 
-# Specify a score threshold to be exceeded before program exits with error.
+# Specify a score threshold under which the program will exit with error.
 fail-under = 10
 
 # Interpret the stdin as a python script, whose filename needs to be passed as

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -154,7 +154,7 @@ def _make_linter_options(linter: PyLinter) -> Options:
                 "default": 10,
                 "type": "float",
                 "metavar": "<score>",
-                "help": "Specify a score threshold to be exceeded before program exits with error.",
+                "help": "Specify a score threshold under which the program will exit with error.",
             },
         ),
         (

--- a/pylintrc
+++ b/pylintrc
@@ -61,7 +61,7 @@ py-version = 3.7.2
 # complex, nested conditions.
 limit-inference-results=100
 
-# Specify a score threshold to be exceeded before program exits with error.
+# Specify a score threshold under which the program will exit with error.
 fail-under=10.0
 
 # Return non-zero exit code if any of these messages/categories are detected,


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|     | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

To exceed a threshold here sonds to me as if the score would have to be _above_ the threshold, which is the opposite of what actually happens. Use "maintain" instead of "exceed" to "fix" the description. Another possibility would be to "meet" the threshold, or to rephrase the description altogether.