### PR TITLE
Fix false positive for ``unhashable-member`` when subclassing ``dict``.

### DIFF
--- a/doc/whatsnew/fragments/7501.false_positive
+++ b/doc/whatsnew/fragments/7501.false_positive
@@ -1,0 +1,3 @@
+Fix false positive for ``unhashable-member`` when subclassing ``dict``.
+
+Closes #7501

--- a/doc/whatsnew/fragments/7501.false_positive
+++ b/doc/whatsnew/fragments/7501.false_positive
@@ -1,3 +1,3 @@
-Fix false positive for ``unhashable-member`` when subclassing ``dict``.
+Fix false positive for ``unhashable-member`` when subclassing ``dict`` and using the subclass as a dictionary key.
 
 Closes #7501

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2012,7 +2012,7 @@ def is_hashable(node: nodes.NodeNG) -> bool:
     """
     try:
         for inferred in node.infer():
-            if inferred is astroid.Uninferable:
+            if inferred is astroid.Uninferable or isinstance(inferred, nodes.ClassDef):
                 return True
             if not hasattr(inferred, "igetattr"):
                 return True

--- a/tests/functional/u/unhashable_member.py
+++ b/tests/functional/u/unhashable_member.py
@@ -22,3 +22,9 @@ class Unhashable:
 {"tomato": "tomahto"}
 {dict: {}}
 {lambda x: x: "tomato"}  # pylint: disable=unnecessary-lambda
+
+
+class FromDict(dict):
+    ...
+
+{FromDict: 1}


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
Let `nodes.ClassDef` nodes be considered hashable.

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #7501
