### PR TITLE
Increase new primer timeout to 60m

### DIFF
--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -21,7 +21,7 @@ jobs:
   run-primer:
     name: Run / ${{ matrix.python-version }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: ["3.7", "3.10"]


### PR DESCRIPTION
See [last run](https://github.com/PyCQA/pylint/actions/runs/2644912539) on main. The 3.7 job sometimes takes just barely over 45 minutes. The old primer timeout was set to 60m.

Clearly we need to add some concurrency. Rather than parallelizing the primer message comparison infrastructure, my hope is that we can just (later this year or next) solve the underlying issues with `--jobs` (see label `topic: multiprocessing`) and use that.