### PR TITLE
Refactor context manager for sys path and current working directory in tests

### DIFF
--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -8,6 +8,8 @@ import contextlib
 import os
 import sys
 from collections.abc import Generator, Iterator
+from copy import copy
+from pathlib import Path
 from typing import TextIO
 
 
@@ -23,18 +25,26 @@ def _patch_streams(out: TextIO) -> Iterator[None]:
 
 
 @contextlib.contextmanager
-def _test_sys_path() -> Generator[None, None, None]:
+def _test_sys_path(
+    replacement_sys_path: list[str] | None = None,
+) -> Generator[None, None, None]:
     original_path = sys.path
     try:
+        if replacement_sys_path is not None:
+            sys.path = copy(replacement_sys_path)
         yield
     finally:
         sys.path = original_path
 
 
 @contextlib.contextmanager
-def _test_cwd() -> Generator[None, None, None]:
+def _test_cwd(
+    current_working_directory: str | Path | None = None,
+) -> Generator[None, None, None]:
     original_dir = os.getcwd()
     try:
+        if current_working_directory is not None:
+            os.chdir(current_working_directory)
         yield
     finally:
         os.chdir(original_dir)

--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import contextlib
 import os
 import sys
-from collections.abc import Iterator
+from collections.abc import Generator, Iterator
 from typing import TextIO
 
 
@@ -20,6 +20,24 @@ def _patch_streams(out: TextIO) -> Iterator[None]:
     finally:
         sys.stderr = sys.__stderr__
         sys.stdout = sys.__stdout__
+
+
+@contextlib.contextmanager
+def _test_sys_path() -> Generator[None, None, None]:
+    original_path = sys.path
+    try:
+        yield
+    finally:
+        sys.path = original_path
+
+
+@contextlib.contextmanager
+def _test_cwd() -> Generator[None, None, None]:
+    original_dir = os.getcwd()
+    try:
+        yield
+    finally:
+        os.chdir(original_dir)
 
 
 def create_files(paths: list[str], chroot: str = ".") -> None:

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -37,7 +37,7 @@ from pylint.reporters import JSONReporter
 from pylint.reporters.text import BaseReporter, ColorizedTextReporter, TextReporter
 from pylint.testutils._run import _add_rcfile_default_pylintrc
 from pylint.testutils._run import _Run as Run
-from pylint.testutils.utils import _patch_streams
+from pylint.testutils.utils import _patch_streams, _test_cwd, _test_sys_path
 from pylint.utils import utils
 
 if sys.version_info >= (3, 11):
@@ -67,24 +67,6 @@ def _configure_lc_ctype(lc_ctype: str) -> Iterator:
         os.environ.pop(lc_ctype_env)
         if original_lctype:
             os.environ[lc_ctype_env] = original_lctype
-
-
-@contextlib.contextmanager
-def _test_sys_path() -> Generator[None, None, None]:
-    original_path = sys.path
-    try:
-        yield
-    finally:
-        sys.path = original_path
-
-
-@contextlib.contextmanager
-def _test_cwd() -> Generator[None, None, None]:
-    original_dir = os.getcwd()
-    try:
-        yield
-    finally:
-        os.chdir(original_dir)
 
 
 class MultiReporter(BaseReporter):

--- a/tests/testutils/test_testutils_utils.py
+++ b/tests/testutils/test_testutils_utils.py
@@ -1,0 +1,50 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+import os
+import sys
+from pathlib import Path
+
+from pylint.testutils.utils import _test_cwd, _test_sys_path
+
+
+def test__test_sys_path_no_arg() -> None:
+    sys_path = sys.path
+    with _test_sys_path():
+        assert sys.path == sys_path
+        new_sys_path = ["new_sys_path"]
+        sys.path = new_sys_path
+        assert sys.path == new_sys_path
+    assert sys.path == sys_path
+
+
+def test__test_sys_path() -> None:
+    sys_path = sys.path
+    new_sys_path = [".", "/home"]
+    with _test_sys_path(new_sys_path):
+        assert sys.path == new_sys_path
+        newer_sys_path = ["new_sys_path"]
+        sys.path = newer_sys_path
+        assert sys.path == newer_sys_path
+    assert sys.path == sys_path
+
+
+def test__test_cwd_no_arg(tmp_path: Path) -> None:
+    cwd = os.getcwd()
+    with _test_cwd():
+        assert os.getcwd() == cwd
+        os.chdir(tmp_path)
+        assert os.getcwd() == str(tmp_path)
+    assert os.getcwd() == cwd
+
+
+def test__test_cwd(tmp_path: Path) -> None:
+    cwd = os.getcwd()
+    with _test_cwd(tmp_path):
+        assert os.getcwd() == str(tmp_path)
+        new_path = tmp_path / "another_dir"
+        new_path.mkdir()
+        os.chdir(new_path)
+        assert os.getcwd() == str(new_path)
+    assert os.getcwd() == cwd


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |


## Description

There's still a lot to do there, but I'm going slowly. In particular I would have though that some pytest fixtures would have existed for these use cases, but it seem it's not the case, or is non-trivial. 