### PR TITLE
Fix false negative for `no-member`

### DIFF
--- a/doc/whatsnew/fragments/4048.false_negative
+++ b/doc/whatsnew/fragments/4048.false_negative
@@ -1,0 +1,3 @@
+Fix false negative for ``no-member`` when accessing an attribute of a function argument.
+
+Closes #4048

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1093,6 +1093,7 @@ accessed. Python regular expressions are accepted.",
             inferred = list(node.expr.infer())
         except astroid.InferenceError:
             return
+        inferred = [i for i in inferred if i is not astroid.Uninferable]
 
         # list of (node, nodename) which are missing the attribute
         missingattr: set[tuple[SuccessfulInferenceResult, str | None]] = set()

--- a/tests/functional/c/confidence_filter.py
+++ b/tests/functional/c/confidence_filter.py
@@ -5,7 +5,7 @@ class Client:
     """use provider class"""
 
     def __init__(self):
-        self.set_later = 0
+        self.set_later = "tomato"
 
     def set_set_later(self, value):
         """set set_later attribute (introduce an inference ambiguity)"""

--- a/tests/functional/c/consider/consider_join.py
+++ b/tests/functional/c/consider/consider_join.py
@@ -111,7 +111,7 @@ for number in ['1', '2', '3']: result += number  # [consider-using-join]
 
 result = ''
 for number in ['1']:
-    result.result += number
+    result.result += number  # [no-member]
 
 # Does not emit if the body is more complex
 result = {'context': 1}

--- a/tests/functional/c/consider/consider_join.txt
+++ b/tests/functional/c/consider/consider_join.txt
@@ -9,3 +9,4 @@ consider-using-join:71:4:71:20::Consider using str.join(sequence) for concatenat
 consider-using-join:75:4:75:20::Consider using str.join(sequence) for concatenating strings from an iterable:UNDEFINED
 consider-using-join:79:4:79:20::Consider using str.join(sequence) for concatenating strings from an iterable:UNDEFINED
 consider-using-join:110:31:110:47::Consider using str.join(sequence) for concatenating strings from an iterable:UNDEFINED
+no-member:114:4:114:17::Instance of 'str' has no 'result' member:INFERENCE

--- a/tests/functional/m/member/member_checks.py
+++ b/tests/functional/m/member/member_checks.py
@@ -21,7 +21,7 @@ class Client:
         self._prov = Provider()
         self._prov_attr = Provider.cattr
         self._prov_attr2 = Provider.cattribute  # [no-member]
-        self.set_later = 0
+        self.set_later = "tomato"
 
     def set_set_later(self, value):
         """set set_later attribute (introduce an inference ambiguity)"""

--- a/tests/functional/n/no/no_member.py
+++ b/tests/functional/n/no/no_member.py
@@ -46,3 +46,8 @@ print(Derived.label)
 
 # Regression test for https://github.com/PyCQA/pylint/issues/5832
 starter_path = Path(__file__).parents[3].resolve()
+
+
+# https://github.com/PyCQA/pylint/issues/4048
+def _func(param=True):
+    print(param.name)  # [no-member]

--- a/tests/functional/n/no/no_member.txt
+++ b/tests/functional/n/no/no_member.txt
@@ -1,0 +1,1 @@
+no-member:53:10:53:20:_func:Instance of 'bool' has no 'name' member:INFERENCE


### PR DESCRIPTION
Fix false negative for ``no-member`` when accessing an attribute of a function argument.

Closes #4048

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #4048 
