### PR TITLE
More parametrization in ``test_self.py`` tests

### DIFF
--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -50,6 +50,26 @@ def _test_cwd(
         os.chdir(original_dir)
 
 
+@contextlib.contextmanager
+def _test_environ_pythonpath(
+    new_pythonpath: str | None,
+) -> Generator[None, None, None]:
+    original_pythonpath = os.environ.get("PYTHONPATH")
+    if new_pythonpath:
+        os.environ["PYTHONPATH"] = new_pythonpath
+    elif new_pythonpath is None and original_pythonpath is not None:
+        # If new_pythonpath is None, make sure to delete PYTHONPATH if present
+        del os.environ["PYTHONPATH"]
+    try:
+        yield
+    finally:
+        if original_pythonpath:
+            os.environ["PYTHONPATH"] = original_pythonpath
+        elif new_pythonpath is not None:
+            # Only delete PYTHONPATH if new_pythonpath wasn't None
+            del os.environ["PYTHONPATH"]
+
+
 def create_files(paths: list[str], chroot: str = ".") -> None:
     """Creates directories and files found in <path>.
 

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -761,83 +761,52 @@ class TestRunTC:
                     # Only delete PYTHONPATH if new_pythonpath wasn't None
                     del os.environ["PYTHONPATH"]
 
+        cwd = "/tmp/pytest-of-root/pytest-0/test_do_not_import_files_from_0"
+        default_paths = [
+            "/usr/local/lib/python39.zip",
+            "/usr/local/lib/python3.9",
+            "/usr/local/lib/python3.9/lib-dynload",
+            "/usr/local/lib/python3.9/site-packages",
+        ]
         with _test_sys_path(), patch("os.getcwd") as mock_getcwd:
-            cwd = "/tmp/pytest-of-root/pytest-0/test_do_not_import_files_from_0"
             mock_getcwd.return_value = cwd
-            default_paths = [
-                "/usr/local/lib/python39.zip",
-                "/usr/local/lib/python3.9",
-                "/usr/local/lib/python3.9/lib-dynload",
-                "/usr/local/lib/python3.9/site-packages",
-            ]
-
-            paths = [
-                cwd,
-                *default_paths,
-            ]
+            paths = [cwd, *default_paths]
             sys.path = copy(paths)
             with test_environ_pythonpath(None):
                 modify_sys_path()
             assert sys.path == paths[1:]
 
-            paths = [
-                cwd,
-                cwd,
-                *default_paths,
-            ]
+            paths = [cwd, cwd, *default_paths]
             sys.path = copy(paths)
             with test_environ_pythonpath("."):
                 modify_sys_path()
             assert sys.path == paths[1:]
 
-            paths = [
-                cwd,
-                "/custom_pythonpath",
-                *default_paths,
-            ]
+            paths = [cwd, "/custom_pythonpath", *default_paths]
             sys.path = copy(paths)
             with test_environ_pythonpath("/custom_pythonpath"):
                 modify_sys_path()
             assert sys.path == paths[1:]
 
-            paths = [
-                cwd,
-                "/custom_pythonpath",
-                cwd,
-                *default_paths,
-            ]
+            paths = [cwd, "/custom_pythonpath", cwd, *default_paths]
             sys.path = copy(paths)
             with test_environ_pythonpath("/custom_pythonpath:"):
                 modify_sys_path()
             assert sys.path == [paths[1]] + paths[3:]
 
-            paths = [
-                "",
-                cwd,
-                "/custom_pythonpath",
-                *default_paths,
-            ]
+            paths = ["", cwd, "/custom_pythonpath", *default_paths]
             sys.path = copy(paths)
             with test_environ_pythonpath(":/custom_pythonpath"):
                 modify_sys_path()
             assert sys.path == paths[2:]
 
-            paths = [
-                cwd,
-                cwd,
-                "/custom_pythonpath",
-                *default_paths,
-            ]
+            paths = [cwd, cwd, "/custom_pythonpath", *default_paths]
             sys.path = copy(paths)
             with test_environ_pythonpath(":/custom_pythonpath:"):
                 modify_sys_path()
             assert sys.path == paths[2:]
 
-            paths = [
-                cwd,
-                cwd,
-                *default_paths,
-            ]
+            paths = [cwd, cwd, *default_paths]
             sys.path = copy(paths)
             with test_environ_pythonpath(":."):
                 modify_sys_path()
@@ -856,12 +825,7 @@ class TestRunTC:
                 modify_sys_path()
             assert sys.path == paths[1:]
 
-            paths = [
-                "",
-                cwd,
-                *default_paths,
-                cwd,
-            ]
+            paths = ["", cwd, *default_paths, cwd]
             sys.path = copy(paths)
             with test_environ_pythonpath(cwd):
                 modify_sys_path()


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

This is the consensual part of https://github.com/PyCQA/pylint/pull/7173. First step before a MR to fix the pythonpath handling were the pythonpath is not rested correctly.
