### PR TITLE
[towncrier] Add whitespaces between fragment in towncrier

### DIFF
--- a/doc/whatsnew/fragments/_template.rst
+++ b/doc/whatsnew/fragments/_template.rst
@@ -18,7 +18,6 @@ Release date: {{ versiondata.date }}
 {% for text, values in sections[section][category].items() %}
 - {{ text }} ({{ values|join(', ') }})
 
-
 {% endfor %}
 
 {% else %}

--- a/doc/whatsnew/fragments/_template.rst
+++ b/doc/whatsnew/fragments/_template.rst
@@ -17,6 +17,8 @@ Release date: {{ versiondata.date }}
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}
 - {{ text }} ({{ values|join(', ') }})
+
+
 {% endfor %}
 
 {% else %}

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -4,6 +4,7 @@ directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/2/2.16/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"
 issue_format = "`#{issue} <https://github.com/PyCQA/pylint/issues/{issue}>`_"
+wrap = true
 
 # Definition of fragment types.
 # TODO: with the next towncrier release (21.9.1) it will be possible to define


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

Turn out I was checking the wrong file when generating the release notes.
