### PR TITLE
Fix config section name in doc

### DIFF
--- a/doc/exts/pylint_options.py
+++ b/doc/exts/pylint_options.py
@@ -120,7 +120,7 @@ def _create_checker_section(
    <details>
    <summary><a>Example configuration section</a></summary>
 
-**Note:** Only ``pylint.tool`` is required, the section title is not. These are the default values.
+**Note:** Only ``tool.pylint`` is required, the section title is not. These are the default values.
 
 .. code-block:: toml
 


### PR DESCRIPTION
The change should also be reflected in rendered docs, like in `doc/user_guide/configuration/all-options.rst`, but I think those are generated from this doc.