### PR TITLE
Prevent appending distinct crash reports together that occur in the same hour

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -259,7 +259,7 @@ class PyLinter(
     name = MAIN_CHECKER_NAME
     msgs = MSGS
     # Will be used like this : datetime.now().strftime(crash_file_path)
-    crash_file_path: str = "pylint-crash-%Y-%m-%d-%H.txt"
+    crash_file_path: str = "pylint-crash-%Y-%m-%d-%H-%M.txt"
 
     option_groups_descs = {
         "Messages control": "Options controlling analysis messages",

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -259,7 +259,7 @@ class PyLinter(
     name = MAIN_CHECKER_NAME
     msgs = MSGS
     # Will be used like this : datetime.now().strftime(crash_file_path)
-    crash_file_path: str = "pylint-crash-%Y-%m-%d-%H-%M.txt"
+    crash_file_path: str = "pylint-crash-%Y-%m-%d-%H-%M-%S.txt"
 
     option_groups_descs = {
         "Messages control": "Options controlling analysis messages",


### PR DESCRIPTION
Previously, any crash reports generated in the same hour would get appended into the same file.

When debugging multiple failures (or repeating a single failure while trimming down a large file into a minimal example) it's not ideal to have distinct crash reports all appended into the same file IMO.