### PR TITLE
[CI] Run jobs ran only once on python 3.10 as it's faster

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,7 +10,7 @@ on:
 env:
   # Also change CACHE_VERSION in the other workflows
   CACHE_VERSION: 8
-  DEFAULT_PYTHON: 3.8
+  DEFAULT_PYTHON: 3.10
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - published
 
 env:
-  DEFAULT_PYTHON: 3.9
+  DEFAULT_PYTHON: 3.10
 
 jobs:
   release-pypi:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,7 +76,7 @@ jobs:
     needs: tests-linux
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.10"]
     env:
       COVERAGERC_FILE: .coveragerc
     steps:
@@ -122,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: ["3.10"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.2

--- a/doc/test_messages_documentation.py
+++ b/doc/test_messages_documentation.py
@@ -149,10 +149,12 @@ class LintModuleTest:
         expected_messages = self._get_expected()
         actual_messages = self._get_actual()
         if self.is_good_test_file():
-            assert actual_messages.total() == 0, self.assert_message_good(actual_messages)  # type: ignore[attr-defined]
+            assert actual_messages.total() == 0, self.assert_message_good(
+                actual_messages
+            )
         if self.is_bad_test_file():
             msg = "There should be at least one warning raised for 'bad.py'"
-            assert actual_messages.total() > 0, msg  # type: ignore[attr-defined]
+            assert actual_messages.total() > 0, msg
         assert expected_messages == actual_messages
 
     def assert_message_good(self, actual_messages: MessageCounter) -> str:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

Also pre-commit.ci run on 3.10 now.

Follow-up to https://github.com/PyCQA/pylint/pull/7155#issuecomment-1180143017
