### PR TITLE
Add "breaking change" and "user action" fragment types

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ To ease the process of reviewing your PR, do make sure to complete the following
 
 - [ ] Write a good description on what the PR does.
 - [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
-  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
+  included in the changelog. `<type>` can be one of: breaking, new_check, removed_check, extension,
   false_positive, false_negative, bugfix, other, internal. If necessary you can write
   details or offer examples on how the new change is supposed to work.
 - [ ] If you used multiple emails or multiple names when contributing, add your mails

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ To ease the process of reviewing your PR, do make sure to complete the following
 
 - [ ] Write a good description on what the PR does.
 - [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
-  included in the changelog. `<type>` can be one of: breaking, new_check, removed_check, extension,
+  included in the changelog. `<type>` can be one of: breaking, user_action, new_check, removed_check, extension,
   false_positive, false_negative, bugfix, other, internal. If necessary you can write
   details or offer examples on how the new change is supposed to work.
 - [ ] If you used multiple emails or multiple names when contributing, add your mails

--- a/doc/development_guide/contributor_guide/contribute.rst
+++ b/doc/development_guide/contributor_guide/contribute.rst
@@ -67,7 +67,7 @@ your patch gets accepted:
 .. keep this in sync with the description of PULL_REQUEST_TEMPLATE.md!
 
 - Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
-  included in the changelog. `<type>` can be one of: new_check, removed_check, extension,
+  included in the changelog. `<type>` can be one of: breaking, new_check, removed_check, extension,
   false_positive, false_negative, bugfix, other, internal. If necessary you can write
   details or offer examples on how the new change is supposed to work.
 

--- a/doc/development_guide/contributor_guide/contribute.rst
+++ b/doc/development_guide/contributor_guide/contribute.rst
@@ -67,7 +67,7 @@ your patch gets accepted:
 .. keep this in sync with the description of PULL_REQUEST_TEMPLATE.md!
 
 - Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
-  included in the changelog. `<type>` can be one of: breaking, new_check, removed_check, extension,
+  included in the changelog. `<type>` can be one of: breaking, user_action, new_check, removed_check, extension,
   false_positive, false_negative, bugfix, other, internal. If necessary you can write
   details or offer examples on how the new change is supposed to work.
 

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -7,9 +7,15 @@ issue_format = "`#{issue} <https://github.com/PyCQA/pylint/issues/{issue}>`_"
 wrap = true
 
 # Definition of fragment types.
-# TODO: with the next towncrier release (21.9.1) it will be possible to define
-# custom types as toml tables:
-# https://github.com/twisted/towncrier#further-options
+# We want the changelog to show in the same order as the fragment types
+# are defined here. Therefore we have to use the array-style fragment definition.
+# The table-style definition, although more concise, would be sorted alphabetically.
+# https://github.com/twisted/towncrier/issues/437
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking Changes"
+showcontent = true
+
 [[tool.towncrier.type]]
 directory = "new_check"
 name = "New Checks"

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -17,6 +17,11 @@ name = "Breaking Changes"
 showcontent = true
 
 [[tool.towncrier.type]]
+directory = "user_action"
+name = "Changes requiring user actions"
+showcontent = true
+
+[[tool.towncrier.type]]
 directory = "new_check"
 name = "New Checks"
 showcontent = true


### PR DESCRIPTION

- [x] Write a good description on what the PR does.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

See https://github.com/PyCQA/pylint/pull/7581#discussion_r990612131

With `towncrier` V22.8.0 and the array-style definition of fragment types in `towncrier.toml` the order of definition is preserved when generating the changelog file. I updated the comment in `towncrier.toml` so we are not tempted to change that in the future. 😁 
