### PR TITLE
Fix linting namespace packages under a directory on `sys.path`

### DIFF
--- a/doc/whatsnew/fragments/7303.bugfix
+++ b/doc/whatsnew/fragments/7303.bugfix
@@ -1,0 +1,3 @@
+Fix an unreleased regression that prevented linting namespace packages under a parent directory on `sys.path`.
+
+Refs #7303

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -82,10 +82,8 @@ def expand_modules(
             continue
         module_path = get_python_path(something)
         additional_search_path = [".", module_path] + path
-        if os.path.isfile(something) or os.path.exists(
-            os.path.join(something, "__init__.py")
-        ):
-            # this is a file or a directory with an explicit __init__.py
+        if os.path.exists(something):
+            # this is a file or a directory
             try:
                 modname = ".".join(
                     modutils.modpath_from_file(something, path=additional_search_path)
@@ -93,7 +91,11 @@ def expand_modules(
             except ImportError:
                 modname = os.path.splitext(basename)[0]
             if os.path.isdir(something):
-                filepath = os.path.join(something, "__init__.py")
+                init_path = os.path.join(something, "__init__.py")
+                if os.path.exists(init_path):
+                    filepath = init_path
+                else:
+                    filepath = module_path
             else:
                 filepath = something
         else:

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -944,6 +944,18 @@ def test_lint_namespace_package_under_dir(initialized_linter: PyLinter) -> None:
     assert not linter.stats.by_msg
 
 
+def test_lint_namespace_package_under_dir_on_path(initialized_linter: PyLinter) -> None:
+    """If the directory above a namespace package is on sys.path,
+    the namespace module under it is linted."""
+    linter = initialized_linter
+    with tempdir() as tmpdir:
+        create_files(["namespace_on_path/submodule1.py"])
+        os.chdir(tmpdir)
+        with fix_import_path([tmpdir]):
+            linter.check(["namespace_on_path"])
+    assert linter.file_state.base_name == "namespace_on_path"
+
+
 def test_identically_named_nested_module(initialized_linter: PyLinter) -> None:
     with tempdir():
         create_files(["identical/identical.py"])


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fixes an unreleased regression in #7114. Namespace packages under a directory on `sys.path` weren't being linted.