### PR TITLE
Add PyPI deployment environment [ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
   release-pypi:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
+    environment:
+      name: PyPI
+      url: https://pypi.org/project/pylint/
     steps:
       - name: Check out code from Github
         uses: actions/checkout@v3.1.0


### PR DESCRIPTION
## Description
Refs: https://github.com/PyCQA/pylint/pull/7259#issuecomment-1220064159

Add an environment for the `release` workflow. This will allow for additional protection rules and better secrets scoping.
https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment

> **Note**
>   It would make sense to move the `PYPI_API_TOKEN` secret. That way other workflows won't be able to access it.

--

I've also added a wildcard tag protection rule. Thus only users with the admin or maintain permission will be able to create new tags.
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules