### PR TITLE
exclude testutils from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ include =
     pylint/*
 omit =
     */test/*
+    */testutils/*
 # TODO: 3.0: Remove these after these files have been removed
     pylint/config/configuration_mixin.py
     pylint/config/option.py


### PR DESCRIPTION
Maybe this is a silly or unnecessary change, but I noticed that coveralls included the `pylint/testutils` dir in its count for coverage. I"m not sure why this directory is within the `pylint` dir and not within the `test` dir, which already has a `testutils` dir, but I figured we could at least remove `testutils` from being counted in coverage so the coverage % is more accurate. 

changes
```
17109 of 17950 relevant lines covered (95.31%)
```

to 
```
16124 of 16859 relevant lines covered (95.64%)

```