### PR TITLE
Remove unsupported option from our own ``pylintrc``

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,8 +1,5 @@
 [MAIN]
 
-# Specify a configuration file.
-#rcfile=
-
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
 #init-hook=


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Closes https://github.com/PyCQA/pylint/issues/6284.

We don't support this and it would unnecessarily complicate things. The rationale for this is also flimsy at best:
The original reporter wanted to put all `linter` config in a special subdirectory and then create a `.pylintrc` file which would point to a file in that directory. That's just... Use a symlink or just use one file, this unnecessarily complicates stuff. 
_We're a linter, we should not support such anti-patterns_ 😄 