### PR TITLE
Fix false negative ``no-member`` when the code was a `manual` augmented assignments

### DIFF
--- a/doc/whatsnew/fragments/4562.bugfix
+++ b/doc/whatsnew/fragments/4562.bugfix
@@ -1,0 +1,3 @@
+Fix ``no-member`` false negative when augmented assign is done manually, without ``+=``.
+
+Closes #4562

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1160,7 +1160,10 @@ accessed. Python regular expressions are accepted.",
                     try:
                         if isinstance(
                             attr_node.statement(future=True), nodes.AugAssign
-                        ) or utils.is_augassign(attr_node, attr_parent):
+                        ) or (
+                            isinstance(attr_parent, nodes.Assign)
+                            and utils.is_augmented_assign(attr_parent)[0]
+                        ):
                             continue
                     except astroid.exceptions.StatementMissing:
                         break

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1160,7 +1160,7 @@ accessed. Python regular expressions are accepted.",
                     try:
                         if isinstance(
                             attr_node.statement(future=True), nodes.AugAssign
-                        ):
+                        ) or utils.is_augassign(attr_node, attr_parent):
                             continue
                     except astroid.exceptions.StatementMissing:
                         break

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1965,6 +1965,7 @@ def is_hashable(node: nodes.NodeNG) -> bool:
         return True
 
 
+<<<<<<< HEAD
 def get_full_name_of_attribute(node: nodes.Attribute | nodes.AssignAttr) -> str:
     """Return the full name of an attribute and the classes it belongs to.
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1965,7 +1965,6 @@ def is_hashable(node: nodes.NodeNG) -> bool:
         return True
 
 
-<<<<<<< HEAD
 def get_full_name_of_attribute(node: nodes.Attribute | nodes.AssignAttr) -> str:
     """Return the full name of an attribute and the classes it belongs to.
 

--- a/tests/functional/n/no/no_member_augassign.py
+++ b/tests/functional/n/no/no_member_augassign.py
@@ -1,0 +1,25 @@
+"""Tests for no-member in relation to AugAssign operations."""
+# pylint: disable=missing-module-docstring, too-few-public-methods, missing-class-docstring, invalid-name
+
+# Test for: https://github.com/PyCQA/pylint/issues/4562
+class A:
+    value: int
+
+obj_a = A()
+obj_a.value += 1  # [no-member]
+
+
+class B:
+    value: int
+
+obj_b = B()
+obj_b.value = 1 + obj_b.value  # [no-member]
+
+
+class C:
+    value: int
+
+
+obj_c = C()
+obj_c.value += 1  # [no-member]
+obj_c.value = 1 + obj_c.value  # [no-member]

--- a/tests/functional/n/no/no_member_augassign.py
+++ b/tests/functional/n/no/no_member_augassign.py
@@ -1,5 +1,5 @@
 """Tests for no-member in relation to AugAssign operations."""
-# pylint: disable=missing-module-docstring, too-few-public-methods, missing-class-docstring, invalid-name
+# pylint: disable=missing-module-docstring, too-few-public-methods, missing-class-docstring, invalid-name, consider-using-augmented-assign
 
 # Test for: https://github.com/PyCQA/pylint/issues/4562
 class A:

--- a/tests/functional/n/no/no_member_augassign.txt
+++ b/tests/functional/n/no/no_member_augassign.txt
@@ -1,0 +1,4 @@
+no-member:9:0:9:11::Instance of 'A' has no 'value' member:INFERENCE
+no-member:16:18:16:29::Instance of 'B' has no 'value' member:INFERENCE
+no-member:24:0:24:11::Instance of 'C' has no 'value' member:INFERENCE
+no-member:25:18:25:29::Instance of 'C' has no 'value' member:INFERENCE


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Add code to detect `no-member` when an augmented assign is done "manually", that is, when a user does this

`obj.value = 1 + obj.value`
instead of 
`obj.value += 1`

If `no-member` would be raised in the second case, it should also be raised in the first case, which is why this PR is here!

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #4562 (altho I can remove this auto-close if we want to keep it open for the `pydantic` false positive case, though I Personally think it should be a separate issue)
