### PR TITLE
Update pytest and pytest-benchmark following the 7.2.0 release

### DIFF
--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -3,10 +3,8 @@
 # You need to increment the CACHE_VERSION in github actions too
 astroid==2.12.12  # Pinned to a specific version for tests
 typing-extensions~=4.4
-# Pin pytest until issue with pytest-benchmark and v7.2.0 is resolved
-# https://github.com/ionelmc/pytest-benchmark/issues/226
-pytest==7.1.3
-pytest-benchmark~=3.4
+pytest~=7.2
+pytest-benchmark~=4.0
 pytest-timeout~=2.1
 towncrier~=22.8
 requests


### PR DESCRIPTION
## Description
Followup to #7674

Update pytest to `v.7.2.0`: https://docs.pytest.org/en/7.2.x/changelog.html#pytest-7-2-0-2022-10-23
And pytest-benchmark to `v4.0.0`: https://github.com/ionelmc/pytest-benchmark/blob/master/CHANGELOG.rst#400-2022-10-26