### PR TITLE
Fix Pylint spelling in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ ecosystem of existing plugins for popular frameworks such as `pylint-django`_ or
 
 Pylint isn't smarter than you: it may warn you about things that you have
 conscientiously done or check for some things that you don't care about.
-During adoption, especially in a legacy project where pylint was never enforced,
+During adoption, especially in a legacy project where Pylint was never enforced,
 it's best to start with the ``--errors-only`` flag, then disable
 convention and refactor message with ``--disable=C,R`` and progressively
 re-evaluate and re-enable messages as your priorities evolve.
@@ -63,14 +63,14 @@ re-evaluate and re-enable messages as your priorities evolve.
 Pylint ships with three additional tools:
 
 - pyreverse_ (standalone tool that generates package and class diagrams.)
-- symilar_  (duplicate code finder that is also integrated in pylint)
+- symilar_  (duplicate code finder that is also integrated in Pylint)
 - epylint_ (Emacs and Flymake compatible Pylint)
 
 .. _pyreverse: https://pylint.pycqa.org/en/latest/pyreverse.html
 .. _symilar: https://pylint.pycqa.org/en/latest/symilar.html
 .. _epylint: https://pylint.pycqa.org/en/latest/user_guide/ide_integration/flymake-emacs.html
 
-Projects that you might want to use alongside pylint include flake8_ (faster and simpler checks
+Projects that you might want to use alongside Pylint include flake8_ (faster and simpler checks
 with very few false positives), mypy_, pyright_ or pyre_ (typing checks), bandit_ (security
 oriented checks), black_ and isort_ (auto-formatting), autoflake_ (automated removal of
 unused imports or variables), pyupgrade_ (automated upgrade to newer python syntax) and
@@ -94,7 +94,7 @@ Install
 
 .. This is used inside the doc to recover the start of the short text for installation
 
-For command line use, pylint is installed with::
+For command line use, Pylint is installed with::
 
     pip install pylint
 
@@ -126,7 +126,7 @@ make a code contribution.
 Show your usage
 -----------------
 
-You can place this badge in your README to let others know your project uses pylint.
+You can place this badge in your README to let others know your project uses Pylint.
 
     .. image:: https://img.shields.io/badge/linting-pylint-yellowgreen
         :target: https://github.com/PyCQA/pylint
@@ -160,7 +160,7 @@ Please check `the contact information`_.
    :widths: 10 100
 
    * - |tideliftlogo|
-     - Professional support for pylint is available as part of the `Tidelift
+     - Professional support for Pylint is available as part of the `Tidelift
        Subscription`_.  Tidelift gives software development teams a single source for
        purchasing and maintaining their software, with professional grade assurances
        from the experts who know it best, while seamlessly integrating with existing

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,11 +47,11 @@ extensions = [
 ]
 
 
-# Single file redirects are handled in this file and can be done by a pylint
+# Single file redirects are handled in this file and can be done by a Pylint
 # contributor. We use the following extension:
 # https://documatt.gitlab.io/sphinx-reredirects/usage.html
 # Directory redirects are handled in ReadTheDoc admin interface and can only be done
-# by pylint maintainers at the following URL:
+# by Pylint maintainers at the following URL:
 # https://readthedocs.org/dashboard/pylint/redirects/
 redirects: dict[str, str] = {
     # "<source>": "<target>"

--- a/doc/contact.rst
+++ b/doc/contact.rst
@@ -49,7 +49,7 @@ Support
    :align: left
    :class: tideliftlogo
 
-Professional support for pylint is available as part of the `Tidelift
+Professional support for Pylint is available as part of the `Tidelift
 Subscription`_.  Tidelift gives software development teams a single source for
 purchasing and maintaining their software, with professional grade assurances
 from the experts who know it best, while seamlessly integrating with existing

--- a/doc/data/messages/n/no-member/details.rst
+++ b/doc/data/messages/n/no-member/details.rst
@@ -1,14 +1,14 @@
 If you are getting the dreaded ``no-member`` error, there is a possibility that
 either:
 
-- pylint found a bug in your code
-- You're launching pylint without the dependencies installed in its environment.
-- pylint would need to lint a C extension module and is refraining to do so.
+- Pylint found a bug in your code
+- You're launching Pylint without the dependencies installed in its environment.
+- Pylint would need to lint a C extension module and is refraining to do so.
 
 Linting C extension modules is not supported out of the box, especially since
 pylint has no way to get an AST object out of the extension module.
 
-But pylint actually has a mechanism which you might use in case you
+But Pylint actually has a mechanism which you might use in case you
 want to analyze C extensions. Pylint has a flag, called ``extension-pkg-allow-list``
 (formerly ``extension-pkg-whitelist``), through which you can tell it to
 import that module and to build an AST from that imported module::
@@ -20,10 +20,10 @@ active Python interpreter and may run arbitrary code, which you may not want. Th
 is the reason why we disable by default loading C extensions. In case you do not want
 the hassle of passing C extensions module with this flag all the time, you
 can enable ``unsafe-load-any-extension`` in your configuration file, which will
-build AST objects from all the C extensions that pylint encounters::
+build AST objects from all the C extensions that Pylint encounters::
 
    $ pylint --unsafe-load-any-extension=y
 
-Alternatively, since pylint emits a separate error for attributes that cannot be
+Alternatively, since Pylint emits a separate error for attributes that cannot be
 found in C extensions, ``c-extension-no-member``, you can disable this error for
 your project.

--- a/doc/data/messages/t/try-except-raise/details.rst
+++ b/doc/data/messages/t/try-except-raise/details.rst
@@ -15,4 +15,4 @@ The following code shows valid case for re-raising exception immediately::
         except ArithmeticError:
             return float('nan')
 
-The pylint is able to detect this case and does not produce error.
+Pylint is able to detect this case and does not produce error.

--- a/doc/development_guide/api/index.rst
+++ b/doc/development_guide/api/index.rst
@@ -2,7 +2,7 @@
 API
 ###
 
-You can call ``Pylint``, ``epylint``, ``symilar`` and ``pyreverse`` from another
+You can call ``pylint``, ``epylint``, ``symilar`` and ``pyreverse`` from another
 Python program thanks to their APIs:
 
 .. sourcecode:: python

--- a/doc/development_guide/api/pylint.rst
+++ b/doc/development_guide/api/pylint.rst
@@ -20,7 +20,7 @@ Recover the result in a stream
 ------------------------------
 
 You can also use ``pylint.lint.Run`` directly if you want to do something that
-can't be done using only pylint's command line options. Here's the basic example:
+can't be done using only Pylint's command line options. Here's the basic example:
 
 .. sourcecode:: python
 
@@ -28,7 +28,7 @@ can't be done using only pylint's command line options. Here's the basic example
 
     Run(argv=["--disable=line-too-long", "myfile.py"])
 
-With ``Run`` it is possible to invoke pylint programmatically with a
+With ``Run`` it is possible to invoke Pylint programmatically with a
 reporter initialized with a custom stream:
 
 .. sourcecode:: python
@@ -55,11 +55,11 @@ the stream outputs to a file:
         reporter = TextReporter(f)
         Run(["test_file.py"], reporter=reporter, exit=False)
 
-This would be useful to capture pylint output in an open stream which
+This would be useful to capture Pylint output in an open stream which
 can be passed onto another program.
 
 If your program expects that the files being linted might be edited
-between runs, you will need to clear pylint's inference cache:
+between runs, you will need to clear Pylint's inference cache:
 
 .. sourcecode:: python
 

--- a/doc/development_guide/contributor_guide/contribute.rst
+++ b/doc/development_guide/contributor_guide/contribute.rst
@@ -42,7 +42,7 @@ your patch gets accepted:
 
 Tips for Getting Started with Pylint Development
 ------------------------------------------------
-* Read the :ref:`technical-reference`. It gives a short walk through of the pylint
+* Read the :ref:`technical-reference`. It gives a short walk through of the Pylint
   codebase and will help you identify where you will need to make changes
   for what you are trying to implement.
 

--- a/doc/development_guide/contributor_guide/index.rst
+++ b/doc/development_guide/contributor_guide/index.rst
@@ -1,9 +1,9 @@
 .. _contribute_guide:
 
-Contributing to pylint
+Contributing to Pylint
 ======================
 
-The contributor guide will help you if you want to contribute to pylint itself.
+The contributor guide will help you if you want to contribute to Pylint itself.
 
 .. toctree::
    :maxdepth: 2

--- a/doc/development_guide/contributor_guide/major_release.rst
+++ b/doc/development_guide/contributor_guide/major_release.rst
@@ -1,2 +1,2 @@
-- In **major releases** (``1.0.0``) we change everything else (pylint options, json output, dev API...)
+- In **major releases** (``1.0.0``) we change everything else (Pylint options, json output, dev API...)
   while still trying to minimize disruption.

--- a/doc/development_guide/contributor_guide/tests/index.rst
+++ b/doc/development_guide/contributor_guide/tests/index.rst
@@ -2,7 +2,7 @@
 .. _test_your_code:
 
 ==============
-Testing pylint
+Testing Pylint
 ==============
 
 Pylint is very well tested and has a high code coverage. New contributions are not accepted

--- a/doc/development_guide/contributor_guide/tests/install.rst
+++ b/doc/development_guide/contributor_guide/tests/install.rst
@@ -13,7 +13,7 @@ You can clone Pylint using ::
   git clone https://github.com/PyCQA/pylint
 
 Before you start testing your code, you need to install your source-code package locally.
-Suppose you just cloned pylint with the previous ``git clone`` command. To set up your
+Suppose you just cloned Pylint with the previous ``git clone`` command. To set up your
 environment for testing, open a terminal and run::
 
     cd pylint
@@ -31,7 +31,7 @@ Astroid installation
 --------------------
 
 If you're testing new changes in astroid you need to also clone astroid_ and install
-with an editable installation alongside pylint as follows::
+with an editable installation alongside Pylint as follows::
 
     # Suppose you're in the pylint directory
     git clone https://github.com/PyCQA/astroid.git

--- a/doc/development_guide/contributor_guide/tests/writing_test.rst
+++ b/doc/development_guide/contributor_guide/tests/writing_test.rst
@@ -5,7 +5,7 @@ Writing tests
 
 Pylint uses three types of tests: unittests, functional tests and primer tests.
 
-- :ref:`unittests <writing_unittests>` can be found in ``pylint/tests``. Unless you're working on pylint's
+- :ref:`unittests <writing_unittests>` can be found in ``pylint/tests``. Unless you're working on Pylint's
   internal you're probably not going to have to write any.
 - :ref:`Global functional tests <writing_functional_tests>`  can be found in the ``pylint/tests/functional``. They are
   mainly used to test whether Pylint emits the correct messages.

--- a/doc/development_guide/how_tos/custom_checkers.rst
+++ b/doc/development_guide/how_tos/custom_checkers.rst
@@ -176,7 +176,7 @@ Now we know how to use the astroid node, we can implement our check.
 Once we have established that the source code has failed our check,
 we use ``~.BaseChecker.add_message`` to emit our failure message.
 
-Finally, we need to register the checker with pylint.
+Finally, we need to register the checker with Pylint.
 Add the ``register`` function to the top level of the file.
 
 .. code-block:: python
@@ -208,7 +208,7 @@ Put the following into a Python file:
       return 5
 
 After inserting pdb into our checker and installing it,
-we can run pylint with only our checker::
+we can run Pylint with only our checker::
 
   $ pylint --load-plugins=my_plugin --disable=all --enable=non-unique-returns test.py
   (Pdb)
@@ -218,7 +218,7 @@ Now we can debug our checker!
 .. Note::
 
     ``my_plugin`` refers to a module called ``my_plugin.py``.
-    This module can be made available to pylint by putting this
+    This module can be made available to Pylint by putting this
     module's parent directory in your ``PYTHONPATH``
     environment variable or by adding the ``my_plugin.py``
     file to the ``pylint/checkers`` directory if running from source.

--- a/doc/development_guide/technical_reference/checkers.rst
+++ b/doc/development_guide/technical_reference/checkers.rst
@@ -1,7 +1,7 @@
 Checkers
 --------
-All of the default pylint checkers exist in ``pylint.checkers``.
-This is where most of pylint's brains exist.
+All of the default Pylint checkers exist in ``pylint.checkers``.
+This is where most of Pylint's brains exist.
 Most checkers are AST based and so use ``astroid``.
 ``pylint.checkers.utils`` provides a large number of utility methods for
 dealing with ``astroid``.

--- a/doc/development_guide/technical_reference/startup.rst
+++ b/doc/development_guide/technical_reference/startup.rst
@@ -4,7 +4,7 @@ Startup and the Linter Class
 The two main classes in ``pylint.lint`` are
 ``.pylint.lint.Run`` and ``.pylint.lint.PyLinter``.
 
-The ``.pylint.lint.Run`` object is responsible for starting up pylint.
+The ``.pylint.lint.Run`` object is responsible for starting up Pylint.
 It does some basic checking of the given command line options to
 find the initial hook to run,
 find the config file to use,

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -18,7 +18,7 @@ How do I contribute to Pylint?
 Does Pylint follow a versioning scheme?
 ----------------------------------------
 
-See :ref:`upgrading pylint in the installation guide <upgrading_pylint>`.
+See :ref:`upgrading Pylint in the installation guide <upgrading_pylint>`.
 
 How do I find the name corresponding to a specific command line option?
 -----------------------------------------------------------------------

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -86,7 +86,7 @@ Pylint is going to ``pick on``: ::
     * (R) refactor, for bad code smell
     * (W) warning, for python specific problems
     * (E) error, for probable bugs in the code
-    * (F) fatal, if an error occurred which prevented pylint from doing
+    * (F) fatal, if an error occurred which prevented Pylint from doing
     further processing.
 
 When Pylint is first run on a fresh piece of code, a common complaint is that it

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -104,7 +104,7 @@ Basic checker Messages
 :self-assigning-variable (W0127): *Assigning the same variable %r to itself*
   Emitted when we detect that a variable is assigned to itself
 :comparison-with-callable (W0143): *Comparing against a callable, did you omit the parenthesis?*
-  This message is emitted when pylint detects that a comparison with a callable
+  This message is emitted when Pylint detects that a comparison with a callable
   was made, which might suggest that some parenthesis were omitted, resulting
   in potential unwanted behaviour.
 :nan-comparison (W0177): *Comparison %s should be %s*
@@ -516,7 +516,7 @@ Imports checker Messages
   Used when a relative import tries to access too many levels in the current
   package.
 :import-error (E0401): *Unable to import %s*
-  Used when pylint has been unable to import a module.
+  Used when Pylint has been unable to import a module.
 :deprecated-module (W4901): *Deprecated module %r*
   A module marked as deprecated is imported.
 :import-self (W0406): *Module import itself*
@@ -802,7 +802,7 @@ Refactoring checker Messages
   operations, such as for iteration, with statement assignment and exception
   handler assignment.
 :chained-comparison (R1716): *Simplify chained comparison between the operands*
-  This message is emitted when pylint encounters boolean operation like "a < b
+  This message is emitted when Pylint encounters boolean operation like "a < b
   and b < c", suggesting instead to refactor it to "a < b < c"
 :simplifiable-if-expression (R1719): *The if expression can be replaced with %s*
   Used when an if expression can be replaced with 'bool(test)' or simply 'test'
@@ -1250,10 +1250,10 @@ Verbatim name of the checker is ``unsupported_version``.
 Unsupported Version checker Messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 :using-f-string-in-unsupported-version (W2601): *F-strings are not supported by all versions included in the py-version setting*
-  Used when the py-version set by the user is lower than 3.6 and pylint
+  Used when the py-version set by the user is lower than 3.6 and Pylint
   encounters a f-string.
 :using-final-decorator-in-unsupported-version (W2602): *typing.final is not supported by all versions included in the py-version setting*
-  Used when the py-version set by the user is lower than 3.8 and pylint
+  Used when the py-version set by the user is lower than 3.8 and Pylint
   encounters a ``typing.final`` decorator.
 
 

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -162,7 +162,7 @@ Standard Checkers
 
 --py-version
 """"""""""""
-*Minimum Python version to use for version dependent checks. Will default to the version used to run pylint.*
+*Minimum Python version to use for version dependent checks. Will default to the version used to run Pylint.*
 
 **Default:**  ``(3, 10)``
 
@@ -190,7 +190,7 @@ Standard Checkers
 
 --suggestion-mode
 """""""""""""""""
-*When enabled, pylint would attempt to guess common misconfiguration and emit user-friendly hints instead of false-positive error messages.*
+*When enabled, Pylint would attempt to guess common misconfiguration and emit user-friendly hints instead of false-positive error messages.*
 
 **Default:**  ``True``
 
@@ -1365,7 +1365,7 @@ Standard Checkers
 
 --generated-members
 """""""""""""""""""
-*List of members which are set dynamically and missed by pylint inference system, and so shouldn't trigger E1101 when accessed. Python regular expressions are accepted.*
+*List of members which are set dynamically and missed by Pylint inference system, and so shouldn't trigger E1101 when accessed. Python regular expressions are accepted.*
 
 **Default:**  ``()``
 
@@ -1386,7 +1386,7 @@ Standard Checkers
 
 --ignore-on-opaque-inference
 """"""""""""""""""""""""""""
-*This flag controls whether pylint should warn about no-member and similar checks whenever an opaque object is returned when inferring. The inference can return multiple potential results while evaluating a Python object, but some branches might not be evaluated, which results in partial inference. In that case, it might be useful to still emit no-member and other checks for the rest of the inferred objects.*
+*This flag controls whether Pylint should warn about no-member and similar checks whenever an opaque object is returned when inferring. The inference can return multiple potential results while evaluating a Python object, but some branches might not be evaluated, which results in partial inference. In that case, it might be useful to still emit no-member and other checks for the rest of the inferred objects.*
 
 **Default:**  ``True``
 

--- a/doc/user_guide/installation/badge.rst
+++ b/doc/user_guide/installation/badge.rst
@@ -4,14 +4,14 @@
 Show your usage
 ---------------
 
-You can place this badge in your README to let others know your project uses pylint.
+You can place this badge in your README to let others know your project uses Pylint.
 
     .. image:: https://img.shields.io/badge/linting-pylint-yellowgreen
         :target: https://github.com/PyCQA/pylint
 
 Use the badge in your project's README.md (or any other Markdown file)::
 
-    [![linting: pylint](https://img.shields.io/badge/linting-pylint-yellowgreen)](https://github.com/PyCQA/pylint)
+    [![linting: Pylint](https://img.shields.io/badge/linting-pylint-yellowgreen)](https://github.com/PyCQA/pylint)
 
 Use the badge in your project's README.rst (or any other rst file)::
 
@@ -21,5 +21,5 @@ Use the badge in your project's README.rst (or any other rst file)::
 
 If you use GitHub Actions, and one of your CI workflows begins with "name: pylint", you
 can use GitHub's `workflow status badges <https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name>`_
-to show an up-to-date indication of whether pushes to your default branch pass pylint.
+to show an up-to-date indication of whether pushes to your default branch pass Pylint.
 For more detailed information, check the documentation.

--- a/doc/user_guide/installation/command_line_installation.rst
+++ b/doc/user_guide/installation/command_line_installation.rst
@@ -14,12 +14,12 @@ Use the newest Python interpreter if you can.
 
 It's possible to analyse code written for older interpreters by using the ``py-version``
 option and setting it to the old interpreter. For example you can check that there are
-no ``f-strings`` in Python 3.5 code using Python 3.8 with an up-to-date pylint even if
+no ``f-strings`` in Python 3.5 code using Python 3.8 with an up-to-date Pylint even if
 Python 3.5 is past end of life (EOL).
 
 We do not guarantee that ``py-version`` will work for all EOL python interpreters indefinitely,
 (for anything before python 3.5, it probably won't). If a newer version does not work for you,
-the best available pylint might be an old version that works with your old interpreter but
+the best available Pylint might be an old version that works with your old interpreter but
 without the bug fixes and features of later versions.
 
 .. note::

--- a/doc/user_guide/installation/upgrading_pylint.rst
+++ b/doc/user_guide/installation/upgrading_pylint.rst
@@ -1,10 +1,10 @@
 .. _upgrading_pylint:
 
-Upgrading pylint
+Upgrading Pylint
 ================
 
-You should probably set the version of pylint in your development environment in order to
-choose when you actually upgrade pylint's warnings. pylint is following semver versioning.
+You should probably set the version of Pylint in your development environment in order to
+choose when you actually upgrade Pylint's warnings. Pylint is following semver versioning.
 But we can't guarantee that the output between version will stays the same. What this means
 is that:
 

--- a/doc/whatsnew/full_changelog_explanation.rst
+++ b/doc/whatsnew/full_changelog_explanation.rst
@@ -1,4 +1,4 @@
-From pylint's beginning to pylint 2.14.0 included, we had a changelog that contained *all*
+From Pylint's beginning to Pylint 2.14.0 included, we had a changelog that contained *all*
 nontrivial changes to Pylint, including changes that were
 not user facing, i.e. change that might interest you only if you're a developer
-working on pylint or pylint plugins or an open-source historian.
+working on Pylint or Pylint plugins or an open-source historian.


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Add an entry to the change log describing the change in
  `doc/whatsnew/2/2.15/index.rst` (or ``doc/whatsnew/2/2.14/full.rst``
   if the change needs backporting in 2.14). If necessary you can write
   details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

I've fixed all occurrences of "pylint" that I could find in the docs and replaced them by "Pylint" because that's the correct spelling from what I can tell. I excluded occurrences in `doc/whatsnew/**` because there the formatting is a bit inconsistent anyway; cleaning those files up might be a different task altogether IMO. :wink: