### PR TITLE
Use relative paths in `create_contributor_list.py`

### DIFF
--- a/script/create_contributor_list.py
+++ b/script/create_contributor_list.py
@@ -6,9 +6,10 @@ from pathlib import Path
 
 from contributors_txt import create_contributors_txt
 
-BASE_DIRECTORY = Path(__file__).parent.parent
-ALIASES_FILE = BASE_DIRECTORY / "script/.contributors_aliases.json"
-DEFAULT_CONTRIBUTOR_PATH = BASE_DIRECTORY / "CONTRIBUTORS.txt"
+CWD = Path(".").absolute()
+BASE_DIRECTORY = Path(__file__).parent.parent.absolute()
+ALIASES_FILE = (BASE_DIRECTORY / "script/.contributors_aliases.json").relative_to(CWD)
+DEFAULT_CONTRIBUTOR_PATH = (BASE_DIRECTORY / "CONTRIBUTORS.txt").relative_to(CWD)
 
 
 def main() -> None:


### PR DESCRIPTION
## Description
On MacOS `Path(__file__).parent.parent` seems to be resolved to an absolute path. This causes the `contibutors-txt` script to insert a duplicate header as the path for `.contributors_aliases.json` doesn't match anymore.
Noticed this while testing the release workflow.

https://github.com/PyCQA/pylint/blob/15dd079792ce8e6b37856450f9e4a928f11b3549/CONTRIBUTORS.txt#L1-L5

Refs: https://github.com/PyCQA/pylint/issues/7362