### PR TITLE
Remove xfail from passing tests

### DIFF
--- a/tests/pyreverse/test_diadefs.py
+++ b/tests/pyreverse/test_diadefs.py
@@ -106,7 +106,6 @@ class TestDefaultDiadefGenerator:
         ("specialization", "Specialization", "Ancestor"),
     ]
 
-    @pytest.mark.xfail
     def test_extract_relations(self, HANDLER: DiadefsHandler, PROJECT: Project) -> None:
         """Test extract_relations between classes."""
         with pytest.warns(DeprecationWarning):
@@ -115,7 +114,6 @@ class TestDefaultDiadefGenerator:
         relations = _process_relations(cd.relationships)
         assert relations == self._should_rels
 
-    @pytest.mark.xfail
     def test_functional_relation_extraction(
         self, default_config: PyreverseConfig, get_project: GetProjectCallable
     ) -> None:


### PR DESCRIPTION
- [x] Write a good description on what the PR does.
- [x] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

@DudeNr33 Are these test passing correctly? Or should they be made to actually fail again?