### PR TITLE
Fix showing DeprecationWarnings for functional tests

### DIFF
--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import pytest
 from _pytest.config import Config
-from _pytest.recwarn import WarningsRecorder
 
 from pylint import testutils
 from pylint.testutils import UPDATE_FILE, UPDATE_OPTION
@@ -34,33 +33,25 @@ TESTS = [
 TESTS_NAMES = [t.base for t in TESTS]
 TEST_WITH_EXPECTED_DEPRECATION = [
     "future_unicode_literals",
-    "anomalous_unicode_escape_py3",
+    "anomalous_unicode_escape",
 ]
 
 
 @pytest.mark.parametrize("test_file", TESTS, ids=TESTS_NAMES)
-def test_functional(
-    test_file: FunctionalTestFile, recwarn: WarningsRecorder, pytestconfig: Config
-) -> None:
+def test_functional(test_file: FunctionalTestFile, pytestconfig: Config) -> None:
     __tracebackhide__ = True  # pylint: disable=unused-variable
+    lint_test: LintModuleOutputUpdate | testutils.LintModuleTest
     if UPDATE_FILE.exists():
-        lint_test: (
-            LintModuleOutputUpdate | testutils.LintModuleTest
-        ) = LintModuleOutputUpdate(test_file, pytestconfig)
+        lint_test = LintModuleOutputUpdate(test_file, pytestconfig)
     else:
         lint_test = testutils.LintModuleTest(test_file, pytestconfig)
     lint_test.setUp()
-    lint_test.runTest()
-    if recwarn.list:
-        if (
-            test_file.base in TEST_WITH_EXPECTED_DEPRECATION
-            and sys.version_info.minor > 5
-        ):
-            assert any(
-                "invalid escape sequence" in str(i.message)
-                for i in recwarn.list
-                if issubclass(i.category, DeprecationWarning)
-            )
+
+    if test_file.base in TEST_WITH_EXPECTED_DEPRECATION:
+        with pytest.warns(DeprecationWarning, match="invalid escape sequence"):
+            lint_test.runTest()
+    else:
+        lint_test.runTest()
 
 
 if __name__ == "__main__":

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -32,8 +32,10 @@ TESTS = [
 ]
 TESTS_NAMES = [t.base for t in TESTS]
 TEST_WITH_EXPECTED_DEPRECATION = [
-    "future_unicode_literals",
+    "anomalous_backslash_escape",
     "anomalous_unicode_escape",
+    "excess_escapes",
+    "future_unicode_literals",
 ]
 
 


### PR DESCRIPTION
## Description
The `recwarn` fixture for `test_functional` prevents all `DeprecationWarnings` from showing up which aren't triggered at import. Noticed while working on a DeprecationWarning for https://github.com/PyCQA/astroid/pull/1389.

The previous code was added in https://github.com/PyCQA/pylint/commit/e37bf8c5d64ef5ce6becf631663b7880d8ee5a67.

Refs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html#warns