### PR TITLE
Bump timeout for docs check [ci]

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -161,7 +161,7 @@ jobs:
   documentation:
     name: documentation
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     needs: prepare-base
     steps:
       - name: Check out code from GitHub


### PR DESCRIPTION
## Description
Fix failing `documentation` check.
https://github.com/PyCQA/pylint/actions/runs/3463507407/jobs/5784541243#step:8:1276

Ref https://github.com/PyCQA/pylint/pull/7769#issuecomment-1314214505