### PR TITLE
Add the proper confidence in doc param checker's messages

### DIFF
--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -636,26 +636,24 @@ class DocstringParameterChecker(BaseChecker):
         self._add_raise_message(excs, node)
 
     def _add_raise_message(
-        self, missing_excs: set[str], node: nodes.FunctionDef
+        self, missing_exceptions: set[str], node: nodes.FunctionDef
     ) -> None:
         """Adds a message on :param:`node` for the missing exception type.
 
-        :param missing_excs: A list of missing exception types.
-
+        :param missing_exceptions: A list of missing exception types.
         :param node: The node show the message on.
         """
         if node.is_abstract():
             try:
-                missing_excs.remove("NotImplementedError")
+                missing_exceptions.remove("NotImplementedError")
             except KeyError:
                 pass
-
-        if not missing_excs:
-            return
-
-        self.add_message(
-            "missing-raises-doc", args=(", ".join(sorted(missing_excs)),), node=node
-        )
+        if missing_exceptions:
+            self.add_message(
+                "missing-raises-doc",
+                args=(", ".join(sorted(missing_exceptions)),),
+                node=node,
+            )
 
 
 def register(linter: PyLinter) -> None:

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -16,6 +16,7 @@ from pylint.checkers import BaseChecker
 from pylint.checkers import utils as checker_utils
 from pylint.extensions import _check_docs_utils as utils
 from pylint.extensions._check_docs_utils import Docstring
+from pylint.interfaces import HIGH
 
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
@@ -259,7 +260,7 @@ class DocstringParameterChecker(BaseChecker):
         if (node_doc.has_returns() or node_doc.has_rtype()) and not any(
             utils.returns_something(ret_node) for ret_node in return_nodes
         ):
-            self.add_message("redundant-returns-doc", node=node)
+            self.add_message("redundant-returns-doc", node=node, confidence=HIGH)
 
     def check_functiondef_yields(
         self, node: nodes.FunctionDef, node_doc: Docstring
@@ -333,13 +334,13 @@ class DocstringParameterChecker(BaseChecker):
         is_property = checker_utils.decorated_with_property(func_node)
 
         if not (doc.has_returns() or (doc.has_property_returns() and is_property)):
-            self.add_message("missing-return-doc", node=func_node)
+            self.add_message("missing-return-doc", node=func_node, confidence=HIGH)
 
         if func_node.returns:
             return
 
         if not (doc.has_rtype() or (doc.has_property_type() and is_property)):
-            self.add_message("missing-return-type-doc", node=func_node)
+            self.add_message("missing-return-type-doc", node=func_node, confidence=HIGH)
 
     def visit_yield(self, node: nodes.Yield | nodes.YieldFrom) -> None:
         if self.linter.config.accept_no_yields_doc:
@@ -361,10 +362,10 @@ class DocstringParameterChecker(BaseChecker):
             doc_has_yields_type = doc.has_rtype()
 
         if not doc_has_yields:
-            self.add_message("missing-yield-doc", node=func_node)
+            self.add_message("missing-yield-doc", node=func_node, confidence=HIGH)
 
         if not (doc_has_yields_type or func_node.returns):
-            self.add_message("missing-yield-type-doc", node=func_node)
+            self.add_message("missing-yield-type-doc", node=func_node, confidence=HIGH)
 
     visit_yieldfrom = visit_yield
 
@@ -405,6 +406,7 @@ class DocstringParameterChecker(BaseChecker):
                 message_id,
                 args=(", ".join(sorted(missing_argument_names)),),
                 node=warning_node,
+                confidence=HIGH,
             )
 
     def _compare_different_args(
@@ -447,6 +449,7 @@ class DocstringParameterChecker(BaseChecker):
                 message_id,
                 args=(", ".join(sorted(differing_argument_names)),),
                 node=warning_node,
+                confidence=HIGH,
             )
 
     def _compare_ignored_args(
@@ -474,6 +477,7 @@ class DocstringParameterChecker(BaseChecker):
                 message_id,
                 args=(", ".join(sorted(existing_ignored_argument_names)),),
                 node=warning_node,
+                confidence=HIGH,
             )
 
     def check_arguments_in_docstring(
@@ -582,6 +586,7 @@ class DocstringParameterChecker(BaseChecker):
                     "missing-any-param-doc",
                     args=(warning_node.name,),
                     node=warning_node,
+                    confidence=HIGH,
                 )
             else:
                 self._compare_missing_args(
@@ -626,7 +631,10 @@ class DocstringParameterChecker(BaseChecker):
     ) -> None:
         if class_doc.has_params() and init_doc.has_params():
             self.add_message(
-                "multiple-constructor-doc", args=(class_node.name,), node=class_node
+                "multiple-constructor-doc",
+                args=(class_node.name,),
+                node=class_node,
+                confidence=HIGH,
             )
 
     def _handle_no_raise_doc(self, excs: set[str], node: nodes.FunctionDef) -> None:
@@ -653,6 +661,7 @@ class DocstringParameterChecker(BaseChecker):
                 "missing-raises-doc",
                 args=(", ".join(sorted(missing_exceptions)),),
                 node=node,
+                confidence=HIGH,
             )
 
 

--- a/pylint/testutils/functional/test_file.py
+++ b/pylint/testutils/functional/test_file.py
@@ -91,7 +91,7 @@ class FunctionalTestFile:
 
             assert (
                 name in POSSIBLE_TEST_OPTIONS
-            ), f"[testoptions]' can only contains one of {POSSIBLE_TEST_OPTIONS}"
+            ), f"[testoptions]' can only contains one of {POSSIBLE_TEST_OPTIONS} and had '{name}'"
             self.options[name] = conv(value)  # type: ignore[literal-required]
 
     @property

--- a/tests/functional/ext/docparams/docparams.txt
+++ b/tests/functional/ext/docparams/docparams.txt
@@ -1,16 +1,16 @@
-missing-return-doc:4:0:4:18:_private_func1:Missing return documentation:UNDEFINED
-missing-return-type-doc:4:0:4:18:_private_func1:Missing return type documentation:UNDEFINED
-missing-yield-doc:9:0:9:18:_private_func2:Missing yield documentation:UNDEFINED
-missing-yield-type-doc:9:0:9:18:_private_func2:Missing yield type documentation:UNDEFINED
-missing-raises-doc:14:0:14:18:_private_func3:"""Exception"" not documented as being raised":UNDEFINED
-missing-any-param-doc:19:0:19:16:public_func1:"Missing any documentation in ""public_func1""":UNDEFINED
-missing-return-doc:24:0:24:30:_async_private_func1:Missing return documentation:UNDEFINED
-missing-return-type-doc:24:0:24:30:_async_private_func1:Missing return type documentation:UNDEFINED
-missing-yield-doc:29:0:29:30:_async_private_func2:Missing yield documentation:UNDEFINED
-missing-yield-type-doc:29:0:29:30:_async_private_func2:Missing yield type documentation:UNDEFINED
-missing-raises-doc:34:0:34:30:_async_private_func3:"""Exception"" not documented as being raised":UNDEFINED
-missing-any-param-doc:39:0:39:28:async_public_func1:"Missing any documentation in ""async_public_func1""":UNDEFINED
-differing-param-doc:44:0:44:23:differing_param_doc:"""param"" differing in parameter documentation":UNDEFINED
-differing-param-doc:55:0:55:35:differing_param_doc_kwords_only:"""param"" differing in parameter documentation":UNDEFINED
-missing-type-doc:66:0:66:20:missing_type_doc:"""par1"" missing in parameter type documentation":UNDEFINED
-missing-type-doc:76:0:76:32:missing_type_doc_kwords_only:"""par1"" missing in parameter type documentation":UNDEFINED
+missing-return-doc:4:0:4:18:_private_func1:Missing return documentation:HIGH
+missing-return-type-doc:4:0:4:18:_private_func1:Missing return type documentation:HIGH
+missing-yield-doc:9:0:9:18:_private_func2:Missing yield documentation:HIGH
+missing-yield-type-doc:9:0:9:18:_private_func2:Missing yield type documentation:HIGH
+missing-raises-doc:14:0:14:18:_private_func3:"""Exception"" not documented as being raised":HIGH
+missing-any-param-doc:19:0:19:16:public_func1:"Missing any documentation in ""public_func1""":HIGH
+missing-return-doc:24:0:24:30:_async_private_func1:Missing return documentation:HIGH
+missing-return-type-doc:24:0:24:30:_async_private_func1:Missing return type documentation:HIGH
+missing-yield-doc:29:0:29:30:_async_private_func2:Missing yield documentation:HIGH
+missing-yield-type-doc:29:0:29:30:_async_private_func2:Missing yield type documentation:HIGH
+missing-raises-doc:34:0:34:30:_async_private_func3:"""Exception"" not documented as being raised":HIGH
+missing-any-param-doc:39:0:39:28:async_public_func1:"Missing any documentation in ""async_public_func1""":HIGH
+differing-param-doc:44:0:44:23:differing_param_doc:"""param"" differing in parameter documentation":HIGH
+differing-param-doc:55:0:55:35:differing_param_doc_kwords_only:"""param"" differing in parameter documentation":HIGH
+missing-type-doc:66:0:66:20:missing_type_doc:"""par1"" missing in parameter type documentation":HIGH
+missing-type-doc:76:0:76:32:missing_type_doc_kwords_only:"""par1"" missing in parameter type documentation":HIGH

--- a/tests/functional/ext/docparams/docparams_py38.txt
+++ b/tests/functional/ext/docparams/docparams_py38.txt
@@ -1,2 +1,2 @@
-differing-param-doc:4:0:4:32:differing_param_doc_pos_only:"""param"" differing in parameter documentation":UNDEFINED
-missing-type-doc:15:0:15:29:missing_type_doc_pos_only:"""par1"" missing in parameter type documentation":UNDEFINED
+differing-param-doc:4:0:4:32:differing_param_doc_pos_only:"""param"" differing in parameter documentation":HIGH
+missing-type-doc:15:0:15:29:missing_type_doc_pos_only:"""par1"" missing in parameter type documentation":HIGH

--- a/tests/functional/ext/docparams/missing_param_doc.txt
+++ b/tests/functional/ext/docparams/missing_param_doc.txt
@@ -1,18 +1,18 @@
-missing-any-param-doc:3:0:3:11:foobar1:"Missing any documentation in ""foobar1""":UNDEFINED
-missing-any-param-doc:8:0:8:11:foobar2:"Missing any documentation in ""foobar2""":UNDEFINED
-missing-param-doc:15:0:15:11:foobar3:"""arg1, arg2, arg3"" missing in parameter documentation":UNDEFINED
-missing-type-doc:15:0:15:11:foobar3:"""arg2"" missing in parameter type documentation":UNDEFINED
-missing-param-doc:24:0:24:11:foobar4:"""arg2"" missing in parameter documentation":UNDEFINED
-missing-type-doc:24:0:24:11:foobar4:"""arg2"" missing in parameter type documentation":UNDEFINED
-missing-param-doc:33:0:33:11:foobar5:"""arg2"" missing in parameter documentation":UNDEFINED
-missing-type-doc:33:0:33:11:foobar5:"""arg1"" missing in parameter type documentation":UNDEFINED
-missing-param-doc:43:0:43:11:foobar6:"""arg2, arg3"" missing in parameter documentation":UNDEFINED
-missing-type-doc:43:0:43:11:foobar6:"""arg3"" missing in parameter type documentation":UNDEFINED
-missing-any-param-doc:53:0:53:11:foobar7:"Missing any documentation in ""foobar7""":UNDEFINED
-missing-any-param-doc:61:0:61:11:foobar8:"Missing any documentation in ""foobar8""":UNDEFINED
-missing-param-doc:66:0:66:11:foobar9:"""arg1, arg2, arg3"" missing in parameter documentation":UNDEFINED
-missing-param-doc:76:0:76:12:foobar10:"""arg2"" missing in parameter documentation":UNDEFINED
-missing-type-doc:76:0:76:12:foobar10:"""arg1, arg3"" missing in parameter type documentation":UNDEFINED
-missing-any-param-doc:88:0:88:12:foobar11:"Missing any documentation in ""foobar11""":UNDEFINED
-missing-param-doc:97:0:97:12:foobar12:"""arg1, arg3"" missing in parameter documentation":UNDEFINED
-missing-type-doc:97:0:97:12:foobar12:"""arg2, arg3"" missing in parameter type documentation":UNDEFINED
+missing-any-param-doc:3:0:3:11:foobar1:"Missing any documentation in ""foobar1""":HIGH
+missing-any-param-doc:8:0:8:11:foobar2:"Missing any documentation in ""foobar2""":HIGH
+missing-param-doc:15:0:15:11:foobar3:"""arg1, arg2, arg3"" missing in parameter documentation":HIGH
+missing-type-doc:15:0:15:11:foobar3:"""arg2"" missing in parameter type documentation":HIGH
+missing-param-doc:24:0:24:11:foobar4:"""arg2"" missing in parameter documentation":HIGH
+missing-type-doc:24:0:24:11:foobar4:"""arg2"" missing in parameter type documentation":HIGH
+missing-param-doc:33:0:33:11:foobar5:"""arg2"" missing in parameter documentation":HIGH
+missing-type-doc:33:0:33:11:foobar5:"""arg1"" missing in parameter type documentation":HIGH
+missing-param-doc:43:0:43:11:foobar6:"""arg2, arg3"" missing in parameter documentation":HIGH
+missing-type-doc:43:0:43:11:foobar6:"""arg3"" missing in parameter type documentation":HIGH
+missing-any-param-doc:53:0:53:11:foobar7:"Missing any documentation in ""foobar7""":HIGH
+missing-any-param-doc:61:0:61:11:foobar8:"Missing any documentation in ""foobar8""":HIGH
+missing-param-doc:66:0:66:11:foobar9:"""arg1, arg2, arg3"" missing in parameter documentation":HIGH
+missing-param-doc:76:0:76:12:foobar10:"""arg2"" missing in parameter documentation":HIGH
+missing-type-doc:76:0:76:12:foobar10:"""arg1, arg3"" missing in parameter type documentation":HIGH
+missing-any-param-doc:88:0:88:12:foobar11:"Missing any documentation in ""foobar11""":HIGH
+missing-param-doc:97:0:97:12:foobar12:"""arg1, arg3"" missing in parameter documentation":HIGH
+missing-type-doc:97:0:97:12:foobar12:"""arg2, arg3"" missing in parameter type documentation":HIGH

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required.txt
@@ -1,3 +1,3 @@
-missing-any-param-doc:7:0:7:53:test_don_t_tolerate_no_param_documentation_at_all:"Missing any documentation in ""test_don_t_tolerate_no_param_documentation_at_all""":UNDEFINED
-missing-param-doc:44:0:44:40:test_kwonlyargs_are_taken_in_account:"""missing_kwonly"" missing in parameter documentation":UNDEFINED
-missing-type-doc:44:0:44:40:test_kwonlyargs_are_taken_in_account:"""missing_kwonly"" missing in parameter type documentation":UNDEFINED
+missing-any-param-doc:7:0:7:53:test_don_t_tolerate_no_param_documentation_at_all:"Missing any documentation in ""test_don_t_tolerate_no_param_documentation_at_all""":HIGH
+missing-param-doc:44:0:44:40:test_kwonlyargs_are_taken_in_account:"""missing_kwonly"" missing in parameter documentation":HIGH
+missing-type-doc:44:0:44:40:test_kwonlyargs_are_taken_in_account:"""missing_kwonly"" missing in parameter type documentation":HIGH

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Google.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Google.txt
@@ -1,26 +1,26 @@
-missing-param-doc:24:0:24:48:test_missing_func_params_in_google_docstring:"""y"" missing in parameter documentation":UNDEFINED
-missing-type-doc:24:0:24:48:test_missing_func_params_in_google_docstring:"""x, y"" missing in parameter type documentation":UNDEFINED
-missing-type-doc:80:0:80:73:test_missing_func_params_with_partial_annotations_in_google_docstring:"""x"" missing in parameter type documentation":UNDEFINED
-differing-param-doc:131:0:131:65:test_func_params_and_wrong_keyword_params_in_google_docstring:"""these"" differing in parameter documentation":UNDEFINED
-differing-type-doc:131:0:131:65:test_func_params_and_wrong_keyword_params_in_google_docstring:"""these"" differing in parameter type documentation":UNDEFINED
-missing-param-doc:131:0:131:65:test_func_params_and_wrong_keyword_params_in_google_docstring:"""that"" missing in parameter documentation":UNDEFINED
-missing-type-doc:131:0:131:65:test_func_params_and_wrong_keyword_params_in_google_docstring:"""that"" missing in parameter type documentation":UNDEFINED
-missing-param-doc:148:4:148:54:Foo.test_missing_method_params_in_google_docstring:"""y"" missing in parameter documentation":UNDEFINED
-missing-type-doc:148:4:148:54:Foo.test_missing_method_params_in_google_docstring:"""x, y"" missing in parameter type documentation":UNDEFINED
-differing-param-doc:179:0:179:58:test_wrong_name_of_func_params_in_google_docstring_one:"""xarg1, zarg1"" differing in parameter documentation":UNDEFINED
-differing-type-doc:179:0:179:58:test_wrong_name_of_func_params_in_google_docstring_one:"""xarg1, zarg1"" differing in parameter type documentation":UNDEFINED
-missing-param-doc:179:0:179:58:test_wrong_name_of_func_params_in_google_docstring_one:"""xarg, zarg"" missing in parameter documentation":UNDEFINED
-missing-type-doc:179:0:179:58:test_wrong_name_of_func_params_in_google_docstring_one:"""xarg, zarg"" missing in parameter type documentation":UNDEFINED
-differing-param-doc:194:0:194:58:test_wrong_name_of_func_params_in_google_docstring_two:"""yarg1"" differing in parameter documentation":UNDEFINED
-differing-type-doc:194:0:194:58:test_wrong_name_of_func_params_in_google_docstring_two:"""yarg1"" differing in parameter type documentation":UNDEFINED
-missing-param-doc:221:0:221:14:ClassFoo:"""x"" missing in parameter documentation":UNDEFINED
-missing-type-doc:221:0:221:14:ClassFoo:"""x, y"" missing in parameter type documentation":UNDEFINED
-missing-param-doc:239:4:239:16:ClassFoo.__init__:"""x"" missing in parameter documentation":UNDEFINED
-missing-type-doc:239:4:239:16:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":UNDEFINED
-missing-param-doc:251:0:251:14:ClassFoo:"""x"" missing in parameter documentation":UNDEFINED
-missing-type-doc:251:0:251:14:ClassFoo:"""x, y"" missing in parameter type documentation":UNDEFINED
-multiple-constructor-doc:251:0:251:14:ClassFoo:"""ClassFoo"" has constructor parameters documented in class and __init__":UNDEFINED
-missing-param-doc:265:4:265:16:ClassFoo.__init__:"""x"" missing in parameter documentation":UNDEFINED
-missing-type-doc:265:4:265:16:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":UNDEFINED
-missing-param-doc:275:0:275:34:test_warns_missing_args_google:"""*args"" missing in parameter documentation":UNDEFINED
-missing-param-doc:288:0:288:36:test_warns_missing_kwargs_google:"""**kwargs"" missing in parameter documentation":UNDEFINED
+missing-param-doc:24:0:24:48:test_missing_func_params_in_google_docstring:"""y"" missing in parameter documentation":HIGH
+missing-type-doc:24:0:24:48:test_missing_func_params_in_google_docstring:"""x, y"" missing in parameter type documentation":HIGH
+missing-type-doc:80:0:80:73:test_missing_func_params_with_partial_annotations_in_google_docstring:"""x"" missing in parameter type documentation":HIGH
+differing-param-doc:131:0:131:65:test_func_params_and_wrong_keyword_params_in_google_docstring:"""these"" differing in parameter documentation":HIGH
+differing-type-doc:131:0:131:65:test_func_params_and_wrong_keyword_params_in_google_docstring:"""these"" differing in parameter type documentation":HIGH
+missing-param-doc:131:0:131:65:test_func_params_and_wrong_keyword_params_in_google_docstring:"""that"" missing in parameter documentation":HIGH
+missing-type-doc:131:0:131:65:test_func_params_and_wrong_keyword_params_in_google_docstring:"""that"" missing in parameter type documentation":HIGH
+missing-param-doc:148:4:148:54:Foo.test_missing_method_params_in_google_docstring:"""y"" missing in parameter documentation":HIGH
+missing-type-doc:148:4:148:54:Foo.test_missing_method_params_in_google_docstring:"""x, y"" missing in parameter type documentation":HIGH
+differing-param-doc:179:0:179:58:test_wrong_name_of_func_params_in_google_docstring_one:"""xarg1, zarg1"" differing in parameter documentation":HIGH
+differing-type-doc:179:0:179:58:test_wrong_name_of_func_params_in_google_docstring_one:"""xarg1, zarg1"" differing in parameter type documentation":HIGH
+missing-param-doc:179:0:179:58:test_wrong_name_of_func_params_in_google_docstring_one:"""xarg, zarg"" missing in parameter documentation":HIGH
+missing-type-doc:179:0:179:58:test_wrong_name_of_func_params_in_google_docstring_one:"""xarg, zarg"" missing in parameter type documentation":HIGH
+differing-param-doc:194:0:194:58:test_wrong_name_of_func_params_in_google_docstring_two:"""yarg1"" differing in parameter documentation":HIGH
+differing-type-doc:194:0:194:58:test_wrong_name_of_func_params_in_google_docstring_two:"""yarg1"" differing in parameter type documentation":HIGH
+missing-param-doc:221:0:221:14:ClassFoo:"""x"" missing in parameter documentation":HIGH
+missing-type-doc:221:0:221:14:ClassFoo:"""x, y"" missing in parameter type documentation":HIGH
+missing-param-doc:239:4:239:16:ClassFoo.__init__:"""x"" missing in parameter documentation":HIGH
+missing-type-doc:239:4:239:16:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":HIGH
+missing-param-doc:251:0:251:14:ClassFoo:"""x"" missing in parameter documentation":HIGH
+missing-type-doc:251:0:251:14:ClassFoo:"""x, y"" missing in parameter type documentation":HIGH
+multiple-constructor-doc:251:0:251:14:ClassFoo:"""ClassFoo"" has constructor parameters documented in class and __init__":HIGH
+missing-param-doc:265:4:265:16:ClassFoo.__init__:"""x"" missing in parameter documentation":HIGH
+missing-type-doc:265:4:265:16:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":HIGH
+missing-param-doc:275:0:275:34:test_warns_missing_args_google:"""*args"" missing in parameter documentation":HIGH
+missing-param-doc:288:0:288:36:test_warns_missing_kwargs_google:"""**kwargs"" missing in parameter documentation":HIGH

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Numpy.txt
@@ -1,22 +1,22 @@
-missing-param-doc:9:0:9:47:test_missing_func_params_in_numpy_docstring:"""y"" missing in parameter documentation":UNDEFINED
-missing-type-doc:9:0:9:47:test_missing_func_params_in_numpy_docstring:"""x, y"" missing in parameter type documentation":UNDEFINED
-missing-param-doc:27:4:27:53:Foo.test_missing_method_params_in_numpy_docstring:"""y"" missing in parameter documentation":UNDEFINED
-missing-type-doc:27:4:27:53:Foo.test_missing_method_params_in_numpy_docstring:"""x, y"" missing in parameter type documentation":UNDEFINED
-differing-param-doc:66:0:66:53:test_wrong_name_of_func_params_in_numpy_docstring:"""xarg1, zarg1"" differing in parameter documentation":UNDEFINED
-differing-type-doc:66:0:66:53:test_wrong_name_of_func_params_in_numpy_docstring:"""xarg1, zarg1"" differing in parameter type documentation":UNDEFINED
-missing-param-doc:66:0:66:53:test_wrong_name_of_func_params_in_numpy_docstring:"""xarg, zarg"" missing in parameter documentation":UNDEFINED
-missing-type-doc:66:0:66:53:test_wrong_name_of_func_params_in_numpy_docstring:"""xarg, zarg"" missing in parameter type documentation":UNDEFINED
-differing-param-doc:85:0:85:57:test_wrong_name_of_func_params_in_numpy_docstring_two:"""yarg1"" differing in parameter documentation":UNDEFINED
-differing-type-doc:85:0:85:57:test_wrong_name_of_func_params_in_numpy_docstring_two:"""yarg1"" differing in parameter type documentation":UNDEFINED
-missing-param-doc:116:0:116:14:ClassFoo:"""x"" missing in parameter documentation":UNDEFINED
-missing-type-doc:116:0:116:14:ClassFoo:"""x, y"" missing in parameter type documentation":UNDEFINED
-missing-param-doc:156:4:156:16:ClassFoo.__init__:"""x"" missing in parameter documentation":UNDEFINED
-missing-type-doc:156:4:156:16:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":UNDEFINED
-missing-param-doc:172:0:172:14:ClassFoo:"""x"" missing in parameter documentation":UNDEFINED
-missing-type-doc:172:0:172:14:ClassFoo:"""x, y"" missing in parameter type documentation":UNDEFINED
-multiple-constructor-doc:172:0:172:14:ClassFoo:"""ClassFoo"" has constructor parameters documented in class and __init__":UNDEFINED
-missing-param-doc:188:4:188:16:ClassFoo.__init__:"""x"" missing in parameter documentation":UNDEFINED
-missing-type-doc:188:4:188:16:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":UNDEFINED
-missing-param-doc:200:0:200:33:test_warns_missing_args_numpy:"""*args"" missing in parameter documentation":UNDEFINED
-missing-param-doc:217:0:217:35:test_warns_missing_kwargs_numpy:"""**kwargs"" missing in parameter documentation":UNDEFINED
-missing-type-doc:234:0:234:38:test_finds_args_without_type_numpy:"""untyped_arg"" missing in parameter type documentation":UNDEFINED
+missing-param-doc:9:0:9:47:test_missing_func_params_in_numpy_docstring:"""y"" missing in parameter documentation":HIGH
+missing-type-doc:9:0:9:47:test_missing_func_params_in_numpy_docstring:"""x, y"" missing in parameter type documentation":HIGH
+missing-param-doc:27:4:27:53:Foo.test_missing_method_params_in_numpy_docstring:"""y"" missing in parameter documentation":HIGH
+missing-type-doc:27:4:27:53:Foo.test_missing_method_params_in_numpy_docstring:"""x, y"" missing in parameter type documentation":HIGH
+differing-param-doc:66:0:66:53:test_wrong_name_of_func_params_in_numpy_docstring:"""xarg1, zarg1"" differing in parameter documentation":HIGH
+differing-type-doc:66:0:66:53:test_wrong_name_of_func_params_in_numpy_docstring:"""xarg1, zarg1"" differing in parameter type documentation":HIGH
+missing-param-doc:66:0:66:53:test_wrong_name_of_func_params_in_numpy_docstring:"""xarg, zarg"" missing in parameter documentation":HIGH
+missing-type-doc:66:0:66:53:test_wrong_name_of_func_params_in_numpy_docstring:"""xarg, zarg"" missing in parameter type documentation":HIGH
+differing-param-doc:85:0:85:57:test_wrong_name_of_func_params_in_numpy_docstring_two:"""yarg1"" differing in parameter documentation":HIGH
+differing-type-doc:85:0:85:57:test_wrong_name_of_func_params_in_numpy_docstring_two:"""yarg1"" differing in parameter type documentation":HIGH
+missing-param-doc:116:0:116:14:ClassFoo:"""x"" missing in parameter documentation":HIGH
+missing-type-doc:116:0:116:14:ClassFoo:"""x, y"" missing in parameter type documentation":HIGH
+missing-param-doc:156:4:156:16:ClassFoo.__init__:"""x"" missing in parameter documentation":HIGH
+missing-type-doc:156:4:156:16:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":HIGH
+missing-param-doc:172:0:172:14:ClassFoo:"""x"" missing in parameter documentation":HIGH
+missing-type-doc:172:0:172:14:ClassFoo:"""x, y"" missing in parameter type documentation":HIGH
+multiple-constructor-doc:172:0:172:14:ClassFoo:"""ClassFoo"" has constructor parameters documented in class and __init__":HIGH
+missing-param-doc:188:4:188:16:ClassFoo.__init__:"""x"" missing in parameter documentation":HIGH
+missing-type-doc:188:4:188:16:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":HIGH
+missing-param-doc:200:0:200:33:test_warns_missing_args_numpy:"""*args"" missing in parameter documentation":HIGH
+missing-param-doc:217:0:217:35:test_warns_missing_kwargs_numpy:"""**kwargs"" missing in parameter documentation":HIGH
+missing-type-doc:234:0:234:38:test_finds_args_without_type_numpy:"""untyped_arg"" missing in parameter type documentation":HIGH

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Sphinx.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Sphinx.txt
@@ -1,39 +1,39 @@
-missing-param-doc:8:0:8:48:test_missing_func_params_in_sphinx_docstring:"""y"" missing in parameter documentation":UNDEFINED
-missing-type-doc:8:0:8:48:test_missing_func_params_in_sphinx_docstring:"""x, y"" missing in parameter type documentation":UNDEFINED
-missing-param-doc:22:4:22:54:Foo.test_missing_method_params_in_sphinx_docstring:"""y"" missing in parameter documentation":UNDEFINED
-missing-type-doc:22:4:22:54:Foo.test_missing_method_params_in_sphinx_docstring:"""x, y"" missing in parameter type documentation":UNDEFINED
-differing-param-doc:55:0:55:54:test_wrong_name_of_func_params_in_sphinx_docstring:"""xarg1, zarg1"" differing in parameter documentation":UNDEFINED
-differing-type-doc:55:0:55:54:test_wrong_name_of_func_params_in_sphinx_docstring:"""yarg1, zarg1"" differing in parameter type documentation":UNDEFINED
-missing-param-doc:55:0:55:54:test_wrong_name_of_func_params_in_sphinx_docstring:"""xarg, zarg"" missing in parameter documentation":UNDEFINED
-missing-type-doc:55:0:55:54:test_wrong_name_of_func_params_in_sphinx_docstring:"""yarg, zarg"" missing in parameter type documentation":UNDEFINED
-differing-param-doc:72:0:72:58:test_wrong_name_of_func_params_in_sphinx_docstring_two:"""yarg1"" differing in parameter documentation":UNDEFINED
-differing-type-doc:72:0:72:58:test_wrong_name_of_func_params_in_sphinx_docstring_two:"""yarg1"" differing in parameter type documentation":UNDEFINED
-missing-param-doc:99:0:99:14:ClassFoo:"""x"" missing in parameter documentation":UNDEFINED
-missing-type-doc:99:0:99:14:ClassFoo:"""x, y"" missing in parameter type documentation":UNDEFINED
-missing-param-doc:116:4:116:16:ClassFoo.__init__:"""x"" missing in parameter documentation":UNDEFINED
-missing-type-doc:116:4:116:16:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":UNDEFINED
-missing-param-doc:131:0:131:14:ClassFoo:"""x"" missing in parameter documentation":UNDEFINED
-missing-type-doc:131:0:131:14:ClassFoo:"""x, y"" missing in parameter type documentation":UNDEFINED
-multiple-constructor-doc:131:0:131:14:ClassFoo:"""ClassFoo"" has constructor parameters documented in class and __init__":UNDEFINED
-missing-param-doc:144:4:144:16:ClassFoo.__init__:"""x"" missing in parameter documentation":UNDEFINED
-missing-type-doc:144:4:144:16:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":UNDEFINED
+missing-param-doc:8:0:8:48:test_missing_func_params_in_sphinx_docstring:"""y"" missing in parameter documentation":HIGH
+missing-type-doc:8:0:8:48:test_missing_func_params_in_sphinx_docstring:"""x, y"" missing in parameter type documentation":HIGH
+missing-param-doc:22:4:22:54:Foo.test_missing_method_params_in_sphinx_docstring:"""y"" missing in parameter documentation":HIGH
+missing-type-doc:22:4:22:54:Foo.test_missing_method_params_in_sphinx_docstring:"""x, y"" missing in parameter type documentation":HIGH
+differing-param-doc:55:0:55:54:test_wrong_name_of_func_params_in_sphinx_docstring:"""xarg1, zarg1"" differing in parameter documentation":HIGH
+differing-type-doc:55:0:55:54:test_wrong_name_of_func_params_in_sphinx_docstring:"""yarg1, zarg1"" differing in parameter type documentation":HIGH
+missing-param-doc:55:0:55:54:test_wrong_name_of_func_params_in_sphinx_docstring:"""xarg, zarg"" missing in parameter documentation":HIGH
+missing-type-doc:55:0:55:54:test_wrong_name_of_func_params_in_sphinx_docstring:"""yarg, zarg"" missing in parameter type documentation":HIGH
+differing-param-doc:72:0:72:58:test_wrong_name_of_func_params_in_sphinx_docstring_two:"""yarg1"" differing in parameter documentation":HIGH
+differing-type-doc:72:0:72:58:test_wrong_name_of_func_params_in_sphinx_docstring_two:"""yarg1"" differing in parameter type documentation":HIGH
+missing-param-doc:99:0:99:14:ClassFoo:"""x"" missing in parameter documentation":HIGH
+missing-type-doc:99:0:99:14:ClassFoo:"""x, y"" missing in parameter type documentation":HIGH
+missing-param-doc:116:4:116:16:ClassFoo.__init__:"""x"" missing in parameter documentation":HIGH
+missing-type-doc:116:4:116:16:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":HIGH
+missing-param-doc:131:0:131:14:ClassFoo:"""x"" missing in parameter documentation":HIGH
+missing-type-doc:131:0:131:14:ClassFoo:"""x, y"" missing in parameter type documentation":HIGH
+multiple-constructor-doc:131:0:131:14:ClassFoo:"""ClassFoo"" has constructor parameters documented in class and __init__":HIGH
+missing-param-doc:144:4:144:16:ClassFoo.__init__:"""x"" missing in parameter documentation":HIGH
+missing-type-doc:144:4:144:16:ClassFoo.__init__:"""x, y"" missing in parameter type documentation":HIGH
 inconsistent-return-statements:154:0:154:34:test_warns_missing_args_sphinx:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
-missing-param-doc:154:0:154:34:test_warns_missing_args_sphinx:"""*args"" missing in parameter documentation":UNDEFINED
+missing-param-doc:154:0:154:34:test_warns_missing_args_sphinx:"""*args"" missing in parameter documentation":HIGH
 inconsistent-return-statements:169:0:169:36:test_warns_missing_kwargs_sphinx:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
-missing-param-doc:169:0:169:36:test_warns_missing_kwargs_sphinx:"""**kwargs"" missing in parameter documentation":UNDEFINED
+missing-param-doc:169:0:169:36:test_warns_missing_kwargs_sphinx:"""**kwargs"" missing in parameter documentation":HIGH
 inconsistent-return-statements:184:0:184:39:test_finds_args_without_type_sphinx:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
-missing-param-doc:184:0:184:39:test_finds_args_without_type_sphinx:"""*args"" missing in parameter documentation":UNDEFINED
+missing-param-doc:184:0:184:39:test_finds_args_without_type_sphinx:"""*args"" missing in parameter documentation":HIGH
 inconsistent-return-statements:201:0:201:41:test_finds_kwargs_without_type_sphinx:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
-missing-param-doc:201:0:201:41:test_finds_kwargs_without_type_sphinx:"""**kwargs"" missing in parameter documentation":UNDEFINED
+missing-param-doc:201:0:201:41:test_finds_kwargs_without_type_sphinx:"""**kwargs"" missing in parameter documentation":HIGH
 inconsistent-return-statements:218:0:218:39:test_finds_args_without_type_sphinx:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
 inconsistent-return-statements:237:0:237:41:test_finds_kwargs_without_type_sphinx:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
 inconsistent-return-statements:256:0:256:39:test_finds_args_without_type_sphinx:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
 inconsistent-return-statements:274:0:274:41:test_finds_kwargs_without_type_sphinx:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
-missing-raises-doc:299:4:299:11:Foo.foo:"""AttributeError"" not documented as being raised":UNDEFINED
+missing-raises-doc:299:4:299:11:Foo.foo:"""AttributeError"" not documented as being raised":HIGH
 unreachable:325:8:325:17:Foo.foo:Unreachable code:UNDEFINED
-missing-param-doc:328:4:328:11:Foo.foo:"""value"" missing in parameter documentation":UNDEFINED
-missing-raises-doc:328:4:328:11:Foo.foo:"""AttributeError"" not documented as being raised":UNDEFINED
-missing-type-doc:328:4:328:11:Foo.foo:"""value"" missing in parameter type documentation":UNDEFINED
+missing-param-doc:328:4:328:11:Foo.foo:"""value"" missing in parameter documentation":HIGH
+missing-raises-doc:328:4:328:11:Foo.foo:"""AttributeError"" not documented as being raised":HIGH
+missing-type-doc:328:4:328:11:Foo.foo:"""value"" missing in parameter type documentation":HIGH
 unreachable:364:8:364:17:Foo.foo:Unreachable code:UNDEFINED
-useless-param-doc:368:4:368:55:Foo.test_useless_docs_ignored_argument_names_sphinx:"""_, _ignored"" useless ignored parameter documentation":UNDEFINED
-useless-type-doc:368:4:368:55:Foo.test_useless_docs_ignored_argument_names_sphinx:"""_"" useless ignored parameter type documentation":UNDEFINED
+useless-param-doc:368:4:368:55:Foo.test_useless_docs_ignored_argument_names_sphinx:"""_, _ignored"" useless ignored parameter documentation":HIGH
+useless-type-doc:368:4:368:55:Foo.test_useless_docs_ignored_argument_names_sphinx:"""_"" useless ignored parameter type documentation":HIGH

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_no_doc_rgx_check_init.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_no_doc_rgx_check_init.txt
@@ -1,1 +1,1 @@
-missing-param-doc:10:4:10:16:MyClass.__init__:"""my_param"" missing in parameter documentation":UNDEFINED
+missing-param-doc:10:4:10:16:MyClass.__init__:"""my_param"" missing in parameter documentation":HIGH

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_no_doc_rgx_test_all.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_no_doc_rgx_test_all.txt
@@ -1,1 +1,1 @@
-missing-param-doc:25:4:25:16:MyClass.__init__:"""my_param"" missing in parameter documentation":UNDEFINED
+missing-param-doc:25:4:25:16:MyClass.__init__:"""my_param"" missing in parameter documentation":HIGH

--- a/tests/functional/ext/docparams/raise/missing_raises_doc.txt
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc.txt
@@ -1,4 +1,4 @@
 unreachable:25:4:25:25:test_ignores_raise_uninferable:Unreachable code:UNDEFINED
-missing-raises-doc:28:0:28:45:test_ignores_returns_from_inner_functions:"""RuntimeError"" not documented as being raised":UNDEFINED
+missing-raises-doc:28:0:28:45:test_ignores_returns_from_inner_functions:"""RuntimeError"" not documented as being raised":HIGH
 unreachable:42:4:42:25:test_ignores_returns_from_inner_functions:Unreachable code:UNDEFINED
 raising-bad-type:54:4:54:22:test_ignores_returns_use_only_names:Raising int while only classes or instances are allowed:UNDEFINED

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_Google.txt
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_Google.txt
@@ -1,14 +1,14 @@
-missing-raises-doc:6:0:6:35:test_find_missing_google_raises:"""RuntimeError"" not documented as being raised":UNDEFINED
+missing-raises-doc:6:0:6:35:test_find_missing_google_raises:"""RuntimeError"" not documented as being raised":HIGH
 unreachable:13:4:13:25:test_find_missing_google_raises:Unreachable code:UNDEFINED
-missing-raises-doc:38:0:38:46:test_find_valid_missing_google_attr_raises:"""error"" not documented as being raised":UNDEFINED
+missing-raises-doc:38:0:38:46:test_find_valid_missing_google_attr_raises:"""error"" not documented as being raised":HIGH
 unreachable:83:4:83:25:test_find_all_google_raises:Unreachable code:UNDEFINED
 unreachable:94:4:94:25:test_find_multiple_google_raises:Unreachable code:UNDEFINED
 unreachable:95:4:95:30:test_find_multiple_google_raises:Unreachable code:UNDEFINED
 unreachable:96:4:96:27:test_find_multiple_google_raises:Unreachable code:UNDEFINED
-missing-raises-doc:99:0:99:36:test_find_rethrown_google_raises:"""RuntimeError"" not documented as being raised":UNDEFINED
-missing-raises-doc:113:0:113:45:test_find_rethrown_google_multiple_raises:"""RuntimeError, ValueError"" not documented as being raised":UNDEFINED
-missing-raises-doc:148:4:148:18:Foo.foo_method:"""AttributeError"" not documented as being raised":UNDEFINED
+missing-raises-doc:99:0:99:36:test_find_rethrown_google_raises:"""RuntimeError"" not documented as being raised":HIGH
+missing-raises-doc:113:0:113:45:test_find_rethrown_google_multiple_raises:"""RuntimeError, ValueError"" not documented as being raised":HIGH
+missing-raises-doc:148:4:148:18:Foo.foo_method:"""AttributeError"" not documented as being raised":HIGH
 unreachable:158:8:158:17:Foo.foo_method:Unreachable code:UNDEFINED
 unreachable:180:8:180:17:Foo.foo_method:Unreachable code:UNDEFINED
-missing-raises-doc:183:4:183:18:Foo.foo_method:"""AttributeError"" not documented as being raised":UNDEFINED
+missing-raises-doc:183:4:183:18:Foo.foo_method:"""AttributeError"" not documented as being raised":HIGH
 using-constant-test:190:11:190:15:Foo.foo_method:Using a conditional statement with a constant value:INFERENCE

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_Numpy.txt
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_Numpy.txt
@@ -1,11 +1,11 @@
-missing-raises-doc:11:0:11:34:test_find_missing_numpy_raises:"""RuntimeError"" not documented as being raised":UNDEFINED
+missing-raises-doc:11:0:11:34:test_find_missing_numpy_raises:"""RuntimeError"" not documented as being raised":HIGH
 unreachable:20:4:20:25:test_find_missing_numpy_raises:Unreachable code:UNDEFINED
 unreachable:34:4:34:25:test_find_all_numpy_raises:Unreachable code:UNDEFINED
-missing-raises-doc:37:0:37:35:test_find_rethrown_numpy_raises:"""RuntimeError"" not documented as being raised":UNDEFINED
-missing-raises-doc:53:0:53:44:test_find_rethrown_numpy_multiple_raises:"""RuntimeError, ValueError"" not documented as being raised":UNDEFINED
-missing-raises-doc:111:0:111:45:test_find_valid_missing_numpy_attr_raises:"""error"" not documented as being raised":UNDEFINED
-missing-raises-doc:146:4:146:11:Foo.foo:"""AttributeError"" not documented as being raised":UNDEFINED
+missing-raises-doc:37:0:37:35:test_find_rethrown_numpy_raises:"""RuntimeError"" not documented as being raised":HIGH
+missing-raises-doc:53:0:53:44:test_find_rethrown_numpy_multiple_raises:"""RuntimeError, ValueError"" not documented as being raised":HIGH
+missing-raises-doc:111:0:111:45:test_find_valid_missing_numpy_attr_raises:"""error"" not documented as being raised":HIGH
+missing-raises-doc:146:4:146:11:Foo.foo:"""AttributeError"" not documented as being raised":HIGH
 unreachable:158:8:158:17:Foo.foo:Unreachable code:UNDEFINED
 unreachable:182:8:182:17:Foo.foo:Unreachable code:UNDEFINED
-missing-raises-doc:185:4:185:11:Foo.foo:"""AttributeError"" not documented as being raised":UNDEFINED
+missing-raises-doc:185:4:185:11:Foo.foo:"""AttributeError"" not documented as being raised":HIGH
 unreachable:215:8:215:17:Foo.foo:Unreachable code:UNDEFINED

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_Sphinx.txt
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_Sphinx.txt
@@ -1,13 +1,13 @@
-missing-raises-doc:7:0:7:35:test_find_missing_sphinx_raises:"""RuntimeError"" not documented as being raised":UNDEFINED
+missing-raises-doc:7:0:7:35:test_find_missing_sphinx_raises:"""RuntimeError"" not documented as being raised":HIGH
 unreachable:13:4:13:25:test_find_missing_sphinx_raises:Unreachable code:UNDEFINED
 unreachable:36:4:36:25:test_find_all_sphinx_raises:Unreachable code:UNDEFINED
 unreachable:37:4:37:30:test_find_all_sphinx_raises:Unreachable code:UNDEFINED
 unreachable:38:4:38:27:test_find_all_sphinx_raises:Unreachable code:UNDEFINED
 unreachable:48:4:48:25:test_find_multiple_sphinx_raises:Unreachable code:UNDEFINED
-missing-raises-doc:51:0:51:37:test_finds_rethrown_sphinx_raises:"""RuntimeError"" not documented as being raised":UNDEFINED
-missing-raises-doc:64:0:64:46:test_finds_rethrown_sphinx_multiple_raises:"""RuntimeError, ValueError"" not documented as being raised":UNDEFINED
-missing-raises-doc:90:0:90:55:test_find_missing_sphinx_raises_infer_from_instance:"""RuntimeError"" not documented as being raised":UNDEFINED
+missing-raises-doc:51:0:51:37:test_finds_rethrown_sphinx_raises:"""RuntimeError"" not documented as being raised":HIGH
+missing-raises-doc:64:0:64:46:test_finds_rethrown_sphinx_multiple_raises:"""RuntimeError, ValueError"" not documented as being raised":HIGH
+missing-raises-doc:90:0:90:55:test_find_missing_sphinx_raises_infer_from_instance:"""RuntimeError"" not documented as being raised":HIGH
 unreachable:97:4:97:25:test_find_missing_sphinx_raises_infer_from_instance:Unreachable code:UNDEFINED
-missing-raises-doc:100:0:100:55:test_find_missing_sphinx_raises_infer_from_function:"""RuntimeError"" not documented as being raised":UNDEFINED
+missing-raises-doc:100:0:100:55:test_find_missing_sphinx_raises_infer_from_function:"""RuntimeError"" not documented as being raised":HIGH
 unreachable:110:4:110:25:test_find_missing_sphinx_raises_infer_from_function:Unreachable code:UNDEFINED
-missing-raises-doc:133:0:133:46:test_find_valid_missing_sphinx_attr_raises:"""error"" not documented as being raised":UNDEFINED
+missing-raises-doc:133:0:133:46:test_find_valid_missing_sphinx_attr_raises:"""error"" not documented as being raised":HIGH

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_required.txt
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_required.txt
@@ -1,1 +1,1 @@
-missing-raises-doc:6:0:6:28:test_warns_unknown_style:"""RuntimeError"" not documented as being raised":UNDEFINED
+missing-raises-doc:6:0:6:28:test_warns_unknown_style:"""RuntimeError"" not documented as being raised":HIGH

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_required_exc_inheritance.txt
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_required_exc_inheritance.txt
@@ -1,1 +1,1 @@
-missing-raises-doc:12:0:12:38:test_find_missing_raise_for_parent:"""NameError"" not documented as being raised":UNDEFINED
+missing-raises-doc:12:0:12:38:test_find_missing_raise_for_parent:"""NameError"" not documented as being raised":HIGH

--- a/tests/functional/ext/docparams/return/missing_return_doc_Google.txt
+++ b/tests/functional/ext/docparams/return/missing_return_doc_Google.txt
@@ -1,7 +1,7 @@
-redundant-returns-doc:43:0:43:11:my_func:Redundant returns documentation:UNDEFINED
-redundant-returns-doc:52:0:52:11:my_func:Redundant returns documentation:UNDEFINED
-redundant-returns-doc:61:0:61:11:my_func:Redundant returns documentation:UNDEFINED
+redundant-returns-doc:43:0:43:11:my_func:Redundant returns documentation:HIGH
+redundant-returns-doc:52:0:52:11:my_func:Redundant returns documentation:HIGH
+redundant-returns-doc:61:0:61:11:my_func:Redundant returns documentation:HIGH
 unreachable:95:8:95:17:Foo.foo_method:Unreachable code:UNDEFINED
 unreachable:112:8:112:17:Foo.foo_method:Unreachable code:UNDEFINED
-useless-param-doc:167:4:167:18:Foo.foo_method:"""_, _ignored"" useless ignored parameter documentation":UNDEFINED
-useless-type-doc:167:4:167:18:Foo.foo_method:"""_"" useless ignored parameter type documentation":UNDEFINED
+useless-param-doc:167:4:167:18:Foo.foo_method:"""_, _ignored"" useless ignored parameter documentation":HIGH
+useless-type-doc:167:4:167:18:Foo.foo_method:"""_"" useless ignored parameter type documentation":HIGH

--- a/tests/functional/ext/docparams/return/missing_return_doc_Numpy.txt
+++ b/tests/functional/ext/docparams/return/missing_return_doc_Numpy.txt
@@ -1,5 +1,5 @@
-redundant-returns-doc:62:0:62:11:my_func:Redundant returns documentation:UNDEFINED
-redundant-returns-doc:73:0:73:11:my_func:Redundant returns documentation:UNDEFINED
-redundant-returns-doc:98:0:98:11:my_func:Redundant returns documentation:UNDEFINED
-useless-param-doc:164:4:164:11:Foo.foo:"""_, _ignored"" useless ignored parameter documentation":UNDEFINED
-useless-type-doc:164:4:164:11:Foo.foo:"""_"" useless ignored parameter type documentation":UNDEFINED
+redundant-returns-doc:62:0:62:11:my_func:Redundant returns documentation:HIGH
+redundant-returns-doc:73:0:73:11:my_func:Redundant returns documentation:HIGH
+redundant-returns-doc:98:0:98:11:my_func:Redundant returns documentation:HIGH
+useless-param-doc:164:4:164:11:Foo.foo:"""_, _ignored"" useless ignored parameter documentation":HIGH
+useless-type-doc:164:4:164:11:Foo.foo:"""_"" useless ignored parameter type documentation":HIGH

--- a/tests/functional/ext/docparams/return/missing_return_doc_Sphinx.txt
+++ b/tests/functional/ext/docparams/return/missing_return_doc_Sphinx.txt
@@ -1,2 +1,2 @@
-redundant-returns-doc:44:0:44:11:my_func:Redundant returns documentation:UNDEFINED
-redundant-returns-doc:52:0:52:11:my_func:Redundant returns documentation:UNDEFINED
+redundant-returns-doc:44:0:44:11:my_func:Redundant returns documentation:HIGH
+redundant-returns-doc:52:0:52:11:my_func:Redundant returns documentation:HIGH

--- a/tests/functional/ext/docparams/return/missing_return_doc_required.txt
+++ b/tests/functional/ext/docparams/return/missing_return_doc_required.txt
@@ -1,2 +1,2 @@
-missing-return-doc:6:0:6:22:warns_no_docstring:Missing return documentation:UNDEFINED
-missing-return-type-doc:6:0:6:22:warns_no_docstring:Missing return type documentation:UNDEFINED
+missing-return-doc:6:0:6:22:warns_no_docstring:Missing return documentation:HIGH
+missing-return-type-doc:6:0:6:22:warns_no_docstring:Missing return type documentation:HIGH

--- a/tests/functional/ext/docparams/return/missing_return_doc_required_Google.txt
+++ b/tests/functional/ext/docparams/return/missing_return_doc_required_Google.txt
@@ -1,10 +1,10 @@
-missing-return-type-doc:7:0:7:11:my_func:Missing return type documentation:UNDEFINED
-missing-return-doc:16:0:16:11:my_func:Missing return documentation:UNDEFINED
-missing-return-doc:25:0:25:11:my_func:Missing return documentation:UNDEFINED
-missing-return-type-doc:25:0:25:11:my_func:Missing return type documentation:UNDEFINED
-missing-return-doc:34:0:34:11:my_func:Missing return documentation:UNDEFINED
-missing-return-type-doc:50:4:50:18:Foo.foo_method:Missing return type documentation:UNDEFINED
+missing-return-type-doc:7:0:7:11:my_func:Missing return type documentation:HIGH
+missing-return-doc:16:0:16:11:my_func:Missing return documentation:HIGH
+missing-return-doc:25:0:25:11:my_func:Missing return documentation:HIGH
+missing-return-type-doc:25:0:25:11:my_func:Missing return type documentation:HIGH
+missing-return-doc:34:0:34:11:my_func:Missing return documentation:HIGH
+missing-return-type-doc:50:4:50:18:Foo.foo_method:Missing return type documentation:HIGH
 unreachable:57:8:57:17:Foo.foo_method:Unreachable code:UNDEFINED
-missing-return-doc:66:4:66:18:Foo.foo_method:Missing return documentation:UNDEFINED
-missing-return-type-doc:66:4:66:18:Foo.foo_method:Missing return type documentation:UNDEFINED
+missing-return-doc:66:4:66:18:Foo.foo_method:Missing return documentation:HIGH
+missing-return-type-doc:66:4:66:18:Foo.foo_method:Missing return type documentation:HIGH
 unreachable:74:8:74:17:Foo.foo_method:Unreachable code:UNDEFINED

--- a/tests/functional/ext/docparams/return/missing_return_doc_required_Numpy.txt
+++ b/tests/functional/ext/docparams/return/missing_return_doc_required_Numpy.txt
@@ -1,11 +1,11 @@
-missing-return-doc:7:0:7:11:my_func:Missing return documentation:UNDEFINED
-missing-return-doc:22:0:22:11:my_func:Missing return documentation:UNDEFINED
-missing-return-type-doc:22:0:22:11:my_func:Missing return type documentation:UNDEFINED
-missing-return-doc:33:0:33:11:my_func:Missing return documentation:UNDEFINED
-missing-return-type-doc:50:4:50:16:Foo.foo_prop:Missing return type documentation:UNDEFINED
+missing-return-doc:7:0:7:11:my_func:Missing return documentation:HIGH
+missing-return-doc:22:0:22:11:my_func:Missing return documentation:HIGH
+missing-return-type-doc:22:0:22:11:my_func:Missing return type documentation:HIGH
+missing-return-doc:33:0:33:11:my_func:Missing return documentation:HIGH
+missing-return-type-doc:50:4:50:16:Foo.foo_prop:Missing return type documentation:HIGH
 unreachable:59:8:59:17:Foo.foo_prop:Unreachable code:UNDEFINED
-missing-return-doc:68:4:68:18:Foo.foo_method:Missing return documentation:UNDEFINED
-missing-return-type-doc:68:4:68:18:Foo.foo_method:Missing return type documentation:UNDEFINED
+missing-return-doc:68:4:68:18:Foo.foo_method:Missing return documentation:HIGH
+missing-return-type-doc:68:4:68:18:Foo.foo_method:Missing return type documentation:HIGH
 unreachable:78:8:78:17:Foo.foo_method:Unreachable code:UNDEFINED
-missing-return-doc:87:4:87:18:Foo.foo_method:Missing return documentation:UNDEFINED
+missing-return-doc:87:4:87:18:Foo.foo_method:Missing return documentation:HIGH
 unreachable:97:8:97:17:Foo.foo_method:Unreachable code:UNDEFINED

--- a/tests/functional/ext/docparams/return/missing_return_doc_required_Sphinx.txt
+++ b/tests/functional/ext/docparams/return/missing_return_doc_required_Sphinx.txt
@@ -1,9 +1,9 @@
-missing-return-type-doc:8:0:8:11:my_func:Missing return type documentation:UNDEFINED
-missing-return-doc:24:0:24:11:my_func:Missing return documentation:UNDEFINED
-missing-return-doc:32:0:32:31:warn_missing_sphinx_returns:Missing return documentation:UNDEFINED
-missing-return-type-doc:32:0:32:31:warn_missing_sphinx_returns:Missing return type documentation:UNDEFINED
-missing-return-doc:43:0:43:11:my_func:Missing return documentation:UNDEFINED
-missing-return-type-doc:58:4:58:11:Foo.foo:Missing return type documentation:UNDEFINED
+missing-return-type-doc:8:0:8:11:my_func:Missing return type documentation:HIGH
+missing-return-doc:24:0:24:11:my_func:Missing return documentation:HIGH
+missing-return-doc:32:0:32:31:warn_missing_sphinx_returns:Missing return documentation:HIGH
+missing-return-type-doc:32:0:32:31:warn_missing_sphinx_returns:Missing return type documentation:HIGH
+missing-return-doc:43:0:43:11:my_func:Missing return documentation:HIGH
+missing-return-type-doc:58:4:58:11:Foo.foo:Missing return type documentation:HIGH
 unreachable:64:8:64:17:Foo.foo:Unreachable code:UNDEFINED
-missing-return-doc:72:4:72:52:Foo.test_ignores_non_property_return_type_sphinx:Missing return documentation:UNDEFINED
-missing-return-type-doc:72:4:72:52:Foo.test_ignores_non_property_return_type_sphinx:Missing return type documentation:UNDEFINED
+missing-return-doc:72:4:72:52:Foo.test_ignores_non_property_return_type_sphinx:Missing return documentation:HIGH
+missing-return-type-doc:72:4:72:52:Foo.test_ignores_non_property_return_type_sphinx:Missing return type documentation:HIGH

--- a/tests/functional/ext/docparams/useless_type_doc.txt
+++ b/tests/functional/ext/docparams/useless_type_doc.txt
@@ -1,4 +1,4 @@
-useless-param-doc:34:0:34:24:function_useless_doc:"""_some_private_param"" useless ignored parameter documentation":UNDEFINED
-useless-type-doc:34:0:34:24:function_useless_doc:"""_some_private_param"" useless ignored parameter type documentation":UNDEFINED
-useless-param-doc:67:0:67:12:test_two:"""_new"" useless ignored parameter documentation":UNDEFINED
-useless-type-doc:67:0:67:12:test_two:"""_new"" useless ignored parameter type documentation":UNDEFINED
+useless-param-doc:34:0:34:24:function_useless_doc:"""_some_private_param"" useless ignored parameter documentation":HIGH
+useless-type-doc:34:0:34:24:function_useless_doc:"""_some_private_param"" useless ignored parameter type documentation":HIGH
+useless-param-doc:67:0:67:12:test_two:"""_new"" useless ignored parameter documentation":HIGH
+useless-type-doc:67:0:67:12:test_two:"""_new"" useless ignored parameter type documentation":HIGH

--- a/tests/functional/ext/docparams/yield/missing_yield_doc_required.txt
+++ b/tests/functional/ext/docparams/yield/missing_yield_doc_required.txt
@@ -1,2 +1,2 @@
-missing-yield-doc:6:0:6:11:my_func:Missing yield documentation:UNDEFINED
-missing-yield-type-doc:6:0:6:11:my_func:Missing yield type documentation:UNDEFINED
+missing-yield-doc:6:0:6:11:my_func:Missing yield documentation:HIGH
+missing-yield-type-doc:6:0:6:11:my_func:Missing yield type documentation:HIGH

--- a/tests/functional/ext/docparams/yield/missing_yield_doc_required_Google.txt
+++ b/tests/functional/ext/docparams/yield/missing_yield_doc_required_Google.txt
@@ -1,5 +1,5 @@
-missing-yield-doc:34:0:34:11:my_func:Missing yield documentation:UNDEFINED
-missing-yield-type-doc:43:0:43:11:my_func:Missing yield type documentation:UNDEFINED
-missing-yield-doc:52:0:52:11:my_func:Missing yield documentation:UNDEFINED
-missing-yield-doc:61:0:61:11:my_func:Missing yield documentation:UNDEFINED
-missing-yield-type-doc:61:0:61:11:my_func:Missing yield type documentation:UNDEFINED
+missing-yield-doc:34:0:34:11:my_func:Missing yield documentation:HIGH
+missing-yield-type-doc:43:0:43:11:my_func:Missing yield type documentation:HIGH
+missing-yield-doc:52:0:52:11:my_func:Missing yield documentation:HIGH
+missing-yield-doc:61:0:61:11:my_func:Missing yield documentation:HIGH
+missing-yield-type-doc:61:0:61:11:my_func:Missing yield type documentation:HIGH

--- a/tests/functional/ext/docparams/yield/missing_yield_doc_required_Numpy.txt
+++ b/tests/functional/ext/docparams/yield/missing_yield_doc_required_Numpy.txt
@@ -1,3 +1,3 @@
-missing-yield-doc:40:0:40:11:my_func:Missing yield documentation:UNDEFINED
-missing-yield-doc:50:0:50:11:my_func:Missing yield documentation:UNDEFINED
-missing-yield-type-doc:50:0:50:11:my_func:Missing yield type documentation:UNDEFINED
+missing-yield-doc:40:0:40:11:my_func:Missing yield documentation:HIGH
+missing-yield-doc:50:0:50:11:my_func:Missing yield documentation:HIGH
+missing-yield-type-doc:50:0:50:11:my_func:Missing yield type documentation:HIGH

--- a/tests/functional/ext/docparams/yield/missing_yield_doc_required_Sphinx.txt
+++ b/tests/functional/ext/docparams/yield/missing_yield_doc_required_Sphinx.txt
@@ -1,5 +1,5 @@
-missing-yield-doc:35:0:35:11:my_func:Missing yield documentation:UNDEFINED
-missing-yield-type-doc:43:0:43:11:my_func:Missing yield type documentation:UNDEFINED
-missing-yield-doc:51:0:51:11:my_func:Missing yield documentation:UNDEFINED
-missing-yield-doc:59:0:59:11:my_func:Missing yield documentation:UNDEFINED
-missing-yield-type-doc:59:0:59:11:my_func:Missing yield type documentation:UNDEFINED
+missing-yield-doc:35:0:35:11:my_func:Missing yield documentation:HIGH
+missing-yield-type-doc:43:0:43:11:my_func:Missing yield type documentation:HIGH
+missing-yield-doc:51:0:51:11:my_func:Missing yield documentation:HIGH
+missing-yield-doc:59:0:59:11:my_func:Missing yield documentation:HIGH
+missing-yield-type-doc:59:0:59:11:my_func:Missing yield type documentation:HIGH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

Add the confidence for the doc param checker and some minor refactors prior to #7212 


