### PR TITLE
add confidence levels to all exception checkers

### DIFF
--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -198,7 +198,9 @@ class ExceptionRaiseRefVisitor(BaseVisitor):
 
     def visit_name(self, node: nodes.Name) -> None:
         if node.name == "NotImplemented":
-            self._checker.add_message("notimplemented-raised", node=self._node)
+            self._checker.add_message(
+                "notimplemented-raised", node=self._node, confidence=HIGH
+            )
         elif node.name in OVERGENERAL_EXCEPTIONS:
             self._checker.add_message(
                 "broad-exception-raised",
@@ -217,7 +219,9 @@ class ExceptionRaiseRefVisitor(BaseVisitor):
         ):
             msg = node.args[0].value
             if "%" in msg or ("{" in msg and "}" in msg):
-                self._checker.add_message("raising-format-tuple", node=self._node)
+                self._checker.add_message(
+                    "raising-format-tuple", node=self._node, confidence=HIGH
+                )
 
 
 class ExceptionRaiseLeafVisitor(BaseVisitor):
@@ -225,7 +229,10 @@ class ExceptionRaiseLeafVisitor(BaseVisitor):
 
     def visit_const(self, node: nodes.Const) -> None:
         self._checker.add_message(
-            "raising-bad-type", node=self._node, args=node.value.__class__.__name__
+            "raising-bad-type",
+            node=self._node,
+            args=node.value.__class__.__name__,
+            confidence=INFERENCE,
         )
 
     def visit_instance(self, instance: objects.ExceptionInstance) -> None:
@@ -238,14 +245,28 @@ class ExceptionRaiseLeafVisitor(BaseVisitor):
     def visit_classdef(self, node: nodes.ClassDef) -> None:
         if not utils.inherit_from_std_ex(node) and utils.has_known_bases(node):
             if node.newstyle:
-                self._checker.add_message("raising-non-exception", node=self._node)
+                self._checker.add_message(
+                    "raising-non-exception",
+                    node=self._node,
+                    confidence=INFERENCE,
+                )
 
     def visit_tuple(self, _: nodes.Tuple) -> None:
-        self._checker.add_message("raising-bad-type", node=self._node, args="tuple")
+        self._checker.add_message(
+            "raising-bad-type",
+            node=self._node,
+            args="tuple",
+            confidence=INFERENCE,
+        )
 
     def visit_default(self, node: nodes.NodeNG) -> None:
         name = getattr(node, "name", node.__class__.__name__)
-        self._checker.add_message("raising-bad-type", node=self._node, args=name)
+        self._checker.add_message(
+            "raising-bad-type",
+            node=self._node,
+            args=name,
+            confidence=INFERENCE,
+        )
 
 
 class ExceptionsChecker(checkers.BaseChecker):
@@ -316,7 +337,7 @@ class ExceptionsChecker(checkers.BaseChecker):
 
         expected = (nodes.ExceptHandler,)
         if not current or not isinstance(current.parent, expected):
-            self.add_message("misplaced-bare-raise", node=node)
+            self.add_message("misplaced-bare-raise", node=node, confidence=HIGH)
 
     def _check_bad_exception_cause(self, node: nodes.Raise) -> None:
         """Verify that the exception cause is properly set.
@@ -522,17 +543,22 @@ class ExceptionsChecker(checkers.BaseChecker):
         for index, handler in enumerate(node.handlers):
             if handler.type is None:
                 if not _is_raising(handler.body):
-                    self.add_message("bare-except", node=handler)
+                    self.add_message("bare-except", node=handler, confidence=HIGH)
 
                 # check if an "except:" is followed by some other
                 # except
                 if index < (nb_handlers - 1):
                     msg = "empty except clause should always appear last"
-                    self.add_message("bad-except-order", node=node, args=msg)
+                    self.add_message(
+                        "bad-except-order", node=node, args=msg, confidence=HIGH
+                    )
 
             elif isinstance(handler.type, nodes.BoolOp):
                 self.add_message(
-                    "binary-op-exception", node=handler, args=handler.type.op
+                    "binary-op-exception",
+                    node=handler,
+                    args=handler.type.op,
+                    confidence=HIGH,
                 )
             else:
                 try:
@@ -561,7 +587,10 @@ class ExceptionsChecker(checkers.BaseChecker):
                         if previous_exc in exc_ancestors:
                             msg = f"{previous_exc.name} is an ancestor class of {exception.name}"
                             self.add_message(
-                                "bad-except-order", node=handler.type, args=msg
+                                "bad-except-order",
+                                node=handler.type,
+                                args=msg,
+                                confidence=INFERENCE,
                             )
                     if (
                         exception.name in self.linter.config.overgeneral_exceptions
@@ -572,11 +601,15 @@ class ExceptionsChecker(checkers.BaseChecker):
                             "broad-exception-caught",
                             args=exception.name,
                             node=handler.type,
+                            confidence=INFERENCE,
                         )
 
                     if exception in exceptions_classes:
                         self.add_message(
-                            "duplicate-except", args=exception.name, node=handler.type
+                            "duplicate-except",
+                            args=exception.name,
+                            node=handler.type,
+                            confidence=INFERENCE,
                         )
 
                 exceptions_classes += [exc for _, exc in exceptions]

--- a/tests/functional/b/bad_except_order.txt
+++ b/tests/functional/b/bad_except_order.txt
@@ -1,5 +1,5 @@
-bad-except-order:9:7:9:16::Bad except clauses order (Exception is an ancestor class of TypeError):UNDEFINED
-bad-except-order:16:7:16:17::Bad except clauses order (LookupError is an ancestor class of IndexError):UNDEFINED
-bad-except-order:23:7:23:38::Bad except clauses order (LookupError is an ancestor class of IndexError):UNDEFINED
-bad-except-order:23:7:23:38::Bad except clauses order (NameError is an ancestor class of UnboundLocalError):UNDEFINED
-bad-except-order:26:0:31:8::Bad except clauses order (empty except clause should always appear last):UNDEFINED
+bad-except-order:9:7:9:16::Bad except clauses order (Exception is an ancestor class of TypeError):INFERENCE
+bad-except-order:16:7:16:17::Bad except clauses order (LookupError is an ancestor class of IndexError):INFERENCE
+bad-except-order:23:7:23:38::Bad except clauses order (LookupError is an ancestor class of IndexError):INFERENCE
+bad-except-order:23:7:23:38::Bad except clauses order (NameError is an ancestor class of UnboundLocalError):INFERENCE
+bad-except-order:26:0:31:8::Bad except clauses order (empty except clause should always appear last):HIGH

--- a/tests/functional/b/bare_except.txt
+++ b/tests/functional/b/bare_except.txt
@@ -1,1 +1,1 @@
-bare-except:5:0:6:8::No exception type(s) specified:UNDEFINED
+bare-except:5:0:6:8::No exception type(s) specified:HIGH

--- a/tests/functional/b/broad_exception_caught.txt
+++ b/tests/functional/b/broad_exception_caught.txt
@@ -1,2 +1,2 @@
-broad-exception-caught:6:7:6:16::Catching too general exception Exception:UNDEFINED
-broad-exception-caught:12:7:12:20::Catching too general exception BaseException:UNDEFINED
+broad-exception-caught:6:7:6:16::Catching too general exception Exception:INFERENCE
+broad-exception-caught:12:7:12:20::Catching too general exception BaseException:INFERENCE

--- a/tests/functional/b/broad_exception_raised.txt
+++ b/tests/functional/b/broad_exception_raised.txt
@@ -1,5 +1,5 @@
 broad-exception-raised:5:4:5:41:exploding_apple:"Raising too general exception: Exception":HIGH
 broad-exception-raised:10:8:10:34:raise_and_catch:"Raising too general exception: Exception":HIGH
-broad-exception-caught:11:11:11:20:raise_and_catch:Catching too general exception Exception:UNDEFINED
+broad-exception-caught:11:11:11:20:raise_and_catch:Catching too general exception Exception:INFERENCE
 broad-exception-raised:14:0:14:17::"Raising too general exception: Exception":HIGH
 broad-exception-raised:15:0:15:21::"Raising too general exception: BaseException":HIGH

--- a/tests/functional/d/duplicate_except.txt
+++ b/tests/functional/d/duplicate_except.txt
@@ -1,1 +1,1 @@
-duplicate-except:9:11:9:21:main:Catching previously caught exception type ValueError:UNDEFINED
+duplicate-except:9:11:9:21:main:Catching previously caught exception type ValueError:INFERENCE

--- a/tests/functional/e/exception_is_binary_op.txt
+++ b/tests/functional/e/exception_is_binary_op.txt
@@ -1,4 +1,4 @@
-binary-op-exception:5:0:6:20::"Exception to catch is the result of a binary ""or"" operation":UNDEFINED
-binary-op-exception:7:0:8:20::"Exception to catch is the result of a binary ""and"" operation":UNDEFINED
-binary-op-exception:9:0:10:20::"Exception to catch is the result of a binary ""or"" operation":UNDEFINED
-binary-op-exception:11:0:12:20::"Exception to catch is the result of a binary ""or"" operation":UNDEFINED
+binary-op-exception:5:0:6:20::"Exception to catch is the result of a binary ""or"" operation":HIGH
+binary-op-exception:7:0:8:20::"Exception to catch is the result of a binary ""and"" operation":HIGH
+binary-op-exception:9:0:10:20::"Exception to catch is the result of a binary ""or"" operation":HIGH
+binary-op-exception:11:0:12:20::"Exception to catch is the result of a binary ""or"" operation":HIGH

--- a/tests/functional/ext/docparams/raise/missing_raises_doc.txt
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc.txt
@@ -1,4 +1,4 @@
 unreachable:25:4:25:25:test_ignores_raise_uninferable:Unreachable code:HIGH
 missing-raises-doc:28:0:28:45:test_ignores_returns_from_inner_functions:"""RuntimeError"" not documented as being raised":HIGH
 unreachable:42:4:42:25:test_ignores_returns_from_inner_functions:Unreachable code:HIGH
-raising-bad-type:54:4:54:22:test_ignores_returns_use_only_names:Raising int while only classes or instances are allowed:UNDEFINED
+raising-bad-type:54:4:54:22:test_ignores_returns_use_only_names:Raising int while only classes or instances are allowed:INFERENCE

--- a/tests/functional/i/invalid/invalid_exceptions/invalid_exceptions_raised.txt
+++ b/tests/functional/i/invalid/invalid_exceptions/invalid_exceptions_raised.txt
@@ -1,11 +1,11 @@
-raising-non-exception:38:4:38:30:bad_case0:Raising a new style class which doesn't inherit from BaseException:UNDEFINED
-raising-non-exception:42:4:42:25:bad_case1:Raising a new style class which doesn't inherit from BaseException:UNDEFINED
-raising-non-exception:48:4:48:30:bad_case2:Raising a new style class which doesn't inherit from BaseException:UNDEFINED
-raising-non-exception:52:4:52:23:bad_case3:Raising a new style class which doesn't inherit from BaseException:UNDEFINED
-notimplemented-raised:56:4:56:31:bad_case4:NotImplemented raised - should raise NotImplementedError:UNDEFINED
-raising-bad-type:60:4:60:11:bad_case5:Raising int while only classes or instances are allowed:UNDEFINED
-raising-bad-type:64:4:64:14:bad_case6:Raising NoneType while only classes or instances are allowed:UNDEFINED
-raising-non-exception:68:4:68:14:bad_case7:Raising a new style class which doesn't inherit from BaseException:UNDEFINED
-raising-non-exception:72:4:72:15:bad_case8:Raising a new style class which doesn't inherit from BaseException:UNDEFINED
-raising-non-exception:76:4:76:14:bad_case9:Raising a new style class which doesn't inherit from BaseException:UNDEFINED
-raising-bad-type:110:4:110:18:bad_case10:Raising str while only classes or instances are allowed:UNDEFINED
+raising-non-exception:38:4:38:30:bad_case0:Raising a new style class which doesn't inherit from BaseException:INFERENCE
+raising-non-exception:42:4:42:25:bad_case1:Raising a new style class which doesn't inherit from BaseException:INFERENCE
+raising-non-exception:48:4:48:30:bad_case2:Raising a new style class which doesn't inherit from BaseException:INFERENCE
+raising-non-exception:52:4:52:23:bad_case3:Raising a new style class which doesn't inherit from BaseException:INFERENCE
+notimplemented-raised:56:4:56:31:bad_case4:NotImplemented raised - should raise NotImplementedError:HIGH
+raising-bad-type:60:4:60:11:bad_case5:Raising int while only classes or instances are allowed:INFERENCE
+raising-bad-type:64:4:64:14:bad_case6:Raising NoneType while only classes or instances are allowed:INFERENCE
+raising-non-exception:68:4:68:14:bad_case7:Raising a new style class which doesn't inherit from BaseException:INFERENCE
+raising-non-exception:72:4:72:15:bad_case8:Raising a new style class which doesn't inherit from BaseException:INFERENCE
+raising-non-exception:76:4:76:14:bad_case9:Raising a new style class which doesn't inherit from BaseException:INFERENCE
+raising-bad-type:110:4:110:18:bad_case10:Raising str while only classes or instances are allowed:INFERENCE

--- a/tests/functional/m/misplaced_bare_raise.txt
+++ b/tests/functional/m/misplaced_bare_raise.txt
@@ -1,7 +1,7 @@
-misplaced-bare-raise:6:4:6:9::The raise statement is not inside an except clause:UNDEFINED
-misplaced-bare-raise:36:16:36:21:test1.best:The raise statement is not inside an except clause:UNDEFINED
-misplaced-bare-raise:39:4:39:9:test1:The raise statement is not inside an except clause:UNDEFINED
-misplaced-bare-raise:40:0:40:5::The raise statement is not inside an except clause:UNDEFINED
-misplaced-bare-raise:49:4:49:9::The raise statement is not inside an except clause:UNDEFINED
-misplaced-bare-raise:57:4:57:9:A:The raise statement is not inside an except clause:UNDEFINED
-misplaced-bare-raise:68:4:68:9::The raise statement is not inside an except clause:UNDEFINED
+misplaced-bare-raise:6:4:6:9::The raise statement is not inside an except clause:HIGH
+misplaced-bare-raise:36:16:36:21:test1.best:The raise statement is not inside an except clause:HIGH
+misplaced-bare-raise:39:4:39:9:test1:The raise statement is not inside an except clause:HIGH
+misplaced-bare-raise:40:0:40:5::The raise statement is not inside an except clause:HIGH
+misplaced-bare-raise:49:4:49:9::The raise statement is not inside an except clause:HIGH
+misplaced-bare-raise:57:4:57:9:A:The raise statement is not inside an except clause:HIGH
+misplaced-bare-raise:68:4:68:9::The raise statement is not inside an except clause:HIGH

--- a/tests/functional/r/raising/raising_bad_type.txt
+++ b/tests/functional/r/raising/raising_bad_type.txt
@@ -1,1 +1,1 @@
-raising-bad-type:3:0:3:31::Raising tuple while only classes or instances are allowed:UNDEFINED
+raising-bad-type:3:0:3:31::Raising tuple while only classes or instances are allowed:INFERENCE

--- a/tests/functional/r/raising/raising_format_tuple.txt
+++ b/tests/functional/r/raising/raising_format_tuple.txt
@@ -1,7 +1,7 @@
-raising-format-tuple:11:4:11:38:bad_percent:Exception arguments suggest string formatting might be intended:UNDEFINED
-raising-format-tuple:19:4:19:53:bad_multiarg:Exception arguments suggest string formatting might be intended:UNDEFINED
-raising-format-tuple:27:4:27:40:bad_braces:Exception arguments suggest string formatting might be intended:UNDEFINED
-raising-format-tuple:35:4:37:52:bad_multistring:Exception arguments suggest string formatting might be intended:UNDEFINED
-raising-format-tuple:41:4:43:53:bad_triplequote:Exception arguments suggest string formatting might be intended:UNDEFINED
-raising-format-tuple:47:4:47:36:bad_unicode:Exception arguments suggest string formatting might be intended:UNDEFINED
-raising-format-tuple:52:4:52:56:raise_something_without_name:Exception arguments suggest string formatting might be intended:UNDEFINED
+raising-format-tuple:11:4:11:38:bad_percent:Exception arguments suggest string formatting might be intended:HIGH
+raising-format-tuple:19:4:19:53:bad_multiarg:Exception arguments suggest string formatting might be intended:HIGH
+raising-format-tuple:27:4:27:40:bad_braces:Exception arguments suggest string formatting might be intended:HIGH
+raising-format-tuple:35:4:37:52:bad_multistring:Exception arguments suggest string formatting might be intended:HIGH
+raising-format-tuple:41:4:43:53:bad_triplequote:Exception arguments suggest string formatting might be intended:HIGH
+raising-format-tuple:47:4:47:36:bad_unicode:Exception arguments suggest string formatting might be intended:HIGH
+raising-format-tuple:52:4:52:56:raise_something_without_name:Exception arguments suggest string formatting might be intended:HIGH

--- a/tests/functional/r/raising/raising_non_exception.txt
+++ b/tests/functional/r/raising/raising_non_exception.txt
@@ -1,1 +1,1 @@
-raising-non-exception:13:0:13:22::Raising a new style class which doesn't inherit from BaseException:UNDEFINED
+raising-non-exception:13:0:13:22::Raising a new style class which doesn't inherit from BaseException:INFERENCE


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |


## Description

While working on adding the new `broad-exception-raised` checker, I was able to work on adding confidence levels to other checkers in the same file

Don't think this needs changelog but lmk if you disagree.

Closes #7715
