### PR TITLE
[openssf] Add the badge for the openssf foundation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,9 +33,14 @@
    :target: https://bestpractices.coreinfrastructure.org/projects/6328
    :alt: CII Best Practices
 
+.. image:: https://api.securityscorecards.dev/projects/github.com/PyCQA/pylint/badge
+   :target: https://api.securityscorecards.dev/projects/github.com/PyCQA/pylint
+   :alt: OpenSSF Scorecard
+
 .. image:: https://img.shields.io/discord/825463413634891776.svg
    :target: https://discord.gg/qYxpadCgkx
    :alt: Discord
+
 
 What is Pylint?
 ================


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Add the badge for the openssf fondation. Follow-up to #7267 that was already documented in the changelog.

