### PR TITLE
Don't emit ``trailing-whitespace`` twice for multi-line docstrings

### DIFF
--- a/doc/whatsnew/fragments/6936.false_positive
+++ b/doc/whatsnew/fragments/6936.false_positive
@@ -1,0 +1,3 @@
+Fix double emitting ``trailing-whitespace`` for multi-line docstrings.
+
+Closes #6936

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -406,7 +406,7 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
                     self.new_line(TokenWrapper(tokens), idx - 1, idx + 1)
                 # A tokenizer oddity: if a line contains a multi-line string,
                 # the NEWLINE also gets its own token which we already checked in
-                # the multi-line docstring case.
+                # the multi-line docstring case. See https://github.com/PyCQA/pylint/issues/6936
                 elif tok_type == tokenize.NEWLINE:
                     pass
                 else:

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -406,7 +406,8 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
                     self.new_line(TokenWrapper(tokens), idx - 1, idx + 1)
                 # A tokenizer oddity: if a line contains a multi-line string,
                 # the NEWLINE also gets its own token which we already checked in
-                # the multi-line docstring case. See https://github.com/PyCQA/pylint/issues/6936
+                # the multi-line docstring case.
+                # See https://github.com/PyCQA/pylint/issues/6936
                 elif tok_type == tokenize.NEWLINE:
                     pass
                 else:

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -29,6 +29,7 @@ from pylint.checkers.utils import (
     only_required_for_messages,
 )
 from pylint.constants import WarningScope
+from pylint.interfaces import HIGH
 from pylint.typing import MessageDefinitionTuple
 from pylint.utils.pragma_parser import OPTION_PO, PragmaParserError, parse_pragma
 
@@ -403,6 +404,11 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
                 # the full line; therefore we check the next token on the line.
                 if tok_type == tokenize.INDENT:
                     self.new_line(TokenWrapper(tokens), idx - 1, idx + 1)
+                # A tokenizer oddity: if a line contains a multi-line string,
+                # the NEWLINE also gets its own token which we already checked in
+                # the multi-line docstring case.
+                elif tok_type == tokenize.NEWLINE:
+                    pass
                 else:
                     self.new_line(TokenWrapper(tokens), idx - 1, idx)
 
@@ -584,7 +590,10 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
         stripped_line = line.rstrip("\t\n\r\v ")
         if line[len(stripped_line) :] not in ("\n", "\r\n"):
             self.add_message(
-                "trailing-whitespace", line=i, col_offset=len(stripped_line)
+                "trailing-whitespace",
+                line=i,
+                col_offset=len(stripped_line),
+                confidence=HIGH,
             )
 
     def check_line_length(self, line: str, i: int, checker_off: bool) -> None:

--- a/tests/functional/t/trailing_whitespaces.py
+++ b/tests/functional/t/trailing_whitespaces.py
@@ -1,5 +1,5 @@
 """Regression test for trailing-whitespace (C0303)."""
-# pylint: disable=mixed-line-endings
+# pylint: disable=mixed-line-endings,pointless-string-statement
 
 # +1: [trailing-whitespace]
 print('some trailing whitespace')   
@@ -8,3 +8,13 @@ print('trailing whitespace does not count towards the line length limit')
 print('windows line ends are ok')
 # +1: [trailing-whitespace]
 print('but trailing whitespace on win is not')   
+
+# Regression test for https://github.com/PyCQA/pylint/issues/6936
+# +2: [trailing-whitespace]
+""" This module has the Board class.
+""" 
+
+# +3: [trailing-whitespace]
+""" This module has the Board class.
+It's a very nice Board.
+""" 

--- a/tests/functional/t/trailing_whitespaces.txt
+++ b/tests/functional/t/trailing_whitespaces.txt
@@ -1,3 +1,5 @@
-trailing-whitespace:5:33:None:None::Trailing whitespace:UNDEFINED
-trailing-whitespace:7:73:None:None::Trailing whitespace:UNDEFINED
-trailing-whitespace:10:46:None:None::Trailing whitespace:UNDEFINED
+trailing-whitespace:5:33:None:None::Trailing whitespace:HIGH
+trailing-whitespace:7:73:None:None::Trailing whitespace:HIGH
+trailing-whitespace:10:46:None:None::Trailing whitespace:HIGH
+trailing-whitespace:15:3:None:None::Trailing whitespace:HIGH
+trailing-whitespace:20:3:None:None::Trailing whitespace:HIGH


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #6936 and also updates the confidence.