### PR TITLE
[cleanup] Remove '!r' on formatting of string and str call in fstring

### DIFF
--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -767,7 +767,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
                 return None
             self.add_message("relative-beyond-top-level", node=importnode)
         except astroid.AstroidSyntaxError as exc:
-            message = f"Cannot import {modname!r} due to syntax error {str(exc.error)!r}"  # pylint: disable=no-member; false positive
+            message = f"Cannot import {modname!r} due to syntax error {exc.error!r}"  # pylint: disable=no-member; false positive
             self.add_message("syntax-error", line=importnode.lineno, args=message)
 
         except astroid.AstroidBuildingError:

--- a/pylint/config/arguments_provider.py
+++ b/pylint/config/arguments_provider.py
@@ -149,7 +149,7 @@ class _ArgumentsProvider:
             if option[0] == opt:
                 return option[1]
         raise optparse.OptionError(
-            f"no such option {opt} in section {self.name!r}", opt  # type: ignore[arg-type]
+            f"no such option {opt} in section {self.name}", opt  # type: ignore[arg-type]
         )
 
     def options_by_section(

--- a/pylint/config/options_provider_mixin.py
+++ b/pylint/config/options_provider_mixin.py
@@ -94,9 +94,7 @@ class OptionsProviderMixIn:
         for option in self.options:
             if option[0] == opt:
                 return option[1]
-        raise optparse.OptionError(
-            f"no such option {opt} in section {self.name!r}", opt
-        )
+        raise optparse.OptionError(f"no such option {opt} in section {self.name}", opt)
 
     def options_by_section(self):
         """Return an iterator on options grouped by section.

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -53,9 +53,9 @@ class MessageDefinition:
     @staticmethod
     def check_msgid(msgid: str) -> None:
         if len(msgid) != 5:
-            raise InvalidMessageError(f"Invalid message id {msgid!r}")
+            raise InvalidMessageError(f"Invalid message id {msgid}")
         if msgid[0] not in MSG_TYPES:
-            raise InvalidMessageError(f"Bad message type {msgid[0]} in {msgid!r}")
+            raise InvalidMessageError(f"Bad message type {msgid[0]} in {msgid}")
 
     def __eq__(self, other: Any) -> bool:
         return (

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -101,7 +101,7 @@ class Project:
         return self.modules
 
     def __repr__(self) -> str:
-        return f"<Project {self.name!r} at {id(self)} ({len(self.modules)} modules)>"
+        return f"<Project {self.name} at {id(self)} ({len(self.modules)} modules)>"
 
 
 class Linker(IdGeneratorMixIn, utils.LocalsVisitor):

--- a/tests/checkers/base/unittest_name_preset.py
+++ b/tests/checkers/base/unittest_name_preset.py
@@ -47,7 +47,7 @@ class TestNamePresets(unittest.TestCase):
         naming_style: type[base.NamingStyle], name: str, name_type: str
     ) -> None:
         rgx = naming_style.get_regex(name_type)
-        fail = f"{name!r} does not match pattern {rgx!r} (style: {naming_style}, type: {name_type})"
+        fail = f"{name} does not match pattern {rgx!r} (style: {naming_style}, type: {name_type})"
         assert rgx.match(name), fail
 
     @staticmethod
@@ -55,7 +55,7 @@ class TestNamePresets(unittest.TestCase):
         naming_style: type[base.NamingStyle], name: str, name_type: str
     ) -> None:
         rgx = naming_style.get_regex(name_type)
-        fail = f"{name!r} not match pattern {rgx!r} (style: {naming_style}, type: {name_type})"
+        fail = f"{name} not match pattern {rgx!r} (style: {naming_style}, type: {name_type})"
         assert not rgx.match(name), fail
 
     def test_snake_case(self) -> None:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

str's repr is the string, and you don't need a string call in a fstring.

Follow-up to https://github.com/PyCQA/pylint/pull/7153#discussion_r918948296
