### PR TITLE
Use qualified name when checking for overgeneral exceptions

### DIFF
--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -812,7 +812,7 @@ Standard Checkers
 .. code-block:: toml
 
    [tool.pylint.exceptions]
-   overgeneral-exceptions = ["BaseException", "Exception"]
+   overgeneral-exceptions = ["builtins.BaseException", "builtins.Exception"]
 
 
 

--- a/doc/whatsnew/fragments/7495.bugfix
+++ b/doc/whatsnew/fragments/7495.bugfix
@@ -1,4 +1,4 @@
-Allow specifying non-builtin exceptions in overgeneral-exception option
-using exception's qualified name.
+Allow specifying non-builtin exceptions in the ``overgeneral-exception`` option
+using an exception's qualified name.
 
 Closes #7495

--- a/doc/whatsnew/fragments/7495.bugfix
+++ b/doc/whatsnew/fragments/7495.bugfix
@@ -1,0 +1,4 @@
+Allow specifying non-builtin exceptions in overgeneral-exception option
+using exception's qualified name.
+
+Closes #7495

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -307,8 +307,8 @@ min-public-methods=2
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception
 
 
 [FORMAT]

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -264,7 +264,7 @@ min-public-methods = 2
 
 [tool.pylint.exceptions]
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions = ["BaseException", "Exception"]
+overgeneral-exceptions = ["builtins.BaseException", "builtins.Exception"]
 
 [tool.pylint.format]
 # Expected format of line ending, e.g. empty (any line ending), LF or CRLF.

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import builtins
 import inspect
+import warnings
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 
@@ -288,6 +289,15 @@ class ExceptionsChecker(checkers.BaseChecker):
 
     def open(self) -> None:
         self._builtin_exceptions = _builtin_exceptions()
+        if any(
+            "." in exc_name for exc_name in self.linter.config.overgeneral_exceptions
+        ):
+            warnings.warn(
+                "Specifying exception names in overgeneral-exceptions option without"
+                " module name has been deprecated."
+                " Use fully qualified name (e.g. builtins.Exception) instead.",
+                DeprecationWarning,
+            )
         super().open()
 
     @utils.only_required_for_messages(

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -293,7 +293,7 @@ class ExceptionsChecker(checkers.BaseChecker):
                     "Specifying exception names in overgeneral-exceptions option"
                     " without module name is deprecated and support for it"
                     " will be removed in pylint 3.0."
-                    f" Use fully qualified name (e.g. builtins.{exc_name}) instead.",
+                    f" Use fully qualified name (e.g. 'builtins.{exc_name}') instead.",
                     category=UserWarning,
                     filename="pylint: Command line or configuration file",
                     lineno=1,

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -287,15 +287,14 @@ class ExceptionsChecker(checkers.BaseChecker):
 
     def open(self) -> None:
         self._builtin_exceptions = _builtin_exceptions()
-        if any(
-            "." in exc_name for exc_name in self.linter.config.overgeneral_exceptions
-        ):
-            warnings.warn(
-                "Specifying exception names in overgeneral-exceptions option without"
-                " module name has been deprecated."
-                " Use fully qualified name (e.g. builtins.Exception) instead.",
-                DeprecationWarning,
-            )
+        for exc_name in self.linter.config.overgeneral_exceptions:
+            if "." not in exc_name:
+                warnings.warn(
+                    "Specifying exception names in overgeneral-exceptions option"
+                    " without module name has been deprecated."
+                    f" Use fully qualified name (e.g. builtins.{exc_name}) instead.",
+                    DeprecationWarning,
+                )
         super().open()
 
     @utils.only_required_for_messages(

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -221,7 +221,7 @@ class ExceptionRaiseRefVisitor(BaseVisitor):
                     "broad-exception-raised",
                     args=exception.name,
                     node=self._node,
-                    confidence=HIGH,
+                    confidence=INFERENCE,
                 )
 
     def visit_call(self, node: nodes.Call) -> None:

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -208,15 +208,9 @@ class ExceptionRaiseRefVisitor(BaseVisitor):
             return
 
         for _, exception in exceptions:
-            if isinstance(exception, astroid.Instance) and utils.inherit_from_std_ex(
-                exception
-            ):
-                exception = exception._proxied
-
-            if not isinstance(exception, nodes.ClassDef):
-                continue
-
-            if self._checker._is_overgeneral_exception(exception):
+            if isinstance(
+                exception, nodes.ClassDef
+            ) and self._checker._is_overgeneral_exception(exception):
                 self._checker.add_message(
                     "broad-exception-raised",
                     args=exception.name,

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -602,7 +602,7 @@ class ExceptionsChecker(checkers.BaseChecker):
                             )
                     if (
                         exception.qname() in self.linter.config.overgeneral_exceptions
-                        # not a qualified name, deprecated
+                        # TODO: 3.0: not a qualified name, deprecated
                         or "." not in exception.name
                         and exception.name in self.linter.config.overgeneral_exceptions
                         and exception.root().name == utils.EXCEPTIONS_MODULE

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -200,7 +200,7 @@ class ExceptionRaiseRefVisitor(BaseVisitor):
             self._checker.add_message(
                 "notimplemented-raised", node=self._node, confidence=HIGH
             )
-        elif node.name in OVERGENERAL_EXCEPTIONS:
+        elif node.name in self._checker.linter.config.overgeneral_exceptions:
             self._checker.add_message(
                 "broad-exception-raised",
                 args=node.name,

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -300,7 +300,7 @@ class ExceptionsChecker(checkers.BaseChecker):
         for exc_name in self.linter.config.overgeneral_exceptions:
             if "." not in exc_name:
                 warnings.warn_explicit(
-                    "Specifying exception names in overgeneral-exceptions option"
+                    "Specifying exception names in the overgeneral-exceptions option"
                     " without module name is deprecated and support for it"
                     " will be removed in pylint 3.0."
                     f" Use fully qualified name (maybe 'builtins.{exc_name}' ?) instead.",

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -309,7 +309,7 @@ class ExceptionsChecker(checkers.BaseChecker):
                     "Specifying exception names in overgeneral-exceptions option"
                     " without module name is deprecated and support for it"
                     " will be removed in pylint 3.0."
-                    f" Use fully qualified name (e.g. 'builtins.{exc_name}') instead.",
+                    f" Use fully qualified name (maybe 'builtins.{exc_name}' ?) instead.",
                     category=UserWarning,
                     filename="pylint: Command line or configuration file",
                     lineno=1,

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -609,14 +609,13 @@ class ExceptionsChecker(checkers.BaseChecker):
                         or "." not in exception.name
                         and exception.name in self.linter.config.overgeneral_exceptions
                         and exception.root().name == utils.EXCEPTIONS_MODULE
-                    ):
-                        if not _is_raising(handler.body):
-                            self.add_message(
-                                "broad-exception-caught",
-                                args=exception.name,
-                                node=handler.type,
-                                confidence=INFERENCE,
-                            )
+                    ) and not _is_raising(handler.body):
+                        self.add_message(
+                            "broad-exception-caught",
+                            args=exception.name,
+                            node=handler.type,
+                            confidence=INFERENCE,
+                        )
 
                     if exception in exceptions_classes:
                         self.add_message(

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -60,8 +60,6 @@ def _is_raising(body: list[nodes.NodeNG]) -> bool:
     return any(isinstance(node, nodes.Raise) for node in body)
 
 
-OVERGENERAL_EXCEPTIONS = ("builtins.BaseException", "builtins.Exception")
-
 MSGS: dict[str, MessageDefinitionTuple] = {
     "E0701": (
         "Bad except clauses order (%s)",
@@ -279,7 +277,7 @@ class ExceptionsChecker(checkers.BaseChecker):
         (
             "overgeneral-exceptions",
             {
-                "default": OVERGENERAL_EXCEPTIONS,
+                "default": ("builtins.BaseException", "builtins.Exception"),
                 "type": "csv",
                 "metavar": "<comma-separated class names>",
                 "help": "Exceptions that will emit a warning when caught.",

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -289,11 +289,14 @@ class ExceptionsChecker(checkers.BaseChecker):
         self._builtin_exceptions = _builtin_exceptions()
         for exc_name in self.linter.config.overgeneral_exceptions:
             if "." not in exc_name:
-                warnings.warn(
+                warnings.warn_explicit(
                     "Specifying exception names in overgeneral-exceptions option"
                     " without module name has been deprecated."
                     f" Use fully qualified name (e.g. builtins.{exc_name}) instead.",
-                    DeprecationWarning,
+                    category=UserWarning,
+                    filename="pylint: Command line or configuration file",
+                    lineno=1,
+                    module="pylint",
                 )
         super().open()
 

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -291,7 +291,8 @@ class ExceptionsChecker(checkers.BaseChecker):
             if "." not in exc_name:
                 warnings.warn_explicit(
                     "Specifying exception names in overgeneral-exceptions option"
-                    " without module name has been deprecated."
+                    " without module name is deprecated and support for it"
+                    " will be removed in pylint 3.0."
                     f" Use fully qualified name (e.g. builtins.{exc_name}) instead.",
                     category=UserWarning,
                     filename="pylint: Command line or configuration file",

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -604,7 +604,7 @@ class ExceptionsChecker(checkers.BaseChecker):
                             )
                     if (
                         exception.qname() in self.linter.config.overgeneral_exceptions
-                        # undotted name, deprecated
+                        # not a qualified name, deprecated
                         or "." not in exception.name
                         and exception.name in self.linter.config.overgeneral_exceptions
                         and exception.root().name == utils.EXCEPTIONS_MODULE

--- a/pylintrc
+++ b/pylintrc
@@ -510,7 +510,7 @@ preferred-modules=
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception
 
 
 [TYPING]

--- a/tests/functional/b/bad_exception_cause.txt
+++ b/tests/functional/b/bad_exception_cause.txt
@@ -3,4 +3,4 @@ bad-exception-cause:16:4:16:34:test:Exception cause set to something which is no
 bad-exception-cause:22:4:22:36:test:Exception cause set to something which is not an exception, nor None:INFERENCE
 catching-non-exception:30:7:30:15::"Catching an exception which doesn't inherit from Exception: function":UNDEFINED
 bad-exception-cause:31:4:31:28::Exception cause set to something which is not an exception, nor None:INFERENCE
-broad-exception-raised:31:4:31:28::"Raising too general exception: Exception":HIGH
+broad-exception-raised:31:4:31:28::"Raising too general exception: Exception":INFERENCE

--- a/tests/functional/b/broad_exception_caught.py
+++ b/tests/functional/b/broad_exception_caught.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring
-__revision__ = 0
+COUNTER = 0
+
 
 class CustomBroadException(Exception):
     pass
@@ -10,33 +11,33 @@ class CustomNarrowException(CustomBroadException):
 
 
 try:
-    __revision__ += 1
+    COUNTER += 1
 except Exception: # [broad-exception-caught]
     print('error')
 
 
 try:
-    __revision__ += 1
+    COUNTER += 1
 except BaseException: # [broad-exception-caught]
     print('error')
 
 
 try:
-    __revision__ += 1
-except ValueError:
+    COUNTER += 1
+except ValueError as e:
     print('error')
-    raise TypeError()
+    raise TypeError() from e
 
 
 try:
-    __revision__ += 1
-except CustomBroadException as e: # [broad-exception-caught]
+    COUNTER += 1
+except CustomBroadException as e:  # [broad-exception-caught]
     print('error')
     raise CustomNarrowException() from e
 
 
 try:
-    __revision__ += 1
+    COUNTER += 1
 except CustomNarrowException as e:
     print('error')
     raise CustomBroadException() from e  # [broad-exception-raised]

--- a/tests/functional/b/broad_exception_caught.py
+++ b/tests/functional/b/broad_exception_caught.py
@@ -25,15 +25,18 @@ try:
     __revision__ += 1
 except ValueError:
     print('error')
+    raise TypeError()
 
 
 try:
     __revision__ += 1
-except CustomBroadException: # [broad-exception-caught]
+except CustomBroadException as e: # [broad-exception-caught]
     print('error')
+    raise CustomNarrowException() from e
 
 
 try:
     __revision__ += 1
-except CustomNarrowException:
+except CustomNarrowException as e:
     print('error')
+    raise CustomBroadException() from e  # [broad-exception-raised]

--- a/tests/functional/b/broad_exception_caught.py
+++ b/tests/functional/b/broad_exception_caught.py
@@ -1,6 +1,14 @@
 # pylint: disable=missing-docstring
 __revision__ = 0
 
+class CustomBroadException(Exception):
+    pass
+
+
+class CustomNarrowException(CustomBroadException):
+    pass
+
+
 try:
     __revision__ += 1
 except Exception: # [broad-exception-caught]
@@ -10,4 +18,22 @@ except Exception: # [broad-exception-caught]
 try:
     __revision__ += 1
 except BaseException: # [broad-exception-caught]
+    print('error')
+
+
+try:
+    __revision__ += 1
+except ValueError:
+    print('error')
+
+
+try:
+    __revision__ += 1
+except CustomBroadException: # [broad-exception-caught]
+    print('error')
+
+
+try:
+    __revision__ += 1
+except CustomNarrowException:
     print('error')

--- a/tests/functional/b/broad_exception_caught.py
+++ b/tests/functional/b/broad_exception_caught.py
@@ -25,18 +25,15 @@ try:
     __revision__ += 1
 except ValueError:
     print('error')
-    raise TypeError()
 
 
 try:
     __revision__ += 1
-except CustomBroadException as e: # [broad-exception-caught]
+except CustomBroadException: # [broad-exception-caught]
     print('error')
-    raise CustomNarrowException() from e
 
 
 try:
     __revision__ += 1
-except CustomNarrowException as e:
+except CustomNarrowException:
     print('error')
-    raise CustomBroadException() from e  # [broad-exception-raised]

--- a/tests/functional/b/broad_exception_caught.py
+++ b/tests/functional/b/broad_exception_caught.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
-COUNTER = 0
-
+__revision__ = 0
 
 class CustomBroadException(Exception):
     pass
@@ -11,33 +10,33 @@ class CustomNarrowException(CustomBroadException):
 
 
 try:
-    COUNTER += 1
+    __revision__ += 1
 except Exception: # [broad-exception-caught]
     print('error')
 
 
 try:
-    COUNTER += 1
+    __revision__ += 1
 except BaseException: # [broad-exception-caught]
     print('error')
 
 
 try:
-    COUNTER += 1
-except ValueError as e:
+    __revision__ += 1
+except ValueError:
     print('error')
-    raise TypeError() from e
+    raise TypeError()
 
 
 try:
-    COUNTER += 1
-except CustomBroadException as e:  # [broad-exception-caught]
+    __revision__ += 1
+except CustomBroadException as e: # [broad-exception-caught]
     print('error')
     raise CustomNarrowException() from e
 
 
 try:
-    COUNTER += 1
+    __revision__ += 1
 except CustomNarrowException as e:
     print('error')
     raise CustomBroadException() from e  # [broad-exception-raised]

--- a/tests/functional/b/broad_exception_caught.rc
+++ b/tests/functional/b/broad_exception_caught.rc
@@ -1,0 +1,4 @@
+[EXCEPTIONS]
+overgeneral-exceptions=BaseException,
+                       builtins.Exception,
+                       functional.b.broad_exception_caught.CustomBroadException

--- a/tests/functional/b/broad_exception_caught.rc
+++ b/tests/functional/b/broad_exception_caught.rc
@@ -1,4 +1,4 @@
 [EXCEPTIONS]
-overgeneral-exceptions=BaseException,
+overgeneral-exceptions=builtins.BaseException,
                        builtins.Exception,
                        functional.b.broad_exception_caught.CustomBroadException

--- a/tests/functional/b/broad_exception_caught.txt
+++ b/tests/functional/b/broad_exception_caught.txt
@@ -1,2 +1,3 @@
-broad-exception-caught:6:7:6:16::Catching too general exception Exception:INFERENCE
-broad-exception-caught:12:7:12:20::Catching too general exception BaseException:INFERENCE
+broad-exception-caught:14:7:14:16::Catching too general exception Exception:INFERENCE
+broad-exception-caught:20:7:20:20::Catching too general exception BaseException:INFERENCE
+broad-exception-caught:32:7:32:27::Catching too general exception CustomBroadException:INFERENCE

--- a/tests/functional/b/broad_exception_raised.py
+++ b/tests/functional/b/broad_exception_raised.py
@@ -1,5 +1,13 @@
 # pylint: disable=missing-module-docstring, missing-function-docstring, unreachable
 
+class CustomBroadException(Exception):
+    pass
+
+
+class CustomNarrowException(CustomBroadException):
+    pass
+
+
 def exploding_apple(apple):
     print(f"{apple} is about to explode")
     raise Exception("{apple} exploded !")  # [broad-exception-raised]
@@ -13,4 +21,6 @@ def raise_and_catch():
 
 raise Exception()  # [broad-exception-raised]
 raise BaseException()  # [broad-exception-raised]
+raise CustomBroadException()  # [broad-exception-raised]
 raise IndexError from None
+raise CustomNarrowException() from None

--- a/tests/functional/b/broad_exception_raised.py
+++ b/tests/functional/b/broad_exception_raised.py
@@ -1,5 +1,7 @@
 # pylint: disable=missing-docstring, unreachable
 
+ExceptionAlias = Exception
+
 class CustomBroadException(Exception):
     pass
 
@@ -18,6 +20,30 @@ def raise_and_catch():
         raise Exception("Oh No!!")  # [broad-exception-raised]
     except Exception as ex:  # [broad-exception-caught]
         print(ex)
+
+
+def raise_catch_reraise():
+    try:
+        exploding_apple("apple")
+    except Exception as ex:
+        print(ex)
+        raise ex
+
+
+def raise_catch_raise():
+    try:
+        exploding_apple("apple")
+    except Exception as ex:
+        print(ex)
+        raise Exception() from None  # [broad-exception-raised]
+
+
+def raise_catch_raise_using_alias():
+    try:
+        exploding_apple("apple")
+    except Exception as ex:
+        print(ex)
+        raise ExceptionAlias() from None  # [broad-exception-raised]
 
 raise Exception()  # [broad-exception-raised]
 raise BaseException()  # [broad-exception-raised]

--- a/tests/functional/b/broad_exception_raised.py
+++ b/tests/functional/b/broad_exception_raised.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-module-docstring, missing-function-docstring, unreachable
+# pylint: disable=missing-docstring, unreachable
 
 class CustomBroadException(Exception):
     pass

--- a/tests/functional/b/broad_exception_raised.rc
+++ b/tests/functional/b/broad_exception_raised.rc
@@ -1,0 +1,4 @@
+[EXCEPTIONS]
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception,
+                       functional.b.broad_exception_raised.CustomBroadException

--- a/tests/functional/b/broad_exception_raised.txt
+++ b/tests/functional/b/broad_exception_raised.txt
@@ -1,6 +1,6 @@
-broad-exception-raised:13:4:13:41:exploding_apple:"Raising too general exception: Exception":HIGH
-broad-exception-raised:18:8:18:34:raise_and_catch:"Raising too general exception: Exception":HIGH
+broad-exception-raised:13:4:13:41:exploding_apple:"Raising too general exception: Exception":INFERENCE
+broad-exception-raised:18:8:18:34:raise_and_catch:"Raising too general exception: Exception":INFERENCE
 broad-exception-caught:19:11:19:20:raise_and_catch:Catching too general exception Exception:INFERENCE
-broad-exception-raised:22:0:22:17::"Raising too general exception: Exception":HIGH
-broad-exception-raised:23:0:23:21::"Raising too general exception: BaseException":HIGH
-broad-exception-raised:24:0:24:28::"Raising too general exception: CustomBroadException":HIGH
+broad-exception-raised:22:0:22:17::"Raising too general exception: Exception":INFERENCE
+broad-exception-raised:23:0:23:21::"Raising too general exception: BaseException":INFERENCE
+broad-exception-raised:24:0:24:28::"Raising too general exception: CustomBroadException":INFERENCE

--- a/tests/functional/b/broad_exception_raised.txt
+++ b/tests/functional/b/broad_exception_raised.txt
@@ -1,6 +1,8 @@
-broad-exception-raised:13:4:13:41:exploding_apple:"Raising too general exception: Exception":INFERENCE
-broad-exception-raised:18:8:18:34:raise_and_catch:"Raising too general exception: Exception":INFERENCE
-broad-exception-caught:19:11:19:20:raise_and_catch:Catching too general exception Exception:INFERENCE
-broad-exception-raised:22:0:22:17::"Raising too general exception: Exception":INFERENCE
-broad-exception-raised:23:0:23:21::"Raising too general exception: BaseException":INFERENCE
-broad-exception-raised:24:0:24:28::"Raising too general exception: CustomBroadException":INFERENCE
+broad-exception-raised:15:4:15:41:exploding_apple:"Raising too general exception: Exception":INFERENCE
+broad-exception-raised:20:8:20:34:raise_and_catch:"Raising too general exception: Exception":INFERENCE
+broad-exception-caught:21:11:21:20:raise_and_catch:Catching too general exception Exception:INFERENCE
+broad-exception-raised:38:8:38:35:raise_catch_raise:"Raising too general exception: Exception":INFERENCE
+broad-exception-raised:46:8:46:40:raise_catch_raise_using_alias:"Raising too general exception: Exception":INFERENCE
+broad-exception-raised:48:0:48:17::"Raising too general exception: Exception":INFERENCE
+broad-exception-raised:49:0:49:21::"Raising too general exception: BaseException":INFERENCE
+broad-exception-raised:50:0:50:28::"Raising too general exception: CustomBroadException":INFERENCE

--- a/tests/functional/b/broad_exception_raised.txt
+++ b/tests/functional/b/broad_exception_raised.txt
@@ -1,5 +1,6 @@
-broad-exception-raised:5:4:5:41:exploding_apple:"Raising too general exception: Exception":HIGH
-broad-exception-raised:10:8:10:34:raise_and_catch:"Raising too general exception: Exception":HIGH
-broad-exception-caught:11:11:11:20:raise_and_catch:Catching too general exception Exception:INFERENCE
-broad-exception-raised:14:0:14:17::"Raising too general exception: Exception":HIGH
-broad-exception-raised:15:0:15:21::"Raising too general exception: BaseException":HIGH
+broad-exception-raised:13:4:13:41:exploding_apple:"Raising too general exception: Exception":HIGH
+broad-exception-raised:18:8:18:34:raise_and_catch:"Raising too general exception: Exception":HIGH
+broad-exception-caught:19:11:19:20:raise_and_catch:Catching too general exception Exception:INFERENCE
+broad-exception-raised:22:0:22:17::"Raising too general exception: Exception":HIGH
+broad-exception-raised:23:0:23:21::"Raising too general exception: BaseException":HIGH
+broad-exception-raised:24:0:24:28::"Raising too general exception: CustomBroadException":HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Description

Allow specifying non-builtin exceptions in overgeneral-exception option using exception's qualified name.

Additionally, tries to deprecate specifying built-in exception names without dots. Small problem - I don't know how to tell pylint to warn about deprecation as `warnings.warn(...)` does not seem to be a valid way to do that.

Closes #7495
