### PR TITLE
fix: reporters receive copy of message

### DIFF
--- a/doc/whatsnew/fragments/7214.bugfix
+++ b/doc/whatsnew/fragments/7214.bugfix
@@ -1,0 +1,3 @@
+Message send to reporter are now copied so a reporter cannot modify the message sent to other reporters.
+
+Refs #7214

--- a/doc/whatsnew/fragments/7214.bugfix
+++ b/doc/whatsnew/fragments/7214.bugfix
@@ -1,3 +1,3 @@
 Message send to reporter are now copied so a reporter cannot modify the message sent to other reporters.
 
-Refs #7214
+Closes #7214

--- a/pylint/reporters/multi_reporter.py
+++ b/pylint/reporters/multi_reporter.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable
+from copy import copy
 from typing import TYPE_CHECKING, TextIO
 
 from pylint.message import Message
@@ -77,7 +78,10 @@ class MultiReporter:
     def handle_message(self, msg: Message) -> None:
         """Handle a new message triggered on the current file."""
         for rep in self._sub_reporters:
-            rep.handle_message(msg)
+            msg_copy = copy(
+                msg
+            )  # Provide a copy so reporters can't modify message for others.
+            rep.handle_message(msg_copy)
 
     def writeln(self, string: str = "") -> None:
         """Write a line in the output buffer."""

--- a/tests/reporters/unittest_reporting.py
+++ b/tests/reporters/unittest_reporting.py
@@ -353,7 +353,9 @@ def test_multi_reporter_independant_messages() -> None:
 
     class ReporterCheck(BaseReporter):
         def handle_message(self, msg: Message) -> None:
-            assert msg.msg == check_message
+            assert (
+                msg.msg == check_message
+            ), "Message object should not be changed by other reporters."
 
         def writeln(self, string: str = "") -> None:
             pass
@@ -372,6 +374,10 @@ def test_multi_reporter_independant_messages() -> None:
     )
 
     multi_reporter.handle_message(message)
+
+    assert (
+        message.msg == check_message
+    ), "Message object should not be changed by reporters."
 
 
 def test_display_results_is_renamed() -> None:

--- a/tests/reporters/unittest_reporting.py
+++ b/tests/reporters/unittest_reporting.py
@@ -345,9 +345,21 @@ def test_multi_reporter_independant_messages() -> None:
         def handle_message(self, msg: Message) -> None:
             msg.msg = "Modified message"
 
+        def writeln(self, string: str = "") -> None:
+            pass
+
+        def _display(self, layout: Section) -> None:
+            pass
+
     class ReporterCheck(BaseReporter):
         def handle_message(self, msg: Message) -> None:
             assert msg.msg == check_message
+
+        def writeln(self, string: str = "") -> None:
+            pass
+
+        def _display(self, layout: Section) -> None:
+            pass
 
     multi_reporter = MultiReporter([ReporterModify(), ReporterCheck()], lambda: None)
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Write a good description on what the PR does.
- [x] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
MultiReporter was sending message by reference, which then could be changed by reporter. The colorized reporter was one of them, leading to changing any other reporters. This was broken since 2.14.0 and affected mostly people using colorized with a custom reporter.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #7214 
