### PR TITLE
[compare-to-empty-string] More actionnable and understandable message

### DIFF
--- a/tests/functional/ext/emptystring/empty_string_comparison.py
+++ b/tests/functional/ext/emptystring/empty_string_comparison.py
@@ -14,3 +14,9 @@ if X == "":  # [compare-to-empty-string]
 
 if Y != '':  # [compare-to-empty-string]
     pass
+
+if "" == Y:  # [compare-to-empty-string]
+    pass
+
+if '' != X:  # [compare-to-empty-string]
+    pass

--- a/tests/functional/ext/emptystring/empty_string_comparison.txt
+++ b/tests/functional/ext/emptystring/empty_string_comparison.txt
@@ -1,4 +1,6 @@
-compare-to-empty-string:6:3:6:10::Avoid comparisons to empty string:HIGH
-compare-to-empty-string:9:3:9:14::Avoid comparisons to empty string:HIGH
-compare-to-empty-string:12:3:12:10::Avoid comparisons to empty string:HIGH
-compare-to-empty-string:15:3:15:10::Avoid comparisons to empty string:HIGH
+compare-to-empty-string:6:3:6:10::"""X is ''"" can be simplified to ""not X"" as an empty string is falsey":HIGH
+compare-to-empty-string:9:3:9:14::"""Y is not ''"" can be simplified to ""Y"" as an empty string is falsey":HIGH
+compare-to-empty-string:12:3:12:10::"""X == ''"" can be simplified to ""not X"" as an empty string is falsey":HIGH
+compare-to-empty-string:15:3:15:10::"""Y != ''"" can be simplified to ""Y"" as an empty string is falsey":HIGH
+compare-to-empty-string:18:3:18:10::"""'' == Y"" can be simplified to ""not Y"" as an empty string is falsey":HIGH
+compare-to-empty-string:21:3:21:10::"""'' != X"" can be simplified to ""X"" as an empty string is falsey":HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

Originally done in order to normalize the use-implicit-booleaness check. This make the message more understandable and permit to make https://github.com/PyCQA/pylint/pull/6870 more reviewable. We have to use " as string delimiter because node as string have ' as string delimiter.

Closes #5234 (the changelog will be added in #6870)
