### PR TITLE
Remove hard-coded default in 'ignored-argument-names' description

### DIFF
--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -1523,7 +1523,7 @@ Standard Checkers
 
 --ignored-argument-names
 """"""""""""""""""""""""
-*Argument names that match this expression will be ignored. Default to name with leading underscore.*
+*Argument names that match this expression will be ignored.*
 
 **Default:**  ``re.compile('_.*|^ignored_|^unused_')``
 

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -468,8 +468,7 @@ callbacks=cb_,
 # not be used).
 dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
 
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore.
+# Argument names that match this expression will be ignored.
 ignored-argument-names=_.*|^ignored_|^unused_
 
 # Tells whether we should check for unused import in __init__ files.

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -509,8 +509,7 @@ callbacks = ["cb_", "_cb"]
 # be used).
 dummy-variables-rgx = "_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_"
 
-# Argument names that match this expression will be ignored. Default to name with
-# leading underscore.
+# Argument names that match this expression will be ignored.
 ignored-argument-names = "_.*|^ignored_|^unused_"
 
 # Tells whether we should check for unused import in __init__ files.

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1056,8 +1056,7 @@ class VariablesChecker(BaseChecker):
                 "default": IGNORED_ARGUMENT_NAMES,
                 "type": "regexp",
                 "metavar": "<regexp>",
-                "help": "Argument names that match this expression will be "
-                "ignored. Default to name with leading underscore.",
+                "help": "Argument names that match this expression will be ignored.",
             },
         ),
         (


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

The default was out of date and we can use the real default value dynamically anyway.