### PR TITLE
[doc] Remove dead link to the mail archives prior to 2013

### DIFF
--- a/doc/contact.rst
+++ b/doc/contact.rst
@@ -37,8 +37,8 @@ https://mail.python.org/mailman3/lists/code-quality.python.org/
 Archives are available at
 https://mail.python.org/pipermail/code-quality/
 
-Archives before April 2013 are available at
-https://lists.logilab.org/pipermail/python-projects/
+Archives before April 2013 are not available anymore. At
+https://mail.python.org/pipermail/ it was under ``python-projects``.
 
 Support
 -------


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

I think the link is permanently down, no idea where this discussion is now and I never used it myself.
