### PR TITLE
fix FP For used-before-assignment if terminating func is used

### DIFF
--- a/doc/whatsnew/fragments/7563.false_positive
+++ b/doc/whatsnew/fragments/7563.false_positive
@@ -1,0 +1,3 @@
+Fix ``used-before-assignment`` false positive when else branch calls ``sys.exit`` or similar terminating functions.
+
+Closes #7563

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2138,3 +2138,24 @@ def is_singleton_const(node: nodes.NodeNG) -> bool:
     return isinstance(node, nodes.Const) and any(
         node.value is value for value in SINGLETON_VALUES
     )
+
+
+def is_terminating_func(node: nodes.Call) -> bool:
+    """Detect call to exit(), quit(), os._exit(), or sys.exit()."""
+    if (
+        not isinstance(node.func, nodes.Attribute)
+        and not (isinstance(node.func, nodes.Name))
+        or isinstance(node.parent, nodes.Lambda)
+    ):
+        return False
+
+    qnames = {"_sitebuiltins.Quitter", "sys.exit", "posix._exit", "nt._exit"}
+
+    try:
+        for inferred in node.func.infer():
+            if hasattr(inferred, "qname") and inferred.qname() in qnames:
+                return True
+    except (StopIteration, astroid.InferenceError):
+        pass
+
+    return False

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -715,6 +715,7 @@ scope_type : {self._atomic.scope_type}
             )
             else_block_exits = any(
                 isinstance(else_statement, nodes.Expr)
+                and isinstance(else_statement.value, nodes.Call)
                 and utils.is_terminating_func(else_statement.value)
                 for else_statement in closest_try_except.orelse
             )

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -713,7 +713,13 @@ scope_type : {self._atomic.scope_type}
                 isinstance(else_statement, nodes.Return)
                 for else_statement in closest_try_except.orelse
             )
-            if try_block_returns or else_block_returns:
+            else_block_exits = any(
+                isinstance(else_statement, nodes.Expr)
+                and utils.is_terminating_func(else_statement.value)
+                for else_statement in closest_try_except.orelse
+            )
+
+            if try_block_returns or else_block_returns or else_block_exits:
                 # Exception: if this node is in the final block of the other_node_statement,
                 # it will execute before returning. Assume the except statements are uncertain.
                 if (

--- a/tests/functional/u/used/used_before_assignment_else_return.py
+++ b/tests/functional/u/used/used_before_assignment_else_return.py
@@ -1,5 +1,6 @@
 """If the else block returns, it is generally safe to rely on assignments in the except."""
-
+# pylint: disable=missing-function-docstring, invalid-name
+import sys
 
 def valid():
     """https://github.com/PyCQA/pylint/issues/6790"""
@@ -59,3 +60,15 @@ def invalid_4():
     else:
         print(error)  # [used-before-assignment]
         return
+
+def valid_exit():
+    try:
+        pass
+    except SystemExit as e:
+        lint_result = e.code
+    else:
+        sys.exit("Bad")
+    if lint_result != 0:
+        sys.exit("Error is 0.")
+
+    print(lint_result)

--- a/tests/functional/u/used/used_before_assignment_else_return.txt
+++ b/tests/functional/u/used/used_before_assignment_else_return.txt
@@ -1,4 +1,4 @@
-used-before-assignment:25:14:25:19:invalid:Using variable 'error' before assignment:CONTROL_FLOW
-used-before-assignment:38:14:38:19:invalid_2:Using variable 'error' before assignment:CONTROL_FLOW
-used-before-assignment:50:14:50:19:invalid_3:Using variable 'error' before assignment:CONTROL_FLOW
-used-before-assignment:60:14:60:19:invalid_4:Using variable 'error' before assignment:CONTROL_FLOW
+used-before-assignment:26:14:26:19:invalid:Using variable 'error' before assignment:CONTROL_FLOW
+used-before-assignment:39:14:39:19:invalid_2:Using variable 'error' before assignment:CONTROL_FLOW
+used-before-assignment:51:14:51:19:invalid_3:Using variable 'error' before assignment:CONTROL_FLOW
+used-before-assignment:61:14:61:19:invalid_4:Using variable 'error' before assignment:CONTROL_FLOW


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #7563

If a terminating func such as sys.exit, quit, etc is used in an else statement, `used-before-assignment` should not be flagged.
