### PR TITLE
[test] Use LocalPath.as_cwd() instead of our own ContextManager

### DIFF
--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -9,7 +9,6 @@ import os
 import sys
 from collections.abc import Generator, Iterator
 from copy import copy
-from pathlib import Path
 from typing import TextIO
 
 
@@ -35,19 +34,6 @@ def _test_sys_path(
         yield
     finally:
         sys.path = original_path
-
-
-@contextlib.contextmanager
-def _test_cwd(
-    current_working_directory: str | Path | None = None,
-) -> Generator[None, None, None]:
-    original_dir = os.getcwd()
-    try:
-        if current_working_directory is not None:
-            os.chdir(current_working_directory)
-        yield
-    finally:
-        os.chdir(original_dir)
 
 
 @contextlib.contextmanager

--- a/tests/testutils/test_testutils_utils.py
+++ b/tests/testutils/test_testutils_utils.py
@@ -2,11 +2,9 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
-import os
 import sys
-from pathlib import Path
 
-from pylint.testutils.utils import _test_cwd, _test_sys_path
+from pylint.testutils.utils import _test_sys_path
 
 
 def test__test_sys_path_no_arg() -> None:
@@ -28,23 +26,3 @@ def test__test_sys_path() -> None:
         sys.path = newer_sys_path
         assert sys.path == newer_sys_path
     assert sys.path == sys_path
-
-
-def test__test_cwd_no_arg(tmp_path: Path) -> None:
-    cwd = os.getcwd()
-    with _test_cwd():
-        assert os.getcwd() == cwd
-        os.chdir(tmp_path)
-        assert os.getcwd() == str(tmp_path)
-    assert os.getcwd() == cwd
-
-
-def test__test_cwd(tmp_path: Path) -> None:
-    cwd = os.getcwd()
-    with _test_cwd(tmp_path):
-        assert os.getcwd() == str(tmp_path)
-        new_path = tmp_path / "another_dir"
-        new_path.mkdir()
-        os.chdir(new_path)
-        assert os.getcwd() == str(new_path)
-    assert os.getcwd() == cwd


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Follow-up to #7155 

Pytest suggest to not use tmpdir but tmp_path instead, but a Path do not have ``as_cwd()``, so I'm open to counter proposal.. But we're already using ``tmpdir.as_cwd()`` in the codebase so I think this can be merged then we take care of ``tmpdir.as_cwd()`` later if it's bad practice.
