### PR TITLE
[github actions] Set write permission for backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,6 +5,9 @@ on:
       - closed
       - labeled
 
+permissions:
+  contents: write
+
 jobs:
   backport:
     name: Backport


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

We also gave default write permissions for all jobs in the settings.

The permissions were explicitely defined in each job already

See https://github.com/PyCQA/pylint/actions/runs/3483774315 for the result without the right (write) permission.