### PR TITLE
add new ``invalid-bases-assignment`` check

### DIFF
--- a/doc/data/messages/i/invalid-bases-assignment/bad.py
+++ b/doc/data/messages/i/invalid-bases-assignment/bad.py
@@ -1,0 +1,4 @@
+class Apple:
+    pass
+
+Apple.__bases__ = "green"  # [invalid-bases-assignment]

--- a/doc/data/messages/i/invalid-bases-assignment/good.py
+++ b/doc/data/messages/i/invalid-bases-assignment/good.py
@@ -1,4 +1,4 @@
 class Apple:
     pass
 
-Apple.__bases__ = ("green", "red", )  # [invalid-bases-assignment]
+Apple.__bases__ = ("green", "red", )

--- a/doc/data/messages/i/invalid-bases-assignment/good.py
+++ b/doc/data/messages/i/invalid-bases-assignment/good.py
@@ -1,0 +1,4 @@
+class Apple:
+    pass
+
+Apple.__bases__ = ("green", "red", )  # [invalid-bases-assignment]

--- a/doc/whatsnew/fragments/584.new_check
+++ b/doc/whatsnew/fragments/584.new_check
@@ -1,0 +1,3 @@
+Added ``invalid-bases-assignment`` which flags assigning anything other than a populated tuple to ``__bases__``.
+
+Closes #584

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -48,7 +48,7 @@ from pylint.checkers.utils import (
     supports_membership_test,
     supports_setitem,
 )
-from pylint.interfaces import INFERENCE, HIGH
+from pylint.interfaces import HIGH, INFERENCE
 from pylint.typing import MessageDefinitionTuple
 
 if sys.version_info >= (3, 8):

--- a/tests/functional/i/invalid/invalid_bases_assignment.py
+++ b/tests/functional/i/invalid/invalid_bases_assignment.py
@@ -1,0 +1,13 @@
+# pylint: disable=missing-module-docstring, missing-class-docstring
+# pylint: disable=too-few-public-methods
+
+
+class Apple:
+    pass
+
+
+Apple.__bases__ = ()  # [invalid-bases-assignment]
+Apple.__bases__ = "lala"  # [invalid-bases-assignment]
+Apple.__bases__ = True  # [invalid-bases-assignment]
+Apple.__bases__ = (1,)
+Apple.__bases__ = ("red", "green")

--- a/tests/functional/i/invalid/invalid_bases_assignment.py
+++ b/tests/functional/i/invalid/invalid_bases_assignment.py
@@ -11,3 +11,6 @@ Apple.__bases__ = "lala"  # [invalid-bases-assignment]
 Apple.__bases__ = True  # [invalid-bases-assignment]
 Apple.__bases__ = (1,)
 Apple.__bases__ = ("red", "green")
+
+bases = ("orange", "yellow")
+Apple.__bases__ = bases  # [invalid-bases-assignment]

--- a/tests/functional/i/invalid/invalid_bases_assignment.txt
+++ b/tests/functional/i/invalid/invalid_bases_assignment.txt
@@ -1,3 +1,4 @@
 invalid-bases-assignment:9:0:9:20::__bases__ should be assigned to a populated tuple:HIGH
 invalid-bases-assignment:10:0:10:24::__bases__ should be assigned to a populated tuple:HIGH
 invalid-bases-assignment:11:0:11:22::__bases__ should be assigned to a populated tuple:HIGH
+invalid-bases-assignment:16:0:16:23::__bases__ should be assigned to a populated tuple:HIGH

--- a/tests/functional/i/invalid/invalid_bases_assignment.txt
+++ b/tests/functional/i/invalid/invalid_bases_assignment.txt
@@ -1,3 +1,3 @@
-invalid-bases-assignment:7:0:7:20::__bases__ should be assigned to a populated tuple:HIGH
-invalid-bases-assignment:8:0:8:24::__bases__ should be assigned to a populated tuple:HIGH
-invalid-bases-assignment:9:0:9:22::__bases__ should be assigned to a populated tuple:HIGH
+invalid-bases-assignment:9:0:9:20::__bases__ should be assigned to a populated tuple:HIGH
+invalid-bases-assignment:10:0:10:24::__bases__ should be assigned to a populated tuple:HIGH
+invalid-bases-assignment:11:0:11:22::__bases__ should be assigned to a populated tuple:HIGH

--- a/tests/functional/i/invalid/invalid_bases_assignment.txt
+++ b/tests/functional/i/invalid/invalid_bases_assignment.txt
@@ -1,0 +1,3 @@
+invalid-bases-assignment:7:0:7:20::__bases__ should be assigned to a populated tuple:HIGH
+invalid-bases-assignment:8:0:8:24::__bases__ should be assigned to a populated tuple:HIGH
+invalid-bases-assignment:9:0:9:22::__bases__ should be assigned to a populated tuple:HIGH

--- a/tests/functional/n/non/non_str_assignment_to_dunder_name.txt
+++ b/tests/functional/n/non/non_str_assignment_to_dunder_name.txt
@@ -1,8 +1,8 @@
-non-str-assignment-to-dunder-name:37:0:37:25::Non-string value assigned to __name__:UNDEFINED
-non-str-assignment-to-dunder-name:38:0:38:28::Non-string value assigned to __name__:UNDEFINED
-non-str-assignment-to-dunder-name:39:0:39:39::Non-string value assigned to __name__:UNDEFINED
-non-str-assignment-to-dunder-name:40:0:40:37::Non-string value assigned to __name__:UNDEFINED
-non-str-assignment-to-dunder-name:46:0:46:29::Non-string value assigned to __name__:UNDEFINED
-non-str-assignment-to-dunder-name:47:0:47:32::Non-string value assigned to __name__:UNDEFINED
-non-str-assignment-to-dunder-name:48:0:48:43::Non-string value assigned to __name__:UNDEFINED
-non-str-assignment-to-dunder-name:49:0:49:41::Non-string value assigned to __name__:UNDEFINED
+non-str-assignment-to-dunder-name:37:0:37:25::Non-string value assigned to __name__:INFERENCE
+non-str-assignment-to-dunder-name:38:0:38:28::Non-string value assigned to __name__:INFERENCE
+non-str-assignment-to-dunder-name:39:0:39:39::Non-string value assigned to __name__:INFERENCE
+non-str-assignment-to-dunder-name:40:0:40:37::Non-string value assigned to __name__:INFERENCE
+non-str-assignment-to-dunder-name:46:0:46:29::Non-string value assigned to __name__:INFERENCE
+non-str-assignment-to-dunder-name:47:0:47:32::Non-string value assigned to __name__:INFERENCE
+non-str-assignment-to-dunder-name:48:0:48:43::Non-string value assigned to __name__:INFERENCE
+non-str-assignment-to-dunder-name:49:0:49:41::Non-string value assigned to __name__:INFERENCE


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Description

Pylint should warn a user if a class's `__bases__` dunder method is being assigned to anything other than a populated tuple. Python interpreter would raise a `TyperError` in these cases, for example

```
>>> class Apple:
...     pass
...
>>> Apple.__bases__ = "green"  
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: can only assign tuple to Apple.__bases__, not str

>>> Apple.__bases__ = ()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: can only assign non-empty tuple to Apple.__bases__, not ()

```

So this check would warn a pylint user about this before the interpreter would.

Closes #584
