### PR TITLE
Remove unused `ExtSlice` code paths

### DIFF
--- a/tests/functional/i/invalid/invalid_sequence_index.py
+++ b/tests/functional/i/invalid/invalid_sequence_index.py
@@ -202,7 +202,7 @@ def function24():
     test[0] = 0 # setitem with int, no error
     del test[0] # delitem with int, no error
 
-# Teest ExtSlice usage
+# Test ExtSlice usage
 def function25():
     """Extended slice used with a list"""
     return TESTLIST[..., 0] # [invalid-sequence-index]


### PR DESCRIPTION
## Description
The `ExtSlice` node has long been deprecated in astroid and is actually not used anymore since it was merged in `Subscript`. https://github.com/PyCQA/astroid/pull/1026

This PR removes the references to `nodes.ExtSlice` that I seem to have missed in #4568.