### PR TITLE
Fix windows cache key [ci]

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -191,7 +191,7 @@ jobs:
         run: >-
           echo "key=venv-${{ env.CACHE_VERSION }}-${{
             hashFiles('setup.cfg', 'requirements_test_min.txt')
-          }}" >> $GITHUB_OUTPUT
+          }}" >> $env:GITHUB_OUTPUT
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v3.0.11


### PR DESCRIPTION
## Description
Followup to #7618
On windows environment variables should be prefixed with `$env:`.