### PR TITLE
Make the order of functional tests deterministic

### DIFF
--- a/pylint/testutils/functional/find_functional_tests.py
+++ b/pylint/testutils/functional/find_functional_tests.py
@@ -38,9 +38,11 @@ def get_functional_test_files_from_directory(
 
     _check_functional_tests_structure(Path(input_dir))
 
-    for dirpath, _, filenames in os.walk(input_dir):
+    for dirpath, dirnames, filenames in os.walk(input_dir):
         if dirpath.endswith("__pycache__"):
             continue
+        dirnames.sort()
+        filenames.sort()
         for filename in filenames:
             if filename != "__init__.py" and filename.endswith(".py"):
                 suite.append(FunctionalTestFile(dirpath, filename))


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | Tests                  |

## Description

The pull request fixes the non deterministic ordering of functional tests depending on the underlying system.

Refs #7464
