### PR TITLE
Disambiguate between str and enum member args to typing.Literal

### DIFF
--- a/doc/whatsnew/fragments/3299.bugfix
+++ b/doc/whatsnew/fragments/3299.bugfix
@@ -1,0 +1,4 @@
+Fix bug in scanning of names inside arguments to `typing.Literal`.
+See https://peps.python.org/pep-0586/#literals-enums-and-forward-references for details.
+
+Refs #3299

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2924,15 +2924,10 @@ class VariablesChecker(BaseChecker):
         parent = node.parent
         if isinstance(parent, nodes.Tuple):
             parent = parent.parent
-
         if isinstance(parent, nodes.Subscript):
             origin = next(parent.get_children(), None)
             if origin is not None and utils.is_typing_literal(origin):
                 return
-
-        if node.value.isidentifier():
-            self._type_annotation_names.append(node.value)
-            return
 
         try:
             annotation = extract_node(node.value)

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2919,16 +2919,6 @@ class VariablesChecker(BaseChecker):
             return
         if not utils.is_node_in_type_annotation_context(node):
             return
-        if not node.value.isidentifier():
-            try:
-                annotation = extract_node(node.value)
-                self._store_type_annotation_node(annotation)
-            except ValueError:
-                # e.g. node.value is white space
-                return
-            except astroid.AstroidSyntaxError:
-                # e.g. "?" or ":" in typing.Literal["?", ":"]
-                return
 
         # Check if parent's or grandparent's first child is typing.Literal
         parent = node.parent
@@ -2940,7 +2930,19 @@ class VariablesChecker(BaseChecker):
             if origin is not None and utils.is_typing_literal(origin):
                 return
 
-        self._type_annotation_names.append(node.value)
+        if node.value.isidentifier():
+            self._type_annotation_names.append(node.value)
+            return
+
+        try:
+            annotation = extract_node(node.value)
+            self._store_type_annotation_node(annotation)
+        except ValueError:
+            # e.g. node.value is white space
+            pass
+        except astroid.AstroidSyntaxError:
+            # e.g. "?" or ":" in typing.Literal["?", ":"]
+            pass
 
 
 def register(linter: PyLinter) -> None:

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
@@ -21,6 +21,11 @@ def example3(_: "os.PathLike[str]") -> None:
 def example4(_: "PathLike[str]") -> None:
     """unused-import shouldn't be emitted for PathLike."""
 
+# pylint shouldn't crash with the following strings in a type annotation context
+example5: Set[""]
+example6: Set[" "]
+example7: Set["?"]
+
 class Class:
     """unused-import shouldn't be emitted for Namespace"""
     cls: "Namespace"

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.py
@@ -2,7 +2,7 @@
 
 from argparse import ArgumentParser # [unused-import]
 from argparse import Namespace  # [unused-import]
-import http #[unused-import]
+import http  # [unused-import]
 from http import HTTPStatus
 import typing as t
 from typing import Literal as Lit

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.py
@@ -2,8 +2,10 @@
 
 from argparse import ArgumentParser # [unused-import]
 from argparse import Namespace  # [unused-import]
-from typing import Literal as Lit
+import http #[unused-import]
+from http import HTTPStatus
 import typing as t
+from typing import Literal as Lit
 
 # str inside Literal shouldn't be treated as names
 example1: t.Literal["ArgumentParser", Lit["Namespace", "ArgumentParser"]]
@@ -18,3 +20,8 @@ def unused_variable_example():
 
 # pylint shouldn't crash with the following strings in a type annotation context
 example3: Lit["", " ", "?"] = "?"
+
+
+# See https://peps.python.org/pep-0586/#literals-enums-and-forward-references
+example4: t.Literal["http.HTTPStatus.OK", "http.HTTPStatus.NOT_FOUND"]
+example5: "t.Literal[HTTPStatus.OK, HTTPStatus.NOT_FOUND]"

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.txt
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.txt
@@ -1,4 +1,5 @@
 unused-import:3:0:3:35::Unused ArgumentParser imported from argparse:UNDEFINED
 unused-import:4:0:4:30::Unused Namespace imported from argparse:UNDEFINED
-unused-variable:13:4:13:9:unused_variable_example:Unused variable 'hello':UNDEFINED
-unused-variable:14:4:14:9:unused_variable_example:Unused variable 'world':UNDEFINED
+unused-import:5:0:5:11::Unused import http:UNDEFINED
+unused-variable:15:4:15:9:unused_variable_example:Unused variable 'hello':UNDEFINED
+unused-variable:16:4:16:9:unused_variable_example:Unused variable 'world':UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This is a continuation of #7400. This PR fixes some errors in the handling of typing.Literal.

From https://peps.python.org/pep-0586/#literals-enums-and-forward-references:

> One potential ambiguity is between literal strings and forward references to literal enum members. For example, suppose we have the type Literal["Color.RED"]. Does this literal type contain a string literal or a forward reference to some Color.RED enum member?

> In cases like these, we always assume the user meant to construct a literal string. If the user wants a forward reference, they must wrap the entire literal type in a string – e.g. "Literal[Color.RED]".