### PR TITLE
Fix crash while iteraring over a class attribute

### DIFF
--- a/doc/whatsnew/fragments/7380.bugfix
+++ b/doc/whatsnew/fragments/7380.bugfix
@@ -1,3 +1,3 @@
-Fixed a crash with ``for`` loops that iterate over class attributes.
+Update ``modified_iterating`` checker to fix a crash with ``for`` loops on empty list
 
 Closes #7380

--- a/doc/whatsnew/fragments/7380.bugfix
+++ b/doc/whatsnew/fragments/7380.bugfix
@@ -1,3 +1,3 @@
-Update ``modified_iterating`` checker to fix a crash with ``for`` loops on empty list
+Update ``modified_iterating`` checker to fix a crash with ``for`` loops on empty list.
 
 Closes #7380

--- a/doc/whatsnew/fragments/7380.bugfix
+++ b/doc/whatsnew/fragments/7380.bugfix
@@ -1,0 +1,3 @@
+Fixed a crash with ``for`` loops that iterate over class attributes.
+
+Closes #7380

--- a/pylint/checkers/modified_iterating_checker.py
+++ b/pylint/checkers/modified_iterating_checker.py
@@ -81,7 +81,7 @@ class ModifiedIterationChecker(checkers.BaseChecker):
                 msg_id = "modified-iterating-dict"
             elif isinstance(inferred, nodes.Set):
                 msg_id = "modified-iterating-set"
-        elif not isinstance(iter_obj, nodes.Name):
+        elif not isinstance(iter_obj, (nodes.Name, nodes.Attribute)):
             pass
         elif self._modified_iterating_list_cond(node, iter_obj):
             msg_id = "modified-iterating-list"
@@ -90,10 +90,14 @@ class ModifiedIterationChecker(checkers.BaseChecker):
         elif self._modified_iterating_set_cond(node, iter_obj):
             msg_id = "modified-iterating-set"
         if msg_id:
+            if isinstance(iter_obj, nodes.Attribute):
+                obj_name = iter_obj.attrname
+            else:
+                obj_name = iter_obj.name
             self.add_message(
                 msg_id,
                 node=node,
-                args=(iter_obj.name,),
+                args=(obj_name,),
                 confidence=interfaces.INFERENCE,
             )
 

--- a/tests/functional/m/modified_iterating.py
+++ b/tests/functional/m/modified_iterating.py
@@ -26,7 +26,7 @@ my_dict = {"1": 1, "2": 2, "3": 3}
 i = 1
 for item in my_dict:
     item_list[0] = i  # for coverage, see reference at /pull/5628#discussion_r792181642
-    my_dict[i] = 1      # [modified-iterating-dict]
+    my_dict[i] = 1  # [modified-iterating-dict]
     i += 1
 
 i = 1
@@ -93,3 +93,15 @@ def update_existing_key():
     for key in my_dict:
         new_key = key.lower()
         my_dict[new_key] = 1  # [modified-iterating-dict]
+
+
+class MyClass:  # pylint: disable=too-few-public-methods
+    """Regression test for https://github.com/PyCQA/pylint/issues/7380"""
+
+    def __init__(self) -> None:
+        self.attribute = [1, 2, 3]
+
+    def my_method(self):
+        """This should raise as we are deleting."""
+        for var in self.attribute:
+            del var  # [modified-iterating-list]

--- a/tests/functional/m/modified_iterating.py
+++ b/tests/functional/m/modified_iterating.py
@@ -1,5 +1,5 @@
 """Tests for iterating-modified messages"""
-# pylint: disable=not-callable,unnecessary-comprehension
+# pylint: disable=not-callable,unnecessary-comprehension,too-few-public-methods
 
 import copy
 
@@ -95,7 +95,7 @@ def update_existing_key():
         my_dict[new_key] = 1  # [modified-iterating-dict]
 
 
-class MyClass:  # pylint: disable=too-few-public-methods
+class MyClass:
     """Regression test for https://github.com/PyCQA/pylint/issues/7380"""
 
     def __init__(self) -> None:

--- a/tests/functional/m/modified_iterating.txt
+++ b/tests/functional/m/modified_iterating.txt
@@ -13,3 +13,4 @@ modified-iterating-list:64:4:64:23::Iterated list 'item_list' is being modified 
 modified-iterating-list:67:12:67:31::Iterated list 'item_list' is being modified inside for loop body, consider iterating through a copy of it instead.:INFERENCE
 modified-iterating-list:69:16:69:35::Iterated list 'item_list' is being modified inside for loop body, consider iterating through a copy of it instead.:INFERENCE
 modified-iterating-dict:95:8:95:28:update_existing_key:Iterated dict 'my_dict' is being modified inside for loop body, iterate through a copy of it instead.:INFERENCE
+modified-iterating-list:107:12:107:19:MyClass.my_method:Iterated list 'attribute' is being modified inside for loop body, consider iterating through a copy of it instead.:INFERENCE


### PR DESCRIPTION
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a ChangeLog entry describing what your PR does.
- [x] If it's a new feature, or an important bug fix, add a What's New entry in
      `doc/whatsnew/<current release.rst>`.
- [x] Write a good description on what the PR does.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #7380

@orSolocate I haven't created an issue for this but:

```python
class MyClass:
    def __init__(self) -> None:
        self.attribute = [1, 2, 3]

   def my_other_method(self):
        """This should raise as we are appending."""
        for var in self.attribute:
            self.attribute.append(var)  # [modified-iterating-list]
```

Currently doesn't raise like it should.

This would require quite a bit of refactoring in the current checker as it isn't really suited for checking class attributes. I'm not sure and there is no obligation, but perhaps you find this interesting and want to look into it?