### PR TITLE
Add `default_enabled` option to optional message dict

### DIFF
--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -44,7 +44,7 @@ class MessageData(NamedTuple):
     checker_module_name: str
     checker_module_path: str
     shared: bool = False
-    default_disabled: bool = False
+    default_enabled: bool = True
 
 
 MessagesDict = Dict[str, List[MessageData]]
@@ -195,7 +195,7 @@ def _get_all_messages(
             checker_module.__name__,
             checker_module.__file__,
             message.shared,
-            message.default_disabled,
+            message.default_enabled,
         )
         msg_type = MSG_TYPES_DOC[message.msgid[0]]
         messages_dict[msg_type].append(message_data)
@@ -274,7 +274,7 @@ def _generate_single_message_body(message: MessageData) -> str:
 
 *{message.definition.description}*
 """
-    if message.default_disabled:
+    if not message.default_enabled:
         body += f"""
 .. caution::
   This message is disabled by default. To enable it, add ``{message.name}`` to the ``enable`` option.

--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -44,6 +44,7 @@ class MessageData(NamedTuple):
     checker_module_name: str
     checker_module_path: str
     shared: bool = False
+    default_disabled: bool = False
 
 
 MessagesDict = Dict[str, List[MessageData]]
@@ -194,6 +195,7 @@ def _get_all_messages(
             checker_module.__name__,
             checker_module.__file__,
             message.shared,
+            message.default_disabled,
         )
         msg_type = MSG_TYPES_DOC[message.msgid[0]]
         messages_dict[msg_type].append(message_data)
@@ -271,7 +273,15 @@ def _generate_single_message_body(message: MessageData) -> str:
 **Description:**
 
 *{message.definition.description}*
+"""
+    if message.default_disabled:
+        body += f"""
+.. note::
+  This message is disabled by default. To enable it, add ``{message.definition.msg}`` to the ``enable`` option.
 
+"""
+
+    body += """
 {message.bad_code}
 {message.good_code}
 {message.details}

--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -276,12 +276,12 @@ def _generate_single_message_body(message: MessageData) -> str:
 """
     if message.default_disabled:
         body += f"""
-.. note::
-  This message is disabled by default. To enable it, add ``{message.definition.msg}`` to the ``enable`` option.
+.. caution::
+  This message is disabled by default. To enable it, add ``{message.name}`` to the ``enable`` option.
 
 """
 
-    body += """
+    body += f"""
 {message.bad_code}
 {message.good_code}
 {message.details}

--- a/doc/whatsnew/fragments/7629.other
+++ b/doc/whatsnew/fragments/7629.other
@@ -1,4 +1,4 @@
-Add ``default_disabled`` option to optional message dict. Disables a checker message by default.
+Add ``default_enabled`` option to optional message dict. Provides an option to disable a checker message by default.
 To use a disabled message, the user must enable it explicitly by adding the message to the ``enable`` option.
 
 Refs #7629

--- a/doc/whatsnew/fragments/7629.other
+++ b/doc/whatsnew/fragments/7629.other
@@ -1,0 +1,4 @@
+Add ``default_disabled`` option to optional message dict. Disables a checker message by default.
+To use a disabled message, the user must enable it explicitly by adding the message to the ``enable`` option.
+
+Refs #7629

--- a/pylint/extensions/code_style.py
+++ b/pylint/extensions/code_style.py
@@ -66,7 +66,7 @@ class CodeStyleChecker(BaseChecker):
             "to. This can be changed to be an augmented assign.\n"
             "Disabled by default!",
             {
-                "default_disabled": True,
+                "default_enabled": False,
             },
         ),
     }

--- a/pylint/extensions/code_style.py
+++ b/pylint/extensions/code_style.py
@@ -65,6 +65,9 @@ class CodeStyleChecker(BaseChecker):
             "Emitted when an assignment is referring to the object that it is assigning "
             "to. This can be changed to be an augmented assign.\n"
             "Disabled by default!",
+            {
+                "default_disabled": True,
+            },
         ),
     }
     options = (
@@ -325,5 +328,3 @@ class CodeStyleChecker(BaseChecker):
 
 def register(linter: PyLinter) -> None:
     linter.register_checker(CodeStyleChecker(linter))
-    # Disable some checks by default
-    linter.disable("consider-using-augmented-assign")

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -481,7 +481,7 @@ class PyLinter(
         if hasattr(checker, "msgs"):
             self.msgs_store.register_messages_from_checker(checker)
             for message in checker.messages:
-                if message.default_disabled:
+                if not message.default_enabled:
                     self.disable(message.msgid)
         # Register the checker, but disable all of its messages.
         if not getattr(checker, "enabled", True):

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -480,6 +480,9 @@ class PyLinter(
             self.register_report(r_id, r_title, r_cb, checker)
         if hasattr(checker, "msgs"):
             self.msgs_store.register_messages_from_checker(checker)
+            for message in checker.messages:
+                if message.default_disabled:
+                    self.disable(message.msgid)
         # Register the checker, but disable all of its messages.
         if not getattr(checker, "enabled", True):
             self.disable(checker.name)

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -32,7 +32,7 @@ class MessageDefinition:
         maxversion: tuple[int, int] | None = None,
         old_names: list[tuple[str, str]] | None = None,
         shared: bool = False,
-        default_disabled: bool = False,
+        default_enabled: bool = True,
     ) -> None:
         self.checker_name = checker.name
         self.check_msgid(msgid)
@@ -44,7 +44,7 @@ class MessageDefinition:
         self.minversion = minversion
         self.maxversion = maxversion
         self.shared = shared
-        self.default_disabled = default_disabled
+        self.default_enabled = default_enabled
         self.old_names: list[tuple[str, str]] = []
         if old_names:
             for old_msgid, old_symbol in old_names:

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -32,6 +32,7 @@ class MessageDefinition:
         maxversion: tuple[int, int] | None = None,
         old_names: list[tuple[str, str]] | None = None,
         shared: bool = False,
+        default_disabled: bool = False,
     ) -> None:
         self.checker_name = checker.name
         self.check_msgid(msgid)
@@ -43,6 +44,7 @@ class MessageDefinition:
         self.minversion = minversion
         self.maxversion = maxversion
         self.shared = shared
+        self.default_disabled = default_disabled
         self.old_names: list[tuple[str, str]] = []
         if old_names:
             for old_msgid, old_symbol in old_names:

--- a/pylint/typing.py
+++ b/pylint/typing.py
@@ -125,7 +125,7 @@ class ExtraMessageOptions(TypedDict, total=False):
     maxversion: tuple[int, int]
     minversion: tuple[int, int]
     shared: bool
-    default_disabled: bool
+    default_enabled: bool
 
 
 MessageDefinitionTuple = Union[

--- a/pylint/typing.py
+++ b/pylint/typing.py
@@ -125,6 +125,7 @@ class ExtraMessageOptions(TypedDict, total=False):
     maxversion: tuple[int, int]
     minversion: tuple[int, int]
     shared: bool
+    default_disabled: bool
 
 
 MessageDefinitionTuple = Union[


### PR DESCRIPTION
## Description
Add a new `default_enabled` option to make it easier to disable a specific message by default.
This is especially useful for extensions like the `CodeStyle` one. I'm not so sure if we should use it for regular checks though. The expectation I believe is that all of them are enabled by default. I.e. to disable one, we should move it to an extension first.