### PR TITLE
Update assert-on-tuple for any populated tuple

### DIFF
--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -188,7 +188,7 @@ class BasicChecker(_BasicChecker):
             "re-raised.",
         ),
         "W0199": (
-            "Assert called on a 2-item-tuple. Did you mean 'assert x,y'?",
+            "Assert called on a populated tuple. Did you mean 'assert x,y'?",
             "assert-on-tuple",
             "A call of assert on a tuple will always evaluate to true if "
             "the tuple is not empty, and will always evaluate to false if "
@@ -681,9 +681,8 @@ class BasicChecker(_BasicChecker):
     def visit_assert(self, node: nodes.Assert) -> None:
         """Check whether assert is used on a tuple or string literal."""
         if (
-            node.fail is None
-            and isinstance(node.test, nodes.Tuple)
-            and len(node.test.elts) == 2
+            isinstance(node.test, nodes.Tuple)
+            and len(node.test.elts) > 0
         ):
             self.add_message("assert-on-tuple", node=node)
 

--- a/tests/functional/a/assert_on_tuple.py
+++ b/tests/functional/a/assert_on_tuple.py
@@ -1,11 +1,11 @@
 '''Assert check example'''
 
 # pylint: disable=comparison-with-itself, comparison-of-constants
-assert (1 == 1, 2 == 2), "no error"
+assert (1 == 1, 2 == 2), "no error" # [assert-on-tuple]
 assert (1 == 1, 2 == 2) # [assert-on-tuple]
 assert 1 == 1, "no error"
-assert (1 == 1, ), "no error"
-assert (1 == 1, )
-assert (1 == 1, 2 == 2, 3 == 5), "no error"
+assert (1 == 1, ), "no error" # [assert-on-tuple]
+assert (1 == 1, ) # [assert-on-tuple]
+assert (1 == 1, 2 == 2, 3 == 5), "no error" # [assert-on-tuple]
 assert ()
 assert (True, 'error msg') # [assert-on-tuple]

--- a/tests/functional/a/assert_on_tuple.txt
+++ b/tests/functional/a/assert_on_tuple.txt
@@ -1,2 +1,6 @@
+assert-on-tuple:4:0:4:35::Assert called on a 2-item-tuple. Did you mean 'assert x,y'?:UNDEFINED
 assert-on-tuple:5:0:5:23::Assert called on a 2-item-tuple. Did you mean 'assert x,y'?:UNDEFINED
+assert-on-tuple:7:0:7:29::Assert called on a 2-item-tuple. Did you mean 'assert x,y'?:UNDEFINED
+assert-on-tuple:8:0:8:17::Assert called on a 2-item-tuple. Did you mean 'assert x,y'?:UNDEFINED
+assert-on-tuple:9:0:9:43::Assert called on a 2-item-tuple. Did you mean 'assert x,y'?:UNDEFINED
 assert-on-tuple:11:0:11:26::Assert called on a 2-item-tuple. Did you mean 'assert x,y'?:UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

This PR updates the behavior of `assert-on-tuple` to give a warning on any populated tuple that was asserted on, even if the assert has an error message attached to it or not. Updated tests demonstrate when this warning will now be raised.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #4655
