### PR TITLE
Fix the documented shorthand for --reports=y

### DIFF
--- a/doc/user_guide/usage/output.rst
+++ b/doc/user_guide/usage/output.rst
@@ -131,7 +131,7 @@ Following the analysis message, Pylint can display a set of reports,
 each one focusing on a particular aspect of the project, such as number
 of messages by categories, modules dependencies. These features can
 be enabled through the ``--reports=y`` option, or its shorthand
-version ``-rn``.
+version ``-ry``.
 
 For instance, the metrics report displays summaries gathered from the
 current run.


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Fixes the documented shorthand for --reports=y to be `-ry` rather than the incorrect `-rn`.