### PR TITLE
In "Messages Overview", show the `bad_code` first

### DIFF
--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -272,8 +272,8 @@ def _generate_single_message_body(message: MessageData) -> str:
 
 *{message.definition.description}*
 
-{message.good_code}
 {message.bad_code}
+{message.good_code}
 {message.details}
 {message.related_links}
 """

--- a/doc/whatsnew/2/2.15/index.rst
+++ b/doc/whatsnew/2/2.15/index.rst
@@ -86,6 +86,10 @@ Other Changes
 
   Closes #6953
 
+* In Documentation, in "Messages Overview", show the `bad_code` first (instead of showing the correct code first)
+
+  Refs #7143
+
 
 Internal changes
 ================

--- a/doc/whatsnew/2/2.15/index.rst
+++ b/doc/whatsnew/2/2.15/index.rst
@@ -86,10 +86,6 @@ Other Changes
 
   Closes #6953
 
-* In Documentation, in "Messages Overview", show the `bad_code` first (instead of showing the correct code first)
-
-  Refs #7143
-
 
 Internal changes
 ================


### PR DESCRIPTION
It makes more sense to _first define the problem_, then solve it.

Mentions issue https://github.com/PyCQA/pylint/issues/7143

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Add an entry to the change log describing the change in
  `doc/whatsnew/2/2.15/index.rst` (or ``doc/whatsnew/2/2.14/full.rst``
   if the change needs backporting in 2.14). If necessary you can write
   details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

Refs #7143

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->
