### PR TITLE
Added documentation examples for `bad-format-string-key`

### DIFF
--- a/doc/data/messages/b/bad-format-string-key/bad.py
+++ b/doc/data/messages/b/bad-format-string-key/bad.py
@@ -1,0 +1,1 @@
+print("%(one)d" % {"one": 1, 2: 2})  # [bad-format-string-key]

--- a/doc/data/messages/b/bad-format-string-key/details.rst
+++ b/doc/data/messages/b/bad-format-string-key/details.rst
@@ -1,1 +1,6 @@
-You can help us make the doc better `by contributing <https://github.com/PyCQA/pylint/issues/5953>`_ !
+This check only works for old-style string formatting using the '%' operator.
+
+This check only works if the dictionary with the values to be formatted is defined inline.
+Passing a variable will not trigger the check as the other keys in this dictionary may be
+used in other contexts, while an inline defined dictionary is clearly only intended to hold
+the values that should be formatted.

--- a/doc/data/messages/b/bad-format-string-key/good.py
+++ b/doc/data/messages/b/bad-format-string-key/good.py
@@ -1,1 +1,1 @@
-# This is a placeholder for correct code for this message.
+print("%(one)d, %(two)d" % {"one": 1, "two": 2})


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description
Documentation examples for `bad-format-string-key`.

Refs #5953

