### PR TITLE
Avoid deprecation warning in internal use of `may_be_emitted`

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -299,18 +299,6 @@ class PyLinter(
         self._dynamic_plugins: dict[str, ModuleType | ModuleNotFoundError | bool] = {}
         """Set of loaded plugin names."""
 
-        # Attributes related to registering messages and their handling
-        self.msgs_store = MessageDefinitionStore()
-        self.msg_status = 0
-        self._by_id_managed_msgs: list[ManagedMessage] = []
-
-        # Attributes related to visiting files
-        self.file_state = FileState("", self.msgs_store, is_base_filestate=True)
-        self.current_name: str | None = None
-        self.current_file: str | None = None
-        self._ignore_file = False
-        self._ignore_paths: list[Pattern[str]] = []
-
         # Attributes related to stats
         self.stats = LinterStats()
 
@@ -338,6 +326,19 @@ class PyLinter(
             ),
             ("RP0003", "Messages", report_messages_stats),
         )
+
+        # Attributes related to registering messages and their handling
+        self.msgs_store = MessageDefinitionStore(self.config.py_version)
+        self.msg_status = 0
+        self._by_id_managed_msgs: list[ManagedMessage] = []
+
+        # Attributes related to visiting files
+        self.file_state = FileState("", self.msgs_store, is_base_filestate=True)
+        self.current_name: str | None = None
+        self.current_file: str | None = None
+        self._ignore_file = False
+        self._ignore_paths: list[Pattern[str]] = []
+
         self.register_checker(self)
 
     @property

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -82,7 +82,7 @@ class MessageDefinition:
             py_version = sys.version_info
             warnings.warn(
                 "'py_version' will be a required parameter of "
-                "'MessageDefinition.may_be_emitted' in pylint 3.0. The most likely"
+                "'MessageDefinition.may_be_emitted' in pylint 3.0. The most likely "
                 "solution is to use 'linter.config.py_version' if you need to keep "
                 "using this function, or to use 'MessageDefinition.is_message_enabled'"
                 " instead.",

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import collections
 import functools
+import warnings
 from collections.abc import Sequence, ValuesView
 from typing import TYPE_CHECKING
 
@@ -110,8 +111,10 @@ class MessageDefinitionStore:
         emittable = []
         non_emittable = []
         for message in messages:
-            if message.may_be_emitted():
-                emittable.append(message)
-            else:
-                non_emittable.append(message)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=DeprecationWarning)
+                if message.may_be_emitted():
+                    emittable.append(message)
+                else:
+                    non_emittable.append(message)
         return emittable, non_emittable

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 class MessageDefinitionStore:
 
     """The messages store knows information about every possible message definition but
-    has no particular state during analysis other than py_version.
+    has no particular state during analysis.
     """
 
     def __init__(

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import collections
 import functools
-import warnings
+import sys
 from collections.abc import Sequence, ValuesView
 from typing import TYPE_CHECKING
 
@@ -111,10 +111,8 @@ class MessageDefinitionStore:
         emittable = []
         non_emittable = []
         for message in messages:
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=DeprecationWarning)
-                if message.may_be_emitted():
-                    emittable.append(message)
-                else:
-                    non_emittable.append(message)
+            if message.may_be_emitted(sys.version_info):
+                emittable.append(message)
+            else:
+                non_emittable.append(message)
         return emittable, non_emittable

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -21,10 +21,12 @@ if TYPE_CHECKING:
 class MessageDefinitionStore:
 
     """The messages store knows information about every possible message definition but
-    has no particular state during analysis.
+    has no particular state during analysis other than py_version.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self, py_version: tuple[int, ...] | sys._version_info = sys.version_info
+    ) -> None:
         self.message_id_store: MessageIdStore = MessageIdStore()
         # Primary registry for all active messages definitions.
         # It contains the 1:1 mapping from msgid to MessageDefinition.
@@ -32,6 +34,7 @@ class MessageDefinitionStore:
         self._messages_definitions: dict[str, MessageDefinition] = {}
         # MessageDefinition kept by category
         self._msgs_by_category: dict[str, list[str]] = collections.defaultdict(list)
+        self.py_version = py_version
 
     @property
     def messages(self) -> ValuesView[MessageDefinition]:
@@ -111,7 +114,7 @@ class MessageDefinitionStore:
         emittable = []
         non_emittable = []
         for message in messages:
-            if message.may_be_emitted(sys.version_info):
+            if message.may_be_emitted(self.py_version):
                 emittable.append(message)
             else:
                 non_emittable.append(message)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |


## Description

#7580 added a deprecation warning but didn't silence it in the test suite. Just a cleanup.
