### PR TITLE
handle no-member false positive for generators

### DIFF
--- a/doc/whatsnew/fragments/2567.bugfix
+++ b/doc/whatsnew/fragments/2567.bugfix
@@ -1,0 +1,3 @@
+Fixed a false positive case when a generator object received ``no-member`` error.
+
+Closes #2567

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -510,6 +510,14 @@ def _emit_no_member(
             return False
         except astroid.NotFoundError:
             pass
+    if isinstance(owner, astroid.bases.Generator) and node.attrname in {
+        "__enter__",
+        "__exit__",
+    }:
+        # Avoid false positive on generators.
+        # See https://github.com/PyCQA/pylint/issues/2567
+        return False
+
     if owner_name and node.attrname.startswith("_" + owner_name):
         # Test if an attribute has been mangled ('private' attribute)
         unmangled_name = node.attrname.split("_" + owner_name)[-1]

--- a/tests/functional/n/no/no_member_generators.py
+++ b/tests/functional/n/no/no_member_generators.py
@@ -1,0 +1,15 @@
+"""Test no-member for generators
+"""
+# pylint: disable=missing-docstring, too-few-public-methods
+import contextlib
+
+@contextlib.contextmanager
+def context_manager():
+    try:
+        yield
+    finally:
+        pass
+
+cm = context_manager()
+cm.__enter__()
+cm.__exit__(None, None, None)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

A false positive for when a generator called internal enter / exit methods was reported. This PR handles this case in the same way other outlier cases are handled, by adding code to detect this is a generator.

Closes #2567
