### PR TITLE
[missing-raises-doc] Take 'accept-no-raise-doc' option into account

### DIFF
--- a/doc/whatsnew/fragments/7208.bugfix
+++ b/doc/whatsnew/fragments/7208.bugfix
@@ -1,0 +1,6 @@
+The ``accept-no-raise-doc`` option related to ``missing-raises-doc`` will now be correctly
+taken into account all the time. As the default value was false and was not taken into
+account because of a bug, it means you will have to add ``accept-no-raise-doc=no`` in
+your configuration to keep the same behavior.
+
+Closes #7208

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -274,6 +274,8 @@ class DocstringParameterChecker(BaseChecker):
             self.add_message("redundant-yields-doc", node=node)
 
     def visit_raise(self, node: nodes.Raise) -> None:
+        if self.linter.config.accept_no_raise_doc:
+            return
         func_node = node.frame(future=True)
         if not isinstance(func_node, astroid.FunctionDef):
             return
@@ -296,7 +298,7 @@ class DocstringParameterChecker(BaseChecker):
         if not doc.matching_sections():
             if doc.doc:
                 missing = {exc.name for exc in expected_excs}
-                self._handle_no_raise_doc(missing, func_node)
+                self._add_raise_message(missing, func_node)
             return
 
         found_excs_full_names = doc.exceptions()
@@ -636,12 +638,6 @@ class DocstringParameterChecker(BaseChecker):
                 node=class_node,
                 confidence=HIGH,
             )
-
-    def _handle_no_raise_doc(self, excs: set[str], node: nodes.FunctionDef) -> None:
-        if self.linter.config.accept_no_raise_doc:
-            return
-
-        self._add_raise_message(excs, node)
 
     def _add_raise_message(
         self, missing_exceptions: set[str], node: nodes.FunctionDef

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Sphinx.rc
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Sphinx.rc
@@ -3,5 +3,6 @@ load-plugins = pylint.extensions.docparams
 
 [BASIC]
 accept-no-param-doc=no
+accept-no-raise-doc=no
 no-docstring-rgx=^$
 docstring-min-length: -1

--- a/tests/functional/ext/docparams/raise/missing_raises_doc.py
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc.py
@@ -11,7 +11,7 @@ def test_ignores_no_docstring(self):
     raise RuntimeError("hi")
 
 
-def test_ignores_unknown_style(self):
+def test_ignores_unknown_style(self):  # [missing-raises-doc]
     """This is a docstring."""
     raise RuntimeError("hi")
 

--- a/tests/functional/ext/docparams/raise/missing_raises_doc.rc
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc.rc
@@ -1,2 +1,5 @@
 [MAIN]
 load-plugins = pylint.extensions.docparams
+
+[BASIC]
+accept-no-raise-doc=no

--- a/tests/functional/ext/docparams/raise/missing_raises_doc.txt
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc.txt
@@ -1,3 +1,4 @@
+missing-raises-doc:14:0:14:30:test_ignores_unknown_style:"""RuntimeError"" not documented as being raised":HIGH
 unreachable:25:4:25:25:test_ignores_raise_uninferable:Unreachable code:HIGH
 missing-raises-doc:28:0:28:45:test_ignores_returns_from_inner_functions:"""RuntimeError"" not documented as being raised":HIGH
 unreachable:42:4:42:25:test_ignores_returns_from_inner_functions:Unreachable code:HIGH

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_Google.rc
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_Google.rc
@@ -1,2 +1,5 @@
 [MAIN]
 load-plugins = pylint.extensions.docparams
+
+[BASIC]
+accept-no-raise-doc=no

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_Numpy.rc
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_Numpy.rc
@@ -1,2 +1,5 @@
 [MAIN]
 load-plugins = pylint.extensions.docparams
+
+[BASIC]
+accept-no-raise-doc=no

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_Sphinx.rc
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_Sphinx.rc
@@ -1,2 +1,5 @@
 [MAIN]
 load-plugins = pylint.extensions.docparams
+
+[BASIC]
+accept-no-raise-doc=no

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_options.py
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_options.py
@@ -1,0 +1,15 @@
+"""Minimal example where a W9006 message is displayed even if the
+accept-no-raise-doc option is set to True.
+
+Requires at least one matching section (`Docstring.matching_sections`).
+
+Taken from https://github.com/PyCQA/pylint/issues/7208
+"""
+
+
+def w9006issue(dummy: int):
+    """Sample function.
+
+    :param dummy: Unused
+    """
+    raise AssertionError()

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_options.rc
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_options.rc
@@ -1,0 +1,5 @@
+[MAIN]
+load-plugins = pylint.extensions.docparams
+
+[BASIC]
+accept-no-raise-doc=yes


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #7208

It's better for performance to simply cut short at the beginning of the function imo.

Co-authored-by: Brice Chardin <brice.chardin@gmail.com>
