### PR TITLE
Don't emit super-init-not-called for Enum subclasses

### DIFF
--- a/doc/whatsnew/2/2.15/index.rst
+++ b/doc/whatsnew/2/2.15/index.rst
@@ -33,6 +33,8 @@ Extensions
 False positives fixed
 =====================
 
+* Don't report ``super-init-not-called`` for subclasses of ``Enum`` (on Python >= 3.11).
+
 * Don't report ``unsupported-binary-operation`` on Python <= 3.9 when using the ``|`` operator
   with types, if one has a metaclass that overloads ``__or__`` or ``__ror__`` as appropriate.
 

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -2059,6 +2059,11 @@ a metaclass class method.",
                 except astroid.InferenceError:
                     continue
 
+            # Skip if klass is Enum, Python's own docs and examples
+            # do not recommend Enum subclasses call Enum.__init__
+            if klass.name == "Enum":
+                continue
+
             if decorated_with(node, ["typing.overload"]):
                 continue
             cls = node_frame_class(method)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [X] Write a good description on what the PR does.
- [X] Add an entry to the change log describing the change in
  `doc/whatsnew/2/2.15/index.rst` (or ``doc/whatsnew/2/2.14/full.rst``
   if the change needs backporting in 2.14). If necessary you can write
   details or offer examples on how the new change is supposed to work.
- [-] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

For some reason, commit 83d544b to cpython added a `__init__`
to `Enum` which does nothing (it just says `pass`). The examples
in the Enum docs:
https://docs.python.org/3.11/howto/enum.html
still do not include calling super's `__init__` for Enum
subclasses, that define their own `__init__`, and obviously there
is no practical point to calling a method that does nothing, so
it seems best just to skip this warning for Enum.

Signed-off-by: Adam Williamson <awilliam@redhat.com>

Blocked by https://github.com/python/cpython/pull/30582#issuecomment-1181055042