### PR TITLE
Improve TypeVar name regex

### DIFF
--- a/doc/data/messages/i/invalid-name/details.rst
+++ b/doc/data/messages/i/invalid-name/details.rst
@@ -84,7 +84,7 @@ The following type of names are checked with a predefined pattern:
 | Name type          | Good names                                        | Bad names                                                  |
 +====================+===================================================+============================================================+
 | ``typevar``        | ``T``, ``_CallableT``, ``_T_co``, ``AnyStr``,     | ``DICT_T``, ``CALLABLE_T``, ``ENUM_T``, ``DeviceType``,    |
-|                    | ``DeviceTypeT``, ``IPAddressT``                   | ``_StrType``                                               |
+|                    | ``DeviceTypeT``, ``IPAddressT``                   | ``_StrType``, ``TAnyStr``                                  |
 +--------------------+---------------------------------------------------+------------------------------------------------------------+
 
 Custom regular expressions

--- a/doc/whatsnew/fragments/7322.false-positive
+++ b/doc/whatsnew/fragments/7322.false-positive
@@ -1,2 +1,4 @@
 Improve default TypeVar name regex. Disallow names prefixed with ``T``.
 E.g. use ``AnyStrT`` instead of ``TAnyStr``.
+
+Refs #7322

--- a/doc/whatsnew/fragments/7322.false-positive
+++ b/doc/whatsnew/fragments/7322.false-positive
@@ -1,0 +1,2 @@
+Improve default TypeVar name regex. Disallow names prefixed with ``T`` or ``Type``.
+E.g. use ``AnyStrT`` instead of ``TAnyStr``.

--- a/doc/whatsnew/fragments/7322.false-positive
+++ b/doc/whatsnew/fragments/7322.false-positive
@@ -1,2 +1,2 @@
-Improve default TypeVar name regex. Disallow names prefixed with ``T`` or ``Type``.
+Improve default TypeVar name regex. Disallow names prefixed with ``T``.
 E.g. use ``AnyStrT`` instead of ``TAnyStr``.

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -39,7 +39,7 @@ _BadNamesTuple = Tuple[nodes.NodeNG, str, str, interfaces.Confidence]
 # Default patterns for name types that do not have styles
 DEFAULT_PATTERNS = {
     "typevar": re.compile(
-        r"^_{0,2}(?:[^\W\da-z_]+|(?:[^\W\da-z_]+[^\WA-Z_]+)+T?(?<!Type))(?:_co(?:ntra)?)?$"
+        r"^_{0,2}(?!T[A-Z]|Type)(?:[A-Z]+|(?:[A-Z]+[a-z]+)+T?(?<!Type))(?:_co(?:ntra)?)?$"
     )
 }
 

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -39,7 +39,7 @@ _BadNamesTuple = Tuple[nodes.NodeNG, str, str, interfaces.Confidence]
 # Default patterns for name types that do not have styles
 DEFAULT_PATTERNS = {
     "typevar": re.compile(
-        r"^_{0,2}(?!T[A-Z]|Type)(?:[A-Z]+|(?:[A-Z]+[a-z]+)+T?(?<!Type))(?:_co(?:ntra)?)?$"
+        r"^_{0,2}(?!T[A-Z])(?:[A-Z]+|(?:[A-Z]+[a-z]+)+T?(?<!Type))(?:_co(?:ntra)?)?$"
     )
 }
 

--- a/tests/functional/a/assigning/assigning_non_slot.py
+++ b/tests/functional/a/assigning/assigning_non_slot.py
@@ -164,10 +164,10 @@ from typing import (
     TypeVar,
 )
 
-TYPE = TypeVar('TYPE')
+TypeT = TypeVar('TypeT')
 
 
-class Cls(Generic[TYPE]):
+class Cls(Generic[TypeT]):
     """ Simple class with slots """
     __slots__ = ['value']
 

--- a/tests/functional/t/typevar_naming_style_default.py
+++ b/tests/functional/t/typevar_naming_style_default.py
@@ -32,6 +32,7 @@ AnyStr = TypeVar("AnyStr")
 DeviceTypeT = TypeVar("DeviceTypeT")
 HVACModeT = TypeVar("HVACModeT")
 TodoT = TypeVar("TodoT")
+TypeT = TypeVar("TypeT")
 _IPAddress = TypeVar("_IPAddress")
 CALLABLE_T = TypeVar("CALLABLE_T")  # [invalid-name]
 DeviceType = TypeVar("DeviceType")  # [invalid-name]
@@ -39,7 +40,6 @@ IPAddressU = TypeVar("IPAddressU")  # [invalid-name]
 
 # Wrong prefix
 TAnyStr = TypeVar("TAnyStr")  # [invalid-name]
-TypeAnyStr = TypeVar("TypeAnyStr")  # [invalid-name]
 
 # camelCase names with prefix
 badName = TypeVar("badName")  # [invalid-name]

--- a/tests/functional/t/typevar_naming_style_default.py
+++ b/tests/functional/t/typevar_naming_style_default.py
@@ -31,10 +31,15 @@ T_contra = TypeVar("T_contra", covariant=False, contravariant=True)
 AnyStr = TypeVar("AnyStr")
 DeviceTypeT = TypeVar("DeviceTypeT")
 HVACModeT = TypeVar("HVACModeT")
+TodoT = TypeVar("TodoT")
 _IPAddress = TypeVar("_IPAddress")
 CALLABLE_T = TypeVar("CALLABLE_T")  # [invalid-name]
 DeviceType = TypeVar("DeviceType")  # [invalid-name]
 IPAddressU = TypeVar("IPAddressU")  # [invalid-name]
+
+# Wrong prefix
+TAnyStr = TypeVar("TAnyStr")  # [invalid-name]
+TypeAnyStr = TypeVar("TypeAnyStr")  # [invalid-name]
 
 # camelCase names with prefix
 badName = TypeVar("badName")  # [invalid-name]

--- a/tests/functional/t/typevar_naming_style_default.txt
+++ b/tests/functional/t/typevar_naming_style_default.txt
@@ -5,13 +5,15 @@ typevar-double-variance:23:0:23:4::TypeVar cannot be both covariant and contrava
 typevar-name-incorrect-variance:23:0:23:4::Type variable name does not reflect variance:INFERENCE
 typevar-double-variance:24:0:24:8::TypeVar cannot be both covariant and contravariant:INFERENCE
 typevar-name-incorrect-variance:24:0:24:8::Type variable name does not reflect variance:INFERENCE
-invalid-name:35:0:35:10::"Type variable name ""CALLABLE_T"" doesn't conform to predefined naming style":HIGH
-invalid-name:36:0:36:10::"Type variable name ""DeviceType"" doesn't conform to predefined naming style":HIGH
-invalid-name:37:0:37:10::"Type variable name ""IPAddressU"" doesn't conform to predefined naming style":HIGH
-invalid-name:40:0:40:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
-invalid-name:41:0:41:10::"Type variable name ""badName_co"" doesn't conform to predefined naming style":HIGH
-invalid-name:42:0:42:14::"Type variable name ""badName_contra"" doesn't conform to predefined naming style":HIGH
-invalid-name:46:4:46:13::"Type variable name ""a_BadName"" doesn't conform to predefined naming style":HIGH
-invalid-name:47:4:47:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to predefined naming style":HIGH
-typevar-name-incorrect-variance:47:4:47:26::"Type variable name does not reflect variance. ""a_BadNameWithoutContra"" is contravariant, use ""a_BadNameWithoutContra_contra"" instead":INFERENCE
-invalid-name:49:13:49:29::"Type variable name ""a_BadName_contra"" doesn't conform to predefined naming style":HIGH
+invalid-name:36:0:36:10::"Type variable name ""CALLABLE_T"" doesn't conform to predefined naming style":HIGH
+invalid-name:37:0:37:10::"Type variable name ""DeviceType"" doesn't conform to predefined naming style":HIGH
+invalid-name:38:0:38:10::"Type variable name ""IPAddressU"" doesn't conform to predefined naming style":HIGH
+invalid-name:41:0:41:7::"Type variable name ""TAnyStr"" doesn't conform to predefined naming style":HIGH
+invalid-name:42:0:42:10::"Type variable name ""TypeAnyStr"" doesn't conform to predefined naming style":HIGH
+invalid-name:45:0:45:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
+invalid-name:46:0:46:10::"Type variable name ""badName_co"" doesn't conform to predefined naming style":HIGH
+invalid-name:47:0:47:14::"Type variable name ""badName_contra"" doesn't conform to predefined naming style":HIGH
+invalid-name:51:4:51:13::"Type variable name ""a_BadName"" doesn't conform to predefined naming style":HIGH
+invalid-name:52:4:52:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to predefined naming style":HIGH
+typevar-name-incorrect-variance:52:4:52:26::"Type variable name does not reflect variance. ""a_BadNameWithoutContra"" is contravariant, use ""a_BadNameWithoutContra_contra"" instead":INFERENCE
+invalid-name:54:13:54:29::"Type variable name ""a_BadName_contra"" doesn't conform to predefined naming style":HIGH

--- a/tests/functional/t/typevar_naming_style_default.txt
+++ b/tests/functional/t/typevar_naming_style_default.txt
@@ -5,11 +5,10 @@ typevar-double-variance:23:0:23:4::TypeVar cannot be both covariant and contrava
 typevar-name-incorrect-variance:23:0:23:4::Type variable name does not reflect variance:INFERENCE
 typevar-double-variance:24:0:24:8::TypeVar cannot be both covariant and contravariant:INFERENCE
 typevar-name-incorrect-variance:24:0:24:8::Type variable name does not reflect variance:INFERENCE
-invalid-name:36:0:36:10::"Type variable name ""CALLABLE_T"" doesn't conform to predefined naming style":HIGH
-invalid-name:37:0:37:10::"Type variable name ""DeviceType"" doesn't conform to predefined naming style":HIGH
-invalid-name:38:0:38:10::"Type variable name ""IPAddressU"" doesn't conform to predefined naming style":HIGH
-invalid-name:41:0:41:7::"Type variable name ""TAnyStr"" doesn't conform to predefined naming style":HIGH
-invalid-name:42:0:42:10::"Type variable name ""TypeAnyStr"" doesn't conform to predefined naming style":HIGH
+invalid-name:37:0:37:10::"Type variable name ""CALLABLE_T"" doesn't conform to predefined naming style":HIGH
+invalid-name:38:0:38:10::"Type variable name ""DeviceType"" doesn't conform to predefined naming style":HIGH
+invalid-name:39:0:39:10::"Type variable name ""IPAddressU"" doesn't conform to predefined naming style":HIGH
+invalid-name:42:0:42:7::"Type variable name ""TAnyStr"" doesn't conform to predefined naming style":HIGH
 invalid-name:45:0:45:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
 invalid-name:46:0:46:10::"Type variable name ""badName_co"" doesn't conform to predefined naming style":HIGH
 invalid-name:47:0:47:14::"Type variable name ""badName_contra"" doesn't conform to predefined naming style":HIGH


### PR DESCRIPTION
## Description
Small improvements for the `TypeVar` name regex.

* Simplify `[^\W\da-z_]` to `[A-Z]`
* Add negative lookahead to prevent `T` or `Type` prefix. E.g. `TAnyStr` should be marked as `invalid-name`.