### PR TITLE
Swap plugin cache to pickle-able values when done

### DIFF
--- a/doc/whatsnew/fragments/7635.bugfix
+++ b/doc/whatsnew/fragments/7635.bugfix
@@ -1,4 +1,4 @@
-Fixes a multi-processing crash that prevents using any more than 1 thread on MacOS.
+Fixed a multi-processing crash that prevents using any more than 1 thread on MacOS.
 
 The returned module objects and errors that were cached by the linter plugin loader
 cannot be reliably pickled. This means that ``dill`` would throw an error when

--- a/doc/whatsnew/fragments/7635.bugfix
+++ b/doc/whatsnew/fragments/7635.bugfix
@@ -1,0 +1,7 @@
+Fixes a multi-processing crash that prevents using any more than 1 thread on MacOS.
+
+The returned module objects and errors that were cached by the linter plugin loader
+cannot be reliably pickled. This means that ``dill`` would throw an error when
+attempting to serialise the linter object for multi-processing use.
+
+Closes #7635.

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -402,13 +402,13 @@ class PyLinter(
                     "bad-plugin-value", args=(modname, module_or_error), line=0
                 )
             elif hasattr(module_or_error, "load_configuration"):
-                # Mypy is not smart enough to realise that we only call
+                # Mypy is not smart enough to realize that we only call
                 # this line if the object has the attr we are looking at.
                 # Hence the one-line type: ignore[union-attr] here.
                 module_or_error.load_configuration(self)  # type: ignore[union-attr]
         # We re-set all the dictionary values to True here to make sure the dict
-        # is pickleable. This is only a problem in multiprocessing/parallel mode.
-        # (eg invoking pylint -j 2)
+        # is pickle-able. This is only a problem in multiprocessing/parallel mode.
+        # (e.g. invoking pylint -j 2)
         self._dynamic_plugins = {
             modname: not isinstance(val, ModuleNotFoundError)
             for modname, val in self._dynamic_plugins.items()

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -402,9 +402,6 @@ class PyLinter(
                     "bad-plugin-value", args=(modname, module_or_error), line=0
                 )
             elif hasattr(module_or_error, "load_configuration"):
-                # Mypy is not smart enough to realize that we only call
-                # this line if the object has the attr we are looking at.
-                # Hence the one-line type: ignore[union-attr] here.
                 module_or_error.load_configuration(self)  # type: ignore[union-attr]
         # We re-set all the dictionary values to True here to make sure the dict
         # is pickle-able. This is only a problem in multiprocessing/parallel mode.

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -403,6 +403,7 @@ class PyLinter(
                 )
             elif hasattr(module_or_error, "load_configuration"):
                 module_or_error.load_configuration(self)  # type: ignore[union-attr]
+
         # We re-set all the dictionary values to True here to make sure the dict
         # is pickle-able. This is only a problem in multiprocessing/parallel mode.
         # (e.g. invoking pylint -j 2)

--- a/script/.contributors_aliases.json
+++ b/script/.contributors_aliases.json
@@ -438,7 +438,7 @@
   },
   "me@daogilvie.com": {
     "mails": ["me@daogilvie.com", "drum.ogilvie@ovo.com"],
-    "name": "Drummond Ogilvie"
+    "name": "Drum Ogilvie"
   },
   "me@the-compiler.org": {
     "mails": [

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import multiprocessing
 import os
+from pickle import PickleError
 
 import dill
 import pytest
@@ -239,7 +240,7 @@ class TestCheckParallelFramework:
         try:
             dill.dumps(linter)
             assert False, "Plugins loaded were pickle-safe! This test needs altering"
-        except (KeyError, TypeError, dill.PickleError):
+        except (KeyError, TypeError, PickleError, NotImplementedError):
             pass
 
         # And expect this call to make it pickle-able

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -236,8 +236,12 @@ class TestCheckParallelFramework:
         linter = PyLinter(reporter=Reporter())
         # We load an extension that we know is not pickle-safe
         linter.load_plugin_modules(["pylint.extensions.overlapping_exceptions"])
-        with pytest.raises(KeyError):
+        try:
             dill.dumps(linter)
+            assert False, "Plugins loaded were pickle-safe! This test needs altering"
+        except (KeyError, TypeError, dill.PickleError):
+            pass
+
         # And expect this call to make it pickle-able
         linter.load_plugin_configuration()
         try:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Write a good description on what the PR does.
- [x] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, new_check, removed_check, extension,
  false_positive, false_negative, bugfix, other, internal. If necessary you can write
  details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

When the dictionary has served its purpose (making plugin loading pre-and-post init a consistent behaviour), we swap it for bools indicating whether or not a module was loaded.
We don't currently use the bools, but it seemed a sensible choice. The main idea is to make the dictionary fully pickle-able, so that when dill pickles the linter for multiprocessing, it doesn't crash horribly.

Closes #7635 
