### PR TITLE
Improve bad-threading-instantiation check

### DIFF
--- a/doc/whatsnew/fragments/7570.bugfix
+++ b/doc/whatsnew/fragments/7570.bugfix
@@ -1,0 +1,3 @@
+Improve ``bad-thread-instantiation`` check to warn if ``target`` is not passed in as a keyword argument.
+
+Closes #7570

--- a/doc/whatsnew/fragments/7570.bugfix
+++ b/doc/whatsnew/fragments/7570.bugfix
@@ -1,3 +1,4 @@
-Improve ``bad-thread-instantiation`` check to warn if ``target`` is not passed in as a keyword argument.
+Improve ``bad-thread-instantiation`` check to warn if ``target`` is not passed in as a keyword argument
+or as a second argument.
 
 Closes #7570

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -378,10 +378,10 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
             "should be emitted.",
         ),
         "W1506": (
-            "threading.Thread needs the target function passed as a kwarg",
+            "threading.Thread needs the target function",
             "bad-thread-instantiation",
             "The warning is emitted when a threading.Thread class "
-            "is instantiated without the target function being passed as a kwarg. "
+            "is instantiated without the target function being passed as a kwarg or as a second argument. "
             "By default, the first parameter is the group param, not the target param.",
         ),
         "W1507": (
@@ -488,7 +488,11 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
         # synced with the config argument deprecated-modules
 
     def _check_bad_thread_instantiation(self, node: nodes.Call) -> None:
-        if not node.kwargs and "target" not in {key.arg for key in node.keywords}:
+        if (
+            len(node.args) < 2
+            and not node.kwargs
+            and "target" not in {key.arg for key in node.keywords}
+        ):
             self.add_message(
                 "bad-thread-instantiation", node=node, confidence=interfaces.HIGH
             )

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -378,10 +378,10 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
             "should be emitted.",
         ),
         "W1506": (
-            "threading.Thread needs the target function",
+            "threading.Thread needs the target function passed as a kwarg",
             "bad-thread-instantiation",
             "The warning is emitted when a threading.Thread class "
-            "is instantiated without the target function being passed. "
+            "is instantiated without the target function being passed as a kwarg. "
             "By default, the first parameter is the group param, not the target param.",
         ),
         "W1507": (
@@ -488,8 +488,10 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
         # synced with the config argument deprecated-modules
 
     def _check_bad_thread_instantiation(self, node: nodes.Call) -> None:
-        if not node.kwargs and not node.keywords and len(node.args) <= 1:
-            self.add_message("bad-thread-instantiation", node=node)
+        if not node.kwargs and "target" not in {key.arg for key in node.keywords}:
+            self.add_message(
+                "bad-thread-instantiation", node=node, confidence=interfaces.HIGH
+            )
 
     def _check_for_preexec_fn_in_popen(self, node: nodes.Call) -> None:
         if node.keywords:

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -488,11 +488,11 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
         # synced with the config argument deprecated-modules
 
     def _check_bad_thread_instantiation(self, node: nodes.Call) -> None:
-        if (
-            len(node.args) < 2
-            and not node.kwargs
-            and "target" not in {key.arg for key in node.keywords}
-        ):
+        func_kwargs = {key.arg for key in node.keywords}
+        if "target" in func_kwargs:
+            return
+
+        if len(node.args) < 2 and (not node.kwargs or "target" not in func_kwargs):
             self.add_message(
                 "bad-thread-instantiation", node=node, confidence=interfaces.HIGH
             )

--- a/tests/functional/b/bad_thread_instantiation.py
+++ b/tests/functional/b/bad_thread_instantiation.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, redundant-keyword-arg, invalid-name
+# pylint: disable=missing-docstring, redundant-keyword-arg, invalid-name, line-too-long
 import threading
 
 
@@ -16,3 +16,9 @@ def thread_target(n):
 
 
 thread = threading.Thread(thread_target, args=(10,))  # [bad-thread-instantiation]
+
+
+kw = {'target_typo': lambda x: x}
+threading.Thread(None, **kw)  # [unexpected-keyword-arg, bad-thread-instantiation]
+
+threading.Thread(None, target_typo=lambda x: x)  # [unexpected-keyword-arg, bad-thread-instantiation]

--- a/tests/functional/b/bad_thread_instantiation.py
+++ b/tests/functional/b/bad_thread_instantiation.py
@@ -1,10 +1,18 @@
-# pylint: disable=missing-docstring, redundant-keyword-arg
+# pylint: disable=missing-docstring, redundant-keyword-arg, invalid-name
 import threading
 
 
 threading.Thread(lambda: None).run()  # [bad-thread-instantiation]
-threading.Thread(None, lambda: None)  # [bad-thread-instantiation]
+threading.Thread(None, lambda: None)
 threading.Thread(lambda: None, group=None)  # [bad-thread-instantiation]
 threading.Thread()  # [bad-thread-instantiation]
 
 threading.Thread(group=None, target=lambda: None).run()
+threading.Thread(group=None, target=None, name=None, args=(), kwargs={})
+threading.Thread(None, None, "name")
+
+def thread_target(n):
+    print(n ** 2)
+
+
+thread = threading.Thread(thread_target, args=(10,))  # [bad-thread-instantiation]

--- a/tests/functional/b/bad_thread_instantiation.py
+++ b/tests/functional/b/bad_thread_instantiation.py
@@ -1,8 +1,10 @@
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring, redundant-keyword-arg
 import threading
 
 
 threading.Thread(lambda: None).run()  # [bad-thread-instantiation]
-threading.Thread(None, lambda: None)
+threading.Thread(None, lambda: None)  # [bad-thread-instantiation]
+threading.Thread(lambda: None, group=None)  # [bad-thread-instantiation]
+threading.Thread()  # [bad-thread-instantiation]
+
 threading.Thread(group=None, target=lambda: None).run()
-threading.Thread() # [bad-thread-instantiation]

--- a/tests/functional/b/bad_thread_instantiation.txt
+++ b/tests/functional/b/bad_thread_instantiation.txt
@@ -1,4 +1,4 @@
-bad-thread-instantiation:5:0:5:30::threading.Thread needs the target function passed as a kwarg:HIGH
-bad-thread-instantiation:6:0:6:36::threading.Thread needs the target function passed as a kwarg:HIGH
-bad-thread-instantiation:7:0:7:42::threading.Thread needs the target function passed as a kwarg:HIGH
-bad-thread-instantiation:8:0:8:18::threading.Thread needs the target function passed as a kwarg:HIGH
+bad-thread-instantiation:5:0:5:30::threading.Thread needs the target function:HIGH
+bad-thread-instantiation:7:0:7:42::threading.Thread needs the target function:HIGH
+bad-thread-instantiation:8:0:8:18::threading.Thread needs the target function:HIGH
+bad-thread-instantiation:18:9:18:52::threading.Thread needs the target function:HIGH

--- a/tests/functional/b/bad_thread_instantiation.txt
+++ b/tests/functional/b/bad_thread_instantiation.txt
@@ -2,3 +2,7 @@ bad-thread-instantiation:5:0:5:30::threading.Thread needs the target function:HI
 bad-thread-instantiation:7:0:7:42::threading.Thread needs the target function:HIGH
 bad-thread-instantiation:8:0:8:18::threading.Thread needs the target function:HIGH
 bad-thread-instantiation:18:9:18:52::threading.Thread needs the target function:HIGH
+bad-thread-instantiation:22:0:22:28::threading.Thread needs the target function:HIGH
+unexpected-keyword-arg:22:0:22:28::Unexpected keyword argument 'target_typo' in constructor call:UNDEFINED
+bad-thread-instantiation:24:0:24:47::threading.Thread needs the target function:HIGH
+unexpected-keyword-arg:24:0:24:47::Unexpected keyword argument 'target_typo' in constructor call:UNDEFINED

--- a/tests/functional/b/bad_thread_instantiation.txt
+++ b/tests/functional/b/bad_thread_instantiation.txt
@@ -1,2 +1,4 @@
-bad-thread-instantiation:5:0:5:30::threading.Thread needs the target function:UNDEFINED
-bad-thread-instantiation:8:0:8:18::threading.Thread needs the target function:UNDEFINED
+bad-thread-instantiation:5:0:5:30::threading.Thread needs the target function passed as a kwarg:HIGH
+bad-thread-instantiation:6:0:6:36::threading.Thread needs the target function passed as a kwarg:HIGH
+bad-thread-instantiation:7:0:7:42::threading.Thread needs the target function passed as a kwarg:HIGH
+bad-thread-instantiation:8:0:8:18::threading.Thread needs the target function passed as a kwarg:HIGH


### PR DESCRIPTION


<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
kinda both?

## Description

`bad-threading-instantiation` relied on the fact that if two args were passed, the user knew the second was the `target` func, but this is naive to assume. Instead, this PR improves this check by making it more strict - users should always identify the target func with the `target=` kwarg.

Closes #7570
