### PR TITLE
Fix false positive for `while-used`

### DIFF
--- a/doc/whatsnew/fragments/7748.false_positive
+++ b/doc/whatsnew/fragments/7748.false_positive
@@ -1,3 +1,3 @@
-Fix false positive for `while-used` when the condition is a constant
+Fix false positive for `while-used` when the condition is a constant.
 
 Closes #7748

--- a/doc/whatsnew/fragments/7748.false_positive
+++ b/doc/whatsnew/fragments/7748.false_positive
@@ -1,0 +1,3 @@
+Fix false positive for `while-used` when the condition is a constant
+
+Closes #7748

--- a/pylint/extensions/while_used.py
+++ b/pylint/extensions/while_used.py
@@ -30,6 +30,8 @@ class WhileChecker(BaseChecker):
 
     @only_required_for_messages("while-used")
     def visit_while(self, node: nodes.While) -> None:
+        if isinstance(node.test, nodes.Const):
+            return
         self.add_message("while-used", node=node)
 
 

--- a/tests/functional/ext/while_used/while_used.py
+++ b/tests/functional/ext/while_used/while_used.py
@@ -1,10 +1,21 @@
-"""Functional test"""
+# pylint: disable=invalid-name,missing-docstring
 
-while True:  # [while-used]
-    print("asdf")
+while True:
+    print("Text")
 
-def fff():
-    "zxcv"
+while 1:
+    print("Text")
+
+while False:
+    print("Unreachable")
+
+
+var = True
+while var:  # [while-used]
+    var = not var
+
+
+def func():
     i = 0
     while i < 10:  # [while-used]
         i += 1

--- a/tests/functional/ext/while_used/while_used.txt
+++ b/tests/functional/ext/while_used/while_used.txt
@@ -1,2 +1,2 @@
-while-used:3:0:4:17::Used `while` loop:UNDEFINED
-while-used:9:4:10:14:fff:Used `while` loop:UNDEFINED
+while-used:14:0:15:17::Used `while` loop:UNDEFINED
+while-used:21:4:22:14:func:Used `while` loop:UNDEFINED

--- a/tests/functional/ext/while_used/while_used.txt
+++ b/tests/functional/ext/while_used/while_used.txt
@@ -1,2 +1,2 @@
 while-used:14:0:15:17::Used `while` loop:UNDEFINED
-while-used:21:4:22:14:func:Used `while` loop:UNDEFINED
+while-used:20:4:21:14:func:Used `while` loop:UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->
The `while_used` checker now no longer reports `while-used` when the condition of the while loop is a constant

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

<!-- If this PR references an issue without fixing it: -->

Refs #XXXX

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #7748 
