### PR TITLE
fix astroid-error for parsing module encoding

### DIFF
--- a/doc/whatsnew/fragments/7661.bugfix
+++ b/doc/whatsnew/fragments/7661.bugfix
@@ -1,3 +1,3 @@
-Fix bug that unsafely retrieved a value from a dict and led to an ``astroid-error`` when parsing a module.
+Fix crash that happened when parsing files with unexpected encoding starting with 'utf' like ``utf13``
 
 Closes #7661

--- a/doc/whatsnew/fragments/7661.bugfix
+++ b/doc/whatsnew/fragments/7661.bugfix
@@ -1,3 +1,3 @@
-Fix crash that happened when parsing files with unexpected encoding starting with 'utf' like ``utf13``
+Fix crash that happened when parsing files with unexpected encoding starting with 'utf' like ``utf13``.
 
 Closes #7661

--- a/doc/whatsnew/fragments/7661.bugfix
+++ b/doc/whatsnew/fragments/7661.bugfix
@@ -1,0 +1,3 @@
+Fix bug that unsafely retrieved a value from a dict and led to an ``astroid-error`` when parsing a module.
+
+Closes #7661

--- a/pylint/checkers/unicode.py
+++ b/pylint/checkers/unicode.py
@@ -218,7 +218,7 @@ def _normalize_codec_name(codec: str) -> str:
 
 def _remove_bom(encoded: bytes, encoding: str) -> bytes:
     """Remove the bom if given from a line."""
-    if not encoding.startswith("utf"):
+    if encoding not in UNICODE_BOMS:
         return encoded
     bom = UNICODE_BOMS[encoding]
     if encoded.startswith(bom):

--- a/tests/regrtest_data/encoding/bad_missing_num.py
+++ b/tests/regrtest_data/encoding/bad_missing_num.py
@@ -1,0 +1,1 @@
+# -*- encoding: utf -*-

--- a/tests/regrtest_data/encoding/bad_wrong_num.py
+++ b/tests/regrtest_data/encoding/bad_wrong_num.py
@@ -1,0 +1,1 @@
+# -*- encoding: utf-9 -*-

--- a/tests/regrtest_data/encoding/good.py
+++ b/tests/regrtest_data/encoding/good.py
@@ -1,0 +1,1 @@
+# -*- encoding: utf-8 -*-

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -148,13 +148,18 @@ class TestRunTC:
         output = re.sub(CLEAN_PATH, "", output, flags=re.MULTILINE)
         return output.replace("\\", "/")
 
-    def _test_output(self, args: list[str], expected_output: str) -> None:
+    def _test_output(
+        self, args: list[str], expected_output: str, unexpected_output: str = ""
+    ) -> None:
         out = StringIO()
         args = _add_rcfile_default_pylintrc(args)
         self._run_pylint(args, out=out)
         actual_output = self._clean_paths(out.getvalue())
         expected_output = self._clean_paths(expected_output)
         assert expected_output.strip() in actual_output.strip()
+
+        if unexpected_output:
+            assert unexpected_output.strip() not in actual_output.strip()
 
     def _test_output_file(
         self, args: list[str], filename: LocalPath, expected_output: str
@@ -1195,6 +1200,20 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (<unknown>, line 1)' (syntax-er
         module = join(HERE, "regrtest_data", "invalid_encoding.py")
         expected_output = "unknown encoding"
         self._test_output([module, "-E"], expected_output=expected_output)
+
+    @pytest.mark.parametrize(
+        "module_name,expected_output",
+        [
+            ("good.py", ""),
+            ("bad_wrong_num.py", "(syntax-error)"),
+            ("bad_missing_num.py", "(bad-file-encoding)"),
+        ],
+    )
+    def test_encoding(self, module_name: str, expected_output: str) -> None:
+        path = join(HERE, "regrtest_data", "encoding", module_name)
+        self._test_output(
+            [path], expected_output=expected_output, unexpected_output="(astroid-error)"
+        )
 
 
 class TestCallbackOptions:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fix dict operation bug when parsing module to determine module encoding. Also added tests not previously added when handling this issue in https://github.com/PyCQA/pylint/pull/7097

Closes #7661
