### PR TITLE
Preserve file name when copying commit string file in primer job

### DIFF
--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -126,7 +126,7 @@ jobs:
       - name: Copy and unzip the commit string
         run: |
           unzip primer_commitstring.zip
-          cp commit_string_${{ matrix.python-version }}.txt tests/.pylint_primer_tests/commit_string.txt
+          cp commit_string_${{ matrix.python-version }}.txt tests/.pylint_primer_tests/commit_string_${{ matrix.python-version }}.txt
       - name: Unzip the output of 'main'
         run: unzip primer_output_main.zip
       - name: Get commit string


### PR DESCRIPTION
@mbyrnepr2 Finally this is launching the primer on a PR (this one). Fancy reviewing, and then I can merge?