### PR TITLE
Use trace not turtle in import_outside_toplevel test

### DIFF
--- a/tests/functional/i/import_outside_toplevel.py
+++ b/tests/functional/i/import_outside_toplevel.py
@@ -27,7 +27,7 @@ class C:
     import tokenize  # [import-outside-toplevel]
 
     def j(self):
-        import turtle  # [import-outside-toplevel]
+        import trace  # [import-outside-toplevel]
 
 
 def k(flag):

--- a/tests/functional/i/import_outside_toplevel.txt
+++ b/tests/functional/i/import_outside_toplevel.txt
@@ -3,7 +3,7 @@ import-outside-toplevel:15:4:15:18:g:Import outside toplevel (os, sys):UNDEFINED
 import-outside-toplevel:19:4:19:24:h:Import outside toplevel (time):UNDEFINED
 import-outside-toplevel:23:4:23:41:i:Import outside toplevel (random, socket):UNDEFINED
 import-outside-toplevel:27:4:27:19:C:Import outside toplevel (tokenize):UNDEFINED
-import-outside-toplevel:30:8:30:21:C.j:Import outside toplevel (turtle):UNDEFINED
+import-outside-toplevel:30:8:30:20:C.j:Import outside toplevel (trace):UNDEFINED
 import-outside-toplevel:35:8:35:23:k:Import outside toplevel (tabnanny):UNDEFINED
 import-outside-toplevel:39:4:39:39:j:Import outside toplevel (collections.defaultdict):UNDEFINED
 import-outside-toplevel:43:4:43:48:m:Import outside toplevel (math.sin, math.cos):UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [X] Write a good description on what the PR does.
- [-] Add an entry to the change log describing the change in
  `doc/whatsnew/2/2.15/index.rst` (or ``doc/whatsnew/2/2.14/full.rst``
   if the change needs backporting in 2.14). If necessary you can write
   details or offer examples on how the new change is supposed to work.
- [-] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Downstream (e.g. in Fedora) tkinter and turtle aren't always
included in the core Python package in order to avoid pulling in
a lot of graphical dependencies on systems that do not need them.
It doesn't really matter what libs are used in this test, so
let's replace it with trace.