### PR TITLE
Update `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 2.4
+minversion = 3.0
 envlist = formatting, py37, py38, py39, py310, pypy, benchmark
 skip_missing_interpreters = true
 requires = pip >=21.3.1
@@ -7,23 +7,21 @@ isolated_build = true
 
 [testenv:pylint]
 deps =
-    -r {toxinidir}/requirements_test_min.txt
-    pre-commit~=2.13
+    -r {toxinidir}/requirements_test.txt
 commands =
     pre-commit run pylint --all-files
 
 [testenv:formatting]
 basepython = python3
 deps =
-    -r {toxinidir}/requirements_test_min.txt
-    pre-commit~=2.13
+    -r {toxinidir}/requirements_test.txt
 commands =
     pre-commit run --all-files
 
 [testenv:mypy]
 basepython = python3
 deps =
-    pre-commit~=2.13
+    pre-commit~=2.20
 commands =
     pre-commit run mypy --all-files
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
|    | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
- Install `requirements_test.txt` into `formatting` & `pylint` environments.
  `import-error` was showing during the `pylint` run for `contributors-txt` & `colorama` in these two environments.
- Bump `minversion` to match the version in `requirements_test.txt`.
- Bump `pre-commit` dependency version in the `mypy` environment to match the version in `requirements_test.txt`.

```python
************* Module script.create_contributor_list
script/create_contributor_list.py:7:0: E0401: Unable to import 'contributors_txt' (import-error)
************* Module pylint.reporters.text
pylint/reporters/text.py:282:16: E0401: Unable to import 'colorama' (import-error)
```

Testing
```python
tox -e pylint -r
tox -e formatting -r
```

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->
