### PR TITLE
Fix false positive for `no-self-argument`

### DIFF
--- a/doc/whatsnew/fragments/7300.false_positive
+++ b/doc/whatsnew/fragments/7300.false_positive
@@ -1,0 +1,3 @@
+Fix false positive for `no-self-argument` when a staticmethod is applied to a function but uses a different name.
+
+Closes #7300

--- a/doc/whatsnew/fragments/7300.false_positive
+++ b/doc/whatsnew/fragments/7300.false_positive
@@ -1,3 +1,3 @@
-Fix false positive for `no-self-argument` when a staticmethod is applied to a function but uses a different name.
+Fix false positive for `no-self-argument`/`no-method-argument` when a staticmethod is applied to a function but uses a different name.
 
 Closes #7300

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1926,7 +1926,7 @@ a metaclass class method.",
                 self.add_message("bad-staticmethod-argument", args=first, node=node)
                 return
             self._first_attrs[-1] = None
-        elif any(name == "builtins.staticmethod" for name in node.decoratornames()):
+        elif "builtins.staticmethod" in node.decoratornames():
             # Check if there is a decorator which is not named `staticmethod` but is assigned to one.
             return
         # class / regular method with no args

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1926,6 +1926,9 @@ a metaclass class method.",
                 self.add_message("bad-staticmethod-argument", args=first, node=node)
                 return
             self._first_attrs[-1] = None
+        elif any(name == "builtins.staticmethod" for name in node.decoratornames()):
+            # Check if there is a decorator which is not named `staticmethod` but is assigned to one.
+            return
         # class / regular method with no args
         elif not node.args.args and not node.args.posonlyargs:
             self.add_message("no-method-argument", node=node)

--- a/tests/functional/n/no/no_self_argument.py
+++ b/tests/functional/n/no/no_self_argument.py
@@ -35,6 +35,6 @@ class NoSelfArgument:
         print("goodbye!")
 
     @returns_staticmethod
-    def sum_strings(string1, string2):
+    def concatenate_strings(string1, string2):
         """A staticmethod created by `returns_staticmethod` function"""
         return string1 + string2

--- a/tests/functional/n/no/no_self_argument.py
+++ b/tests/functional/n/no/no_self_argument.py
@@ -1,8 +1,15 @@
 """Check for method without self as first argument"""
-# pylint: disable=useless-object-inheritance
-from __future__ import print_function
 
-class NoSelfArgument(object):
+
+MYSTATICMETHOD = staticmethod
+
+
+def returns_staticmethod(my_function):
+    """Create a staticmethod from function `my_function`"""
+    return staticmethod(my_function)
+
+
+class NoSelfArgument:
     """dummy class"""
 
     def __init__(truc):  # [no-self-argument]
@@ -16,3 +23,18 @@ class NoSelfArgument(object):
     def edf(self):
         """just another method"""
         print('yapudju in', self)
+
+    @staticmethod
+    def say_hello():
+        """A standard staticmethod"""
+        print("hello!")
+
+    @MYSTATICMETHOD
+    def say_goodbye():
+        """A staticmethod but using a different name"""
+        print("goodbye!")
+
+    @returns_staticmethod
+    def sum_strings(string1, string2):
+        """A staticmethod created by `returns_staticmethod` function"""
+        return string1 + string2

--- a/tests/functional/n/no/no_self_argument.txt
+++ b/tests/functional/n/no/no_self_argument.txt
@@ -1,2 +1,2 @@
-no-self-argument:8:4:8:16:NoSelfArgument.__init__:"Method should have ""self"" as first argument":UNDEFINED
-no-self-argument:12:4:12:12:NoSelfArgument.abdc:"Method should have ""self"" as first argument":UNDEFINED
+no-self-argument:15:4:15:16:NoSelfArgument.__init__:"Method should have ""self"" as first argument":UNDEFINED
+no-self-argument:19:4:19:12:NoSelfArgument.abdc:"Method should have ""self"" as first argument":UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
Fix false positive for `no-self-argument` when a staticmethod is applied to a function but uses a different name.

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #7300
