### PR TITLE
Better error message for unpacking-non-sequence and unbalanced-tuple-unpacking

### DIFF
--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -990,8 +990,8 @@ Stdlib checker Messages
   https://docs.python.org/3/library/subprocess.html#subprocess.run
 :bad-thread-instantiation (W1506): *threading.Thread needs the target function*
   The warning is emitted when a threading.Thread class is instantiated without
-  the target function being passed. By default, the first parameter is the
-  group param, not the target param.
+  the target function being passed as a kwarg or as a second argument. By
+  default, the first parameter is the group param, not the target param.
 
 
 String checker
@@ -1309,7 +1309,7 @@ Variables checker Messages
   variable is not defined in the module scope.
 :self-cls-assignment (W0642): *Invalid assignment to %s in method*
   Invalid assignment to self or cls in instance or class method respectively.
-:unbalanced-tuple-unpacking (W0632): *Possible unbalanced tuple unpacking with sequence%s: left side has %d label(s), right side has %d value(s)*
+:unbalanced-tuple-unpacking (W0632): *Possible unbalanced tuple unpacking with sequence %s: left side has %d label%s, right side has %d value%s*
   Used when there is an unbalanced tuple unpacking in assignment
 :possibly-unused-variable (W0641): *Possibly unused variable %r*
   Used when a variable is defined but might not be used. The possibility comes

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -99,7 +99,7 @@ Standard Checkers
 
 --ignore-paths
 """"""""""""""
-*Add files or directories matching the regular expressions patterns to the ignore-list. The regex matches against paths and can be in Posix or Windows format. Because '\' represents the directory delimiter on Windows systems, it can't be used as an escape character.*
+*Add files or directories matching the regular expressions patterns to the ignore-list. The regex matches against paths and can be in Posix or Windows format. Because '\\' represents the directory delimiter on Windows systems, it can't be used as an escape character.*
 
 **Default:**  ``[]``
 
@@ -798,7 +798,7 @@ Standard Checkers
 """"""""""""""""""""""""
 *Exceptions that will emit a warning when caught.*
 
-**Default:**  ``('BaseException', 'Exception')``
+**Default:**  ``('builtins.BaseException', 'builtins.Exception')``
 
 
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2681,9 +2681,9 @@ class VariablesChecker(BaseChecker):
                     args=(
                         details,
                         len(targets),
-                        "s" if len(targets) > 1 else "",
+                        "" if len(targets) == 1 else "s",
                         len(values),
-                        "s" if len(values) > 1 else "",
+                        "" if len(values) == 1 else "s",
                     ),
                 )
         # attempt to check unpacking may be possible (i.e. RHS is iterable)

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -167,11 +167,11 @@ def _get_unpacking_extra_info(node: nodes.Assign, inferred: InferenceResult) -> 
     inferred_module = inferred.root().name
     if node.root().name == inferred_module:
         if node.lineno == inferred.lineno:
-            more = f" {inferred.as_string()}"
+            more = f"'{inferred.as_string()}'"
         elif inferred.lineno:
-            more = f" defined at line {inferred.lineno}"
+            more = f"defined at line {inferred.lineno}"
     elif inferred.lineno:
-        more = f" defined at line {inferred.lineno} of {inferred_module}"
+        more = f"defined at line {inferred.lineno} of {inferred_module}"
     return more
 
 
@@ -480,9 +480,8 @@ MSGS: dict[str, MessageDefinitionTuple] = {
         "the loop.",
     ),
     "W0632": (
-        "Possible unbalanced tuple unpacking with "
-        "sequence%s: "
-        "left side has %d label(s), right side has %d value(s)",
+        "Possible unbalanced tuple unpacking with sequence %s: left side has %d "
+        "label%s, right side has %d value%s",
         "unbalanced-tuple-unpacking",
         "Used when there is an unbalanced tuple unpacking in assignment",
         {"old_names": [("E0632", "old-unbalanced-tuple-unpacking")]},
@@ -490,8 +489,7 @@ MSGS: dict[str, MessageDefinitionTuple] = {
     "E0633": (
         "Attempting to unpack a non-sequence%s",
         "unpacking-non-sequence",
-        "Used when something which is not "
-        "a sequence is used in an unpack assignment",
+        "Used when something which is not a sequence is used in an unpack assignment",
         {"old_names": [("W0633", "old-unpacking-non-sequence")]},
     ),
     "W0640": (
@@ -2671,6 +2669,7 @@ class VariablesChecker(BaseChecker):
 
         # Attempt to check unpacking is properly balanced
         values = self._nodes_to_unpack(inferred)
+        details = _get_unpacking_extra_info(node, inferred)
         if values is not None:
             if len(targets) != len(values):
                 # Check if we have starred nodes.
@@ -2680,18 +2679,18 @@ class VariablesChecker(BaseChecker):
                     "unbalanced-tuple-unpacking",
                     node=node,
                     args=(
-                        _get_unpacking_extra_info(node, inferred),
+                        details,
                         len(targets),
+                        "s" if len(targets) > 1 else "",
                         len(values),
+                        "s" if len(values) > 1 else "",
                     ),
                 )
         # attempt to check unpacking may be possible (i.e. RHS is iterable)
         elif not utils.is_iterable(inferred):
-            self.add_message(
-                "unpacking-non-sequence",
-                node=node,
-                args=(_get_unpacking_extra_info(node, inferred),),
-            )
+            if details and not details.startswith(" "):
+                details = f" {details}"
+            self.add_message("unpacking-non-sequence", node=node, args=details)
 
     @staticmethod
     def _nodes_to_unpack(node: nodes.NodeNG) -> list[nodes.NodeNG] | None:

--- a/tests/functional/u/unbalanced_tuple_unpacking.txt
+++ b/tests/functional/u/unbalanced_tuple_unpacking.txt
@@ -5,5 +5,5 @@ unbalanced-tuple-unpacking:82:4:82:28:do_stuff9:"Possible unbalanced tuple unpac
 unbalanced-tuple-unpacking:96:8:96:33:UnbalancedUnpacking.test:"Possible unbalanced tuple unpacking with sequence defined at line 7 of functional.u.unpacking.unpacking: left side has 2 labels, right side has 3 values":UNDEFINED
 unbalanced-tuple-unpacking:140:8:140:43:MyClass.sum_unpack_3_into_4:"Possible unbalanced tuple unpacking with sequence defined at line 128: left side has 4 labels, right side has 3 values":UNDEFINED
 unbalanced-tuple-unpacking:145:8:145:28:MyClass.sum_unpack_3_into_2:"Possible unbalanced tuple unpacking with sequence defined at line 128: left side has 2 labels, right side has 3 values":UNDEFINED
-unbalanced-tuple-unpacking:157:0:157:24::"Possible unbalanced tuple unpacking with sequence defined at line 151: left side has 2 labels, right side has 0 value":UNDEFINED
+unbalanced-tuple-unpacking:157:0:157:24::"Possible unbalanced tuple unpacking with sequence defined at line 151: left side has 2 labels, right side has 0 values":UNDEFINED
 unbalanced-tuple-unpacking:162:0:162:16::"Possible unbalanced tuple unpacking with sequence '(1, 2)': left side has 3 labels, right side has 2 values":UNDEFINED

--- a/tests/functional/u/unbalanced_tuple_unpacking.txt
+++ b/tests/functional/u/unbalanced_tuple_unpacking.txt
@@ -1,9 +1,9 @@
-unbalanced-tuple-unpacking:11:4:11:27:do_stuff:"Possible unbalanced tuple unpacking with sequence (1, 2, 3): left side has 2 label(s), right side has 3 value(s)":UNDEFINED
-unbalanced-tuple-unpacking:17:4:17:29:do_stuff1:"Possible unbalanced tuple unpacking with sequence [1, 2, 3]: left side has 2 label(s), right side has 3 value(s)":UNDEFINED
-unbalanced-tuple-unpacking:23:4:23:29:do_stuff2:"Possible unbalanced tuple unpacking with sequence (1, 2, 3): left side has 2 label(s), right side has 3 value(s)":UNDEFINED
-unbalanced-tuple-unpacking:82:4:82:28:do_stuff9:"Possible unbalanced tuple unpacking with sequence defined at line 7 of functional.u.unpacking.unpacking: left side has 2 label(s), right side has 3 value(s)":UNDEFINED
-unbalanced-tuple-unpacking:96:8:96:33:UnbalancedUnpacking.test:"Possible unbalanced tuple unpacking with sequence defined at line 7 of functional.u.unpacking.unpacking: left side has 2 label(s), right side has 3 value(s)":UNDEFINED
-unbalanced-tuple-unpacking:140:8:140:43:MyClass.sum_unpack_3_into_4:"Possible unbalanced tuple unpacking with sequence defined at line 128: left side has 4 label(s), right side has 3 value(s)":UNDEFINED
-unbalanced-tuple-unpacking:145:8:145:28:MyClass.sum_unpack_3_into_2:"Possible unbalanced tuple unpacking with sequence defined at line 128: left side has 2 label(s), right side has 3 value(s)":UNDEFINED
-unbalanced-tuple-unpacking:157:0:157:24::"Possible unbalanced tuple unpacking with sequence defined at line 151: left side has 2 label(s), right side has 0 value(s)":UNDEFINED
-unbalanced-tuple-unpacking:162:0:162:16::"Possible unbalanced tuple unpacking with sequence (1, 2): left side has 3 label(s), right side has 2 value(s)":UNDEFINED
+unbalanced-tuple-unpacking:11:4:11:27:do_stuff:"Possible unbalanced tuple unpacking with sequence '(1, 2, 3)': left side has 2 labels, right side has 3 values":UNDEFINED
+unbalanced-tuple-unpacking:17:4:17:29:do_stuff1:"Possible unbalanced tuple unpacking with sequence '[1, 2, 3]': left side has 2 labels, right side has 3 values":UNDEFINED
+unbalanced-tuple-unpacking:23:4:23:29:do_stuff2:"Possible unbalanced tuple unpacking with sequence '(1, 2, 3)': left side has 2 labels, right side has 3 values":UNDEFINED
+unbalanced-tuple-unpacking:82:4:82:28:do_stuff9:"Possible unbalanced tuple unpacking with sequence defined at line 7 of functional.u.unpacking.unpacking: left side has 2 labels, right side has 3 values":UNDEFINED
+unbalanced-tuple-unpacking:96:8:96:33:UnbalancedUnpacking.test:"Possible unbalanced tuple unpacking with sequence defined at line 7 of functional.u.unpacking.unpacking: left side has 2 labels, right side has 3 values":UNDEFINED
+unbalanced-tuple-unpacking:140:8:140:43:MyClass.sum_unpack_3_into_4:"Possible unbalanced tuple unpacking with sequence defined at line 128: left side has 4 labels, right side has 3 values":UNDEFINED
+unbalanced-tuple-unpacking:145:8:145:28:MyClass.sum_unpack_3_into_2:"Possible unbalanced tuple unpacking with sequence defined at line 128: left side has 2 labels, right side has 3 values":UNDEFINED
+unbalanced-tuple-unpacking:157:0:157:24::"Possible unbalanced tuple unpacking with sequence defined at line 151: left side has 2 labels, right side has 0 value":UNDEFINED
+unbalanced-tuple-unpacking:162:0:162:16::"Possible unbalanced tuple unpacking with sequence '(1, 2)': left side has 3 labels, right side has 2 values":UNDEFINED

--- a/tests/functional/u/unpacking/unpacking_non_sequence.txt
+++ b/tests/functional/u/unpacking/unpacking_non_sequence.txt
@@ -1,7 +1,7 @@
 unpacking-non-sequence:77:0:77:15::Attempting to unpack a non-sequence defined at line 74:UNDEFINED
 unpacking-non-sequence:78:0:78:17::Attempting to unpack a non-sequence:UNDEFINED
-unpacking-non-sequence:79:0:79:11::Attempting to unpack a non-sequence None:UNDEFINED
-unpacking-non-sequence:80:0:80:8::Attempting to unpack a non-sequence 1:UNDEFINED
+unpacking-non-sequence:79:0:79:11::Attempting to unpack a non-sequence 'None':UNDEFINED
+unpacking-non-sequence:80:0:80:8::Attempting to unpack a non-sequence '1':UNDEFINED
 unpacking-non-sequence:81:0:81:13::Attempting to unpack a non-sequence defined at line 9 of functional.u.unpacking.unpacking:UNDEFINED
 unpacking-non-sequence:82:0:82:15::Attempting to unpack a non-sequence defined at line 11 of functional.u.unpacking.unpacking:UNDEFINED
 unpacking-non-sequence:83:0:83:18::Attempting to unpack a non-sequence:UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

Necessary to be able to do https://github.com/PyCQA/pylint/pull/7750 without thinking about it.
