### PR TITLE
Make primer use ``3.10``

### DIFF
--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -37,7 +37,7 @@ jobs:
         id: python
         uses: actions/setup-python@v4.2.0
         with:
-          python-version: "3.11-dev"
+          python-version: "3.10"
 
       # Restore cached Python environment
       - name: Restore Python virtual environment

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ["3.7", "3.11-dev"]
+        python-version: ["3.7", "3.10"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.2

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
-        python-version: ["3.7", "3.11-dev"]
+        python-version: ["3.7", "3.10"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.2


### PR DESCRIPTION
- [x] Write a good description on what the PR does.
- [x] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Primer has been broken since we use `sys.version` to get the correct version for some attributes but that returns something different than the version that GA returns when determining the versions.
I don't really want to start investigating as this is fixed in a month or so. Let's just return to `3.10` while `3.11` is not officially released.