### PR TITLE
Fix #3299 false positives with names in string literal type annotations

### DIFF
--- a/doc/whatsnew/fragments/3299.false_positive
+++ b/doc/whatsnew/fragments/3299.false_positive
@@ -1,0 +1,3 @@
+Fix false positive for ``unused-variable`` and ``unused-import`` when a name is only used in a string literal type annotation.
+
+Closes #3299

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1891,6 +1891,25 @@ def in_type_checking_block(node: nodes.NodeNG) -> bool:
     return False
 
 
+def is_typing_literal(node: nodes.NodeNG) -> bool:
+    """Check if a node refers to typing.Literal."""
+    if isinstance(node, nodes.Name):
+        import_from = node.lookup(node.name)[1][0]
+        if isinstance(import_from, nodes.ImportFrom):
+            return (
+                import_from.modname == "typing"
+                and import_from.real_name(node.name) == "Literal"
+            )
+    elif isinstance(node, nodes.Attribute):
+        inferred_module = safe_infer(node.expr)
+        return (
+            isinstance(inferred_module, nodes.Module)
+            and inferred_module.name == "typing"
+            and node.attrname == "Literal"
+        )
+    return False
+
+
 @lru_cache()
 def in_for_else_branch(parent: nodes.NodeNG, stmt: nodes.Statement) -> bool:
     """Returns True if stmt is inside the else branch for a parent For stmt."""

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1894,7 +1894,10 @@ def in_type_checking_block(node: nodes.NodeNG) -> bool:
 def is_typing_literal(node: nodes.NodeNG) -> bool:
     """Check if a node refers to typing.Literal."""
     if isinstance(node, nodes.Name):
-        import_from = node.lookup(node.name)[1][0]
+        try:
+            import_from = node.lookup(node.name)[1][0]
+        except IndexError:
+            return False
         if isinstance(import_from, nodes.ImportFrom):
             return (
                 import_from.modname == "typing"

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2922,9 +2922,15 @@ class VariablesChecker(BaseChecker):
         if not utils.is_node_in_type_annotation_context(node):
             return
         if not node.value.isidentifier():
-            annotation = extract_node(node.value)
-            self._store_type_annotation_node(annotation)
-            return
+            try:
+                annotation = extract_node(node.value)
+                self._store_type_annotation_node(annotation)
+            except ValueError:
+                # e.g. node.value is whitespace
+                return
+            except astroid.AstroidSyntaxError:
+                # e.g. "?" or ":" in typing.Literal["?", ":"]
+                return
 
         # Check if parent's or grandparent's first child is typing.Literal
         parent = node.parent

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -19,7 +19,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 import astroid
-from astroid import nodes
+from astroid import extract_node, nodes
 from astroid.typing import InferenceResult
 
 from pylint.checkers import BaseChecker, utils
@@ -2922,6 +2922,8 @@ class VariablesChecker(BaseChecker):
         if not utils.is_node_in_type_annotation_context(node):
             return
         if not node.value.isidentifier():
+            annotation = extract_node(node.value)
+            self._store_type_annotation_node(annotation)
             return
 
         # Check if parent's or grandparent's first child is typing.Literal

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2913,9 +2913,8 @@ class VariablesChecker(BaseChecker):
         "unused-variable",
     )
     def visit_const(self, node: nodes.Const) -> None:
-        """Take note of names that appear inside string literal type annotations...
-
-        ...Unless the string is a parameter to typing.Literal.
+        """Take note of names that appear inside string literal type annotations
+        unless the string is a parameter to typing.Literal.
         """
         if node.pytype() != "builtins.str":
             return
@@ -2926,7 +2925,7 @@ class VariablesChecker(BaseChecker):
                 annotation = extract_node(node.value)
                 self._store_type_annotation_node(annotation)
             except ValueError:
-                # e.g. node.value is whitespace
+                # e.g. node.value is white space
                 return
             except astroid.AstroidSyntaxError:
                 # e.g. "?" or ":" in typing.Literal["?", ":"]

--- a/tests/checkers/unittest_utils.py
+++ b/tests/checkers/unittest_utils.py
@@ -489,3 +489,29 @@ def test_deprecation_check_messages() -> None:
             records[0].message.args[0]
             == "utils.check_messages will be removed in favour of calling utils.only_required_for_messages in pylint 3.0"
         )
+
+
+def test_is_typing_literal() -> None:
+    code = astroid.extract_node(
+        """
+    from typing import Literal as Lit, Set as Literal
+    import typing as t
+
+    Literal #@
+    Lit #@
+    t.Literal #@
+    """
+    )
+
+    assert not utils.is_typing_literal(code[0])
+    assert utils.is_typing_literal(code[1])
+    assert utils.is_typing_literal(code[2])
+
+    code = astroid.extract_node(
+        """
+    Literal #@
+    typing.Literal #@
+    """
+    )
+    assert not utils.is_typing_literal(code[0])
+    assert not utils.is_typing_literal(code[1])

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
@@ -1,0 +1,21 @@
+"""Test if pylint sees names inside string literal type annotations. #3299"""
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from typing import TypeAlias
+
+def unused_variable_should_not_be_emitted():
+    """unused-variable shouldn't be emitted for Example1."""
+    Example1: TypeAlias = int
+    result: set["Example1"] = set()
+    return result
+
+# unused-import shouldn't be emitted for Path
+example2: set["Path"] = set()
+
+def example3(_: "ArgumentParser"):
+    """unused-import shouldn't be emitted for ArgumentParser"""
+
+# pylint: disable=too-few-public-methods
+class Class:
+    """unused-import shouldn't be emitted for Namespace"""
+    cls: "Namespace"

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
@@ -1,7 +1,10 @@
 """Test if pylint sees names inside string literal type annotations. #3299"""
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import TypeAlias
+from sys import argv    # [unused-import]
+from sys import version_info    # [unused-import]
+from typing import Literal as Lit, TypeAlias
+import typing as t
 
 def unused_variable_should_not_be_emitted():
     """unused-variable shouldn't be emitted for Example1."""
@@ -19,3 +22,6 @@ def example3(_: "ArgumentParser"):
 class Class:
     """unused-import shouldn't be emitted for Namespace"""
     cls: "Namespace"
+
+# str inside Literal shouldn't be treated as names
+example4: t.Literal["argv", Lit["version_info"]]

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
@@ -1,10 +1,7 @@
 """Test if pylint sees names inside string literal type annotations. #3299"""
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from sys import argv    # [unused-import]
-from sys import version_info    # [unused-import]
-from typing import Literal as Lit, TypeAlias
-import typing as t
+from typing import TypeAlias
 
 def unused_variable_should_not_be_emitted():
     """unused-variable shouldn't be emitted for Example1."""
@@ -22,6 +19,3 @@ def example3(_: "ArgumentParser"):
 class Class:
     """unused-import shouldn't be emitted for Namespace"""
     cls: "Namespace"
-
-# str inside Literal shouldn't be treated as names
-example4: t.Literal["argv", Lit["version_info"]]

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
@@ -1,5 +1,7 @@
 """Test if pylint sees names inside string literal type annotations. #3299"""
 from argparse import ArgumentParser, Namespace
+import os
+from os import PathLike
 from pathlib import Path
 from typing import NoReturn, Set
 
@@ -10,6 +12,12 @@ def example2(_: "ArgumentParser") -> "NoReturn":
     """unused-import shouldn't be emitted for ArgumentParser or NoReturn."""
     while True:
         pass
+
+def example3(_: "os.PathLike[str]") -> None:
+    """unused-import shouldn't be emitted for os."""
+
+def example4(_: "PathLike[str]") -> None:
+    """unused-import shouldn't be emitted for PathLike."""
 
 # pylint: disable=too-few-public-methods
 class Class:

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
@@ -1,4 +1,6 @@
 """Test if pylint sees names inside string literal type annotations. #3299"""
+# pylint: disable=too-few-public-methods
+
 from argparse import ArgumentParser, Namespace
 import os
 from os import PathLike
@@ -19,7 +21,6 @@ def example3(_: "os.PathLike[str]") -> None:
 def example4(_: "PathLike[str]") -> None:
     """unused-import shouldn't be emitted for PathLike."""
 
-# pylint: disable=too-few-public-methods
 class Class:
     """unused-import shouldn't be emitted for Namespace"""
     cls: "Namespace"

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
@@ -1,18 +1,12 @@
 """Test if pylint sees names inside string literal type annotations. #3299"""
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import TypeAlias
-
-def unused_variable_should_not_be_emitted():
-    """unused-variable shouldn't be emitted for Example1."""
-    Example1: TypeAlias = int
-    result: set["Example1"] = set()
-    return result
+from typing import Set
 
 # unused-import shouldn't be emitted for Path
-example2: set["Path"] = set()
+example1: Set["Path"] = set()
 
-def example3(_: "ArgumentParser"):
+def example2(_: "ArgumentParser"):
     """unused-import shouldn't be emitted for ArgumentParser"""
 
 # pylint: disable=too-few-public-methods

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
@@ -1,13 +1,15 @@
 """Test if pylint sees names inside string literal type annotations. #3299"""
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import Set
+from typing import NoReturn, Set
 
 # unused-import shouldn't be emitted for Path
 example1: Set["Path"] = set()
 
-def example2(_: "ArgumentParser"):
-    """unused-import shouldn't be emitted for ArgumentParser"""
+def example2(_: "ArgumentParser") -> "NoReturn":
+    """unused-import shouldn't be emitted for ArgumentParser or NoReturn."""
+    while True:
+        pass
 
 # pylint: disable=too-few-public-methods
 class Class:

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.txt
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.txt
@@ -1,2 +1,0 @@
-unused-import:4:0:4:20::Unused argv imported from sys:UNDEFINED
-unused-import:5:0:5:28::Unused version_info imported from sys:UNDEFINED

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.txt
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.txt
@@ -1,0 +1,2 @@
+unused-import:4:0:4:20::Unused argv imported from sys:UNDEFINED
+unused-import:5:0:5:28::Unused version_info imported from sys:UNDEFINED

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py310.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py310.py
@@ -1,0 +1,8 @@
+# pylint: disable=missing-docstring
+from typing import TypeAlias
+
+def unused_variable_should_not_be_emitted():
+    """unused-variable shouldn't be emitted for Example."""
+    Example: TypeAlias = int
+    result: set["Example"] = set()
+    return result

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py310.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py310.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-docstring
+
 from typing import TypeAlias
 
 def unused_variable_should_not_be_emitted():

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py310.rc
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py310.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.10

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.py
@@ -5,4 +5,11 @@ from typing import Literal as Lit
 import typing as t
 
 # str inside Literal shouldn't be treated as names
-example: t.Literal["ArgumentParser", Lit["Namespace", "ArgumentParser"]]
+example1: t.Literal["ArgumentParser", Lit["Namespace", "ArgumentParser"]]
+
+
+def unused_variable_example():
+    hello = "hello" # [unused-variable]
+    world = "world" # [unused-variable]
+    example2: Lit["hello", "world"] = "hello"
+    return example2

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-docstring
+
 from argparse import ArgumentParser # [unused-import]
 from argparse import Namespace  # [unused-import]
 from typing import Literal as Lit

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.py
@@ -13,3 +13,7 @@ def unused_variable_example():
     world = "world" # [unused-variable]
     example2: Lit["hello", "world"] = "hello"
     return example2
+
+
+# pylint shouldn't crash with the following strings in a type annotation context
+example3: Lit["", " ", "?"] = "?"

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.py
@@ -1,0 +1,8 @@
+# pylint: disable=missing-docstring
+from argparse import ArgumentParser # [unused-import]
+from argparse import Namespace  # [unused-import]
+from typing import Literal as Lit
+import typing as t
+
+# str inside Literal shouldn't be treated as names
+example: t.Literal["ArgumentParser", Lit["Namespace", "ArgumentParser"]]

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.rc
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.8

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.txt
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.txt
@@ -1,2 +1,4 @@
 unused-import:2:0:2:35::Unused ArgumentParser imported from argparse:UNDEFINED
 unused-import:3:0:3:30::Unused Namespace imported from argparse:UNDEFINED
+unused-variable:12:4:12:9:unused_variable_example:Unused variable 'hello':UNDEFINED
+unused-variable:13:4:13:9:unused_variable_example:Unused variable 'world':UNDEFINED

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.txt
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.txt
@@ -1,0 +1,2 @@
+unused-import:2:0:2:35::Unused ArgumentParser imported from argparse:UNDEFINED
+unused-import:3:0:3:30::Unused Namespace imported from argparse:UNDEFINED

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.txt
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.txt
@@ -1,4 +1,4 @@
-unused-import:2:0:2:35::Unused ArgumentParser imported from argparse:UNDEFINED
-unused-import:3:0:3:30::Unused Namespace imported from argparse:UNDEFINED
-unused-variable:12:4:12:9:unused_variable_example:Unused variable 'hello':UNDEFINED
-unused-variable:13:4:13:9:unused_variable_example:Unused variable 'world':UNDEFINED
+unused-import:3:0:3:35::Unused ArgumentParser imported from argparse:UNDEFINED
+unused-import:4:0:4:30::Unused Namespace imported from argparse:UNDEFINED
+unused-variable:13:4:13:9:unused_variable_example:Unused variable 'hello':UNDEFINED
+unused-variable:14:4:14:9:unused_variable_example:Unused variable 'world':UNDEFINED

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py39.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py39.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-docstring
+
 import graphlib
 from graphlib import TopologicalSorter
 

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py39.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py39.py
@@ -1,0 +1,10 @@
+# pylint: disable=missing-docstring
+import graphlib
+from graphlib import TopologicalSorter
+
+def example(
+    sorter1: "graphlib.TopologicalSorter[int]",
+    sorter2: "TopologicalSorter[str]",
+) -> None:
+    """unused-import shouldn't be emitted for graphlib or TopologicalSorter."""
+    print(sorter1, sorter2)

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py39.rc
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py39.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.9


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #3299

Changes:

- `VariablesChecker` now checks for possible names in `Const` strings that appear in a typing annotation context. This fixes some false positives for `unused-import` and `unused-variable`.
- string `Const`s used as args to `typing.Literal` aren't treated as names.
- String annotations like `"os.PathLike[str]"` or `"graphlib.TopologicalSorter[T]"` now work

