### PR TITLE
[tests] Test no-member false positive on exception without str args

### DIFF
--- a/doc/whatsnew/fragments/7233.false_positive
+++ b/doc/whatsnew/fragments/7233.false_positive
@@ -1,0 +1,3 @@
+Fixed a false positive 'no-member' for first exception argument that were not a string. It's usually a string but not always.
+
+Closes #7233

--- a/tests/functional/r/regression_02/regression_7233.py
+++ b/tests/functional/r/regression_02/regression_7233.py
@@ -1,0 +1,22 @@
+"""Regression test for https://github.com/PyCQA/pylint/issues/7233"""
+
+# pylint: disable=missing-docstring
+
+from dataclasses import dataclass
+
+
+class MyHelloError(RuntimeError):
+    @property
+    def detail(self):
+        return self.args[0]
+
+
+@dataclass
+class ErrorInfo:
+    errorcode: int
+
+
+try:
+    raise MyHelloError(ErrorInfo(1234))
+except MyHelloError as exc:
+    print(exc.detail.errorcode)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description

Regression test for #7233, the fix is in https://github.com/PyCQA/astroid/pull/1722, it will require an astroid update.

Closes #7233
