### PR TITLE
test_run_pylint_config: ignore pytest args

### DIFF
--- a/tests/config/pylint_config/test_run_pylint_config.py
+++ b/tests/config/pylint_config/test_run_pylint_config.py
@@ -18,7 +18,7 @@ def test_invocation_of_pylint_config(capsys: CaptureFixture[str]) -> None:
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="NOTE:.*", category=UserWarning)
         with pytest.raises(SystemExit) as ex:
-            _run_pylint_config()
+            _run_pylint_config([""])
         captured = capsys.readouterr()
         assert captured.err.startswith("usage: pylint-config [options]")
         assert ex.value.code == 2


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [X] Write a good description on what the PR does.
- [-] Add an entry to the change log describing the change in
  `doc/whatsnew/2/2.15/index.rst` (or ``doc/whatsnew/2/2.14/full.rst``
   if the change needs backporting in 2.14). If necessary you can write
   details or offer examples on how the new change is supposed to work.
- [-] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This test fails if run through pytest with any args, because
`_run_pylint_config` passes through args from the command line
without checking if the args are actually intended for
pylint-config. We have to pass it some fake args that evaluate
truth-y but don't break anything, to avoid this.

Signed-off-by: Adam Williamson <awilliam@redhat.com>