### PR TITLE
Upgrade astroid version following 2.12.4 release

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   # Also change CACHE_VERSION in the other workflows
-  CACHE_VERSION: 21
+  CACHE_VERSION: 22
   DEFAULT_PYTHON: "3.10"
 
 jobs:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -8,7 +8,7 @@ on:
   pull_request: ~
 
 env:
-  CACHE_VERSION: 21
+  CACHE_VERSION: 22
   DEFAULT_PYTHON: "3.10"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
 

--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/primer-test.yaml"
 
 env:
-  CACHE_VERSION: 21
+  CACHE_VERSION: 22
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -14,7 +14,7 @@ on:
 
 env:
   # This needs to be the SAME as in the Main and PR job
-  CACHE_VERSION: 21
+  CACHE_VERSION: 22
 
 permissions:
   contents: read

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   # This needs to be the SAME as in the PR and comment job
-  CACHE_VERSION: 21
+  CACHE_VERSION: 22
 
 jobs:
   run-primer:

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -25,7 +25,7 @@ concurrency:
 
 env:
   # This needs to be the SAME as in the Main and comment job
-  CACHE_VERSION: 21
+  CACHE_VERSION: 22
 
 jobs:
   run-primer:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ on:
       - doc/data/messages/**
 
 env:
-  CACHE_VERSION: 21
+  CACHE_VERSION: 22
 
 jobs:
   tests-linux:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies    = [
     # Also upgrade requirements_test_min.txt if you are bumping astroid.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/PyCQA/astroid/issues/1341
-    "astroid>=2.12.3,<=2.14.0-dev0",
+    "astroid>=2.12.4,<=2.14.0-dev0",
     "isort>=4.2.5,<6",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 -e .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==2.12.3  # Pinned to a specific version for tests
+astroid==2.12.4  # Pinned to a specific version for tests
 typing-extensions~=4.3
 pytest~=7.1
 pytest-benchmark~=3.4


### PR DESCRIPTION
Required to be done as a standalone before #7355 because the primer can't work when we upgrade astroid.