### PR TITLE
Fix `used-before-assignment` for functions/classes defined in type checking guard

### DIFF
--- a/doc/whatsnew/fragments/7368.false_positive
+++ b/doc/whatsnew/fragments/7368.false_positive
@@ -1,0 +1,3 @@
+Fix ``used-before-assignment`` for functions/classes defined in type checking guard.
+
+Closes #7368

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1841,7 +1841,6 @@ class VariablesChecker(BaseChecker):
         base_scope_type,
         is_recursive_klass,
     ) -> tuple[bool, bool, bool]:
-        # pylint: disable=too-many-nested-blocks
         maybe_before_assign = True
         annotation_return = False
         use_outer_definition = False
@@ -2014,8 +2013,13 @@ class VariablesChecker(BaseChecker):
                                 for target in definition.targets
                                 if isinstance(target, nodes.AssignName)
                             )
-                            if defined_in_or_else:
-                                break
+                        elif isinstance(
+                            definition, (nodes.ClassDef, nodes.FunctionDef)
+                        ):
+                            defined_in_or_else = definition.name == node.name
+
+                        if defined_in_or_else:
+                            break
 
                     if not used_in_branch and not defined_in_or_else:
                         maybe_before_assign = True

--- a/tests/functional/u/undefined/undefined_variable.py
+++ b/tests/functional/u/undefined/undefined_variable.py
@@ -267,15 +267,24 @@ if TYPE_CHECKING:
 if TYPE_CHECKING:
     from collections import Counter
     from collections import OrderedDict
+    from collections import defaultdict
+    from collections import UserDict
 else:
     Counter = object
     OrderedDict = object
+    def defaultdict():
+        return {}
+    class UserDict(dict):
+        pass
 
 
 def tick(counter: Counter, name: str, dictionary: OrderedDict) -> OrderedDict:
     counter[name] += 1
     return dictionary
 
+defaultdict()
+
+UserDict()
 
 # pylint: disable=unused-argument
 def not_using_loop_variable_accordingly(iterator):

--- a/tests/functional/u/undefined/undefined_variable.txt
+++ b/tests/functional/u/undefined/undefined_variable.txt
@@ -28,12 +28,12 @@ undefined-variable:171:4:171:13::Undefined variable 'unicode_3':UNDEFINED
 undefined-variable:226:25:226:37:LambdaClass4.<lambda>:Undefined variable 'LambdaClass4':UNDEFINED
 undefined-variable:234:25:234:37:LambdaClass5.<lambda>:Undefined variable 'LambdaClass5':UNDEFINED
 used-before-assignment:255:26:255:34:func_should_fail:Using variable 'datetime' before assignment:HIGH
-undefined-variable:282:18:282:24:not_using_loop_variable_accordingly:Undefined variable 'iteree':UNDEFINED
-undefined-variable:299:27:299:28:undefined_annotation:Undefined variable 'x':UNDEFINED
-used-before-assignment:300:7:300:8:undefined_annotation:Using variable 'x' before assignment:HIGH
-undefined-variable:330:11:330:12:decorated3:Undefined variable 'x':UNDEFINED
-undefined-variable:335:19:335:20:decorated4:Undefined variable 'y':UNDEFINED
-undefined-variable:356:10:356:20:global_var_mixed_assignment:Undefined variable 'GLOBAL_VAR':HIGH
-undefined-variable:368:19:368:44:RepeatedReturnAnnotations.x:Undefined variable 'RepeatedReturnAnnotations':UNDEFINED
-undefined-variable:370:19:370:44:RepeatedReturnAnnotations.y:Undefined variable 'RepeatedReturnAnnotations':UNDEFINED
-undefined-variable:372:19:372:44:RepeatedReturnAnnotations.z:Undefined variable 'RepeatedReturnAnnotations':UNDEFINED
+undefined-variable:291:18:291:24:not_using_loop_variable_accordingly:Undefined variable 'iteree':UNDEFINED
+undefined-variable:308:27:308:28:undefined_annotation:Undefined variable 'x':UNDEFINED
+used-before-assignment:309:7:309:8:undefined_annotation:Using variable 'x' before assignment:HIGH
+undefined-variable:339:11:339:12:decorated3:Undefined variable 'x':UNDEFINED
+undefined-variable:344:19:344:20:decorated4:Undefined variable 'y':UNDEFINED
+undefined-variable:365:10:365:20:global_var_mixed_assignment:Undefined variable 'GLOBAL_VAR':HIGH
+undefined-variable:377:19:377:44:RepeatedReturnAnnotations.x:Undefined variable 'RepeatedReturnAnnotations':UNDEFINED
+undefined-variable:379:19:379:44:RepeatedReturnAnnotations.y:Undefined variable 'RepeatedReturnAnnotations':UNDEFINED
+undefined-variable:381:19:381:44:RepeatedReturnAnnotations.z:Undefined variable 'RepeatedReturnAnnotations':UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [X] Write a good description on what the PR does.
- [X] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [N/A] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #7368

This PR fixes the following false-positive:

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from typing_extensions import assert_type
else:

    def assert_type(val, _):
        return val

ANSWER = 42
assert_type(ANSWER, int)  # E0601: Using variable 'assert_type' before assignment (used-before-assignment)
```

The issue comes from definitions in the `else` block of a `if` type-guard.

In 3159b1744caee14068b4d875bb5adaa5ffbebd44 the case was already handled for assignments, I had only added cases for function and class that are defined in the `else` part.