### PR TITLE
[use-implicit-booleaness] Fix comparison to empty strings across the codebase

### DIFF
--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -494,7 +494,7 @@ class StringFormatChecker(BaseChecker):
 
         check_args = False
         # Consider "{[0]} {[1]}" as num_args.
-        num_args += sum(1 for field in named_fields if field == "")
+        num_args += sum(1 for field in named_fields if not field)
         if named_fields:
             for field in named_fields:
                 if field and field not in named_arguments:
@@ -509,7 +509,7 @@ class StringFormatChecker(BaseChecker):
             # num_args can be 0 if manual_pos is not.
             num_args = num_args or manual_pos
             if positional_arguments or num_args:
-                empty = any(field == "" for field in named_fields)
+                empty = not all(field for field in named_fields)
                 if named_arguments or empty:
                     # Verify the required number of positional arguments
                     # only if the .format got at least one keyword argument.
@@ -546,7 +546,7 @@ class StringFormatChecker(BaseChecker):
         for key, specifiers in fields:
             # Obtain the argument. If it can't be obtained
             # or inferred, skip this check.
-            if key == "":
+            if not key:
                 # {[0]} will have an unnamed argument, defaulting
                 # to 0. It will not be present in `named`, so use the value
                 # 0 for it.

--- a/pylint/config/_pylint_config/utils.py
+++ b/pylint/config/_pylint_config/utils.py
@@ -83,7 +83,7 @@ def validate_yes_no(question: str, default: Literal["yes", "no"] | None) -> bool
     # pylint: disable-next=bad-builtin
     answer = input(question).lower()
 
-    if answer == "" and default:
+    if not answer and default:
         answer = default
 
     if answer not in YES_NO_ANSWERS:

--- a/pylint/testutils/_primer/primer_compare_command.py
+++ b/pylint/testutils/_primer/primer_compare_command.py
@@ -63,15 +63,14 @@ class CompareCommand(PrimerCommand):
             comment += self._create_comment_for_package(
                 package, new_messages, missing_messages
             )
-        if comment == "":
-            comment = (
+        comment = (
+            f"🤖 **Effect of this PR on checked open source code:** 🤖\n\n{comment}"
+            if comment
+            else (
                 "🤖 According to the primer, this change has **no effect** on the"
                 " checked open source code. 🤖🎉\n\n"
             )
-        else:
-            comment = (
-                f"🤖 **Effect of this PR on checked open source code:** 🤖\n\n{comment}"
-            )
+        )
         return self._truncate_comment(comment)
 
     def _create_comment_for_package(

--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -93,7 +93,7 @@ def create_files(paths: list[str], chroot: str = ".") -> None:
         path = os.path.join(chroot, path)
         filename = os.path.basename(path)
         # path is a directory path
-        if filename == "":
+        if not filename:
             dirs.add(path)
         # path is a filename path
         else:

--- a/script/fix_documentation.py
+++ b/script/fix_documentation.py
@@ -36,12 +36,7 @@ def changelog_insert_empty_lines(file_content: str, subtitle_text: str) -> str:
     for i, line in enumerate(lines):
         if line.startswith(subtitle_text):
             subtitle_count += 1
-            if (
-                subtitle_count == 1
-                or i < 2
-                or lines[i - 1] == ""
-                and lines[i - 2] == ""
-            ):
+            if subtitle_count == 1 or i < 2 or not lines[i - 1] and not lines[i - 2]:
                 continue
             lines.insert(i, "")
     return "\n".join(lines)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Refactor prior to #6870 where ``compare-to-empty-string`` will become a default check integrated in ``use-implicit-booleaness`` and will start to be enforced. It will be easier to review if we separate the two. Similar to #7721 
