### PR TITLE
Improve docs clarity on loading custom checkers

### DIFF
--- a/doc/development_guide/how_tos/custom_checkers.rst
+++ b/doc/development_guide/how_tos/custom_checkers.rst
@@ -223,8 +223,7 @@ Now we can debug our checker!
 
     Alternatively, this module can be made available to pylint by
     putting this module's parent directory in your ``PYTHONPATH``
-    environment variable or by adding the ``my_plugin.py``
-    file to the ``pylint/checkers`` directory if running from source.
+    environment variable.
 
     If your pylint config has an init-hook that modifies
     ``sys.path`` to include the module's parent directory, this

--- a/doc/development_guide/how_tos/custom_checkers.rst
+++ b/doc/development_guide/how_tos/custom_checkers.rst
@@ -219,7 +219,8 @@ Now we can debug our checker!
 
     ``my_plugin`` refers to a module called ``my_plugin.py``.
     The preferred way of making this plugin available to pylint is
-    by installing it as a package, such as with ``pip install .``.
+    by installing it as a package. This can be done either from a packaging index like
+    ``PyPI`` or by installing it from a local source such as with ``pip install .``.
 
     Alternatively, the plugin module can be made available to pylint by
     putting this module's parent directory in your ``PYTHONPATH``

--- a/doc/development_guide/how_tos/custom_checkers.rst
+++ b/doc/development_guide/how_tos/custom_checkers.rst
@@ -225,10 +225,10 @@ Now we can debug our checker!
 
     If your pylint config has an init-hook that modifies
     ``sys.path`` to include the module's parent directory, this
-    will also work, but only if:
+    will also work, but only if either:
 
     * the ``init-hook`` and the ``load-plugins`` list are both
-      defined in a pylintrc file.
+      defined in a pylintrc file, or...
     * the ``init-hook`` is passed as a command-line argument and
       the ``load-plugins`` list is in the pylintrc file
 

--- a/doc/development_guide/how_tos/custom_checkers.rst
+++ b/doc/development_guide/how_tos/custom_checkers.rst
@@ -221,7 +221,7 @@ Now we can debug our checker!
     The preferred way of making this plugin available to pylint is
     by installing it as a package, such as with ``pip install .``.
 
-    Alternatively, this module can be made available to pylint by
+    Alternatively, the plugin module can be made available to pylint by
     putting this module's parent directory in your ``PYTHONPATH``
     environment variable.
 

--- a/doc/development_guide/how_tos/custom_checkers.rst
+++ b/doc/development_guide/how_tos/custom_checkers.rst
@@ -223,6 +223,18 @@ Now we can debug our checker!
     environment variable or by adding the ``my_plugin.py``
     file to the ``pylint/checkers`` directory if running from source.
 
+    If your pylint config has an init-hook that modifies
+    ``sys.path`` to include the module's parent directory, this
+    will also work, but only if:
+
+    * the ``init-hook`` and the ``load-plugins`` list are both
+      defined in a pylintrc file.
+    * the ``init-hook`` is passed as a command-line argument and
+      the ``load-plugins`` list is in the pylintrc file
+
+    This is because pylint loads plugins specified on command
+    line before loading any configuration from other sources.
+
 Defining a Message
 ------------------
 

--- a/doc/development_guide/how_tos/custom_checkers.rst
+++ b/doc/development_guide/how_tos/custom_checkers.rst
@@ -218,8 +218,11 @@ Now we can debug our checker!
 .. Note::
 
     ``my_plugin`` refers to a module called ``my_plugin.py``.
-    This module can be made available to pylint by putting this
-    module's parent directory in your ``PYTHONPATH``
+    The preferred way of making this plugin available to pylint is
+    by installing it as a package, such as with ``pip install .``.
+
+    Alternatively, this module can be made available to pylint by
+    putting this module's parent directory in your ``PYTHONPATH``
     environment variable or by adding the ``my_plugin.py``
     file to the ``pylint/checkers`` directory if running from source.
 

--- a/doc/whatsnew/fragments/7264.other
+++ b/doc/whatsnew/fragments/7264.other
@@ -1,0 +1,3 @@
+Dev documentation now clearer on custom checker loading.
+
+Closes #7264

--- a/doc/whatsnew/fragments/7264.other
+++ b/doc/whatsnew/fragments/7264.other
@@ -1,3 +1,3 @@
-Dev documentation now clearer on custom checker loading.
+Dev documentation is now clearer about custom checker loading.
 
 Closes #7264


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Write a good description on what the PR does.
- [x] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description
### Short
This PR just updates the documentation page on writing custom checkers. It adds
information about some restrictions between how `init-hook` changes the loading
path and when you can use that to import your custom module.
### Long (in the commit message)
Whilst the docs on testing custom checkers do touch on the fact the
module has to be in your load path, there are some restrictions that
were not made clear before.
Specifically, the init-hook configuration item (which is often used
explicitly to change the sys.path) is not automatically sufficient. If
the init hook is in a file, but the load-plugins argument is passed in
the CLI, then the plugins are loaded before the init-hook has run, and
so will not be imported. In this case, the failure can also be silent,
so the outcome is a lint that will simply not contain any information
from the checker, as opposed to a run that will error.
This corner case may merit fixing in a separate PR, that is to be
confirmed.

Closes #7264