### PR TITLE
Replace no-method-argument with no-self-argument when variadic args present

### DIFF
--- a/doc/whatsnew/fragments/7507.bugfix
+++ b/doc/whatsnew/fragments/7507.bugfix
@@ -1,0 +1,4 @@
+Report `no-self-argument` rather than `no-method-argument` for methods
+with variadic arguments.
+
+Closes #7507

--- a/doc/whatsnew/fragments/7507.bugfix
+++ b/doc/whatsnew/fragments/7507.bugfix
@@ -1,4 +1,4 @@
-Report `no-self-argument` rather than `no-method-argument` for methods
+Report ``no-self-argument`` rather than ``no-method-argument`` for methods
 with variadic arguments.
 
 Closes #7507

--- a/doc/whatsnew/fragments/7507.other
+++ b/doc/whatsnew/fragments/7507.other
@@ -1,3 +1,3 @@
-Add method name to the error messages of no-method-argument and no-self-argument.
+Add method name to the error messages of ``no-method-argument`` and ``no-self-argument``.
 
 Closes #7507

--- a/doc/whatsnew/fragments/7507.other
+++ b/doc/whatsnew/fragments/7507.other
@@ -1,0 +1,3 @@
+Add method name to the error messages of no-method-argument and no-self-argument.
+
+Closes #7507

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1950,11 +1950,11 @@ a metaclass class method.",
             # Check if there is a decorator which is not named `staticmethod` but is assigned to one.
             return
         # class / regular method with no args
-        elif (
-            not node.args.args
-            and not node.args.posonlyargs
-            and not node.args.vararg
-            and not node.args.kwarg
+        elif not (
+            node.args.args
+            or node.args.posonlyargs
+            or node.args.vararg
+            or node.args.kwarg
         ):
             self.add_message("no-method-argument", node=node, args=node.name)
         # metaclass

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -526,13 +526,13 @@ MSGS: dict[str, MessageDefinitionTuple] = {
         "descendant of the class where it's defined.",
     ),
     "E0211": (
-        "Method has no argument",
+        "Method %r has no argument",
         "no-method-argument",
         "Used when a method which should have the bound instance as "
         "first argument has no argument defined.",
     ),
     "E0213": (
-        'Method should have "self" as first argument',
+        'Method %r should have "self" as first argument',
         "no-self-argument",
         'Used when a method has an attribute different the "self" as '
         "first argument. This is considered as an error since this is "
@@ -1956,7 +1956,7 @@ a metaclass class method.",
             and not node.args.vararg
             and not node.args.kwarg
         ):
-            self.add_message("no-method-argument", node=node)
+            self.add_message("no-method-argument", node=node, args=node.name)
         # metaclass
         elif metaclass:
             # metaclass __new__ or classmethod
@@ -1988,7 +1988,7 @@ a metaclass class method.",
             )
         # regular class with regular method without self as argument
         elif first != "self":
-            self.add_message("no-self-argument", node=node)
+            self.add_message("no-self-argument", node=node, args=node.name)
 
     def _check_first_arg_config(
         self,

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1950,7 +1950,12 @@ a metaclass class method.",
             # Check if there is a decorator which is not named `staticmethod` but is assigned to one.
             return
         # class / regular method with no args
-        elif not node.args.args and not node.args.posonlyargs:
+        elif (
+            not node.args.args
+            and not node.args.posonlyargs
+            and not node.args.vararg
+            and not node.args.kwarg
+        ):
             self.add_message("no-method-argument", node=node)
         # metaclass
         elif metaclass:

--- a/tests/functional/m/missing/missing_self_argument.txt
+++ b/tests/functional/m/missing/missing_self_argument.txt
@@ -1,3 +1,3 @@
-no-method-argument:11:4:11:14:MyClass.method:Method has no argument:UNDEFINED
-no-method-argument:14:4:14:13:MyClass.setup:Method has no argument:UNDEFINED
+no-method-argument:11:4:11:14:MyClass.method:Method 'method' has no argument:UNDEFINED
+no-method-argument:14:4:14:13:MyClass.setup:Method 'setup' has no argument:UNDEFINED
 undefined-variable:16:8:16:12:MyClass.setup:Undefined variable 'self':UNDEFINED

--- a/tests/functional/n/no/no_method_argument_py38.py
+++ b/tests/functional/n/no/no_method_argument_py38.py
@@ -1,6 +1,17 @@
-# pylint: disable=missing-docstring,too-few-public-methods
+# pylint: disable=missing-docstring,no-self-argument
 
 
 class Cls:
     def __init__(self, obj, /):
         self.obj = obj
+
+    # regression tests for no-method-argument getting reported
+    # instead of no-self-argument
+    def varargs(*args):
+        """A method without a self argument but with *args."""
+
+    def kwargs(**kwargs):
+        """A method without a self argument but with **kwargs."""
+
+    def varargs_and_kwargs(*args, **kwargs):
+        """A method without a self argument but with *args and **kwargs."""

--- a/tests/functional/n/no/no_self_argument.py
+++ b/tests/functional/n/no/no_self_argument.py
@@ -38,3 +38,12 @@ class NoSelfArgument:
     def concatenate_strings(string1, string2):
         """A staticmethod created by `returns_staticmethod` function"""
         return string1 + string2
+
+    def varargs(*args):  # [no-self-argument]
+        """A method without a self argument but with *args."""
+
+    def kwargs(**kwargs):  # [no-self-argument]
+        """A method without a self argument but with **kwargs."""
+
+    def varargs_and_kwargs(*args, **kwargs):  # [no-self-argument]
+        """A method without a self argument but with *args and **kwargs."""

--- a/tests/functional/n/no/no_self_argument.txt
+++ b/tests/functional/n/no/no_self_argument.txt
@@ -1,5 +1,5 @@
-no-self-argument:15:4:15:16:NoSelfArgument.__init__:"Method should have ""self"" as first argument":UNDEFINED
-no-self-argument:19:4:19:12:NoSelfArgument.abdc:"Method should have ""self"" as first argument":UNDEFINED
-no-self-argument:42:4:42:15:NoSelfArgument.varargs:"Method should have ""self"" as first argument":UNDEFINED
-no-self-argument:45:4:45:14:NoSelfArgument.kwargs:"Method should have ""self"" as first argument":UNDEFINED
-no-self-argument:48:4:48:26:NoSelfArgument.varargs_and_kwargs:"Method should have ""self"" as first argument":UNDEFINED
+no-self-argument:15:4:15:16:NoSelfArgument.__init__:"Method '__init__' should have ""self"" as first argument":UNDEFINED
+no-self-argument:19:4:19:12:NoSelfArgument.abdc:"Method 'abdc' should have ""self"" as first argument":UNDEFINED
+no-self-argument:42:4:42:15:NoSelfArgument.varargs:"Method 'varargs' should have ""self"" as first argument":UNDEFINED
+no-self-argument:45:4:45:14:NoSelfArgument.kwargs:"Method 'kwargs' should have ""self"" as first argument":UNDEFINED
+no-self-argument:48:4:48:26:NoSelfArgument.varargs_and_kwargs:"Method 'varargs_and_kwargs' should have ""self"" as first argument":UNDEFINED

--- a/tests/functional/n/no/no_self_argument.txt
+++ b/tests/functional/n/no/no_self_argument.txt
@@ -1,2 +1,5 @@
 no-self-argument:15:4:15:16:NoSelfArgument.__init__:"Method should have ""self"" as first argument":UNDEFINED
 no-self-argument:19:4:19:12:NoSelfArgument.abdc:"Method should have ""self"" as first argument":UNDEFINED
+no-self-argument:42:4:42:15:NoSelfArgument.varargs:"Method should have ""self"" as first argument":UNDEFINED
+no-self-argument:45:4:45:14:NoSelfArgument.kwargs:"Method should have ""self"" as first argument":UNDEFINED
+no-self-argument:48:4:48:26:NoSelfArgument.varargs_and_kwargs:"Method should have ""self"" as first argument":UNDEFINED

--- a/tests/functional/n/no/no_self_argument_py37.txt
+++ b/tests/functional/n/no/no_self_argument_py37.txt
@@ -1,1 +1,1 @@
-no-self-argument:13:4:13:23:Toto.__class_other__:"Method should have ""self"" as first argument":UNDEFINED
+no-self-argument:13:4:13:23:Toto.__class_other__:"Method '__class_other__' should have ""self"" as first argument":UNDEFINED

--- a/tests/functional/r/regression/regression_4723.txt
+++ b/tests/functional/r/regression/regression_4723.txt
@@ -1,1 +1,1 @@
-no-method-argument:15:4:15:12:B.play:Method has no argument:UNDEFINED
+no-method-argument:15:4:15:12:B.play:Method 'play' has no argument:UNDEFINED

--- a/tests/functional/u/unexpected_special_method_signature.txt
+++ b/tests/functional/u/unexpected_special_method_signature.txt
@@ -4,7 +4,7 @@ unexpected-special-method-signature:14:4:14:18:Invalid.__format__:The special me
 unexpected-special-method-signature:17:4:17:19:Invalid.__setattr__:The special method '__setattr__' expects 2 param(s), 0 was given:UNDEFINED
 unexpected-special-method-signature:20:4:20:17:Invalid.__round__:The special method '__round__' expects between 0 or 1 param(s), 2 were given:UNDEFINED
 unexpected-special-method-signature:23:4:23:20:Invalid.__deepcopy__:The special method '__deepcopy__' expects 1 param(s), 2 were given:UNDEFINED
-no-method-argument:26:4:26:16:Invalid.__iter__:Method has no argument:UNDEFINED
+no-method-argument:26:4:26:16:Invalid.__iter__:Method '__iter__' has no argument:UNDEFINED
 unexpected-special-method-signature:30:4:30:19:Invalid.__getattr__:The special method '__getattr__' expects 1 param(s), 2 were given:UNDEFINED
 unexpected-special-method-signature:33:4:33:22:Invalid.__subclasses__:The special method '__subclasses__' expects 0 param(s), 1 was given:UNDEFINED
 unexpected-special-method-signature:40:4:40:16:FirstBadContextManager.__exit__:The special method '__exit__' expects 3 param(s), 1 was given:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Report `no-self-argument` rather than `no-method-argument` for methods with variadic arguments.
Per the comment in #7507, I also added method name to the error messages of no-method-argument and no-self-argument

Closes #7507
