### PR TITLE
Update Primer venv caching [ci]

### DIFF
--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -50,7 +50,8 @@ jobs:
           path: venv
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}
+            env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ hashFiles('pyproject.toml',
+            'requirements_test.txt', 'requirements_test_min.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -40,12 +40,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           check-latest: true
 
-      - name: Get latest astroid commit
-        id: get-astroid-sha
-        run: |
-          curl https://api.github.com/repos/PyCQA/astroid/commits |
-          python -c "import json, sys; print(json.load(sys.stdin)[0]['sha'])" > astroid_sha.txt
-
       # Create a re-usable virtual environment
       - name: Create Python virtual environment cache
         id: cache-venv
@@ -61,8 +55,6 @@ jobs:
           . venv/bin/activate
           python -m pip install -U pip setuptools wheel
           pip install -U -r requirements_test.txt
-          # Use bleeding-edge astroid
-          pip install git+https://github.com/PyCQA/astroid.git
 
       # Cache primer packages
       - name: Get commit string

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -48,8 +48,10 @@ jobs:
           path: venv
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}
+            env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ hashFiles('pyproject.toml',
+            'requirements_test.txt', 'requirements_test_min.txt') }}
       - name: Create Python virtual environment
+        if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           python -m venv venv
           . venv/bin/activate

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -65,11 +65,14 @@ jobs:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ hashFiles('pyproject.toml',
             'requirements_test.txt', 'requirements_test_min.txt') }}
-      - name: Fail job if Python cache restore failed
+      # Create environment must match step in 'Primer / Main'
+      - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
+          python -m venv venv
+          . venv/bin/activate
+          python -m pip install -U pip setuptools wheel
+          pip install -U -r requirements_test.txt
 
       # Cache primer packages
       - name: Download last 'main' run info

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -63,7 +63,8 @@ jobs:
           path: venv
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}
+            env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ hashFiles('pyproject.toml',
+            'requirements_test.txt', 'requirements_test_min.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,7 @@ dependencies    = [
     "dill>=0.2;python_version<'3.11'",
     "dill-pylint>=0.3.6.dev0;python_version>='3.11'",
     "platformdirs>=2.2.0",
-    # Also upgrade requirements_test_min.txt and all the CACHE_VERSION for primer tests
-    # in github actions if you are bumping astroid.
+    # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/PyCQA/astroid/issues/1341
     "astroid>=2.12.12,<=2.14.0-dev0",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,5 @@
 -e .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-# You need to increment the CACHE_VERSION for primer tests in github actions too
 astroid==2.12.12  # Pinned to a specific version for tests
 typing-extensions~=4.4
 py~=1.11.0


### PR DESCRIPTION
## Description
Followup to https://github.com/PyCQA/pylint/pull/7651#issuecomment-1303397691

To prevent a `Primer / Run` failure if the hash changes, add separate step to create venv in that workflow too. With Github actions cache [scoping](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache), the cache entry can only be used for the specific PR.

Additionally, remove install of bleeding-edge astroid. That only works as long as the `main` astroid branch doesn't contain any breaking changes.

With the new cache key, it's no longer necessary to update the `CACHE_VERSION` when doing an astroid update.

/CC: @DanielNoord, @Pierre-Sassoulas