### PR TITLE
Fix typevar-rgx description in pylintrc

### DIFF
--- a/doc/whatsnew/fragments/7455.other
+++ b/doc/whatsnew/fragments/7455.other
@@ -1,0 +1,3 @@
+Description for ``typevar-rgx`` configuration (introduced by #5894) is mentioning ``typevar-naming-style``, which currently does not exist.
+
+Refs #7455

--- a/doc/whatsnew/fragments/7455.other
+++ b/doc/whatsnew/fragments/7455.other
@@ -1,3 +1,0 @@
-Description for ``typevar-rgx`` configuration (introduced by #5894) is mentioning ``typevar-naming-style``, which currently does not exist.
-
-Refs #7455

--- a/pylintrc
+++ b/pylintrc
@@ -320,7 +320,7 @@ method-naming-style=snake_case
 # Regular expression matching correct method names
 method-rgx=[a-z_][a-z0-9_]{2,}$
 
-# Regular expression which can overwrite the naming style set by typevar-naming-style.
+# Regular expression matching correct type variable names
 #typevar-rgx=
 
 # Regular expression which should only match function or class names that do


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

- [x] Write a good description on what the PR does.
- [x] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Description for `typevar-rgx` configuration (introduced by #5894) is mentioning `typevar-naming-style`, which currently does not exist.

https://github.com/PyCQA/pylint/blame/63738bf93f7b20e769923ae5a918b83058a70b78/pylintrc#L323

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Refs #7455