### PR TITLE
[test] Temporary xfail deprecated methods py36 on pypy

### DIFF
--- a/tests/functional/d/deprecated/deprecated_methods_py36.rc
+++ b/tests/functional/d/deprecated/deprecated_methods_py36.rc
@@ -1,6 +1,3 @@
-[Imports]
-deprecated-modules=imp
-
 [testoptions]
 # TODO: Check if astroid 2.12.3 fixes this
 except_implementations=PyPy


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Maybe astroid 2.12.3 will fix this because of https://github.com/PyCQA/astroid/pull/1714 but this is taking some time to be released.
