### PR TITLE
Prevent `useless-parent-delegation` for overriding builtins with new args

### DIFF
--- a/doc/whatsnew/fragments/7319.bugfix
+++ b/doc/whatsnew/fragments/7319.bugfix
@@ -1,0 +1,4 @@
+Prevent `useless-parent-delegation` for delegating to a builtin
+written in C (e.g. `Exception.__init__`) with non-self arguments.
+
+Closes #7319

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1290,6 +1290,8 @@ a metaclass class method.",
                 or _has_different_parameters_default_value(
                     meth_node.args, function.args
                 )
+                # arguments to builtins such as Exception.__init__() cannot be inspected
+                or (meth_node.args.args is None and function.argnames() != ["self"])
             ):
                 return
             break

--- a/tests/functional/u/useless/useless_parent_delegation.py
+++ b/tests/functional/u/useless/useless_parent_delegation.py
@@ -425,3 +425,8 @@ class Fruit:
 class Lemon(Fruit):
     def __init__(*, tastes_bitter=True):
         super().__init__(tastes_bitter=tastes_bitter)
+
+
+class CustomError(Exception):
+    def __init__(self, message="default"):
+        super().__init__(message)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
`useless-parent-delegation` tries to be smart enough to detect when there are different default values to an overridden method's arguments and then silence itself--but it was not capturing the case where the source method is uninspectable (e.g. written in C.)

Now, we check for that, but we still catch trivial delegations (e.g. only "self" and no other arguments).

Closes #7319
