### PR TITLE
Revert "Fix the failure to lint modules contained under an identically named directory"

### DIFF
--- a/doc/whatsnew/fragments/4444.bugfix
+++ b/doc/whatsnew/fragments/4444.bugfix
@@ -1,3 +1,0 @@
-Fix the failure to lint modules contained under an identically named directory.
-
-Closes #4444

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -82,10 +82,8 @@ def expand_modules(
             continue
         module_path = get_python_path(something)
         additional_search_path = [".", module_path] + path
-        if os.path.isfile(something) or os.path.exists(
-            os.path.join(something, "__init__.py")
-        ):
-            # this is a file or a directory with an explicit __init__.py
+        if os.path.exists(something):
+            # this is a file or a directory
             try:
                 modname = ".".join(
                     modutils.modpath_from_file(something, path=additional_search_path)

--- a/tests/checkers/unittest_imports.py
+++ b/tests/checkers/unittest_imports.py
@@ -61,8 +61,7 @@ class TestImportsChecker(CheckerTestCase):
         )
         output2, errors2 = capsys.readouterr()
 
-        # The first package fails to lint
-        assert len(output.split("\n")) == 1
+        assert len(output.split("\n")) == 5
         assert len(output2.split("\n")) == 5
         assert errors == errors2
 

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -942,12 +942,3 @@ def test_lint_namespace_package_under_dir(initialized_linter: PyLinter) -> None:
         create_files(["outer/namespace/__init__.py", "outer/namespace/module.py"])
         linter.check(["outer.namespace"])
     assert not linter.stats.by_msg
-
-
-def test_identically_named_nested_module(initialized_linter: PyLinter) -> None:
-    with tempdir():
-        create_files(["identical/identical.py"])
-        with open("identical/identical.py", "w", encoding="utf-8") as f:
-            f.write("import imp")
-        initialized_linter.check(["identical"])
-    assert initialized_linter.stats.by_msg["deprecated-module"] == 1

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -942,3 +942,15 @@ def test_lint_namespace_package_under_dir(initialized_linter: PyLinter) -> None:
         create_files(["outer/namespace/__init__.py", "outer/namespace/module.py"])
         linter.check(["outer.namespace"])
     assert not linter.stats.by_msg
+
+
+def test_lint_namespace_package_under_dir_on_path(initialized_linter: PyLinter) -> None:
+    """If the directory above a namespace package is on sys.path,
+    the namespace module under it is linted."""
+    linter = initialized_linter
+    with tempdir() as tmpdir:
+        create_files(["namespace_on_path/submodule1.py"])
+        os.chdir(tmpdir)
+        with fix_import_path([tmpdir]):
+            linter.check(["namespace_on_path"])
+    assert linter.file_state.base_name == "namespace_on_path"


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Fixes the failure to lint namespace packages under a directory on `sys.path`. Will need to reopen #4444 and find a new solution for it.
