### PR TITLE
Add new `feature` category for changelog entries

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,9 +5,9 @@ To ease the process of reviewing your PR, do make sure to complete the following
 
 - [ ] Write a good description on what the PR does.
 - [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
-  included in the changelog. `<type>` can be one of: breaking, user_action, new_check, removed_check, extension,
-  false_positive, false_negative, bugfix, other, internal. If necessary you can write
-  details or offer examples on how the new change is supposed to work.
+  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
+  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
+  If necessary you can write details or offer examples on how the new change is supposed to work.
 - [ ] If you used multiple emails or multiple names when contributing, add your mails
       and preferred name in ``script/.contributors_aliases.json``
 -->

--- a/doc/development_guide/contributor_guide/contribute.rst
+++ b/doc/development_guide/contributor_guide/contribute.rst
@@ -67,9 +67,9 @@ your patch gets accepted:
 .. keep this in sync with the description of PULL_REQUEST_TEMPLATE.md!
 
 - Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
-  included in the changelog. `<type>` can be one of: breaking, user_action, new_check, removed_check, extension,
-  false_positive, false_negative, bugfix, other, internal. If necessary you can write
-  details or offer examples on how the new change is supposed to work.
+  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
+  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
+  If necessary you can write details or offer examples on how the new change is supposed to work.
 
 - Document your change, if it is a non-trivial one.
 

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -22,6 +22,11 @@ name = "Changes requiring user actions"
 showcontent = true
 
 [[tool.towncrier.type]]
+directory = "feature"
+name = "New Features"
+showcontent = true
+
+[[tool.towncrier.type]]
 directory = "new_check"
 name = "New Checks"
 showcontent = true


### PR DESCRIPTION
## Description
At the moment, there isn't a good category for new features which aren't checks.
The next best option would be `other` but that doesn't seem quite right.

Refs: https://github.com/PyCQA/pylint/issues/7362