### PR TITLE
Ignore path doc: double escape to add escape character in rst

### DIFF
--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -69,7 +69,7 @@ def _make_linter_options(linter: PyLinter) -> Options:
                 "default": [],
                 "help": "Add files or directories matching the regular expressions patterns to the "
                 "ignore-list. The regex matches against paths and can be in "
-                "Posix or Windows format. Because '\\' represents the directory delimiter "
+                "Posix or Windows format. Because '\\\\' represents the directory delimiter "
                 "on Windows systems, it can't be used as an escape character.",
             },
         ),


### PR DESCRIPTION
Adding another escape to small doc PR submitted in #7103, looks like the autoupgrade removed the escape.

CC @Pierre-Sassoulas 