### PR TITLE
Fix a crash in the `modified-iterating-dict` checker involving instance attributes

### DIFF
--- a/doc/whatsnew/fragments/7461.bugfix
+++ b/doc/whatsnew/fragments/7461.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in the ``modified-iterating-dict`` checker involving instance attributes.
+
+Closes #7461

--- a/pylint/checkers/modified_iterating_checker.py
+++ b/pylint/checkers/modified_iterating_checker.py
@@ -128,7 +128,7 @@ class ModifiedIterationChecker(checkers.BaseChecker):
         )
 
     def _modified_iterating_list_cond(
-        self, node: nodes.NodeNG, iter_obj: nodes.NodeNG
+        self, node: nodes.NodeNG, iter_obj: nodes.Name | nodes.Attribute
     ) -> bool:
         if not self._is_node_expr_that_calls_attribute_name(node):
             return False
@@ -141,7 +141,7 @@ class ModifiedIterationChecker(checkers.BaseChecker):
         )
 
     def _modified_iterating_dict_cond(
-        self, node: nodes.NodeNG, iter_obj: nodes.NodeNG
+        self, node: nodes.NodeNG, iter_obj: nodes.Name | nodes.Attribute
     ) -> bool:
         if not self._is_node_assigns_subscript_name(node):
             return False
@@ -159,10 +159,14 @@ class ModifiedIterationChecker(checkers.BaseChecker):
             return False
         if infer_val != utils.safe_infer(iter_obj):
             return False
-        return node.targets[0].value.name == iter_obj.name  # type: ignore[no-any-return]
+        if isinstance(iter_obj, nodes.Attribute):
+            iter_obj_name = iter_obj.attrname
+        else:
+            iter_obj_name = iter_obj.name
+        return node.targets[0].value.name == iter_obj_name  # type: ignore[no-any-return]
 
     def _modified_iterating_set_cond(
-        self, node: nodes.NodeNG, iter_obj: nodes.NodeNG
+        self, node: nodes.NodeNG, iter_obj: nodes.Name | nodes.Attribute
     ) -> bool:
         if not self._is_node_expr_that_calls_attribute_name(node):
             return False

--- a/tests/functional/m/modified_iterating.py
+++ b/tests/functional/m/modified_iterating.py
@@ -105,3 +105,15 @@ class MyClass:
         """This should raise as we are deleting."""
         for var in self.attribute:
             del var  # [modified-iterating-list]
+
+
+class MyClass2:
+    """Regression test for https://github.com/PyCQA/pylint/issues/7461"""
+    def __init__(self) -> None:
+        self.attribute = {}
+
+    def my_method(self):
+        """This should not raise, as a copy was made."""
+        for key in self.attribute:
+            tmp = self.attribute.copy()
+            tmp[key] = None


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Closes #7461

As of bcd4ca3052411e8c0823712d38cb970e354713f6 we know that the `iter_obj` is a `Name` or an `Attribute`, so tighten the typing.