### PR TITLE
[primer] display results early instead of priming all the packages first

### DIFF
--- a/pylint/testutils/_primer/primer_run_command.py
+++ b/pylint/testutils/_primer/primer_run_command.py
@@ -48,7 +48,7 @@ class RunCommand(PrimerCommand):
     def _filter_astroid_errors(
         self, messages: list[OldJsonExport]
     ) -> tuple[list[Message], list[Message]]:
-        """This is to avoid introducing a dependency on bleeding-edge astroid."""
+        """Separate fatal errors caused by astroid so we can report them independently."""
         astroid_errors = []
         other_fatal_msgs = []
         for raw_message in messages:

--- a/pylint/testutils/_primer/primer_run_command.py
+++ b/pylint/testutils/_primer/primer_run_command.py
@@ -8,13 +8,13 @@ import json
 import sys
 import warnings
 from io import StringIO
-from itertools import chain
 
 from pylint.lint import Run
 from pylint.message import Message
 from pylint.reporters import JSONReporter
+from pylint.reporters.json_reporter import OldJsonExport
 from pylint.testutils._primer.package_to_lint import PackageToLint
-from pylint.testutils._primer.primer_command import PackageMessages, PrimerCommand
+from pylint.testutils._primer.primer_command import PrimerCommand
 
 GITHUB_CRASH_TEMPLATE_LOCATION = "/home/runner/.cache"
 CRASH_TEMPLATE_INTRO = "There is a pre-filled template"
@@ -22,49 +22,38 @@ CRASH_TEMPLATE_INTRO = "There is a pre-filled template"
 
 class RunCommand(PrimerCommand):
     def run(self) -> None:
-        packages: PackageMessages = {}
-
+        packages: dict[str, list[OldJsonExport]] = {}
         for package, data in self.packages.items():
-            packages[package] = self._lint_package(data)
-            print(f"Successfully primed {package}.")
+            packages[package] = self._lint_package(package, data)
+        path = (
+            self.primer_directory
+            / f"output_{'.'.join(str(i) for i in sys.version_info[:3])}_{self.config.type}.txt"
+        )
+        print(f"Writing result in {path}")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(packages, f)
 
+    def _get_astroid_errors(
+        self, messages: list[OldJsonExport]
+    ) -> tuple[list[Message], list[Message]]:
         astroid_errors = []
         other_fatal_msgs = []
-        for msg in chain.from_iterable(packages.values()):
-            if msg.category == "fatal":
-                if GITHUB_CRASH_TEMPLATE_LOCATION in msg.msg:
+        for raw_message in messages:
+            message = JSONReporter.deserialize(raw_message)
+            if message.category == "fatal":
+                if GITHUB_CRASH_TEMPLATE_LOCATION in message.msg:
                     # Remove the crash template location if we're running on GitHub.
                     # We were falsely getting "new" errors when the timestamp changed.
-                    msg.msg = msg.msg.rsplit(CRASH_TEMPLATE_INTRO)[0]
-                if msg.symbol == "astroid-error":
-                    astroid_errors.append(msg)
+                    message.msg = message.msg.rsplit(CRASH_TEMPLATE_INTRO)[0]
+                if message.symbol == "astroid-error":
+                    astroid_errors.append(message)
                 else:
-                    other_fatal_msgs.append(msg)
+                    other_fatal_msgs.append(message)
+        return astroid_errors, other_fatal_msgs
 
-        with open(
-            self.primer_directory
-            / f"output_{'.'.join(str(i) for i in sys.version_info[:3])}_{self.config.type}.txt",
-            "w",
-            encoding="utf-8",
-        ) as f:
-            json.dump(
-                {
-                    p: [JSONReporter.serialize(m) for m in msgs]
-                    for p, msgs in packages.items()
-                },
-                f,
-            )
-
-        # Fail loudly (and fail CI pipelines) if any fatal errors are found,
-        # unless they are astroid-errors, in which case just warn.
-        # This is to avoid introducing a dependency on bleeding-edge astroid
-        # for pylint CI pipelines generally, even though we want to use astroid main
-        # for the purpose of diffing emitted messages and generating PR comments.
-        if astroid_errors:
-            warnings.warn(f"Fatal errors traced to astroid:  {astroid_errors}")
-        assert not other_fatal_msgs, other_fatal_msgs
-
-    def _lint_package(self, data: PackageToLint) -> list[Message]:
+    def _lint_package(
+        self, package_name: str, data: PackageToLint
+    ) -> list[OldJsonExport]:
         # We want to test all the code we can
         enables = ["--enable-all-extensions", "--enable=all"]
         # Duplicate code takes too long and is relatively safe
@@ -73,5 +62,31 @@ class RunCommand(PrimerCommand):
         arguments = data.pylint_args + enables + disables
         output = StringIO()
         reporter = JSONReporter(output)
-        Run(arguments, reporter=reporter, exit=False)
-        return [JSONReporter.deserialize(m) for m in json.loads(output.getvalue())]
+        print(f"Running 'pylint {', '.join(arguments)}'")
+        pylint_exit_code = -1
+        try:
+            Run(arguments, reporter=reporter)
+        except SystemExit as e:
+            pylint_exit_code = int(e.code)
+        readable_messages: str = output.getvalue()
+        messages: list[OldJsonExport] = json.loads(readable_messages)
+        if pylint_exit_code % 2 == 0:
+            print(f"Successfully primed {package_name}.")
+        else:
+            print(
+                f"Encountered fatal errors while priming {package_name} !\n{readable_messages}"
+            )
+            astroid_errors, other_fatal_msgs = self._get_astroid_errors(messages)
+            # Fail loudly (and fail CI pipelines) if any fatal errors are found,
+            # unless they are astroid-errors, in which case just warn.
+            # This is to avoid introducing a dependency on bleeding-edge astroid
+            # for pylint CI pipelines generally, even though we want to use astroid main
+            # for the purpose of diffing emitted messages and generating PR comments.
+            if astroid_errors:
+                warnings.warn(f"Fatal errors traced to astroid: {astroid_errors}")
+            plural = "s" if len(other_fatal_msgs) > 1 else ""
+            assert not other_fatal_msgs, (
+                f"We encountered {len(other_fatal_msgs)} fatal error message{plural}"
+                " that can't be attributed to bleeding edge astroid alone (see log)."
+            )
+        return messages

--- a/pylint/testutils/_primer/primer_run_command.py
+++ b/pylint/testutils/_primer/primer_run_command.py
@@ -45,9 +45,10 @@ class RunCommand(PrimerCommand):
         with open(path, "w", encoding="utf-8") as f:
             json.dump(packages, f)
 
-    def _get_astroid_errors(
+    def _filter_astroid_errors(
         self, messages: list[OldJsonExport]
     ) -> tuple[list[Message], list[Message]]:
+        """This is to avoid introducing a dependency on bleeding-edge astroid."""
         astroid_errors = []
         other_fatal_msgs = []
         for raw_message in messages:
@@ -90,12 +91,7 @@ class RunCommand(PrimerCommand):
             print(
                 f"Encountered fatal errors while priming {package_name} !\n{readable_messages}"
             )
-            astroid_errors, other_fatal_msgs = self._get_astroid_errors(messages)
-            # Fail loudly (and fail CI pipelines) if any fatal errors are found,
-            # unless they are astroid-errors, in which case just warn.
-            # This is to avoid introducing a dependency on bleeding-edge astroid
-            # for pylint CI pipelines generally, even though we want to use astroid main
-            # for the purpose of diffing emitted messages and generating PR comments.
+            astroid_errors, other_fatal_msgs = self._filter_astroid_errors(messages)
             if astroid_errors:
                 warnings.warn(f"Fatal errors traced to astroid: {astroid_errors}")
         return messages, astroid_errors, other_fatal_msgs

--- a/pylint/testutils/_primer/primer_run_command.py
+++ b/pylint/testutils/_primer/primer_run_command.py
@@ -48,7 +48,9 @@ class RunCommand(PrimerCommand):
     def _filter_astroid_errors(
         self, messages: list[OldJsonExport]
     ) -> tuple[list[Message], list[Message]]:
-        """Separate fatal errors caused by astroid so we can report them independently."""
+        """Separate fatal errors caused by astroid so we can report them
+        independently.
+        """
         astroid_errors = []
         other_fatal_msgs = []
         for raw_message in messages:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

This permits to fail early instead of priming all the packages in case of fatal error in the primer. It also adds more and easier to read print. For example if astroid can be primed, but black cannot (it was not downloaded previously). 

```
Running 'pylint tests/.pylint_primer_tests/PyCQA/astroid/astroid, --rcfile=tests/.pylint_primer_tests/PyCQA/astroid/pylintrc, --enable-all-extensions, --enable=all, --disable=duplicate-code,cyclic-import'

Successfully primed astroid.

Running 'pylint tests/.pylint_primer_tests/psf/black/src/black, tests/.pylint_primer_tests/psf/black/src/blackd, tests/.pylint_primer_tests/psf/black/src/blib2to3, --enable-all-extensions, --enable=all, --disable=duplicate-code,cyclic-import'

Encountered fatal errors while priming black !

[

    {

        "type": "fatal",

        "module": "tests/.pylint_primer_tests/psf/black/src/black",

        "obj": "",

        "line": 1,

        "column": 0,

        "endLine": null,

        "endColumn": null,

        "path": "tests/.pylint_primer_tests/psf/black/src/black",

        "symbol": "fatal",

        "message": "No module named tests/.pylint_primer_tests/psf/black/src/black",

        "message-id": "F0001"

    },

    {

        "type": "fatal",

        "module": "tests/.pylint_primer_tests/psf/black/src/blackd",

        "obj": "",

        "line": 1,

        "column": 0,

        "endLine": null,

        "endColumn": null,

        "path": "tests/.pylint_primer_tests/psf/black/src/blackd",

        "symbol": "fatal",

        "message": "No module named tests/.pylint_primer_tests/psf/black/src/blackd",

        "message-id": "F0001"

    },

    {

        "type": "fatal",

        "module": "tests/.pylint_primer_tests/psf/black/src/blib2to3",

        "obj": "",

        "line": 1,

        "column": 0,

        "endLine": null,

        "endColumn": null,

        "path": "tests/.pylint_primer_tests/psf/black/src/blib2to3",

        "symbol": "fatal",

        "message": "No module named tests/.pylint_primer_tests/psf/black/src/blib2to3",

        "message-id": "F0001"

    }

]



Traceback (most recent call last):

  File "/home/pierre/pylint/tests/primer/__main__.py", line 17, in <module>

    primer.run()

  File "/home/pierre/pylint/pylint/testutils/_primer/primer.py", line 92, in run

    self.command.run()

  File "/home/pierre/pylint/pylint/testutils/_primer/primer_run_command.py", line 27, in run

    packages[package] = self._lint_package(package, data)

  File "/home/pierre/pylint/pylint/testutils/_primer/primer_run_command.py", line 86, in _lint_package

    assert not other_fatal_msgs, (

AssertionError: We encountered 3 fatal error messages that can't be attributed to bleeding edge astroid alone (see log).
```

Previously we were priming everything even in case of errors and were printing a success:
```
Successfully primed astroid.

Successfully primed black.

Successfully primed django.

Successfully primed flask.

Successfully primed pandas.

Successfully primed psycopg.

Successfully primed pygame.

Successfully primed pytest.

Successfully primed sentry.

Traceback (most recent call last):

  File "/home/pierre/pylint/tests/primer/__main__.py", line 17, in <module>

    primer.run()

  File "/home/pierre/pylint/pylint/testutils/_primer/primer.py", line 90, in run

    self.command.run()

  File "/home/pierre/pylint/pylint/testutils/_primer/primer_run_command.py", line 65, in run

    assert not other_fatal_msgs, other_fatal_msgs

AssertionError: [Message(msg_id='F0001', symbol='fatal', msg='No module named tests/.pylint_primer_tests/psf/black/src/black', C='F', category='fatal', confidence=Confidence(name='UNDEFINED', description='Warning without any associated confidence level.'), abspath='tests/.pylint_primer_tests/psf/black/src/black', path='tests/.pylint_primer_tests/psf/black/src/black', module='tests/.pylint_primer_tests/psf/black/src/black', obj='', line=1, column=0, end_line=None, end_column=None), Message(msg_id='F0001', symbol='fatal', msg='No module named tests/.pylint_primer_tests/psf/black/src/blackd', C='F', category='fatal', confidence=Confidence(name='UNDEFINED', description='Warning without any associated confidence level.'), abspath='tests/.pylint_primer_tests/psf/black/src/blackd', path='tests/.pylint_primer_tests/psf/black/src/blackd', module='tests/.pylint_primer_tests/psf/black/src/blackd', obj='', line=1, column=0, end_line=None, end_column=None), Message(msg_id='F0001', symbol='fatal', msg='No module named tests/.pylint_primer_tests/psf/black/src/blib2to3', C='F', category='fatal', confidence=Confidence(name='UNDEFINED', description='Warning without any associated confidence level.'), abspath='tests/.pylint_primer_tests/psf/black/src/blib2to3', path='tests/.pylint_primer_tests/psf/black/src/blib2to3', module='tests/.pylint_primer_tests/psf/black/src/blib2to3', obj='', line=1, column=0, end_line=None, end_column=None), Message(msg_id='F0001', symbol='fatal', msg='No module named tests/.pylint_primer_tests/django/django/django', C='F', category='fatal', confidence=Confidence(name='UNDEFINED', description='Warning without any associated confidence level.'), abspath='tests/.pylint_primer_tests/django/django/django', path='tests/.pylint_primer_tests/django/django/django', module='tests/.pylint_primer_tests/django/django/django', obj='', line=1, column=0, end_line=None, end_column=None), Message(msg_id='F0001', symbol='fatal', msg='No module named tests/.pylint_primer_tests/pallets/flask/src/flask', C='F', category='fatal', confidence=Confidence(name='UNDEFINED', description='Warning without any associated confidence level.'), abspath='tests/.pylint_primer_tests/pallets/flask/src/flask', path='tests/.pylint_primer_tests/pallets/flask/src/flask', module='tests/.pylint_primer_tests/pallets/flask/src/flask', obj='', line=1, column=0, end_line=None, end_column=None), Message(msg_id='F0001', symbol='fatal', msg='No module named tests/.pylint_primer_tests/pandas-dev/pandas/pandas', C='F', category='fatal', confidence=Confidence(name='UNDEFINED', description='Warning without any associated confidence level.'), abspath='tests/.pylint_primer_tests/pandas-dev/pandas/pandas', path='tests/.pylint_primer_tests/pandas-dev/pandas/pandas', module='tests/.pylint_primer_tests/pandas-dev/pandas/pandas', obj='', line=1, column=0, end_line=None, end_column=None), Message(msg_id='F0001', symbol='fatal', msg='No module named tests/.pylint_primer_tests/psycopg/psycopg/psycopg/psycopg', C='F', category='fatal', confidence=Confidence(name='UNDEFINED', description='Warning without any associated confidence level.'), abspath='tests/.pylint_primer_tests/psycopg/psycopg/psycopg/psycopg', path='tests/.pylint_primer_tests/psycopg/psycopg/psycopg/psycopg', module='tests/.pylint_primer_tests/psycopg/psycopg/psycopg/psycopg', obj='', line=1, column=0, end_line=None, end_column=None), Message(msg_id='F0001', symbol='fatal', msg='No module named tests/.pylint_primer_tests/pygame/pygame/src_py', C='F', category='fatal', confidence=Confidence(name='UNDEFINED', description='Warning without any associated confidence level.'), abspath='tests/.pylint_primer_tests/pygame/pygame/src_py', path='tests/.pylint_primer_tests/pygame/pygame/src_py', module='tests/.pylint_primer_tests/pygame/pygame/src_py', obj='', line=1, column=0, end_line=None, end_column=None), Message(msg_id='F0001', symbol='fatal', msg='No module named tests/.pylint_primer_tests/pytest-dev/pytest/src/_pytest', C='F', category='fatal', confidence=Confidence(name='UNDEFINED', description='Warning without any associated confidence level.'), abspath='tests/.pylint_primer_tests/pytest-dev/pytest/src/_pytest', path='tests/.pylint_primer_tests/pytest-dev/pytest/src/_pytest', module='tests/.pylint_primer_tests/pytest-dev/pytest/src/_pytest', obj='', line=1, column=0, end_line=None, end_column=None), Message(msg_id='F0001', symbol='fatal', msg='No module named tests/.pylint_primer_tests/getsentry/sentry/src/sentry', C='F', category='fatal', confidence=Confidence(name='UNDEFINED', description='Warning without any associated confidence level.'), abspath='tests/.pylint_primer_tests/getsentry/sentry/src/sentry', path='tests/.pylint_primer_tests/getsentry/sentry/src/sentry', module='tests/.pylint_primer_tests/getsentry/sentry/src/sentry', obj='', line=1, column=0, end_line=None, end_column=None)]
```