### PR TITLE
Hotfix mypy precommit errors for colorama and typing on Windows

### DIFF
--- a/doc/whatsnew/fragments/7530.internal
+++ b/doc/whatsnew/fragments/7530.internal
@@ -1,3 +1,3 @@
-Fix pre-commit mypy crashes on Windows for colorama missing imports and typing modules
+Fix pre-commit mypy crashes on Windows for colorama missing imports and typing modules.
 
 Closes #7530

--- a/doc/whatsnew/fragments/7530.internal
+++ b/doc/whatsnew/fragments/7530.internal
@@ -1,0 +1,3 @@
+Fix pre-commit mypy crashes on Windows for colorama missing imports and typing modules
+
+Closes #7530

--- a/doc/whatsnew/fragments/7530.internal
+++ b/doc/whatsnew/fragments/7530.internal
@@ -1,3 +1,0 @@
-Fix pre-commit mypy crashes on Windows for colorama missing imports and typing modules.
-
-Closes #7530

--- a/pylint/config/configuration_mixin.py
+++ b/pylint/config/configuration_mixin.py
@@ -2,18 +2,15 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
-import warnings
+from __future__ import annotations
 
-# For Python 3.8 and below you must use `typing.List` instead of `list`. e.g.
+import warnings
 from typing import Any
 
 from pylint.config.option_manager_mixin import OptionsManagerMixIn
 from pylint.config.options_provider_mixin import (  # type: ignore[attr-defined]
     OptionsProviderMixIn,
 )
-
-from typing import List as list
-from typing import Tuple as tuple
 
 
 class ConfigurationMixIn(OptionsManagerMixIn, OptionsProviderMixIn):  # type: ignore[misc]

--- a/pylint/config/configuration_mixin.py
+++ b/pylint/config/configuration_mixin.py
@@ -3,12 +3,17 @@
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
 import warnings
+
+# For Python 3.8 and below you must use `typing.List` instead of `list`. e.g.
 from typing import Any
 
 from pylint.config.option_manager_mixin import OptionsManagerMixIn
 from pylint.config.options_provider_mixin import (  # type: ignore[attr-defined]
     OptionsProviderMixIn,
 )
+
+from typing import List as list
+from typing import Tuple as tuple
 
 
 class ConfigurationMixIn(OptionsManagerMixIn, OptionsProviderMixIn):  # type: ignore[misc]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ disallow_untyped_decorators = false
 
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
+# `colorama` ignore is needed for Windows environment
 module = [
     "_pytest.*",
     "_string",
@@ -125,4 +126,5 @@ module = [
     "pytest_benchmark.*",
     "pytest",
     "sphinx.*",
+    "colorama",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,8 @@ module = [
     "_pytest.*",
     "_string",
     "astroid.*",
+    # `colorama` ignore is needed for Windows environment
+    "colorama",
     "contributors_txt",
     "coverage",
     "dill",
@@ -125,6 +127,4 @@ module = [
     "pytest_benchmark.*",
     "pytest",
     "sphinx.*",
-    # `colorama` ignore is needed for Windows environment
-    "colorama",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,5 +126,6 @@ module = [
     "pytest_benchmark.*",
     "pytest",
     "sphinx.*",
+    # `colorama` ignore is needed for Windows environment
     "colorama",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ disallow_untyped_decorators = false
 
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
-# `colorama` ignore is needed for Windows environment
 module = [
     "_pytest.*",
     "_string",


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [V] Write a good description on what the PR does.
- [V] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [V] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|  | :sparkles: New feature |
|   | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
Fixing `mypy` checker using `pre-commit` on Windows.
See bug description below.

Fix details:
1. `colorama`  module added to `mypy`'s `ignore_missing_imports`.
2. typing was fixed for Python 3.8 and lower, think the error was never discovered before because pre-commit runs on a newer version in CI.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #7530
