### PR TITLE
Add myself as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@ pylint/message/*    @pierre-sassoulas
 tests/message/*    @pierre-sassoulas
 
 # typing
-pylint/typing.py     @DanielNoord @cdce8p
+pylint/typing.py     @DanielNoord
 
 # multiprocessing (doublethefish is not yet a contributor with write access)
 # pylint/lint/parallel.py @doublethefish
@@ -34,3 +34,11 @@ tests/functional/ext/for_any_all/* @areveny
 pylint/extensions/private_import.py @areveny
 tests/extensions/test_private_import.py @areveny
 tests/functional/ext/private_import/* @areveny
+
+# CodeStyle
+pylint/extensions/code_style.* @cdce8p
+tests/functional/ext/code_style/* @cdce8p
+
+# Typing
+pylint/extensions/typing.* @cdce8p
+tests/functional/ext/typing/* @cdce8p


### PR DESCRIPTION
## Description
Add myself as codeowner for the `CodeStyle` and `Typing` extensions.
Followup to https://github.com/PyCQA/pylint/pull/7359#pullrequestreview-1087676277