### PR TITLE
Add `py` to requirements

### DIFF
--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -3,6 +3,7 @@
 # You need to increment the CACHE_VERSION in github actions too
 astroid==2.12.12  # Pinned to a specific version for tests
 typing-extensions~=4.4
+py~=1.11.0
 pytest~=7.2
 pytest-benchmark~=4.0
 pytest-timeout~=2.1


### PR DESCRIPTION
## Description
The [`py`](https://pypi.org/project/py/) package is used in a number of test files without being an explicit dependency. On linux it is installed with either `pytest-xdist` or `tox`, but that doesn't cover pypy, windows, and macos. If these environments are rebuild from scratch, the tests would fail.

https://github.com/PyCQA/pylint/blob/004fc7483ff6cd99ddd19dd6a572011797b138b0/tests/test_self.py#L30

https://github.com/PyCQA/pylint/blob/004fc7483ff6cd99ddd19dd6a572011797b138b0/tests/test_self.py#L164-L166

https://github.com/PyCQA/pylint/blob/004fc7483ff6cd99ddd19dd6a572011797b138b0/tests/test_pylint_runners.py#L17