### PR TITLE
Provide more context in these two DeprecationWarning.

### DIFF
--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -42,7 +42,8 @@ def _convert_option_to_argument(
     if "level" in optdict and "hide" not in optdict:
         warnings.warn(
             "The 'level' key in optdicts has been deprecated. "
-            "Use 'hide' with a boolean to hide an option from the help message.",
+            "Use 'hide' with a boolean to hide an option from the help message. "
+            f"optdict={optdict}",
             DeprecationWarning,
         )
 
@@ -79,7 +80,8 @@ def _convert_option_to_argument(
         warnings.warn(
             "An option dictionary should have a 'default' key to specify "
             "the option's default value. This key will be required in pylint "
-            "3.0. It is not required for 'store_true' and callable actions.",
+            "3.0. It is not required for 'store_true' and callable actions. "
+            f"optdict={optdict}",
             DeprecationWarning,
         )
         default = None


### PR DESCRIPTION
Since this is called a few frame levels inside Pylint, providing the context of what optdict= can help with finding where the option originally comes from.

This is a follow-up to #7465

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | Maintenance          |

## Description

<!-- If this PR references an issue without fixing it: -->

This improves the deprecation warnings similar to #7463.
