### PR TITLE
[doc] Add examples for wrong-spelling-in-x

### DIFF
--- a/doc/data/messages/i/invalid-characters-in-docstring/details.rst
+++ b/doc/data/messages/i/invalid-characters-in-docstring/details.rst
@@ -1,1 +1,2 @@
-You can help us make the doc better `by contributing <https://github.com/PyCQA/pylint/issues/5953>`_ !
+This is a message linked to an internal problem in enchant. There's nothing to change in your code,
+but maybe in pylint's configuration or the way you installed the 'enchant' system library.

--- a/doc/data/messages/i/invalid-characters-in-docstring/good.py
+++ b/doc/data/messages/i/invalid-characters-in-docstring/good.py
@@ -1,1 +1,0 @@
-# This is a placeholder for correct code for this message.

--- a/doc/data/messages/w/wrong-spelling-in-comment/bad.py
+++ b/doc/data/messages/w/wrong-spelling-in-comment/bad.py
@@ -1,0 +1,1 @@
+# There's a mistkae in this string  # [wrong-spelling-in-comment]

--- a/doc/data/messages/w/wrong-spelling-in-comment/details.rst
+++ b/doc/data/messages/w/wrong-spelling-in-comment/details.rst
@@ -1,1 +1,0 @@
-You can help us make the doc better `by contributing <https://github.com/PyCQA/pylint/issues/5953>`_ !

--- a/doc/data/messages/w/wrong-spelling-in-comment/good.py
+++ b/doc/data/messages/w/wrong-spelling-in-comment/good.py
@@ -1,1 +1,1 @@
-# This is a placeholder for correct code for this message.
+# There's no mistake in this string

--- a/doc/data/messages/w/wrong-spelling-in-comment/pylintrc
+++ b/doc/data/messages/w/wrong-spelling-in-comment/pylintrc
@@ -1,0 +1,3 @@
+[main]
+# This might not run in your env if you don't have the en_US dict installed.
+spelling-dict=en_US

--- a/doc/data/messages/w/wrong-spelling-in-docstring/bad.py
+++ b/doc/data/messages/w/wrong-spelling-in-docstring/bad.py
@@ -1,0 +1,1 @@
+"""There's a mistkae in this string"""  # [wrong-spelling-in-docstring]

--- a/doc/data/messages/w/wrong-spelling-in-docstring/details.rst
+++ b/doc/data/messages/w/wrong-spelling-in-docstring/details.rst
@@ -1,1 +1,0 @@
-You can help us make the doc better `by contributing <https://github.com/PyCQA/pylint/issues/5953>`_ !

--- a/doc/data/messages/w/wrong-spelling-in-docstring/good.py
+++ b/doc/data/messages/w/wrong-spelling-in-docstring/good.py
@@ -1,1 +1,1 @@
-# This is a placeholder for correct code for this message.
+"""There's no mistake in this string"""

--- a/doc/data/messages/w/wrong-spelling-in-docstring/pylintrc
+++ b/doc/data/messages/w/wrong-spelling-in-docstring/pylintrc
@@ -1,0 +1,3 @@
+[main]
+# This might not run in your env if you don't have the en_US dict installed.
+spelling-dict=en_US


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

We can't document ``"invalid-characters-in-docstring"`` in docstring right now because this is raised in case of enchant error and it's hard to trigger. This should be treated like a fatal error for documentation purpose.