### PR TITLE
Added documentation examples for `redefined-outer-name`

### DIFF
--- a/doc/data/messages/r/redefined-outer-name/bad.py
+++ b/doc/data/messages/r/redefined-outer-name/bad.py
@@ -1,0 +1,6 @@
+count = 10
+
+
+def count_it(count):  # [redefined-outer-name]
+    for i in range(count):
+        print(i)

--- a/doc/data/messages/r/redefined-outer-name/details.rst
+++ b/doc/data/messages/r/redefined-outer-name/details.rst
@@ -1,1 +1,23 @@
-You can help us make the doc better `by contributing <https://github.com/PyCQA/pylint/issues/5953>`_ !
+A common issue is that this message is triggered when using `pytest` `fixtures <https://docs.pytest.org/en/7.1.x/how-to/fixtures.html>`_:
+
+.. code-block:: python
+
+    import pytest
+
+    @pytest.fixture
+    def setup():
+        ...
+
+
+    def test_something(setup):  # [redefined-outer-name]
+        ...
+
+One solution to this problem is to explicitly name the fixture:
+
+.. code-block:: python
+
+    @pytest.fixture(name="setup")
+    def setup_fixture():
+        ...
+
+Alternatively `pylint` plugins like `pylint-pytest <https://pypi.org/project/pylint-pytest/>`_ can be used.

--- a/doc/data/messages/r/redefined-outer-name/good.py
+++ b/doc/data/messages/r/redefined-outer-name/good.py
@@ -1,1 +1,6 @@
-# This is a placeholder for correct code for this message.
+count = 10
+
+
+def count_it(limit):
+    for i in range(limit):
+        print(i)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Refs #5953
