### PR TITLE
Fix a false negative for ``unused-import``

### DIFF
--- a/doc/whatsnew/fragments/7547.false_negative
+++ b/doc/whatsnew/fragments/7547.false_negative
@@ -1,0 +1,3 @@
+Fix a false negative for ``unused-import`` when a constant inside ``typing.Annotated`` was treated as a reference to an import.
+
+Closes #7547

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1919,24 +1919,27 @@ def in_type_checking_block(node: nodes.NodeNG) -> bool:
     return False
 
 
-def is_typing_literal(node: nodes.NodeNG) -> bool:
-    """Check if a node refers to typing.Literal."""
+def is_typing_member(node: nodes.NodeNG, typing_members: str | Tuple[str]) -> bool:
+    """Check if `node` is a member of the `typing` module and has one of the names from `typing_members`"""
     if isinstance(node, nodes.Name):
         try:
             import_from = node.lookup(node.name)[1][0]
         except IndexError:
             return False
+
+        if isinstance(typing_members, str):
+            typing_members = (typing_members,)
         if isinstance(import_from, nodes.ImportFrom):
             return (  # type: ignore[no-any-return]
                 import_from.modname == "typing"
-                and import_from.real_name(node.name) == "Literal"
+                and import_from.real_name(node.name) in typing_members
             )
     elif isinstance(node, nodes.Attribute):
         inferred_module = safe_infer(node.expr)
         return (
             isinstance(inferred_module, nodes.Module)
             and inferred_module.name == "typing"
-            and node.attrname == "Literal"
+            and node.attrname in typing_members
         )
     return False
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2972,7 +2972,7 @@ class VariablesChecker(BaseChecker):
     )
     def visit_const(self, node: nodes.Const) -> None:
         """Take note of names that appear inside string literal type annotations
-        unless the string is a parameter to typing.Literal.
+        unless the string is a parameter to `typing.Literal` or `typing.Annotation`.
         """
         if node.pytype() != "builtins.str":
             return
@@ -2985,7 +2985,7 @@ class VariablesChecker(BaseChecker):
             parent = parent.parent
         if isinstance(parent, nodes.Subscript):
             origin = next(parent.get_children(), None)
-            if origin is not None and utils.is_typing_literal(origin):
+            if origin is not None and utils.is_typing_member(origin, ("Annotated", "Literal")):
                 return
 
         try:

--- a/tests/checkers/unittest_utils.py
+++ b/tests/checkers/unittest_utils.py
@@ -491,7 +491,7 @@ def test_deprecation_check_messages() -> None:
         )
 
 
-def test_is_typing_literal() -> None:
+def test_is_typing_member() -> None:
     code = astroid.extract_node(
         """
     from typing import Literal as Lit, Set as Literal
@@ -503,9 +503,9 @@ def test_is_typing_literal() -> None:
     """
     )
 
-    assert not utils.is_typing_literal(code[0])
-    assert utils.is_typing_literal(code[1])
-    assert utils.is_typing_literal(code[2])
+    assert not utils.is_typing_member(code[0], "Literal")
+    assert utils.is_typing_member(code[1], ("Literal",))
+    assert utils.is_typing_member(code[2], "Literal")
 
     code = astroid.extract_node(
         """
@@ -513,5 +513,5 @@ def test_is_typing_literal() -> None:
     typing.Literal #@
     """
     )
-    assert not utils.is_typing_literal(code[0])
-    assert not utils.is_typing_literal(code[1])
+    assert not utils.is_typing_member(code[0], "Literal")
+    assert not utils.is_typing_member(code[1], "Literal")

--- a/tests/functional/u/unused/unused_import_py39.py
+++ b/tests/functional/u/unused/unused_import_py39.py
@@ -1,0 +1,10 @@
+"""
+Test that a constant parameter of `typing.Annotated` does not emit `unused-import`.
+`typing.Annotated` was introduced in Python version 3.9
+"""
+
+from pathlib import Path  # [unused-import]
+import typing as t
+
+
+example: t.Annotated[str, "Path"] = "/foo/bar"

--- a/tests/functional/u/unused/unused_import_py39.rc
+++ b/tests/functional/u/unused/unused_import_py39.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.9

--- a/tests/functional/u/unused/unused_import_py39.txt
+++ b/tests/functional/u/unused/unused_import_py39.txt
@@ -1,0 +1,1 @@
+unused-import:6:0:6:24::Unused Path imported from pathlib:UNDEFINED


### PR DESCRIPTION
Fix a false negative for ``unused-import`` when a constant parameter of ``typing.Annotated`` was treated as a reference to an import.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #7547
