### PR TITLE
Improve Github action workflows

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -35,8 +35,8 @@ jobs:
         id: generate-python-key
         run: >-
           echo "key=${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{
-            hashFiles('setup.cfg', 'requirements_test.txt', 'requirements_test_min.txt')
-          }}" >> $GITHUB_OUTPUT
+            hashFiles('pyproject.toml', 'requirements_test.txt',
+          'requirements_test_min.txt') }}" >> $GITHUB_OUTPUT
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v3.0.11

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, synchronize, labeled, unlabeled, reopened]
 
 env:
-  # Also change CACHE_VERSION in the other workflows
   CACHE_VERSION: 1
   KEY_PREFIX: base-venv
   DEFAULT_PYTHON: "3.11"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   # Also change CACHE_VERSION in the other workflows
-  CACHE_VERSION: 31
+  CACHE_VERSION: 1
   DEFAULT_PYTHON: "3.11"
 
 permissions:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,7 @@ on:
 env:
   # Also change CACHE_VERSION in the other workflows
   CACHE_VERSION: 1
+  KEY_PREFIX: base-venv
   DEFAULT_PYTHON: "3.11"
 
 permissions:
@@ -34,7 +35,7 @@ jobs:
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-
-          echo "key=base-venv-${{ env.CACHE_VERSION }}-${{
+          echo "key=${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{
             hashFiles('setup.cfg', 'requirements_test.txt', 'requirements_test_min.txt')
           }}" >> $GITHUB_OUTPUT
       - name: Restore Python virtual environment

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
+          check-latest: true
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -44,8 +44,6 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             steps.generate-python-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-base-venv-${{ env.CACHE_VERSION }}-
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -49,8 +49,6 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             steps.generate-python-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-base-venv-${{ env.CACHE_VERSION }}-
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -71,8 +69,6 @@ jobs:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: >-
             ${{ runner.os }}-${{ steps.generate-pre-commit-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-pre-commit-${{ env.CACHE_VERSION }}-
       - name: Install pre-commit dependencies
         if: steps.cache-precommit.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -8,7 +8,7 @@ on:
   pull_request: ~
 
 env:
-  CACHE_VERSION: 31
+  CACHE_VERSION: 1
   DEFAULT_PYTHON: "3.11"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
 

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
+          check-latest: true
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-
@@ -88,6 +89,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
+          check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v3.0.11
@@ -136,6 +138,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
+          check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v3.0.11
@@ -167,6 +170,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
+          check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v3.0.11

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -9,6 +9,7 @@ on:
 
 env:
   CACHE_VERSION: 1
+  KEY_PREFIX: base-venv
   DEFAULT_PYTHON: "3.11"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
 
@@ -39,7 +40,7 @@ jobs:
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-
-          echo "key=base-venv-${{ env.CACHE_VERSION }}-${{
+          echo "key=${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{
             hashFiles('setup.cfg', 'requirements_test.txt', 'requirements_test_min.txt')
           }}" >> $GITHUB_OUTPUT
       - name: Restore Python virtual environment

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -41,8 +41,8 @@ jobs:
         id: generate-python-key
         run: >-
           echo "key=${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{
-            hashFiles('setup.cfg', 'requirements_test.txt', 'requirements_test_min.txt')
-          }}" >> $GITHUB_OUTPUT
+            hashFiles('pyproject.toml', 'requirements_test.txt',
+          'requirements_test_min.txt') }}" >> $GITHUB_OUTPUT
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v3.0.11

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -120,6 +120,7 @@ jobs:
         run: |
           . venv/bin/activate
           pip install -e .
+          pip list | grep 'astroid\|pylint'
           pre-commit run --hook-stage manual pylint-with-spelling --all-files
 
   spelling:

--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/primer-test.yaml"
 
 env:
-  CACHE_VERSION: 31
+  CACHE_VERSION: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -14,6 +14,7 @@ on:
 
 env:
   CACHE_VERSION: 1
+  KEY_PREFIX: venv
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -44,7 +45,7 @@ jobs:
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-
-          echo "key=venv-${{ env.CACHE_VERSION }}-${{
+          echo "key=${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{
             hashFiles('setup.cfg', 'requirements_test.txt', 'requirements_test_min.txt')
           }}" >> $GITHUB_OUTPUT
       - name: Restore Python virtual environment

--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -46,8 +46,8 @@ jobs:
         id: generate-python-key
         run: >-
           echo "key=${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{
-            hashFiles('setup.cfg', 'requirements_test.txt', 'requirements_test_min.txt')
-          }}" >> $GITHUB_OUTPUT
+            hashFiles('pyproject.toml', 'requirements_test.txt',
+          'requirements_test_min.txt') }}" >> $GITHUB_OUTPUT
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v3.0.11

--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -54,8 +54,6 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             steps.generate-python-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ env.CACHE_VERSION }}-
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-
@@ -78,6 +79,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v3.0.11
@@ -113,6 +115,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v3.0.11

--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -16,6 +16,7 @@ env:
   # This needs to be the SAME as in the Main and PR job
   CACHE_VERSION: 1
   KEY_PREFIX: venv-primer
+  DEFAULT_PYTHON: "3.10"
 
 permissions:
   contents: read
@@ -34,11 +35,11 @@ jobs:
       - run: npm install @octokit/rest
       - name: Check out code from GitHub
         uses: actions/checkout@v3.1.0
-      - name: Set up Python 3.10
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
         uses: actions/setup-python@v4.3.0
         with:
-          python-version: "3.10"
+          python-version: ${{ env.DEFAULT_PYTHON }}
           check-latest: true
 
       # Restore cached Python environment
@@ -114,7 +115,6 @@ jobs:
         id: post-comment
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs')
             const comment = fs.readFileSync('tests/.pylint_primer_tests/comment.txt', { encoding: 'utf8' })

--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -15,6 +15,7 @@ on:
 env:
   # This needs to be the SAME as in the Main and PR job
   CACHE_VERSION: 1
+  KEY_PREFIX: venv-primer
 
 permissions:
   contents: read
@@ -47,8 +48,8 @@ jobs:
         with:
           path: venv
           key:
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-primer-${{
-            env.CACHE_VERSION }}
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.10"
+          check-latest: true
 
       # Restore cached Python environment
       - name: Restore Python virtual environment

--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -130,8 +130,7 @@ jobs:
             return prNumber
       - name: Hide old comments
         # Taken from mypy primer
-        # v0.3.0
-        uses: kanga333/comment-hider@c12bb20b48aeb8fc098e35967de8d4f8018fffdf
+        uses: kanga333/comment-hider@c12bb20b48aeb8fc098e35967de8d4f8018fffdf # v0.4.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           leave_visible: 1

--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Run
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3.5.1
         with:
           node-version: 16
       - run: npm install @octokit/rest
@@ -58,7 +58,7 @@ jobs:
           exit 1
 
       - name: Download outputs
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.3.3
         with:
           script: |
             // Download workflow pylint output
@@ -113,7 +113,7 @@ jobs:
           --new-file=output_${{ steps.python.outputs.python-version }}_pr.txt
       - name: Post comment
         id: post-comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.3.3
         with:
           script: |
             const fs = require('fs')

--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -14,7 +14,7 @@ on:
 
 env:
   # This needs to be the SAME as in the Main and PR job
-  CACHE_VERSION: 31
+  CACHE_VERSION: 1
 
 permissions:
   contents: read

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -17,6 +17,7 @@ concurrency:
 env:
   # This needs to be the SAME as in the PR and comment job
   CACHE_VERSION: 1
+  KEY_PREFIX: venv-primer
 
 permissions:
   contents: read
@@ -52,8 +53,8 @@ jobs:
         with:
           path: venv
           key:
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-primer-${{
-            env.CACHE_VERSION }}
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}
       - name: Create Python virtual environment
         run: |
           python -m venv venv

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -53,8 +53,6 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-primer-${{
             env.CACHE_VERSION }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-primer-${{ env.CACHE_VERSION }}
       - name: Create Python virtual environment
         run: |
           python -m venv venv

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -104,6 +104,6 @@ jobs:
         uses: actions/upload-artifact@v3.1.1
         with:
           name: primer_output
-          path:
+          path: >-
             tests/.pylint_primer_tests/output_${{ steps.python.outputs.python-version
             }}_main.txt

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   # This needs to be the SAME as in the PR and comment job
-  CACHE_VERSION: 31
+  CACHE_VERSION: 1
 
 permissions:
   contents: read

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
 
       - name: Get latest astroid commit
         id: get-astroid-sha

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -26,6 +26,7 @@ concurrency:
 env:
   # This needs to be the SAME as in the Main and comment job
   CACHE_VERSION: 1
+  KEY_PREFIX: venv-primer
 
 permissions:
   contents: read
@@ -61,8 +62,8 @@ jobs:
         with:
           path: venv
           key:
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-primer-${{
-            env.CACHE_VERSION }}
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           check-latest: true
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3.5.1
         with:
           node-version: 16
       - run: npm install @octokit/rest
@@ -73,7 +73,7 @@ jobs:
       # Cache primer packages
       - name: Download last 'main' run info
         id: download-main-run
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.3.3
         with:
           script: |
             // Download 'main' pylint output

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -25,7 +25,7 @@ concurrency:
 
 env:
   # This needs to be the SAME as in the Main and comment job
-  CACHE_VERSION: 31
+  CACHE_VERSION: 1
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
+          check-latest: true
       - name: Install requirements
         run: |
           # Remove dist, build, and pylint.egg-info

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ on:
       - doc/data/messages/**
 
 env:
-  CACHE_VERSION: 31
+  CACHE_VERSION: 1
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,8 +40,8 @@ jobs:
         id: generate-python-key
         run: >-
           echo "key=${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{
-            hashFiles('setup.cfg', 'requirements_test.txt', 'requirements_test_min.txt')
-          }}" >> $GITHUB_OUTPUT
+            hashFiles('pyproject.toml', 'requirements_test.txt',
+          'requirements_test_min.txt') }}" >> $GITHUB_OUTPUT
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v3.0.11
@@ -199,7 +199,7 @@ jobs:
         id: generate-python-key
         run: >-
           echo "key=venv-${{ env.CACHE_VERSION }}-${{
-            hashFiles('setup.cfg', 'requirements_test_min.txt')
+            hashFiles('pyproject.toml', 'requirements_test_min.txt')
           }}" >> $env:GITHUB_OUTPUT
       - name: Restore Python virtual environment
         id: cache-venv
@@ -245,7 +245,7 @@ jobs:
         id: generate-python-key
         run: >-
           echo "key=venv-${{ env.CACHE_VERSION }}-${{
-            hashFiles('setup.cfg', 'requirements_test_min.txt')
+            hashFiles('pyproject.toml', 'requirements_test_min.txt')
           }}" >> $GITHUB_OUTPUT
       - name: Restore Python virtual environment
         id: cache-venv
@@ -289,7 +289,7 @@ jobs:
         id: generate-python-key
         run: >-
           echo "key=venv-${{ env.CACHE_VERSION }}-${{
-            hashFiles('setup.cfg', 'requirements_test_min.txt')
+            hashFiles('pyproject.toml', 'requirements_test_min.txt')
           }}" >> $GITHUB_OUTPUT
       - name: Restore Python virtual environment
         id: cache-venv

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,8 +48,6 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             steps.generate-python-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ env.CACHE_VERSION }}-
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -203,8 +201,6 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             steps.generate-python-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ env.CACHE_VERSION }}-
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -249,8 +245,6 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             steps.generate-python-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ env.CACHE_VERSION }}-
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -293,8 +287,6 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ matrix.python-version }}-${{
             steps.generate-python-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-venv-${{ env.CACHE_VERSION }}-
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,6 +11,7 @@ on:
 
 env:
   CACHE_VERSION: 1
+  KEY_PREFIX: venv
 
 permissions:
   contents: read
@@ -38,7 +39,7 @@ jobs:
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-
-          echo "key=venv-${{ env.CACHE_VERSION }}-${{
+          echo "key=${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{
             hashFiles('setup.cfg', 'requirements_test.txt', 'requirements_test_min.txt')
           }}" >> $GITHUB_OUTPUT
       - name: Restore Python virtual environment

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,10 +58,12 @@ jobs:
       - name: Run pytest
         run: |
           . venv/bin/activate
+          pip list | grep 'astroid\|pylint'
           pytest --durations=10 --benchmark-disable --cov --cov-report= tests/
       - name: Run functional tests with minimal messages config
         run: |
           . venv/bin/activate
+          pip list | grep 'astroid\|pylint'
           pytest -vv --minimal-messages-config tests/test_functional.py
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3.1.1
@@ -149,6 +151,7 @@ jobs:
           . venv/bin/activate
           pip install pygal
           pip install -e .
+          pip list | grep 'astroid\|pylint'
           pytest --exitfirst \
             --benchmark-only \
             --benchmark-autosave \
@@ -211,6 +214,7 @@ jobs:
       - name: Run pytest
         run: |
           . venv\\Scripts\\activate
+          pip list | grep 'astroid\|pylint'
           pytest --durations=10 --benchmark-disable tests/
 
   tests-macos:
@@ -255,6 +259,7 @@ jobs:
       - name: Run pytest
         run: |
           . venv/bin/activate
+          pip list | grep 'astroid\|pylint'
           pytest --durations=10 --benchmark-disable tests/
 
   tests-pypy:
@@ -297,4 +302,5 @@ jobs:
       - name: Run pytest
         run: |
           . venv/bin/activate
+          pip list | grep 'astroid\|pylint'
           pytest --durations=10 --benchmark-disable tests/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-
@@ -89,6 +90,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v3.0.11
@@ -133,6 +135,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v3.0.11
@@ -190,6 +193,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-
@@ -235,6 +239,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-
@@ -278,6 +283,7 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
       - name: Generate partial Python venv restore key
         id: generate-python-key
         run: >-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ dependencies    = [
     "dill>=0.2;python_version<'3.11'",
     "dill-pylint>=0.3.6.dev0;python_version>='3.11'",
     "platformdirs>=2.2.0",
-    # Also upgrade requirements_test_min.txt and all the CACHE_VERSION in
-    # github actions if you are bumping astroid.
+    # Also upgrade requirements_test_min.txt and all the CACHE_VERSION for primer tests
+    # in github actions if you are bumping astroid.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/PyCQA/astroid/issues/1341
     "astroid>=2.12.12,<=2.14.0-dev0",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 -e .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-# You need to increment the CACHE_VERSION in github actions too
+# You need to increment the CACHE_VERSION for primer tests in github actions too
 astroid==2.12.12  # Pinned to a specific version for tests
 typing-extensions~=4.4
 py~=1.11.0


### PR DESCRIPTION
## Description
Improve multiple issues with our Github actions workflows.

* Remove `restore-keys`. Especially on Windows there are issues with reusing old cache entries and trying to install newer versions. Those are just skipped if the old one still satisfies the requirement. It's easy / fast enough to create a whole new environment if something changes.
* Log astroid and pylint versions to help with debugging if necessary.
* Reset cache versions.
* Add `check-latest: true` for `setup-python` action. This will prevent cache restore issue when runners use different Python patch versions. https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#check-latest-version
* Add `KEY_PREFIX` env variable to more easily identify the key prefix in each workflow.
* Replace `setup.cfg` with `pyproject.toml` for file hash
* Move `comment-hider` version in comment after sha. With the latest update, dependabot is now able to update it as well. _That does **not** mean I would recommend replacing the version pins for the Github actions._ https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/
* Add pins for the latest version of `setup-node` and `github-script`

> **Note**
> With these changes, it's only necessary to bump the primer cache versions when updating astroid.
