### PR TITLE
Add the confidence for 'unreacheable' code

### DIFF
--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -738,19 +738,19 @@ class BasicChecker(_BasicChecker):
         self, node: nodes.Return | nodes.Continue | nodes.Break | nodes.Raise
     ) -> None:
         """Check unreachable code."""
-        unreach_stmt = node.next_sibling()
-        if unreach_stmt is not None:
+        unreachable_statement = node.next_sibling()
+        if unreachable_statement is not None:
             if (
                 isinstance(node, nodes.Return)
-                and isinstance(unreach_stmt, nodes.Expr)
-                and isinstance(unreach_stmt.value, nodes.Yield)
+                and isinstance(unreachable_statement, nodes.Expr)
+                and isinstance(unreachable_statement.value, nodes.Yield)
             ):
                 # Don't add 'unreachable' for empty generators.
                 # Only add warning if 'yield' is followed by another node.
-                unreach_stmt = unreach_stmt.next_sibling()
-                if unreach_stmt is None:
+                unreachable_statement = unreachable_statement.next_sibling()
+                if unreachable_statement is None:
                     return
-            self.add_message("unreachable", node=unreach_stmt)
+            self.add_message("unreachable", node=unreachable_statement, confidence=HIGH)
 
     def _check_not_in_finally(
         self,

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Sphinx.txt
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Sphinx.txt
@@ -30,10 +30,10 @@ inconsistent-return-statements:237:0:237:41:test_finds_kwargs_without_type_sphin
 inconsistent-return-statements:256:0:256:39:test_finds_args_without_type_sphinx:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
 inconsistent-return-statements:274:0:274:41:test_finds_kwargs_without_type_sphinx:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
 missing-raises-doc:299:4:299:11:Foo.foo:"""AttributeError"" not documented as being raised":HIGH
-unreachable:325:8:325:17:Foo.foo:Unreachable code:UNDEFINED
+unreachable:325:8:325:17:Foo.foo:Unreachable code:HIGH
 missing-param-doc:328:4:328:11:Foo.foo:"""value"" missing in parameter documentation":HIGH
 missing-raises-doc:328:4:328:11:Foo.foo:"""AttributeError"" not documented as being raised":HIGH
 missing-type-doc:328:4:328:11:Foo.foo:"""value"" missing in parameter type documentation":HIGH
-unreachable:364:8:364:17:Foo.foo:Unreachable code:UNDEFINED
+unreachable:364:8:364:17:Foo.foo:Unreachable code:HIGH
 useless-param-doc:368:4:368:55:Foo.test_useless_docs_ignored_argument_names_sphinx:"""_, _ignored"" useless ignored parameter documentation":HIGH
 useless-type-doc:368:4:368:55:Foo.test_useless_docs_ignored_argument_names_sphinx:"""_"" useless ignored parameter type documentation":HIGH

--- a/tests/functional/ext/docparams/raise/missing_raises_doc.txt
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc.txt
@@ -1,4 +1,4 @@
-unreachable:25:4:25:25:test_ignores_raise_uninferable:Unreachable code:UNDEFINED
+unreachable:25:4:25:25:test_ignores_raise_uninferable:Unreachable code:HIGH
 missing-raises-doc:28:0:28:45:test_ignores_returns_from_inner_functions:"""RuntimeError"" not documented as being raised":HIGH
-unreachable:42:4:42:25:test_ignores_returns_from_inner_functions:Unreachable code:UNDEFINED
+unreachable:42:4:42:25:test_ignores_returns_from_inner_functions:Unreachable code:HIGH
 raising-bad-type:54:4:54:22:test_ignores_returns_use_only_names:Raising int while only classes or instances are allowed:UNDEFINED

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_Google.txt
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_Google.txt
@@ -1,14 +1,14 @@
 missing-raises-doc:6:0:6:35:test_find_missing_google_raises:"""RuntimeError"" not documented as being raised":HIGH
-unreachable:13:4:13:25:test_find_missing_google_raises:Unreachable code:UNDEFINED
+unreachable:13:4:13:25:test_find_missing_google_raises:Unreachable code:HIGH
 missing-raises-doc:38:0:38:46:test_find_valid_missing_google_attr_raises:"""error"" not documented as being raised":HIGH
-unreachable:83:4:83:25:test_find_all_google_raises:Unreachable code:UNDEFINED
-unreachable:94:4:94:25:test_find_multiple_google_raises:Unreachable code:UNDEFINED
-unreachable:95:4:95:30:test_find_multiple_google_raises:Unreachable code:UNDEFINED
-unreachable:96:4:96:27:test_find_multiple_google_raises:Unreachable code:UNDEFINED
+unreachable:83:4:83:25:test_find_all_google_raises:Unreachable code:HIGH
+unreachable:94:4:94:25:test_find_multiple_google_raises:Unreachable code:HIGH
+unreachable:95:4:95:30:test_find_multiple_google_raises:Unreachable code:HIGH
+unreachable:96:4:96:27:test_find_multiple_google_raises:Unreachable code:HIGH
 missing-raises-doc:99:0:99:36:test_find_rethrown_google_raises:"""RuntimeError"" not documented as being raised":HIGH
 missing-raises-doc:113:0:113:45:test_find_rethrown_google_multiple_raises:"""RuntimeError, ValueError"" not documented as being raised":HIGH
 missing-raises-doc:148:4:148:18:Foo.foo_method:"""AttributeError"" not documented as being raised":HIGH
-unreachable:158:8:158:17:Foo.foo_method:Unreachable code:UNDEFINED
-unreachable:180:8:180:17:Foo.foo_method:Unreachable code:UNDEFINED
+unreachable:158:8:158:17:Foo.foo_method:Unreachable code:HIGH
+unreachable:180:8:180:17:Foo.foo_method:Unreachable code:HIGH
 missing-raises-doc:183:4:183:18:Foo.foo_method:"""AttributeError"" not documented as being raised":HIGH
 using-constant-test:190:11:190:15:Foo.foo_method:Using a conditional statement with a constant value:INFERENCE

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_Numpy.txt
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_Numpy.txt
@@ -1,11 +1,11 @@
 missing-raises-doc:11:0:11:34:test_find_missing_numpy_raises:"""RuntimeError"" not documented as being raised":HIGH
-unreachable:20:4:20:25:test_find_missing_numpy_raises:Unreachable code:UNDEFINED
-unreachable:34:4:34:25:test_find_all_numpy_raises:Unreachable code:UNDEFINED
+unreachable:20:4:20:25:test_find_missing_numpy_raises:Unreachable code:HIGH
+unreachable:34:4:34:25:test_find_all_numpy_raises:Unreachable code:HIGH
 missing-raises-doc:37:0:37:35:test_find_rethrown_numpy_raises:"""RuntimeError"" not documented as being raised":HIGH
 missing-raises-doc:53:0:53:44:test_find_rethrown_numpy_multiple_raises:"""RuntimeError, ValueError"" not documented as being raised":HIGH
 missing-raises-doc:111:0:111:45:test_find_valid_missing_numpy_attr_raises:"""error"" not documented as being raised":HIGH
 missing-raises-doc:146:4:146:11:Foo.foo:"""AttributeError"" not documented as being raised":HIGH
-unreachable:158:8:158:17:Foo.foo:Unreachable code:UNDEFINED
-unreachable:182:8:182:17:Foo.foo:Unreachable code:UNDEFINED
+unreachable:158:8:158:17:Foo.foo:Unreachable code:HIGH
+unreachable:182:8:182:17:Foo.foo:Unreachable code:HIGH
 missing-raises-doc:185:4:185:11:Foo.foo:"""AttributeError"" not documented as being raised":HIGH
-unreachable:215:8:215:17:Foo.foo:Unreachable code:UNDEFINED
+unreachable:215:8:215:17:Foo.foo:Unreachable code:HIGH

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_Sphinx.txt
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_Sphinx.txt
@@ -1,13 +1,13 @@
 missing-raises-doc:7:0:7:35:test_find_missing_sphinx_raises:"""RuntimeError"" not documented as being raised":HIGH
-unreachable:13:4:13:25:test_find_missing_sphinx_raises:Unreachable code:UNDEFINED
-unreachable:36:4:36:25:test_find_all_sphinx_raises:Unreachable code:UNDEFINED
-unreachable:37:4:37:30:test_find_all_sphinx_raises:Unreachable code:UNDEFINED
-unreachable:38:4:38:27:test_find_all_sphinx_raises:Unreachable code:UNDEFINED
-unreachable:48:4:48:25:test_find_multiple_sphinx_raises:Unreachable code:UNDEFINED
+unreachable:13:4:13:25:test_find_missing_sphinx_raises:Unreachable code:HIGH
+unreachable:36:4:36:25:test_find_all_sphinx_raises:Unreachable code:HIGH
+unreachable:37:4:37:30:test_find_all_sphinx_raises:Unreachable code:HIGH
+unreachable:38:4:38:27:test_find_all_sphinx_raises:Unreachable code:HIGH
+unreachable:48:4:48:25:test_find_multiple_sphinx_raises:Unreachable code:HIGH
 missing-raises-doc:51:0:51:37:test_finds_rethrown_sphinx_raises:"""RuntimeError"" not documented as being raised":HIGH
 missing-raises-doc:64:0:64:46:test_finds_rethrown_sphinx_multiple_raises:"""RuntimeError, ValueError"" not documented as being raised":HIGH
 missing-raises-doc:90:0:90:55:test_find_missing_sphinx_raises_infer_from_instance:"""RuntimeError"" not documented as being raised":HIGH
-unreachable:97:4:97:25:test_find_missing_sphinx_raises_infer_from_instance:Unreachable code:UNDEFINED
+unreachable:97:4:97:25:test_find_missing_sphinx_raises_infer_from_instance:Unreachable code:HIGH
 missing-raises-doc:100:0:100:55:test_find_missing_sphinx_raises_infer_from_function:"""RuntimeError"" not documented as being raised":HIGH
-unreachable:110:4:110:25:test_find_missing_sphinx_raises_infer_from_function:Unreachable code:UNDEFINED
+unreachable:110:4:110:25:test_find_missing_sphinx_raises_infer_from_function:Unreachable code:HIGH
 missing-raises-doc:133:0:133:46:test_find_valid_missing_sphinx_attr_raises:"""error"" not documented as being raised":HIGH

--- a/tests/functional/ext/docparams/return/missing_return_doc_Google.txt
+++ b/tests/functional/ext/docparams/return/missing_return_doc_Google.txt
@@ -1,7 +1,7 @@
 redundant-returns-doc:43:0:43:11:my_func:Redundant returns documentation:HIGH
 redundant-returns-doc:52:0:52:11:my_func:Redundant returns documentation:HIGH
 redundant-returns-doc:61:0:61:11:my_func:Redundant returns documentation:HIGH
-unreachable:95:8:95:17:Foo.foo_method:Unreachable code:UNDEFINED
-unreachable:112:8:112:17:Foo.foo_method:Unreachable code:UNDEFINED
+unreachable:95:8:95:17:Foo.foo_method:Unreachable code:HIGH
+unreachable:112:8:112:17:Foo.foo_method:Unreachable code:HIGH
 useless-param-doc:167:4:167:18:Foo.foo_method:"""_, _ignored"" useless ignored parameter documentation":HIGH
 useless-type-doc:167:4:167:18:Foo.foo_method:"""_"" useless ignored parameter type documentation":HIGH

--- a/tests/functional/ext/docparams/return/missing_return_doc_required_Google.txt
+++ b/tests/functional/ext/docparams/return/missing_return_doc_required_Google.txt
@@ -4,7 +4,7 @@ missing-return-doc:25:0:25:11:my_func:Missing return documentation:HIGH
 missing-return-type-doc:25:0:25:11:my_func:Missing return type documentation:HIGH
 missing-return-doc:34:0:34:11:my_func:Missing return documentation:HIGH
 missing-return-type-doc:50:4:50:18:Foo.foo_method:Missing return type documentation:HIGH
-unreachable:57:8:57:17:Foo.foo_method:Unreachable code:UNDEFINED
+unreachable:57:8:57:17:Foo.foo_method:Unreachable code:HIGH
 missing-return-doc:66:4:66:18:Foo.foo_method:Missing return documentation:HIGH
 missing-return-type-doc:66:4:66:18:Foo.foo_method:Missing return type documentation:HIGH
-unreachable:74:8:74:17:Foo.foo_method:Unreachable code:UNDEFINED
+unreachable:74:8:74:17:Foo.foo_method:Unreachable code:HIGH

--- a/tests/functional/ext/docparams/return/missing_return_doc_required_Numpy.txt
+++ b/tests/functional/ext/docparams/return/missing_return_doc_required_Numpy.txt
@@ -3,9 +3,9 @@ missing-return-doc:22:0:22:11:my_func:Missing return documentation:HIGH
 missing-return-type-doc:22:0:22:11:my_func:Missing return type documentation:HIGH
 missing-return-doc:33:0:33:11:my_func:Missing return documentation:HIGH
 missing-return-type-doc:50:4:50:16:Foo.foo_prop:Missing return type documentation:HIGH
-unreachable:59:8:59:17:Foo.foo_prop:Unreachable code:UNDEFINED
+unreachable:59:8:59:17:Foo.foo_prop:Unreachable code:HIGH
 missing-return-doc:68:4:68:18:Foo.foo_method:Missing return documentation:HIGH
 missing-return-type-doc:68:4:68:18:Foo.foo_method:Missing return type documentation:HIGH
-unreachable:78:8:78:17:Foo.foo_method:Unreachable code:UNDEFINED
+unreachable:78:8:78:17:Foo.foo_method:Unreachable code:HIGH
 missing-return-doc:87:4:87:18:Foo.foo_method:Missing return documentation:HIGH
-unreachable:97:8:97:17:Foo.foo_method:Unreachable code:UNDEFINED
+unreachable:97:8:97:17:Foo.foo_method:Unreachable code:HIGH

--- a/tests/functional/ext/docparams/return/missing_return_doc_required_Sphinx.txt
+++ b/tests/functional/ext/docparams/return/missing_return_doc_required_Sphinx.txt
@@ -4,6 +4,6 @@ missing-return-doc:32:0:32:31:warn_missing_sphinx_returns:Missing return documen
 missing-return-type-doc:32:0:32:31:warn_missing_sphinx_returns:Missing return type documentation:HIGH
 missing-return-doc:43:0:43:11:my_func:Missing return documentation:HIGH
 missing-return-type-doc:58:4:58:11:Foo.foo:Missing return type documentation:HIGH
-unreachable:64:8:64:17:Foo.foo:Unreachable code:UNDEFINED
+unreachable:64:8:64:17:Foo.foo:Unreachable code:HIGH
 missing-return-doc:72:4:72:52:Foo.test_ignores_non_property_return_type_sphinx:Missing return documentation:HIGH
 missing-return-type-doc:72:4:72:52:Foo.test_ignores_non_property_return_type_sphinx:Missing return type documentation:HIGH

--- a/tests/functional/u/unreachable.txt
+++ b/tests/functional/u/unreachable.txt
@@ -1,5 +1,5 @@
-unreachable:7:4:7:24:func1:Unreachable code:UNDEFINED
-unreachable:12:8:12:28:func2:Unreachable code:UNDEFINED
-unreachable:18:8:18:28:func3:Unreachable code:UNDEFINED
-unreachable:22:4:22:16:func4:Unreachable code:UNDEFINED
-unreachable:35:4:35:24:func6:Unreachable code:UNDEFINED
+unreachable:7:4:7:24:func1:Unreachable code:HIGH
+unreachable:12:8:12:28:func2:Unreachable code:HIGH
+unreachable:18:8:18:28:func3:Unreachable code:HIGH
+unreachable:22:4:22:16:func4:Unreachable code:HIGH
+unreachable:35:4:35:24:func6:Unreachable code:HIGH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

Add the confidence for unreachable prior to https://github.com/PyCQA/pylint/pull/7212 because the functional test for the doc param checker have a lot of 'unreachable' in them.
