### PR TITLE
Add `named-expr-without-context` check

### DIFF
--- a/doc/data/messages/n/named-expr-without-context/bad.py
+++ b/doc/data/messages/n/named-expr-without-context/bad.py
@@ -1,0 +1,1 @@
+(a := 42)  # [named-expr-without-context]

--- a/doc/data/messages/n/named-expr-without-context/good.py
+++ b/doc/data/messages/n/named-expr-without-context/good.py
@@ -1,0 +1,2 @@
+if (a := 42):
+    print('Success')

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -135,6 +135,9 @@ Basic checker Messages
   argument list as the lambda itself; such lambda expressions are in all but a
   few cases replaceable with the function being called in the body of the
   lambda.
+:named-expr-without-context (W0131): *Named expression used without context*
+  Emitted if named expression is used to do a regular assignment outside a
+  context like if, for, while, or a comprehension.
 :redeclared-assigned-name (W0128): *Redeclared variable %r in assignment*
   Emitted when we detect that a variable was redeclared in the same assignment.
 :pointless-statement (W0104): *Statement seems to have no effect*

--- a/doc/user_guide/messages/messages_overview.rst
+++ b/doc/user_guide/messages/messages_overview.rst
@@ -277,6 +277,7 @@ All messages in the warning category:
    warning/missing-yield-type-doc
    warning/modified-iterating-list
    warning/multiple-constructor-doc
+   warning/named-expr-without-context
    warning/nan-comparison
    warning/non-ascii-file-name
    warning/non-parent-init-called

--- a/doc/whatsnew/fragments/7760.new_check
+++ b/doc/whatsnew/fragments/7760.new_check
@@ -1,0 +1,5 @@
+Add ``named-expr-without-context`` check to emit a warning if a named
+expression is used outside a context like ``if``, ``for``, ``while``, or
+a comprehension.
+
+Refs #7760

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -252,6 +252,12 @@ class BasicChecker(_BasicChecker):
             "duplicate-value",
             "This message is emitted when a set contains the same value two or more times.",
         ),
+        "W0131": (
+            "Named expression used without context",
+            "named-expr-without-context",
+            "Emitted if named expression is used to do a regular assignment "
+            "outside a context like if, for, while, or a comprehension.",
+        ),
     }
 
     reports = (("RP0101", "Statistics by type", report_by_type_stats),)
@@ -410,7 +416,10 @@ class BasicChecker(_BasicChecker):
         self.linter.stats.node_count["klass"] += 1
 
     @utils.only_required_for_messages(
-        "pointless-statement", "pointless-string-statement", "expression-not-assigned"
+        "pointless-statement",
+        "pointless-string-statement",
+        "expression-not-assigned",
+        "named-expr-without-context",
     )
     def visit_expr(self, node: nodes.Expr) -> None:
         """Check for various kind of statements without effect."""
@@ -448,7 +457,9 @@ class BasicChecker(_BasicChecker):
             or (isinstance(expr, nodes.Const) and expr.value is Ellipsis)
         ):
             return
-        if any(expr.nodes_of_class(nodes.Call)):
+        if isinstance(expr, nodes.NamedExpr):
+            self.add_message("named-expr-without-context", node=node, confidence=HIGH)
+        elif any(expr.nodes_of_class(nodes.Call)):
             self.add_message(
                 "expression-not-assigned", node=node, args=expr.as_string()
             )

--- a/tests/functional/n/named_expr_without_context_py38.py
+++ b/tests/functional/n/named_expr_without_context_py38.py
@@ -1,0 +1,6 @@
+# pylint: disable=missing-docstring
+
+if (a := 2):
+    pass
+
+(b := 1)  # [named-expr-without-context]

--- a/tests/functional/n/named_expr_without_context_py38.rc
+++ b/tests/functional/n/named_expr_without_context_py38.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.8

--- a/tests/functional/n/named_expr_without_context_py38.txt
+++ b/tests/functional/n/named_expr_without_context_py38.txt
@@ -1,0 +1,1 @@
+named-expr-without-context:6:0:6:8::Named expression used without context:HIGH

--- a/tests/functional/s/superfluous_parens_walrus_py38.py
+++ b/tests/functional/s/superfluous_parens_walrus_py38.py
@@ -1,5 +1,5 @@
 """Test the superfluous-parens warning with python 3.8 functionality (walrus operator)"""
-# pylint: disable=missing-function-docstring, invalid-name, missing-class-docstring, import-error, pointless-statement
+# pylint: disable=missing-function-docstring, invalid-name, missing-class-docstring, import-error, pointless-statement,named-expr-without-context
 import numpy
 
 # Test parens in if statements


### PR DESCRIPTION
## Description
Instead of emitting `pointless-statement`, this PR adds a new check `named-expr-without-context` for named expressions outside `if`, `for`, ...
```py
(a := 42)  # named-expr-without-context
```

Closes #7760