### PR TITLE
Fix sys.path pollution in parallel mode

### DIFF
--- a/doc/whatsnew/fragments/7246.bugfix
+++ b/doc/whatsnew/fragments/7246.bugfix
@@ -1,0 +1,3 @@
+Fix sys.path pollution in parallel mode.
+
+Closes #7246

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -651,12 +651,14 @@ class PyLinter(
                     self.get_ast, self._iterate_file_descrs(files_or_modules)
                 )
         else:
+            original_sys_path = sys.path[:]
             check_parallel(
                 self,
                 self.config.jobs,
                 self._iterate_file_descrs(files_or_modules),
-                files_or_modules,
+                files_or_modules,  # this argument patches sys.path
             )
+            sys.path = original_sys_path
 
     def check_single_file(self, name: str, filepath: str, modname: str) -> None:
         warnings.warn(


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #7246

Extracted from #7117

I don't think it's worth adding a context manager just to handle this one fix.
