### PR TITLE
Fix handling of ``--`` as separator between positional args and flags

### DIFF
--- a/doc/whatsnew/fragments/7003.bugfix
+++ b/doc/whatsnew/fragments/7003.bugfix
@@ -1,0 +1,4 @@
+Fixed handling of ``--`` as separator between positional arguments and flags.
+This was not actually fixed in 2.14.5.
+
+Closes #7003, Refs #7096

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -72,12 +72,17 @@ def _config_initialization(
     # the configuration file
     parsed_args_list = linter._parse_command_line_configuration(args_list)
 
+    # Remove the positional arguments separator from the list of arguments
+    try:
+        parsed_args_list.remove("--")
+    except ValueError:
+        pass
+
     # Check if there are any options that we do not recognize
     unrecognized_options: list[str] = []
     for opt in parsed_args_list:
         if opt.startswith("--"):
-            if len(opt) > 2:
-                unrecognized_options.append(opt[2:])
+            unrecognized_options.append(opt[2:])
         elif opt.startswith("-"):
             unrecognized_options.append(opt[1:])
     if unrecognized_options:

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -72,7 +72,7 @@ def _config_initialization(
     # the configuration file
     parsed_args_list = linter._parse_command_line_configuration(args_list)
 
-    # Remove the positional arguments separator from the list of arguments
+    # Remove the positional arguments separator from the list of arguments if it exists
     try:
         parsed_args_list.remove("--")
     except ValueError:

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -148,11 +148,10 @@ def test_short_verbose(capsys: CaptureFixture) -> None:
     assert "Using config file" in output.err
 
 
-def test_argument_separator(capsys: CaptureFixture) -> None:
+def test_argument_separator() -> None:
     """Check that we support using '--' to separate argument types.
 
     Reported in https://github.com/PyCQA/pylint/issues/7003.
     """
-    Run(["--", str(EMPTY_MODULE)], exit=False)
-    output = capsys.readouterr()
-    assert not output.err
+    runner = Run(["--", str(EMPTY_MODULE)], exit=False)
+    assert not runner.linter.stats.by_msg


### PR DESCRIPTION
- [x] Write a good description on what the PR does.
- [x] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes https://github.com/PyCQA/pylint/issues/7003.