### PR TITLE
Prevent `redefined-outer-name` for `if t.TYPE_CHECKING`

### DIFF
--- a/doc/whatsnew/fragments/7524.bugfix
+++ b/doc/whatsnew/fragments/7524.bugfix
@@ -1,0 +1,4 @@
+Fix false positive for ``redefined-outer-name`` when aliasing ``typing``
+e.g. as ``t`` and guarding imports under ``t.TYPE_CHECKING``.
+
+Closes #7524

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1230,9 +1230,7 @@ class VariablesChecker(BaseChecker):
                 # Do not take in account redefined names for the purpose
                 # of type checking.:
                 if any(
-                    isinstance(definition.parent, nodes.If)
-                    and definition.parent.test.as_string() in TYPING_TYPE_CHECKS_GUARDS
-                    for definition in globs[name]
+                    in_type_checking_block(definition) for definition in globs[name]
                 ):
                     continue
 

--- a/tests/functional/r/redefined/redefined_outer_name_type_checking.py
+++ b/tests/functional/r/redefined/redefined_outer_name_type_checking.py
@@ -3,19 +3,27 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+import typing as t
 
 
 class Cls:
-    def func(self, stuff: defaultdict):
-        # This import makes the definition work.
+    def func(self, stuff: defaultdict, my_deque: deque):
+        # These imports make the definition work.
         # pylint: disable=import-outside-toplevel
         from collections import defaultdict
+        from collections import deque
 
         obj = defaultdict()
+        obj2 = deque()
         obj.update(stuff)
+        obj2.append(my_deque)
         return obj
 
 
 if TYPE_CHECKING:
     # This import makes the annotations work.
     from collections import defaultdict
+
+if t.TYPE_CHECKING:
+    # This import makes the annotations work.
+    from collections import deque


### PR DESCRIPTION


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #7524
Similar solution to #6787