### PR TITLE
reimported should detect aliased imports

### DIFF
--- a/doc/data/messages/s/shadowed-import/bad.py
+++ b/doc/data/messages/s/shadowed-import/bad.py
@@ -1,0 +1,2 @@
+from pathlib import Path
+import FastAPI.Path as Path  # [shadowed-import]

--- a/doc/data/messages/s/shadowed-import/bad.py
+++ b/doc/data/messages/s/shadowed-import/bad.py
@@ -1,2 +1,3 @@
 from pathlib import Path
+
 import FastAPI.Path as Path  # [shadowed-import]

--- a/doc/data/messages/s/shadowed-import/good.py
+++ b/doc/data/messages/s/shadowed-import/good.py
@@ -1,0 +1,2 @@
+from pathlib import Path
+import FastAPI.Path as FastApiPath

--- a/doc/data/messages/s/shadowed-import/good.py
+++ b/doc/data/messages/s/shadowed-import/good.py
@@ -1,2 +1,3 @@
 from pathlib import Path
+
 import FastAPI.Path as FastApiPath

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -529,7 +529,9 @@ Imports checker Messages
 :preferred-module (W0407): *Prefer importing %r instead of %r*
   Used when a module imported has a preferred replacement module.
 :reimported (W0404): *Reimport %r (imported line %s)*
-  Used when a module is reimported multiple times.
+  Used when a module is imported more than once.
+:shadowed-import (W0416): *Shadowed %r (imported line %s)*
+  Used when a module is aliased with a name that shadowed another import.
 :wildcard-import (W0401): *Wildcard import %s*
   Used when `from module import *` is detected.
 :misplaced-future (W0410): *__future__ import is not the first non docstring statement*

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -531,7 +531,7 @@ Imports checker Messages
 :reimported (W0404): *Reimport %r (imported line %s)*
   Used when a module is imported more than once.
 :shadowed-import (W0416): *Shadowed %r (imported line %s)*
-  Used when a module is aliased with a name that shadowed another import.
+  Used when a module is aliased with a name that shadows another import.
 :wildcard-import (W0401): *Wildcard import %s*
   Used when `from module import *` is detected.
 :misplaced-future (W0410): *__future__ import is not the first non docstring statement*

--- a/doc/user_guide/messages/messages_overview.rst
+++ b/doc/user_guide/messages/messages_overview.rst
@@ -305,6 +305,7 @@ All messages in the warning category:
    warning/reimported
    warning/self-assigning-variable
    warning/self-cls-assignment
+   warning/shadowed-import
    warning/shallow-copy-environ
    warning/signature-differs
    warning/subclassed-final-class

--- a/doc/whatsnew/fragments/4836.bugfix
+++ b/doc/whatsnew/fragments/4836.bugfix
@@ -1,0 +1,3 @@
+Update ``reimported`` help message for clarity and ensure aliased imports are also detected.
+
+Closes #4836

--- a/doc/whatsnew/fragments/4836.bugfix
+++ b/doc/whatsnew/fragments/4836.bugfix
@@ -1,3 +1,3 @@
-Update ``reimported`` help message for clarity and ensure aliased imports are also detected.
+Update ``reimported`` help message for clarity and add a ``shadowed-import`` message for aliased imports.
 
 Closes #4836

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -951,7 +951,9 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
                 )
                 if first is not None and msg is not None:
                     name = name if msg == "reimported" else alias
-                    self.add_message(msg, node=node, args=(name, first.fromlineno))
+                    self.add_message(
+                        msg, node=node, args=(name, first.fromlineno), confidence=HIGH
+                    )
 
     def _report_external_dependencies(
         self, sect: Section, _: LinterStats, _dummy: LinterStats | None

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -125,6 +125,9 @@ def _get_first_import(
                     ):
                         found = True
                         break
+                    if imported_name == alias:
+                        found = True
+                        break
                 if found:
                     break
     if found and not astroid.are_exclusive(first, node):
@@ -252,7 +255,7 @@ MSGS: dict[str, MessageDefinitionTuple] = {
     "W0404": (
         "Reimport %r (imported line %s)",
         "reimported",
-        "Used when a module is reimported multiple times.",
+        "Used when a module of the same name is reimported or aliased.",
     ),
     "W0406": (
         "Module import itself",
@@ -914,7 +917,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
         basename: str | None = None,
         level: int | None = None,
     ) -> None:
-        """Check if the import is necessary (i.e. not already done)."""
+        """Check if a module with the same name is already imported or aliased."""
         if not self.linter.is_message_enabled("reimported"):
             return
 

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -12,7 +12,7 @@ import os
 import sys
 from collections import defaultdict
 from collections.abc import ItemsView, Sequence
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 import astroid
 from astroid import nodes
@@ -97,7 +97,7 @@ def _get_first_import(
     base: str | None,
     level: int | None,
     alias: str | None,
-) -> Tuple[nodes.Import | nodes.ImportFrom | None, str | None]:
+) -> tuple[nodes.Import | nodes.ImportFrom | None, str | None]:
     """Return the node where [base.]<name> is imported or None if not found."""
     fullname = f"{base}.{name}" if base else name
 
@@ -933,7 +933,9 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
         level: int | None = None,
     ) -> None:
         """Check if a module with the same name is already imported or aliased."""
-        if not self.linter.is_message_enabled("reimported"):
+        if not self.linter.is_message_enabled(
+            "reimported"
+        ) and not self.linter.is_message_enabled("shadowed-import"):
             return
 
         frame = node.frame(future=True)

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -319,7 +319,7 @@ MSGS: dict[str, MessageDefinitionTuple] = {
     "W0416": (
         "Shadowed %r (imported line %s)",
         "shadowed-import",
-        "Used when a module is aliased with a name that shadowed another import.",
+        "Used when a module is aliased with a name that shadows another import.",
     ),
 }
 

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -114,6 +114,13 @@ def _get_first_import(
             if any(fullname == iname[0] for iname in first.names):
                 found = True
                 break
+            for imported_name, imported_alias in first.names:
+                if not imported_alias and imported_name == alias:
+                    found = True
+                    msg = "shadowed-import"
+                    break
+            if found:
+                break
         elif isinstance(first, nodes.ImportFrom):
             if level == first.level:
                 for imported_name, imported_alias in first.names:
@@ -127,7 +134,7 @@ def _get_first_import(
                     ):
                         found = True
                         break
-                    if imported_name == alias:
+                    if not imported_alias and imported_name == alias:
                         found = True
                         msg = "shadowed-import"
                         break
@@ -940,11 +947,9 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
                 first, msg = _get_first_import(
                     node, known_context, name, basename, known_level, alias
                 )
-                if first is not None:
+                if first is not None and msg is not None:
                     name = name if msg == "reimported" else alias
-                    self.add_message(
-                        msg, node=node, args=(name, first.fromlineno)
-                    )
+                    self.add_message(msg, node=node, args=(name, first.fromlineno))
 
     def _report_external_dependencies(
         self, sect: Section, _: LinterStats, _dummy: LinterStats | None

--- a/tests/functional/i/import_aliasing.py
+++ b/tests/functional/i/import_aliasing.py
@@ -1,4 +1,4 @@
-# pylint: disable=unused-import, missing-docstring, invalid-name, reimported, import-error, wrong-import-order, no-name-in-module
+# pylint: disable=unused-import, missing-docstring, invalid-name, reimported, import-error, wrong-import-order, no-name-in-module, shadowed-import
 # Functional tests for import aliasing
 # 1. useless-import-alias
 # 2. consider-using-from-import

--- a/tests/functional/r/reimport.txt
+++ b/tests/functional/r/reimport.txt
@@ -1,4 +1,4 @@
-reimported:7:0:7:9::Reimport 'os' (imported line 5):UNDEFINED
-reimported:15:4:15:30::Reimport 'exists' (imported line 6):UNDEFINED
-reimported:20:4:20:20:func:Reimport 'os' (imported line 5):UNDEFINED
-reimported:22:4:22:13:func:Reimport 're' (imported line 8):UNDEFINED
+reimported:7:0:7:9::Reimport 'os' (imported line 5):HIGH
+reimported:15:4:15:30::Reimport 'exists' (imported line 6):HIGH
+reimported:20:4:20:20:func:Reimport 'os' (imported line 5):HIGH
+reimported:22:4:22:13:func:Reimport 're' (imported line 8):HIGH

--- a/tests/functional/r/reimported.py
+++ b/tests/functional/r/reimported.py
@@ -1,4 +1,6 @@
-# pylint: disable=missing-docstring,unused-import,import-error, wildcard-import,unused-wildcard-import,redefined-builtin,no-name-in-module,ungrouped-imports,wrong-import-order,wrong-import-position,consider-using-from-import
+# pylint: disable=missing-docstring,unused-import,import-error, wildcard-import,unused-wildcard-import
+# pylint: disable=redefined-builtin,no-name-in-module,ungrouped-imports,wrong-import-order,wrong-import-position
+# pylint: disable=consider-using-from-import
 
 from time import sleep, sleep  # [reimported]
 from lala import missing, missing  # [reimported]
@@ -39,7 +41,5 @@ def reimport():
 
 del sys, ElementTree, xml.etree.ElementTree, encoders, email.encoders
 
-from pathlib import Path
-from some_other_lib import CustomPath as Path   # [reimported]
-from pathlib import Path  # [reimported]
-import FastAPI.Path as Path   # [reimported]
+from pandas._libs import algos as libalgos
+import pandas._libs.algos as algos  # [reimported]

--- a/tests/functional/r/reimported.py
+++ b/tests/functional/r/reimported.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring,unused-import,import-error, wildcard-import,unused-wildcard-import,redefined-builtin,no-name-in-module,ungrouped-imports,wrong-import-order
+# pylint: disable=missing-docstring,unused-import,import-error, wildcard-import,unused-wildcard-import,redefined-builtin,no-name-in-module,ungrouped-imports,wrong-import-order,wrong-import-position,consider-using-from-import
 
 from time import sleep, sleep  # [reimported]
 from lala import missing, missing  # [reimported]
@@ -38,3 +38,8 @@ def reimport():
 
 
 del sys, ElementTree, xml.etree.ElementTree, encoders, email.encoders
+
+from pathlib import Path
+from some_other_lib import CustomPath as Path   # [reimported]
+from pathlib import Path  # [reimported]
+import FastAPI.Path as Path   # [reimported]

--- a/tests/functional/r/reimported.txt
+++ b/tests/functional/r/reimported.txt
@@ -1,10 +1,10 @@
 reimported:5:0:5:29::Reimport 'sleep' (imported line 5):UNDEFINED
 reimported:6:0:6:33::Reimport 'missing' (imported line 6):UNDEFINED
-reimported:9:0:9:15::Reimport 'missing1' (imported line 8):UNDEFINED
-reimported:12:0:12:27::Reimport 'deque' (imported line 11):UNDEFINED
-reimported:23:0:23:33::Reimport 'ElementTree' (imported line 22):UNDEFINED
-reimported:26:0:26:21::Reimport 'email.encoders' (imported line 25):UNDEFINED
-reimported:28:0:28:10::Reimport 'sys' (imported line 20):UNDEFINED
+reimported:9:0:9:15::Reimport 'missing1' (imported line 8):HIGH
+reimported:12:0:12:27::Reimport 'deque' (imported line 11):HIGH
+reimported:23:0:23:33::Reimport 'ElementTree' (imported line 22):HIGH
+reimported:26:0:26:21::Reimport 'email.encoders' (imported line 25):HIGH
+reimported:28:0:28:10::Reimport 'sys' (imported line 20):HIGH
 redefined-outer-name:38:4:38:14:reimport:Redefining name 'sys' from outer scope (line 18):UNDEFINED
-reimported:38:4:38:14:reimport:Reimport 'sys' (imported line 20):UNDEFINED
-reimported:45:0:45:34::Reimport 'pandas._libs.algos' (imported line 44):UNDEFINED
+reimported:38:4:38:14:reimport:Reimport 'sys' (imported line 20):HIGH
+reimported:45:0:45:34::Reimport 'pandas._libs.algos' (imported line 44):HIGH

--- a/tests/functional/r/reimported.txt
+++ b/tests/functional/r/reimported.txt
@@ -7,3 +7,6 @@ reimported:24:0:24:21::Reimport 'email.encoders' (imported line 23):UNDEFINED
 reimported:26:0:26:10::Reimport 'sys' (imported line 18):UNDEFINED
 redefined-outer-name:36:4:36:14:reimport:Redefining name 'sys' from outer scope (line 16):UNDEFINED
 reimported:36:4:36:14:reimport:Reimport 'sys' (imported line 18):UNDEFINED
+reimported:43:0:43:45::Reimport 'CustomPath' (imported line 42):UNDEFINED
+reimported:44:0:44:24::Reimport 'Path' (imported line 42):UNDEFINED
+reimported:45:0:45:27::Reimport 'FastAPI.Path' (imported line 42):UNDEFINED

--- a/tests/functional/r/reimported.txt
+++ b/tests/functional/r/reimported.txt
@@ -1,12 +1,10 @@
-reimported:3:0:3:29::Reimport 'sleep' (imported line 3):UNDEFINED
-reimported:4:0:4:33::Reimport 'missing' (imported line 4):UNDEFINED
-reimported:7:0:7:15::Reimport 'missing1' (imported line 6):UNDEFINED
-reimported:10:0:10:27::Reimport 'deque' (imported line 9):UNDEFINED
-reimported:21:0:21:33::Reimport 'ElementTree' (imported line 20):UNDEFINED
-reimported:24:0:24:21::Reimport 'email.encoders' (imported line 23):UNDEFINED
-reimported:26:0:26:10::Reimport 'sys' (imported line 18):UNDEFINED
-redefined-outer-name:36:4:36:14:reimport:Redefining name 'sys' from outer scope (line 16):UNDEFINED
-reimported:36:4:36:14:reimport:Reimport 'sys' (imported line 18):UNDEFINED
-reimported:43:0:43:45::Reimport 'CustomPath' (imported line 42):UNDEFINED
-reimported:44:0:44:24::Reimport 'Path' (imported line 42):UNDEFINED
-reimported:45:0:45:27::Reimport 'FastAPI.Path' (imported line 42):UNDEFINED
+reimported:5:0:5:29::Reimport 'sleep' (imported line 5):UNDEFINED
+reimported:6:0:6:33::Reimport 'missing' (imported line 6):UNDEFINED
+reimported:9:0:9:15::Reimport 'missing1' (imported line 8):UNDEFINED
+reimported:12:0:12:27::Reimport 'deque' (imported line 11):UNDEFINED
+reimported:23:0:23:33::Reimport 'ElementTree' (imported line 22):UNDEFINED
+reimported:26:0:26:21::Reimport 'email.encoders' (imported line 25):UNDEFINED
+reimported:28:0:28:10::Reimport 'sys' (imported line 20):UNDEFINED
+redefined-outer-name:38:4:38:14:reimport:Redefining name 'sys' from outer scope (line 18):UNDEFINED
+reimported:38:4:38:14:reimport:Reimport 'sys' (imported line 20):UNDEFINED
+reimported:45:0:45:34::Reimport 'pandas._libs.algos' (imported line 44):UNDEFINED

--- a/tests/functional/s/shadowed_import.py
+++ b/tests/functional/s/shadowed_import.py
@@ -1,0 +1,17 @@
+# pylint: disable=missing-docstring,unused-import,import-error, consider-using-from-import
+# pylint: disable=wrong-import-order
+
+from pathlib import Path
+from some_other_lib import CustomPath as Path   # [shadowed-import]
+
+from pathlib import Path  # [reimported]
+import FastAPI.Path as Path  # [shadowed-import]
+
+from pandas._libs import algos
+import pandas.core.algorithms as algos  # [shadowed-import]
+
+from sklearn._libs import second as libalgos
+import sklearn.core.algorithms as second
+
+import Hello
+from goodbye import CustomHello as Hello   # [shadowed-import]

--- a/tests/functional/s/shadowed_import.txt
+++ b/tests/functional/s/shadowed_import.txt
@@ -1,0 +1,5 @@
+shadowed-import:5:0:5:45::Shadowed 'Path' (imported line 4):UNDEFINED
+reimported:7:0:7:24::Reimport 'Path' (imported line 4):UNDEFINED
+shadowed-import:8:0:8:27::Shadowed 'Path' (imported line 4):UNDEFINED
+shadowed-import:11:0:11:38::Shadowed 'algos' (imported line 10):UNDEFINED
+shadowed-import:17:0:17:40::Shadowed 'Hello' (imported line 16):UNDEFINED

--- a/tests/functional/s/shadowed_import.txt
+++ b/tests/functional/s/shadowed_import.txt
@@ -1,5 +1,5 @@
-shadowed-import:5:0:5:45::Shadowed 'Path' (imported line 4):UNDEFINED
-reimported:7:0:7:24::Reimport 'Path' (imported line 4):UNDEFINED
-shadowed-import:8:0:8:27::Shadowed 'Path' (imported line 4):UNDEFINED
-shadowed-import:11:0:11:38::Shadowed 'algos' (imported line 10):UNDEFINED
-shadowed-import:17:0:17:40::Shadowed 'Hello' (imported line 16):UNDEFINED
+shadowed-import:5:0:5:45::Shadowed 'Path' (imported line 4):HIGH
+reimported:7:0:7:24::Reimport 'Path' (imported line 4):HIGH
+shadowed-import:8:0:8:27::Shadowed 'Path' (imported line 4):HIGH
+shadowed-import:11:0:11:38::Shadowed 'algos' (imported line 10):HIGH
+shadowed-import:17:0:17:40::Shadowed 'Hello' (imported line 16):HIGH

--- a/tests/functional/u/unused/unused_import.py
+++ b/tests/functional/u/unused/unused_import.py
@@ -80,7 +80,7 @@ if TYPE_CHECKING:
 # Pathological cases
 from io import TYPE_CHECKING  # pylint: disable=no-name-in-module
 import trace as t
-import astroid as typing
+import astroid as typing  # pylint: disable=shadowed-import
 
 TYPE_CHECKING = "red herring"
 

--- a/tests/functional/u/unused/unused_import_py30.txt
+++ b/tests/functional/u/unused/unused_import_py30.txt
@@ -1,1 +1,1 @@
-reimported:7:0:7:40::Reimport 'ABCMeta' (imported line 6):UNDEFINED
+reimported:7:0:7:40::Reimport 'ABCMeta' (imported line 6):HIGH


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Closes #4836

Issue brought up the fact that the `reimported` message was confusing and hinted at something else, while also giving us more test cases to improve the check for imports using aliases.
