### PR TITLE
Use the default config in the messages documentation tests

### DIFF
--- a/doc/data/messages/b/bad-builtin/pylintrc
+++ b/doc/data/messages/b/bad-builtin/pylintrc
@@ -1,0 +1,2 @@
+[MAIN]
+load-plugins = pylint.extensions.bad_builtin

--- a/doc/data/messages/c/consider-using-tuple/pylintrc
+++ b/doc/data/messages/c/consider-using-tuple/pylintrc
@@ -1,0 +1,2 @@
+[MAIN]
+load-plugins=pylint.extensions.code_style

--- a/doc/data/messages/m/missing-param-doc/pylintrc
+++ b/doc/data/messages/m/missing-param-doc/pylintrc
@@ -1,0 +1,2 @@
+[MAIN]
+load-plugins = pylint.extensions.docparams

--- a/doc/data/messages/m/missing-raises-doc/pylintrc
+++ b/doc/data/messages/m/missing-raises-doc/pylintrc
@@ -1,0 +1,2 @@
+[MAIN]
+load-plugins = pylint.extensions.docparams

--- a/doc/data/messages/m/missing-type-doc/pylintrc
+++ b/doc/data/messages/m/missing-type-doc/pylintrc
@@ -1,0 +1,2 @@
+[MAIN]
+load-plugins = pylint.extensions.docparams

--- a/doc/data/messages/o/overlapping-except/pylintrc
+++ b/doc/data/messages/o/overlapping-except/pylintrc
@@ -1,0 +1,2 @@
+[MAIN]
+load-plugins=pylint.extensions.overlapping_exceptions,

--- a/doc/data/messages/r/redefined-variable-type/pylintrc
+++ b/doc/data/messages/r/redefined-variable-type/pylintrc
@@ -1,0 +1,2 @@
+[MAIN]
+load-plugins=pylint.extensions.redefined_variable_type,

--- a/doc/data/messages/u/use-set-for-membership/pylintrc
+++ b/doc/data/messages/u/use-set-for-membership/pylintrc
@@ -1,0 +1,2 @@
+[MAIN]
+load-plugins=pylint.extensions.set_membership

--- a/doc/data/messages/u/using-final-decorator-in-unsupported-version/pylintrc
+++ b/doc/data/messages/u/using-final-decorator-in-unsupported-version/pylintrc
@@ -1,0 +1,2 @@
+[main]
+py-version=3.7

--- a/doc/test_messages_documentation.py
+++ b/doc/test_messages_documentation.py
@@ -147,7 +147,7 @@ class LintModuleTest:
 
     def _runTest(self) -> None:
         """Run the test and assert message differences."""
-        self._linter.check([str(self._test_file[1])])
+        self._linter.check([str(self._test_file[1]), "--rcfile="])
         expected_messages = self._get_expected()
         actual_messages = self._get_actual()
         if self.is_good_test_file():


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Will unblock https://github.com/PyCQA/pylint/pull/7070 and others as it changes the value for `max-return-values` from our own `11` to the default of `6`.