### PR TITLE
Add more cases that emit bad-plugin-value

### DIFF
--- a/.pyenchant_pylint_custom_dict.txt
+++ b/.pyenchant_pylint_custom_dict.txt
@@ -49,6 +49,7 @@ classmethod
 classmethod's
 classname
 classobj
+CLI
 cls
 cmp
 codebase

--- a/doc/whatsnew/fragments/7264.bugfix
+++ b/doc/whatsnew/fragments/7264.bugfix
@@ -1,0 +1,8 @@
+Fixed a case where custom plugins specified by command line could silently fail
+
+Specifically, if a plugin relies on init-hook changing the system path before
+it can be imported, this will now emit a bad-plugin-value message. Before this
+change, it would silently fail to register the plugin for use, but would load
+any configuration, which could have unintended effects.
+
+Fixes part of #7264.

--- a/doc/whatsnew/fragments/7264.bugfix
+++ b/doc/whatsnew/fragments/7264.bugfix
@@ -1,7 +1,7 @@
-Fixed a case where custom plugins specified by command line could silently fail
+Fixed a case where custom plugins specified by command line could silently fail.
 
-Specifically, if a plugin relies on init-hook changing the system path before
-it can be imported, this will now emit a bad-plugin-value message. Before this
+Specifically, if a plugin relies on the ``init-hook`` option changing ``sys.path`` before
+it can be imported, this will now emit a ``bad-plugin-value`` message. Before this
 change, it would silently fail to register the plugin for use, but would load
 any configuration, which could have unintended effects.
 

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -391,7 +391,7 @@ class PyLinter(
         ..note::
             This function previously always tried to load modules again, which
             led to some confusion and silent failure conditions as described
-            in Github issue #7264. Making it use the stored result is more efficient, and
+            in GitHub issue #7264. Making it use the stored result is more efficient, and
             means that we avoid the ``init-hook`` problems from before.
         """
         for modname, module_or_error in self._dynamic_plugins.items():

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -382,7 +382,9 @@ class PyLinter(
         """
         for modname, module_or_error in self._dynamic_plugins.items():
             if isinstance(module_or_error, ModuleNotFoundError):
-                self.add_message("bad-plugin-value", args=(modname, module_or_error), line=0)
+                self.add_message(
+                    "bad-plugin-value", args=(modname, module_or_error), line=0
+                )
             elif hasattr(module_or_error, "load_configuration"):
                 module_or_error.load_configuration(self)
 

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -362,7 +362,7 @@ class PyLinter(
         reporters.initialize(self)
 
     def load_plugin_modules(self, modnames: list[str]) -> None:
-        """Check a list pylint plugins modules, load and register them.
+        """Check a list of pylint plugins modules, load and register them.
 
         If a module cannot be loaded, never try to load it again and instead
         store the error message for later use in ``load_plugin_configuration``
@@ -385,21 +385,17 @@ class PyLinter(
         hook, if exposed, and calls it to allow plugins to configure specific
         settings.
 
-        The dynamic plugins dictionary stores the result of attempting to load
-        the plugin of the given name in ``load_plugin_modules`` above.
+        The result of attempting to load the plugin of the given name
+        is stored in the dynamic plugins dictionary in ``load_plugin_modules`` above.
 
         ..note::
             This function previously always tried to load modules again, which
             led to some confusion and silent failure conditions as described
-            in #7264. Making it use the stored result is more efficient, and
+            in Github issue #7264. Making it use the stored result is more efficient, and
             means that we avoid the ``init-hook`` problems from before.
         """
         for modname, module_or_error in self._dynamic_plugins.items():
             if isinstance(module_or_error, ModuleNotFoundError):
-                # If we tried to import the module again now, it might actually
-                # succeed if init-hook changes to the syspath made it possible.
-                # It would import fine, and load configuration, but would not
-                # have been registered. Safer and cleaner to emit this message.
                 self.add_message(
                     "bad-plugin-value", args=(modname, module_or_error), line=0
                 )

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -362,7 +362,12 @@ class PyLinter(
         reporters.initialize(self)
 
     def load_plugin_modules(self, modnames: list[str]) -> None:
-        """Check a list pylint plugins modules, load and register them."""
+        """Check a list pylint plugins modules, load and register them.
+
+        If a module cannot be loaded, never try to load it again and instead
+        store the error message for later use in ``load_plugin_configuration``
+        below.
+        """
         for modname in modnames:
             if modname in self._dynamic_plugins:
                 continue
@@ -379,9 +384,22 @@ class PyLinter(
         This walks through the list of plugins, grabs the "load_configuration"
         hook, if exposed, and calls it to allow plugins to configure specific
         settings.
+
+        The dynamic plugins dictionary stores the result of attempting to load
+        the plugin of the given name in ``load_plugin_modules`` above.
+
+        ..note::
+            This function previously always tried to load modules again, which
+            led to some confusion and silent failure conditions as described
+            in #7264. Making it use the stored result is more efficient, and
+            means that we avoid the ``init-hook`` problems from before.
         """
         for modname, module_or_error in self._dynamic_plugins.items():
             if isinstance(module_or_error, ModuleNotFoundError):
+                # If we tried to import the module again now, it might actually
+                # succeed if init-hook changes to the syspath made it possible.
+                # It would import fine, and load configuration, but would not
+                # have been registered. Safer and cleaner to emit this message.
                 self.add_message(
                     "bad-plugin-value", args=(modname, module_or_error), line=0
                 )

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -60,7 +60,7 @@ else:
 
 
 @contextmanager
-def fake_home() -> Iterator[None]:
+def fake_home() -> Iterator[str]:
     folder = tempfile.mkdtemp("fake-home")
     old_home = os.environ.get(HOME)
     try:
@@ -526,13 +526,12 @@ def test_load_plugin_command_line() -> None:
 
 
 @pytest.mark.usefixtures("pop_pylintrc")
-@pytest.mark.xfail
 def test_load_plugin_command_line_with_inithook_in_config_bad_value() -> None:
     dummy_plugin_path = abspath(join(REGRTEST_DATA_DIR, "dummy_plugin"))
     with fake_home() as home_path:
         # construct a basic rc file that just modifies the path
         pylintrc_file = join(home_path, "pylintrc")
-        with open(pylintrc_file, "w") as out:
+        with open(pylintrc_file, "w", encoding="utf8") as out:
             out.writelines(
                 [
                     "[MASTER]\n",

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -1,6 +1,6 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
-# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
-# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+# For details: https://GitHub.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://GitHub.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
 # pylint: disable=redefined-outer-name
 
@@ -527,7 +527,7 @@ def test_load_plugin_command_line() -> None:
 
 @pytest.mark.usefixtures("pop_pylintrc")
 def test_load_plugin_path_manipulation_case_6() -> None:
-    """Case 6 refers to Github issue #7264.
+    """Case 6 refers to GitHub issue #7264.
 
     This is where we supply a plugin we want to load on both the CLI and
     config file, but that plugin is only loadable after the ``init-hook`` in
@@ -596,7 +596,7 @@ def test_load_plugin_path_manipulation_case_6() -> None:
 
 @pytest.mark.usefixtures("pop_pylintrc")
 def test_load_plugin_path_manipulation_case_3() -> None:
-    """Case 3 refers to Github issue #7264.
+    """Case 3 refers to GitHub issue #7264.
 
     This is where we supply a plugin we want to load on the CLI only,
     but that plugin is only loadable after the ``init-hook`` in
@@ -1098,7 +1098,7 @@ def test_recursive_ignore(ignore_parameter: str, ignore_parameter_value: str) ->
 
 
 def test_relative_imports(initialized_linter: PyLinter) -> None:
-    """Regression test for https://github.com/PyCQA/pylint/issues/3651"""
+    """Regression test for https://GitHub.com/PyCQA/pylint/issues/3651"""
     linter = initialized_linter
     with tempdir() as tmpdir:
         create_files(["x/y/__init__.py", "x/y/one.py", "x/y/two.py"], tmpdir)
@@ -1151,7 +1151,7 @@ print(submodule1)
 
 
 def test_lint_namespace_package_under_dir(initialized_linter: PyLinter) -> None:
-    """Regression test for https://github.com/PyCQA/pylint/issues/1667"""
+    """Regression test for https://GitHub.com/PyCQA/pylint/issues/1667"""
     linter = initialized_linter
     with tempdir():
         create_files(["outer/namespace/__init__.py", "outer/namespace/module.py"])

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -527,8 +527,8 @@ def test_load_plugin_command_line() -> None:
 
 @pytest.mark.usefixtures("pop_pylintrc")
 def test_load_plugin_path_manipulation_case_6() -> None:
-    """
-    Case 6 refers to issue #7264.
+    """Case 6 refers to Github issue #7264.
+
     This is where we supply a plugin we want to load on both the CLI and
     config file, but that plugin is only loadable after the ``init-hook`` in
     the config file has run. This is not supported, and was previously a silent
@@ -595,9 +595,9 @@ def test_load_plugin_path_manipulation_case_6() -> None:
 
 @pytest.mark.usefixtures("pop_pylintrc")
 def test_load_plugin_path_manipulation_case_3() -> None:
-    """
-    Case 3 refers to issue #7264.
-    This is where we supply a plugin we want to load on both the CLI only,
+    """Case 3 refers to Github issue #7264.
+
+    This is where we supply a plugin we want to load on the CLI only,
     but that plugin is only loadable after the ``init-hook`` in
     the config file has run. This is not supported, and was previously a silent
     failure. This test ensures a ``bad-plugin-value`` message is emitted.
@@ -661,6 +661,7 @@ def test_load_plugin_path_manipulation_case_3() -> None:
 
 
 def test_load_plugin_command_line_before_init_hook() -> None:
+    """Check that the order of 'load-plugins' and 'init-hook' doesn't affect execution."""
     regrtest_data_dir_abs = abspath(REGRTEST_DATA_DIR)
 
     run = Run(

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -680,7 +680,7 @@ def test_load_plugin_command_line_before_init_hook() -> None:
         len([ch.name for ch in run.linter.get_checkers() if ch.name == "dummy_plugin"])
         == 2
     )
-    
+
     # Necessary as the executed init-hook modifies sys.path
     sys.path.remove(regrtest_data_dir_abs)
 

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -590,6 +590,7 @@ def test_load_plugin_path_manipulation_case_6() -> None:
             ),
         )
 
+        # Necessary as the executed init-hook modifies sys.path
         sys.path.remove(home_path)
 
 
@@ -657,6 +658,7 @@ def test_load_plugin_path_manipulation_case_3() -> None:
             ),
         )
 
+        # Necessary as the executed init-hook modifies sys.path
         sys.path.remove(home_path)
 
 
@@ -678,11 +680,12 @@ def test_load_plugin_command_line_before_init_hook() -> None:
         len([ch.name for ch in run.linter.get_checkers() if ch.name == "dummy_plugin"])
         == 2
     )
-
+    
+    # Necessary as the executed init-hook modifies sys.path
     sys.path.remove(regrtest_data_dir_abs)
 
 
-def test_load_plugin_command_line_with_inithook_command_line() -> None:
+def test_load_plugin_command_line_with_init_hook_command_line() -> None:
     regrtest_data_dir_abs = abspath(REGRTEST_DATA_DIR)
 
     run = Run(
@@ -700,6 +703,7 @@ def test_load_plugin_command_line_with_inithook_command_line() -> None:
         == 2
     )
 
+    # Necessary as the executed init-hook modifies sys.path
     sys.path.remove(regrtest_data_dir_abs)
 
 

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -19,7 +19,7 @@ from io import StringIO
 from os import chdir, getcwd
 from os.path import abspath, dirname, join, sep
 from pathlib import Path
-from shutil import rmtree
+from shutil import copy, copytree, rmtree
 
 import platformdirs
 import pytest
@@ -65,7 +65,7 @@ def fake_home() -> Iterator[None]:
     old_home = os.environ.get(HOME)
     try:
         os.environ[HOME] = folder
-        yield
+        yield folder
     finally:
         os.environ.pop("PYLINTRC", "")
         if old_home is None:
@@ -523,6 +523,94 @@ def test_load_plugin_command_line() -> None:
     )
 
     sys.path.remove(dummy_plugin_path)
+
+
+@pytest.mark.usefixtures("pop_pylintrc")
+@pytest.mark.xfail
+def test_load_plugin_command_line_with_inithook_in_config_bad_value() -> None:
+    dummy_plugin_path = abspath(join(REGRTEST_DATA_DIR, "dummy_plugin"))
+    with fake_home() as home_path:
+        # construct a basic rc file that just modifies the path
+        pylintrc_file = join(home_path, "pylintrc")
+        with open(pylintrc_file, "w") as out:
+            out.writelines(
+                [
+                    "[MASTER]\n",
+                    f"init-hook=\"import sys; sys.path.append('{home_path}')\"\n",
+                ]
+            )
+
+        copytree(dummy_plugin_path, join(home_path , "copy_dummy"))
+
+        # To confirm we won't load this module _without_ the init hook running.
+        assert home_path not in sys.path
+
+        run = Run(
+            [
+                "--rcfile",
+                pylintrc_file,
+                "--load-plugins",
+                "copy_dummy",
+                join(REGRTEST_DATA_DIR, "empty.py"),
+            ],
+            reporter=testutils.GenericTestReporter(),
+            exit=False,
+        )
+        assert run._rcfile == pylintrc_file
+        assert home_path in sys.path
+        # The module should not be loaded
+        assert (
+            len(
+                [ch.name for ch in run.linter.get_checkers() if ch.name == "copy_dummy"]
+            )
+            == 0
+        )
+
+        # There should be a bad-plugin-message for this module
+        assert len(run.linter.reporter.messages) == 1
+        assert run.linter.reporter.messages[0] == Message(
+            msg_id="E0013",
+            symbol="bad-plugin-value",
+            msg="Plugin 'copy_dummy' is impossible to load, is it installed ? ('No module named 'copy_dummy'')",
+            confidence=interfaces.Confidence(
+                name="UNDEFINED",
+                description="Warning without any associated confidence level.",
+            ),
+            location=MessageLocationTuple(
+                abspath="Command line or configuration file",
+                path="Command line or configuration file",
+                module="Command line or configuration file",
+                obj="",
+                line=1,
+                column=0,
+                end_line=None,
+                end_column=None,
+            ),
+        )
+
+
+        sys.path.remove(home_path)
+
+
+def test_load_plugin_command_line_with_inithook_command_line() -> None:
+    regrtest_data_dir_abs = abspath(REGRTEST_DATA_DIR)
+
+    run = Run(
+        [
+            "--init-hook",
+            f'import sys; sys.path.append("{regrtest_data_dir_abs}")',
+            "--load-plugins",
+            "dummy_plugin",
+            join(REGRTEST_DATA_DIR, "empty.py"),
+        ],
+        exit=False,
+    )
+    assert (
+        len([ch.name for ch in run.linter.get_checkers() if ch.name == "dummy_plugin"])
+        == 2
+    )
+
+    sys.path.remove(regrtest_data_dir_abs)
 
 
 def test_load_plugin_config_file() -> None:

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -19,7 +19,7 @@ from io import StringIO
 from os import chdir, getcwd
 from os.path import abspath, dirname, join, sep
 from pathlib import Path
-from shutil import copy, copytree, rmtree
+from shutil import copytree, rmtree
 
 import platformdirs
 import pytest
@@ -540,7 +540,7 @@ def test_load_plugin_command_line_with_inithook_in_config_bad_value() -> None:
                 ]
             )
 
-        copytree(dummy_plugin_path, join(home_path , "copy_dummy"))
+        copytree(dummy_plugin_path, join(home_path, "copy_dummy"))
 
         # To confirm we won't load this module _without_ the init hook running.
         assert home_path not in sys.path
@@ -587,7 +587,6 @@ def test_load_plugin_command_line_with_inithook_in_config_bad_value() -> None:
                 end_column=None,
             ),
         )
-
 
         sys.path.remove(home_path)
 

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -1,6 +1,6 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
-# For details: https://GitHub.com/PyCQA/pylint/blob/main/LICENSE
-# Copyright (c) https://GitHub.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
 # pylint: disable=redefined-outer-name
 

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -524,6 +524,7 @@ def test_load_plugin_command_line() -> None:
 
     sys.path.remove(dummy_plugin_path)
 
+
 @pytest.mark.usefixtures("pop_pylintrc")
 def test_load_plugin_command_line_and_config_with_inithook_in_config_bad_value() -> None:
     dummy_plugin_path = abspath(join(REGRTEST_DATA_DIR, "dummy_plugin"))
@@ -535,8 +536,7 @@ def test_load_plugin_command_line_and_config_with_inithook_in_config_bad_value()
                 [
                     "[MASTER]\n",
                     f"init-hook=\"import sys; sys.path.append('{home_path}')\"\n",
-                    "load-plugins=copy_dummy\n"
-
+                    "load-plugins=copy_dummy\n",
                 ]
             )
 
@@ -589,6 +589,7 @@ def test_load_plugin_command_line_and_config_with_inithook_in_config_bad_value()
         )
 
         sys.path.remove(home_path)
+
 
 @pytest.mark.usefixtures("pop_pylintrc")
 def test_load_plugin_command_line_with_inithook_in_config_bad_value() -> None:

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -1098,7 +1098,7 @@ def test_recursive_ignore(ignore_parameter: str, ignore_parameter_value: str) ->
 
 
 def test_relative_imports(initialized_linter: PyLinter) -> None:
-    """Regression test for https://GitHub.com/PyCQA/pylint/issues/3651"""
+    """Regression test for https://github.com/PyCQA/pylint/issues/3651"""
     linter = initialized_linter
     with tempdir() as tmpdir:
         create_files(["x/y/__init__.py", "x/y/one.py", "x/y/two.py"], tmpdir)
@@ -1151,7 +1151,7 @@ print(submodule1)
 
 
 def test_lint_namespace_package_under_dir(initialized_linter: PyLinter) -> None:
-    """Regression test for https://GitHub.com/PyCQA/pylint/issues/1667"""
+    """Regression test for https://github.com/PyCQA/pylint/issues/1667"""
     linter = initialized_linter
     with tempdir():
         create_files(["outer/namespace/__init__.py", "outer/namespace/module.py"])

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -535,7 +535,7 @@ def test_load_plugin_command_line_and_config_with_inithook_in_config_bad_value()
             out.writelines(
                 [
                     "[MASTER]\n",
-                    f"init-hook=\"import sys; sys.path.append('{home_path}')\"\n",
+                    f"init-hook=\"import sys; sys.path.append(r'{home_path}')\"\n",
                     "load-plugins=copy_dummy\n",
                 ]
             )
@@ -601,7 +601,7 @@ def test_load_plugin_command_line_with_inithook_in_config_bad_value() -> None:
             out.writelines(
                 [
                     "[MASTER]\n",
-                    f"init-hook=\"import sys; sys.path.append('{home_path}')\"\n",
+                    f"init-hook=\"import sys; sys.path.append(r'{home_path}')\"\n",
                 ]
             )
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [X] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [X] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

As per #7264, this PR will make the changes covered the lines marked with ❗ in the following table. The table is about the relationship between the `load-plugins` and `init-hook` arguments/configuration options.

| # | Passed on CLI | Supplied in pylintrc | Can be imported before init | Can be imported after init | Current Behaviour | Desired Behaviour | Done |
| -- | -- | -- | -- | -- | -- | -- | -- |
| 1 | ✅ | 🚫 | 🚫 | 🚫 | Emit bad-plugin-value | Emit bad-plugin-value | N/A |
| 2 | 🚫 | ✅ | 🚫 | 🚫 | Emit bad-plugin-value | Emit bad-plugin-value | N/A |
| 3 | ✅ | 🚫 | 🚫 | ✅ | Do not register, but do import config, no emit | ❗ **Emit bad-plugin-value** | ✅  |
| 4| 🚫 | ✅ | 🚫 | ✅ | Load as normal, works fine, no warnings | ❗ **Emit bad-plugin-value** | ❌ |
| 5| ✅ | ✅ | 🚫 | 🚫 | Emit bad-plugin-value | Emit bad-plugin-value | N/A
| 6 | ✅ | ✅ | 🚫 | ✅ | Do not register, but do import config, no emit | ❗ **Emit bad-plugin-value** | ✅  |
| 7 | ✅ | 🚫 | 🟡 (because of cli init hook) | 🚫 | Works perfectly | ❗ **Emit bad-plugin-value** | ❌ |

Refs #7264