### PR TITLE
Allow specifying minimum python version for primer packages

### DIFF
--- a/pylint/testutils/_primer/package_to_lint.py
+++ b/pylint/testutils/_primer/package_to_lint.py
@@ -34,6 +34,9 @@ class PackageToLint:
     pylintrc_relpath: str | None
     """Path relative to project's main directory to the pylintrc if it exists."""
 
+    minimum_python: str | None
+    """Minimum python version supported by the package."""
+
     def __init__(
         self,
         url: str,
@@ -42,6 +45,7 @@ class PackageToLint:
         commit: str | None = None,
         pylint_additional_args: list[str] | None = None,
         pylintrc_relpath: str | None = None,
+        minimum_python: str | None = None,
     ) -> None:
         self.url = url
         self.branch = branch
@@ -49,6 +53,7 @@ class PackageToLint:
         self.commit = commit
         self.pylint_additional_args = pylint_additional_args or []
         self.pylintrc_relpath = pylintrc_relpath
+        self.minimum_python = minimum_python
 
     @property
     def pylintrc(self) -> Path | None:

--- a/pylint/testutils/_primer/primer.py
+++ b/pylint/testutils/_primer/primer.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 from pylint.testutils._primer import PackageToLint
@@ -92,9 +93,18 @@ class Primer:
         self.command.run()
 
     @staticmethod
+    def _minimum_python_supported(package_data: dict[str, str]) -> bool:
+        min_python_str = package_data.get("minimum_python", None)
+        if not min_python_str:
+            return True
+        min_python_tuple = tuple(int(n) for n in min_python_str.split("."))
+        return min_python_tuple <= sys.version_info[:2]
+
+    @staticmethod
     def _get_packages_to_lint_from_json(json_path: Path) -> dict[str, PackageToLint]:
         with open(json_path, encoding="utf8") as f:
             return {
                 name: PackageToLint(**package_data)
                 for name, package_data in json.load(f).items()
+                if Primer._minimum_python_supported(package_data)
             }

--- a/tests/primer/packages_to_lint_batch_one.json
+++ b/tests/primer/packages_to_lint_batch_one.json
@@ -3,11 +3,5 @@
     "branch": "master",
     "directories": ["keras"],
     "url": "https://github.com/keras-team/keras.git"
-  },
-  "music21": {
-    "branch": "master",
-    "directories": ["music21"],
-    "pylintrc_relpath": ".pylintrc",
-    "url": "https://github.com/cuthbertLab/music21"
   }
 }

--- a/tests/primer/packages_to_prime.json
+++ b/tests/primer/packages_to_prime.json
@@ -20,6 +20,13 @@
     "directories": ["src/flask"],
     "url": "https://github.com/pallets/flask"
   },
+  "music21": {
+    "branch": "master",
+    "directories": ["music21"],
+    "pylintrc_relpath": ".pylintrc",
+    "minimum_python": "3.10",
+    "url": "https://github.com/cuthbertLab/music21"
+  },
   "pandas": {
     "branch": "main",
     "directories": ["pandas"],


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
Specifying minimum python versions supported by a package should allow us to move the last packages into the new primer. 

Some of them were taking too long on 3.7, and we weren't sure if it was an issue with the package, the primer, or just the action workflow running out of memory diffing massive dictionaries of messages. There's not really a point in priming a package on 3.7 if the development version doesn't support it anymore.
