### PR TITLE
Update docs to explain escape character not valid

### DIFF
--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -99,7 +99,7 @@ Standard Checkers
 
 --ignore-paths
 """"""""""""""
-*Add files or directories matching the regex patterns to the ignore-list. The regex matches against paths and can be in Posix or Windows format.*
+*Add files or directories matching the regex patterns to the ignore-list. The regex matches against paths and can be in Posix or Windows format. Because '\' represents the directory delimiter on Windows systems, it can't be used as an escape character.*
 
 **Default:**  ``[]``
 

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -69,7 +69,8 @@ def _make_linter_options(linter: PyLinter) -> Options:
                 "default": [],
                 "help": "Add files or directories matching the regex patterns to the "
                 "ignore-list. The regex matches against paths and can be in "
-                "Posix or Windows format.",
+                "Posix or Windows format. Because '\\' represents the directory delimiter "
+                "on Windows systems, it can't be used as an escape character.",
             },
         ),
         (


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

This just adds the note from #5415 to docs to explain that `\` is not valid in ignore-paths per https://github.com/PyCQA/pylint/issues/5398#issuecomment-981156554 because it also currently is needed to support Windows path normalization. This will help avoid additional issues being created (like the one I created in #7089 and also someone else in #7094) to reduce the burden on pylint maintainers/developers.

