### PR TITLE
Prevent leaving pip install cache in Docker iamge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM python:3.10.0-alpine3.15
 
 COPY ./ /tmp/build
 WORKDIR /tmp/build
-RUN python -m pip install . && rm -rf /tmp/build
+RUN python -m pip install --no-cache-dir . && rm -rf /tmp/build
 
 ENTRYPOINT ["pylint"]

--- a/doc/whatsnew/fragments/7544.other
+++ b/doc/whatsnew/fragments/7544.other
@@ -1,1 +1,3 @@
-Prevent leaving pip install cache in Docker iamge
+Prevent leaving the pip install cache in the Docker image.
+
+Refs #7544

--- a/doc/whatsnew/fragments/7544.other
+++ b/doc/whatsnew/fragments/7544.other
@@ -1,0 +1,1 @@
+Prevent leaving pip install cache in Docker iamge


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Use `--no-cache-dir` with `pip install` in Dockerfile to prevent cache and minimize the Docker image.
