### PR TITLE
Add regression test for dataclass kw_only support

### DIFF
--- a/doc/whatsnew/fragments/7290.false_positive
+++ b/doc/whatsnew/fragments/7290.false_positive
@@ -1,0 +1,3 @@
+Pylint now understands the ``kw_only`` keyword argument for ``dataclass``.
+
+Closes #7290, closes #6550, closes #5857

--- a/tests/functional/d/dataclass_kw_only.py
+++ b/tests/functional/d/dataclass_kw_only.py
@@ -1,0 +1,26 @@
+"""Test the behaviour of the kw_only keyword."""
+
+# pylint: disable=invalid-name
+
+from dataclasses import dataclass
+
+
+@dataclass(kw_only=True)
+class FooBar:
+    """Simple dataclass with a kw_only parameter."""
+
+    a: int
+    b: str
+
+
+@dataclass(kw_only=False)
+class BarFoo(FooBar):
+    """Simple dataclass with a negated kw_only parameter."""
+
+    c: int
+
+
+BarFoo(1, a=2, b="")
+BarFoo(  # [missing-kwoa,missing-kwoa,redundant-keyword-arg,too-many-function-args]
+    1, 2, c=2
+)

--- a/tests/functional/d/dataclass_kw_only.rc
+++ b/tests/functional/d/dataclass_kw_only.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.10

--- a/tests/functional/d/dataclass_kw_only.txt
+++ b/tests/functional/d/dataclass_kw_only.txt
@@ -1,0 +1,4 @@
+missing-kwoa:24:0:26:1::Missing mandatory keyword argument 'a' in constructor call:UNDEFINED
+missing-kwoa:24:0:26:1::Missing mandatory keyword argument 'b' in constructor call:UNDEFINED
+redundant-keyword-arg:24:0:26:1::Argument 'c' passed by position and keyword in constructor call:UNDEFINED
+too-many-function-args:24:0:26:1::Too many positional arguments for constructor call:UNDEFINED


### PR DESCRIPTION
- [x] Write a good description on what the PR does.
- [x] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #7290, closes #6550, closes #5857