### PR TITLE
Fix `unhashable-member` crash when `lambda` used as a dict key

### DIFF
--- a/doc/whatsnew/fragments/7453.bugfix
+++ b/doc/whatsnew/fragments/7453.bugfix
@@ -1,0 +1,3 @@
+Fixed a crash in the ``unhashable-member`` checker when using a ``lambda`` as a dict key.
+
+Closes #7453

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Callable, TypeVar
 
 import _string
 import astroid.objects
-from astroid import TooManyLevelsError, bases, nodes
+from astroid import TooManyLevelsError, nodes
 from astroid.context import InferenceContext
 from astroid.exceptions import AstroidError
 from astroid.nodes._base_nodes import ImportNode
@@ -37,15 +37,6 @@ COMP_NODE_TYPES = (
     nodes.SetComp,
     nodes.DictComp,
     nodes.GeneratorExp,
-)
-WITH_IGETATTR = (
-    nodes.Module,
-    nodes.ClassDef,
-    nodes.FunctionDef,
-    astroid.objects.Super,
-    nodes.Slice,
-    bases.UnboundMethod,
-    bases.BaseInstance,
 )
 EXCEPTIONS_MODULE = "builtins"
 ABC_MODULES = {"abc", "_py_abc"}
@@ -1959,7 +1950,7 @@ def is_hashable(node: nodes.NodeNG) -> bool:
         for inferred in node.infer():
             if inferred is astroid.Uninferable:
                 return True
-            if not isinstance(inferred, WITH_IGETATTR):
+            if not hasattr(inferred, "igetattr"):
                 return True
             hash_fn = next(inferred.igetattr("__hash__"))
             if hash_fn.parent is inferred:

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Callable, TypeVar
 
 import _string
 import astroid.objects
-from astroid import TooManyLevelsError, nodes
+from astroid import TooManyLevelsError, bases, nodes
 from astroid.context import InferenceContext
 from astroid.exceptions import AstroidError
 from astroid.nodes._base_nodes import ImportNode
@@ -37,6 +37,15 @@ COMP_NODE_TYPES = (
     nodes.SetComp,
     nodes.DictComp,
     nodes.GeneratorExp,
+)
+WITH_IGETATTR = (
+    nodes.Module,
+    nodes.ClassDef,
+    nodes.FunctionDef,
+    astroid.objects.Super,
+    nodes.Slice,
+    bases.UnboundMethod,
+    bases.BaseInstance,
 )
 EXCEPTIONS_MODULE = "builtins"
 ABC_MODULES = {"abc", "_py_abc"}
@@ -1949,6 +1958,8 @@ def is_hashable(node: nodes.NodeNG) -> bool:
     try:
         for inferred in node.infer():
             if inferred is astroid.Uninferable:
+                return True
+            if not isinstance(inferred, WITH_IGETATTR):
                 return True
             hash_fn = next(inferred.igetattr("__hash__"))
             if hash_fn.parent is inferred:

--- a/tests/functional/u/unhashable_member.py
+++ b/tests/functional/u/unhashable_member.py
@@ -21,3 +21,4 @@ class Unhashable:
 {[1, 2, 3]}  # [unhashable-member]
 {"tomato": "tomahto"}
 {dict: {}}
+{lambda x: x: "tomato"}  # pylint: disable=unnecessary-lambda


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Closes #7453