### PR TITLE
Use stacklevel=2 in warnings.warn calls to DeprecationWarning where makes sense.

### DIFF
--- a/doc/whatsnew/fragments/7463.other
+++ b/doc/whatsnew/fragments/7463.other
@@ -1,1 +1,3 @@
 Relevant `DeprecationWarnings` are now raised with `stacklevel=2`, so they have the callsite attached in the message.
+
+Closes #7463 

--- a/doc/whatsnew/fragments/7463.other
+++ b/doc/whatsnew/fragments/7463.other
@@ -1,3 +1,3 @@
 Relevant `DeprecationWarnings` are now raised with `stacklevel=2`, so they have the callsite attached in the message.
 
-Closes #7463 
+Closes #7463

--- a/doc/whatsnew/fragments/7463.other
+++ b/doc/whatsnew/fragments/7463.other
@@ -1,0 +1,1 @@
+Relevant `DeprecationWarnings` are now raised with `stacklevel=2`, so they have the callsite attached in the message.

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -54,6 +54,7 @@ class BaseChecker(_ArgumentsProvider):
                 "longer supported. Child classes should only inherit BaseChecker or any "
                 "of the other checker types from pylint.checkers.",
                 DeprecationWarning,
+                stacklevel=2,
             )
         if self.name is not None:
             self.name = self.name.lower()

--- a/pylint/checkers/mapreduce_checker.py
+++ b/pylint/checkers/mapreduce_checker.py
@@ -20,6 +20,7 @@ class MapReduceMixin(metaclass=abc.ABCMeta):
             "MapReduceMixin has been deprecated and will be removed in pylint 3.0. "
             "To make a checker reduce map data simply implement get_map_data and reduce_map_data.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
     @abc.abstractmethod

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -244,6 +244,7 @@ def is_inside_lambda(node: nodes.NodeNG) -> bool:
         "utils.is_inside_lambda will be removed in favour of calling "
         "utils.get_node_first_ancestor_of_type(x, nodes.Lambda) in pylint 3.0",
         DeprecationWarning,
+        stacklevel=2,
     )
     return any(isinstance(parent, nodes.Lambda) for parent in node.node_ancestors())
 
@@ -505,6 +506,7 @@ def check_messages(
         "utils.check_messages will be removed in favour of calling "
         "utils.only_required_for_messages in pylint 3.0",
         DeprecationWarning,
+        stacklevel=2,
     )
 
     return only_required_for_messages(*messages)
@@ -1516,6 +1518,7 @@ def is_class_subscriptable_pep585_with_postponed_evaluation_enabled(
         "Use 'is_postponed_evaluation_enabled(node) and "
         "is_node_in_type_annotation_context(node)' instead.",
         DeprecationWarning,
+        stacklevel=2,
     )
     return (
         is_postponed_evaluation_enabled(node)

--- a/pylint/config/__init__.py
+++ b/pylint/config/__init__.py
@@ -48,6 +48,7 @@ def load_results(base: str) -> LinterStats | None:
         "'pylint.config.load_results' is deprecated, please use "
         "'pylint.lint.load_results' instead. This will be removed in 3.0.",
         DeprecationWarning,
+        stacklevel=2,
     )
     return _real_load_results(base, PYLINT_HOME)
 
@@ -61,5 +62,6 @@ def save_results(results: LinterStats, base: str) -> None:
         "'pylint.config.save_results' is deprecated, please use "
         "'pylint.lint.save_results' instead. This will be removed in 3.0.",
         DeprecationWarning,
+        stacklevel=2,
     )
     return _real_save_results(results, base, PYLINT_HOME)

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -125,6 +125,7 @@ class _ArgumentsManager:
         warnings.warn(
             "options_providers has been deprecated. It will be removed in pylint 3.0.",
             DeprecationWarning,
+            stacklevel=2,
         )
         return self._options_providers
 
@@ -133,6 +134,7 @@ class _ArgumentsManager:
         warnings.warn(
             "Setting options_providers has been deprecated. It will be removed in pylint 3.0.",
             DeprecationWarning,
+            stacklevel=2,
         )
         self._options_providers = value
 
@@ -282,6 +284,7 @@ class _ArgumentsManager:
             "reset_parsers has been deprecated. Parsers should be instantiated "
             "once during initialization and do not need to be reset.",
             DeprecationWarning,
+            stacklevel=2,
         )
         # configuration file parser
         self.cfgfile_parser = configparser.ConfigParser(
@@ -301,6 +304,7 @@ class _ArgumentsManager:
             "arguments providers should be registered by initializing ArgumentsProvider. "
             "This automatically registers the provider on the ArgumentsManager.",
             DeprecationWarning,
+            stacklevel=2,
         )
         self.options_providers.append(provider)
         non_group_spec_options = [
@@ -345,6 +349,7 @@ class _ArgumentsManager:
             "registered by initializing ArgumentsProvider. "
             "This automatically registers the group on the ArgumentsManager.",
             DeprecationWarning,
+            stacklevel=2,
         )
         # add option group to the command line parser
         if group_name in self._mygroups:
@@ -381,6 +386,7 @@ class _ArgumentsManager:
             "add_optik_option has been deprecated. Options should be automatically "
             "added by initializing an ArgumentsProvider.",
             DeprecationWarning,
+            stacklevel=2,
         )
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -399,6 +405,7 @@ class _ArgumentsManager:
             "optik_option has been deprecated. Parsing of option dictionaries should be done "
             "automatically by initializing an ArgumentsProvider.",
             DeprecationWarning,
+            stacklevel=2,
         )
         optdict = copy.copy(optdict)
         if "action" in optdict:
@@ -436,6 +443,7 @@ class _ArgumentsManager:
         warnings.warn(
             "generate_config has been deprecated. It will be removed in pylint 3.0.",
             DeprecationWarning,
+            stacklevel=2,
         )
         options_by_section = {}
         sections = []
@@ -495,6 +503,7 @@ class _ArgumentsManager:
             "load_provider_defaults has been deprecated. Parsing of option defaults should be done "
             "automatically by initializing an ArgumentsProvider.",
             DeprecationWarning,
+            stacklevel=2,
         )
         for provider in self.options_providers:
             with warnings.catch_warnings():
@@ -512,6 +521,7 @@ class _ArgumentsManager:
         warnings.warn(
             "read_config_file has been deprecated. It will be removed in pylint 3.0.",
             DeprecationWarning,
+            stacklevel=2,
         )
         if not config_file:
             if verbose:
@@ -583,6 +593,7 @@ class _ArgumentsManager:
         warnings.warn(
             "load_config_file has been deprecated. It will be removed in pylint 3.0.",
             DeprecationWarning,
+            stacklevel=2,
         )
         parser = self.cfgfile_parser
         for section in parser.sections():
@@ -597,6 +608,7 @@ class _ArgumentsManager:
         warnings.warn(
             "load_configuration has been deprecated. It will be removed in pylint 3.0.",
             DeprecationWarning,
+            stacklevel=2,
         )
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -608,6 +620,7 @@ class _ArgumentsManager:
         warnings.warn(
             "DEPRECATED: load_configuration_from_config has been deprecated. It will be removed in pylint 3.0.",
             DeprecationWarning,
+            stacklevel=2,
         )
         for opt, opt_value in config.items():
             opt = opt.replace("_", "-")
@@ -624,6 +637,7 @@ class _ArgumentsManager:
         warnings.warn(
             "load_command_line_configuration has been deprecated. It will be removed in pylint 3.0.",
             DeprecationWarning,
+            stacklevel=2,
         )
         args = sys.argv[1:] if args is None else list(args)
         (options, args) = self.cmdline_parser.parse_args(args=args)
@@ -643,6 +657,7 @@ class _ArgumentsManager:
                 "Supplying a 'level' argument to help() has been deprecated."
                 "You can call help() without any arguments.",
                 DeprecationWarning,
+                stacklevel=2,
             )
         return self._arg_parser.format_help()
 
@@ -654,6 +669,7 @@ class _ArgumentsManager:
         warnings.warn(
             "cb_set_provider_option has been deprecated. It will be removed in pylint 3.0.",
             DeprecationWarning,
+            stacklevel=2,
         )
         if opt.startswith("--"):
             # remove -- on long option
@@ -673,6 +689,7 @@ class _ArgumentsManager:
             "global_set_option has been deprecated. You can use _arguments_manager.set_option "
             "or linter.set_option to set options on the global configuration object.",
             DeprecationWarning,
+            stacklevel=2,
         )
         self.set_option(opt, value)
 
@@ -776,12 +793,14 @@ class _ArgumentsManager:
                 "The 'action' argument has been deprecated. You can use set_option "
                 "without the 'action' or 'optdict' arguments.",
                 DeprecationWarning,
+                stacklevel=2,
             )
         if optdict != "default_value":
             warnings.warn(
                 "The 'optdict' argument has been deprecated. You can use set_option "
                 "without the 'action' or 'optdict' arguments.",
                 DeprecationWarning,
+                stacklevel=2,
             )
 
         self.config = self._arg_parser.parse_known_args(

--- a/pylint/config/arguments_provider.py
+++ b/pylint/config/arguments_provider.py
@@ -24,6 +24,7 @@ class UnsupportedAction(Exception):
         warnings.warn(
             "UnsupportedAction has been deprecated and will be removed in pylint 3.0",
             DeprecationWarning,
+            stacklevel=2,
         )
         super().__init__(*args)
 
@@ -55,6 +56,7 @@ class _ArgumentsProvider:
             "The level attribute has been deprecated. It was used to display the checker in the help or not,"
             " and everything is displayed in the help now. It will be removed in pylint 3.0.",
             DeprecationWarning,
+            stacklevel=2,
         )
         return self._level
 
@@ -65,6 +67,7 @@ class _ArgumentsProvider:
             "Setting the level attribute has been deprecated. It was used to display the checker in the help or not,"
             " and everything is displayed in the help now. It will be removed in pylint 3.0.",
             DeprecationWarning,
+            stacklevel=2,
         )
         self._level = value
 
@@ -75,6 +78,7 @@ class _ArgumentsProvider:
             "The checker-specific config attribute has been deprecated. Please use "
             "'linter.config' to access the global configuration object.",
             DeprecationWarning,
+            stacklevel=2,
         )
         return self._arguments_manager.config
 
@@ -85,6 +89,7 @@ class _ArgumentsProvider:
             "registered by initializing an ArgumentsProvider. "
             "This automatically registers the group on the ArgumentsManager.",
             DeprecationWarning,
+            stacklevel=2,
         )
         for opt, optdict in self.options:
             action = optdict.get("action")
@@ -105,6 +110,7 @@ class _ArgumentsProvider:
             "option_attrname has been deprecated. It will be removed "
             "in a future release.",
             DeprecationWarning,
+            stacklevel=2,
         )
         if optdict is None:
             with warnings.catch_warnings():
@@ -118,6 +124,7 @@ class _ArgumentsProvider:
             "option_value has been deprecated. It will be removed "
             "in a future release.",
             DeprecationWarning,
+            stacklevel=2,
         )
         return getattr(self._arguments_manager.config, opt.replace("-", "_"), None)
 
@@ -136,6 +143,7 @@ class _ArgumentsProvider:
             "set_option has been deprecated. You can use _arguments_manager.set_option "
             "or linter.set_option to set options on the global configuration object.",
             DeprecationWarning,
+            stacklevel=2,
         )
         self._arguments_manager.set_option(optname, value)
 
@@ -148,6 +156,7 @@ class _ArgumentsProvider:
             "get_option_def has been deprecated. It will be removed "
             "in a future release.",
             DeprecationWarning,
+            stacklevel=2,
         )
         assert self.options
         for option in self.options:
@@ -174,6 +183,7 @@ class _ArgumentsProvider:
             "options_by_section has been deprecated. It will be removed "
             "in a future release.",
             DeprecationWarning,
+            stacklevel=2,
         )
         sections: dict[str, list[tuple[str, OptionDict, Any]]] = {}
         for optname, optdict in self.options:
@@ -195,6 +205,7 @@ class _ArgumentsProvider:
             "options_and_values has been deprecated. It will be removed "
             "in a future release.",
             DeprecationWarning,
+            stacklevel=2,
         )
         if options is None:
             options = self.options

--- a/pylint/config/configuration_mixin.py
+++ b/pylint/config/configuration_mixin.py
@@ -21,6 +21,7 @@ class ConfigurationMixIn(OptionsManagerMixIn, OptionsProviderMixIn):  # type: ig
         warnings.warn(
             "ConfigurationMixIn has been deprecated and will be removed in pylint 3.0",
             DeprecationWarning,
+            stacklevel=2,
         )
         if not args:
             kwargs.setdefault("usage", "")

--- a/pylint/config/find_default_config_files.py
+++ b/pylint/config/find_default_config_files.py
@@ -122,6 +122,7 @@ def find_pylintrc() -> str | None:
         "Use find_default_config_files if you want access to pylint's configuration file "
         "finding logic.",
         DeprecationWarning,
+        stacklevel=2,
     )
     for config_file in find_default_config_files():
         if str(config_file).endswith("pylintrc"):

--- a/pylint/config/option.py
+++ b/pylint/config/option.py
@@ -190,6 +190,7 @@ class Option(optparse.Option):
         warnings.warn(
             "Option has been deprecated and will be removed in pylint 3.0",
             DeprecationWarning,
+            stacklevel=2,
         )
         super().__init__(*opts, **attrs)
         if hasattr(self, "hide") and self.hide:  # type: ignore[attr-defined]

--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -77,6 +77,7 @@ class OptionsManagerMixIn:
         warnings.warn(
             "OptionsManagerMixIn has been deprecated and will be removed in pylint 3.0",
             DeprecationWarning,
+            stacklevel=2,
         )
         self.reset_parsers(usage)
         # list of registered options providers

--- a/pylint/config/option_parser.py
+++ b/pylint/config/option_parser.py
@@ -25,6 +25,7 @@ class OptionParser(optparse.OptionParser):
         warnings.warn(
             "OptionParser has been deprecated and will be removed in pylint 3.0",
             DeprecationWarning,
+            stacklevel=2,
         )
         super().__init__(option_class=Option, *args, **kwargs)
 

--- a/pylint/config/options_provider_mixin.py
+++ b/pylint/config/options_provider_mixin.py
@@ -29,6 +29,7 @@ class OptionsProviderMixIn:
         warnings.warn(
             "OptionsProviderMixIn has been deprecated and will be removed in pylint 3.0",
             DeprecationWarning,
+            stacklevel=2,
         )
         self.config = optparse.Values()
         self.load_defaults()

--- a/pylint/interfaces.py
+++ b/pylint/interfaces.py
@@ -57,6 +57,7 @@ class Interface:
             "Interface and all of its subclasses have been deprecated "
             "and will be removed in pylint 3.0.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
     @classmethod
@@ -78,6 +79,7 @@ def implements(
         "implements has been deprecated in favour of using basic "
         "inheritance patterns without using __implements__.",
         DeprecationWarning,
+        stacklevel=2,
     )
     implements_ = getattr(obj, "__implements__", ())
     if not isinstance(implements_, (list, tuple)):

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -346,6 +346,7 @@ class PyLinter(
         warnings.warn(
             "The option_groups attribute has been deprecated and will be removed in pylint 3.0",
             DeprecationWarning,
+            stacklevel=2,
         )
         return self._option_groups
 
@@ -354,6 +355,7 @@ class PyLinter(
         warnings.warn(
             "The option_groups attribute has been deprecated and will be removed in pylint 3.0",
             DeprecationWarning,
+            stacklevel=2,
         )
         self._option_groups = value
 
@@ -650,6 +652,7 @@ class PyLinter(
             warnings.warn(
                 "In pylint 3.0, the checkers check function will only accept sequence of string",
                 DeprecationWarning,
+                stacklevel=2,
             )
             files_or_modules = (files_or_modules,)  # type: ignore[assignment]
         if self.config.recursive:
@@ -721,6 +724,7 @@ class PyLinter(
             "In pylint 3.0, the checkers check_single_file function will be removed. "
             "Use check_single_file_item instead.",
             DeprecationWarning,
+            stacklevel=2,
         )
         self.check_single_file_item(FileItem(name, filepath, modname))
 
@@ -903,6 +907,7 @@ class PyLinter(
                     "If unknown it should be initialized as an empty string."
                 ),
                 DeprecationWarning,
+                stacklevel=2,
             )
         self.current_name = modname
         self.current_file = filepath or modname

--- a/pylint/message/message.py
+++ b/pylint/message/message.py
@@ -43,6 +43,7 @@ class Message:  # pylint: disable=too-many-instance-attributes
             warn(
                 "In pylint 3.0, Messages will only accept a MessageLocationTuple as location parameter",
                 DeprecationWarning,
+                stacklevel=2,
             )
             location = MessageLocationTuple(
                 location[0],

--- a/pylint/reporters/base_reporter.py
+++ b/pylint/reporters/base_reporter.py
@@ -36,6 +36,7 @@ class BaseReporter:
                 "Using the __implements__ inheritance pattern for BaseReporter is no "
                 "longer supported. Child classes should only inherit BaseReporter",
                 DeprecationWarning,
+                stacklevel=2,
             )
         self.linter: PyLinter
         self.section = 0
@@ -54,6 +55,7 @@ class BaseReporter:
         warn(
             "'set_output' will be removed in 3.0, please use 'reporter.out = stream' instead",
             DeprecationWarning,
+            stacklevel=2,
         )
         self.out = output or sys.stdout
 

--- a/pylint/reporters/text.py
+++ b/pylint/reporters/text.py
@@ -135,6 +135,7 @@ def colorize_ansi(
         warnings.warn(
             "In pylint 3.0, the colorize_ansi function of Text reporters will only accept a MessageStyle parameter",
             DeprecationWarning,
+            stacklevel=2,
         )
         color = kwargs.get("color")
         style_attrs = tuple(_splitstrip(style))
@@ -225,6 +226,7 @@ class ParseableTextReporter(TextReporter):
         warnings.warn(
             f"{self.name} output format is deprecated. This is equivalent to --msg-template={self.line_format}",
             DeprecationWarning,
+            stacklevel=2,
         )
         super().__init__(output)
 
@@ -265,6 +267,7 @@ class ColorizedTextReporter(TextReporter):
             warnings.warn(
                 "In pylint 3.0, the ColorizedTextReporter will only accept ColorMappingDict as color_mapping parameter",
                 DeprecationWarning,
+                stacklevel=2,
             )
             temp_color_mapping: ColorMappingDict = {}
             for key, value in color_mapping.items():

--- a/pylint/testutils/checker_test_case.py
+++ b/pylint/testutils/checker_test_case.py
@@ -85,6 +85,7 @@ class CheckerTestCase:
                         f"the expected value in {expected_msg}. In pylint 3.0 correct end_line "
                         "attributes will be required for MessageTest.",
                         DeprecationWarning,
+                        stacklevel=2,
                     )
                 if not expected_msg.end_col_offset == gotten_msg.end_col_offset:
                     warnings.warn(  # pragma: no cover
@@ -92,6 +93,7 @@ class CheckerTestCase:
                         f"the expected value in {expected_msg}. In pylint 3.0 correct end_col_offset "
                         "attributes will be required for MessageTest.",
                         DeprecationWarning,
+                        stacklevel=2,
                     )
 
     def walk(self, node: nodes.NodeNG) -> None:

--- a/pylint/testutils/functional_test_file.py
+++ b/pylint/testutils/functional_test_file.py
@@ -20,4 +20,5 @@ warnings.warn(
     "'pylint.testutils.functional_test_file' will be accessible from"
     " the 'pylint.testutils.functional' namespace in pylint 3.0.",
     DeprecationWarning,
+    stacklevel=2,
 )

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -98,6 +98,7 @@ class OutputLine(NamedTuple):
                     "expected confidence level, expected end_line and expected end_column. "
                     "An OutputLine should thus have a length of 8.",
                     DeprecationWarning,
+                    stacklevel=2,
                 )
                 return cls(
                     row[0],
@@ -115,6 +116,7 @@ class OutputLine(NamedTuple):
                     "expected end_line and expected end_column. An OutputLine should thus have "
                     "a length of 8.",
                     DeprecationWarning,
+                    stacklevel=2,
                 )
                 return cls(
                     row[0], int(row[1]), column, None, None, row[3], row[4], row[5]

--- a/pylint/utils/file_state.py
+++ b/pylint/utils/file_state.py
@@ -47,12 +47,14 @@ class FileState:
                 "FileState needs a string as modname argument. "
                 "This argument will be required in pylint 3.0",
                 DeprecationWarning,
+                stacklevel=2,
             )
         if msg_store is None:
             warnings.warn(
                 "FileState needs a 'MessageDefinitionStore' as msg_store argument. "
                 "This argument will be required in pylint 3.0",
                 DeprecationWarning,
+                stacklevel=2,
             )
         self.base_name = modname
         self._module_msgs_state: MessageStateDict = {}
@@ -79,6 +81,7 @@ class FileState:
         warnings.warn(
             "'collect_block_lines' has been deprecated and will be removed in pylint 3.0.",
             DeprecationWarning,
+            stacklevel=2,
         )
         for msg, lines in self._module_msgs_state.items():
             self._raw_module_msgs_state[msg] = lines.copy()

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -281,6 +281,7 @@ def get_global_option(
         "get_global_option has been deprecated. You can use "
         "checker.linter.config to get all global options instead.",
         DeprecationWarning,
+        stacklevel=2,
     )
     return getattr(checker.linter.config, option.replace("-", "_"))
 
@@ -367,6 +368,7 @@ def format_section(
     warnings.warn(
         "format_section has been deprecated. It will be removed in pylint 3.0.",
         DeprecationWarning,
+        stacklevel=2,
     )
     if doc:
         print(_comment(doc), file=stream)
@@ -381,6 +383,7 @@ def _ini_format(stream: TextIO, options: list[tuple[str, OptionDict, Any]]) -> N
     warnings.warn(
         "_ini_format has been deprecated. It will be removed in pylint 3.0.",
         DeprecationWarning,
+        stacklevel=2,
     )
     for optname, optdict, value in options:
         # Skip deprecated option


### PR DESCRIPTION
With this change, relevant `DeprecationWarnings` are now raised with `stacklevel=2`, so they have the callsite attached in the message.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

I'm not sure this fits anything below?

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #7463
