### PR TITLE
Update W1402 message example to be an actually working code

### DIFF
--- a/doc/data/messages/a/anomalous-unicode-escape-in-string/bad.py
+++ b/doc/data/messages/a/anomalous-unicode-escape-in-string/bad.py
@@ -1,1 +1,1 @@
-print(b"\u{0}".format("0394"))  # [anomalous-unicode-escape-in-string]
+print(b"\u%b" % b"0394")  # [anomalous-unicode-escape-in-string]

--- a/doc/data/messages/a/anomalous-unicode-escape-in-string/good.py
+++ b/doc/data/messages/a/anomalous-unicode-escape-in-string/good.py
@@ -1,1 +1,1 @@
-print(b"\\u{0}".format("0394"))
+print(b"\\u%b" % b"0394")

--- a/doc/whatsnew/fragments/7482.other
+++ b/doc/whatsnew/fragments/7482.other
@@ -1,0 +1,2 @@
+Replace erroneous usage of `.format()` on the `bytes` object with %-formatting
+in the message example for W1402 (anomalous-unicode-escape-in-string).

--- a/doc/whatsnew/fragments/7482.other
+++ b/doc/whatsnew/fragments/7482.other
@@ -1,2 +1,0 @@
-Replace erroneous usage of `.format()` on the `bytes` object with %-formatting
-in the message example for W1402 (anomalous-unicode-escape-in-string).


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Replaces erroneous usage of `.format()` on the `bytes` object with %-formatting in the message example for W1402 (anomalous-unicode-escape-in-string) so that the good example can actually be run.