### PR TITLE
[release process] Add a github actions to backport fix automatically

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,25 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    steps:
+      - uses: tibdex/backport@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/development_guide/contributor_guide/release.md
+++ b/doc/development_guide/contributor_guide/release.md
@@ -49,17 +49,12 @@ branch
 
 ## Back-porting a fix from `main` to the maintenance branch
 
-Whenever a commit on `main` should be released in a patch release on the current
-maintenance branch we cherry-pick the commit from `main`.
+Whenever a PR on `main` should be released in a patch release on the current maintenance
+branch:
 
-- During the merge request on `main`, make sure that the changelog is for the patch
-  version `X.Y-1.Z'`. (For example: `v2.3.5`)
-- After the PR is merged on `main` cherry-pick the commits on the
-  `release-branch-X.Y-1.Z'` branch created from `maintenance/X.Y-1.x` then cherry-pick
-  the commit from the `main` branch. (For example: `release-branch-2.3.5` from
-  `maintenance/2.3.x`)
-- Remove the "need backport" label from cherry-picked issues
-
+- Label the PR with `backport maintenance/X.Y-1.x`. (For example
+  `backport maintenance/2.3.x`)
+- Squash the PR before merging (alternatively rebase if there's a single commit)
 - Release a patch version
 
 ## Releasing a patch version


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :scroll: Docs          |

## Description

Based on https://github.com/tibdex/backport which seems awfully conveniant.
