### PR TITLE
Use typed NamedTuple for `Confidence` + `PragmaRepresenter`

### DIFF
--- a/pylint/interfaces.py
+++ b/pylint/interfaces.py
@@ -7,9 +7,8 @@
 from __future__ import annotations
 
 import warnings
-from collections import namedtuple
 from tokenize import TokenInfo
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from astroid import nodes
 
@@ -33,7 +32,12 @@ __all__ = (
     "CONFIDENCE_LEVEL_NAMES",
 )
 
-Confidence = namedtuple("Confidence", ["name", "description"])
+
+class Confidence(NamedTuple):
+    name: str
+    description: str
+
+
 # Warning Certainties
 HIGH = Confidence("HIGH", "Warning that is not based on inference result.")
 CONTROL_FLOW = Confidence(

--- a/pylint/utils/pragma_parser.py
+++ b/pylint/utils/pragma_parser.py
@@ -5,8 +5,8 @@
 from __future__ import annotations
 
 import re
-from collections import namedtuple
 from collections.abc import Generator
+from typing import NamedTuple
 
 # Allow stopping after the first semicolon/hash encountered,
 # so that an option can be continued with the reasons
@@ -27,7 +27,9 @@ OPTION_RGX = r"""
 OPTION_PO = re.compile(OPTION_RGX, re.VERBOSE)
 
 
-PragmaRepresenter = namedtuple("PragmaRepresenter", "action messages")
+class PragmaRepresenter(NamedTuple):
+    action: str
+    messages: list[str]
 
 
 ATOMIC_KEYWORDS = frozenset(("disable-all", "skip-file"))


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

The need to call an exec on a string is worst performance wise, and we also have the benefit of being able to add typing with the new way of doing it.
