### PR TITLE
Restore `sys.path` in `test_load_plugin_configuration`

### DIFF
--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -555,6 +555,8 @@ def test_load_plugin_configuration() -> None:
         ],
         exit=False,
     )
+
+    sys.path.remove(dummy_plugin_path)
     assert run.linter.config.ignore == ["foo", "bar", "bin"]
 
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Found while working on #7117
