### PR TITLE
``unnecessary-list-index-lookup`` false negative

### DIFF
--- a/doc/whatsnew/fragments/7770.false_negative
+++ b/doc/whatsnew/fragments/7770.false_negative
@@ -1,0 +1,3 @@
+Fixes ``unnecessary-list-index-lookup`` false negative when ``enumerate`` is called with ``iterable`` as a kwarg.
+
+Closes #7770

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -2146,9 +2146,17 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             not isinstance(node.iter, nodes.Call)
             or not isinstance(node.iter.func, nodes.Name)
             or not node.iter.func.name == "enumerate"
-            or not node.iter.args
-            or not isinstance(node.iter.args[0], nodes.Name)
         ):
+            return
+
+        try:
+            iterable_arg = utils.get_argument_from_call(
+                node.iter, position=0, keyword="iterable"
+            )
+        except utils.NoSuchArgumentError:
+            return
+
+        if not isinstance(iterable_arg, nodes.Name):
             return
 
         if not isinstance(node.target, nodes.Tuple) or len(node.target.elts) < 2:
@@ -2166,7 +2174,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             # is not redundant, hence we should not report an error.
             return
 
-        iterating_object_name = node.iter.args[0].name
+        iterating_object_name = iterable_arg.name
         value_variable = node.target.elts[1]
 
         # Store potential violations. These will only be reported if we don't

--- a/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
+++ b/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
@@ -130,3 +130,11 @@ def return_start(start):
 
 for i, k in enumerate(series, return_start(20)):
     print(series[idx])
+
+for idx, val in enumerate(iterable=series, start=0):
+    print(series[idx])  # [unnecessary-list-index-lookup]
+
+result = [my_list[idx] for idx, val in enumerate(iterable=my_list)]  # [unnecessary-list-index-lookup]
+
+for idx, val in enumerate():
+    print(my_list[idx])

--- a/tests/functional/u/unnecessary/unnecessary_list_index_lookup.txt
+++ b/tests/functional/u/unnecessary/unnecessary_list_index_lookup.txt
@@ -6,3 +6,5 @@ unnecessary-list-index-lookup:112:10:112:21::Unnecessary list index lookup, use 
 unnecessary-list-index-lookup:115:10:115:21::Unnecessary list index lookup, use 'val' instead:HIGH
 unnecessary-list-index-lookup:119:10:119:21::Unnecessary list index lookup, use 'val' instead:INFERENCE
 unnecessary-list-index-lookup:122:10:122:21::Unnecessary list index lookup, use 'val' instead:INFERENCE
+unnecessary-list-index-lookup:135:10:135:21::Unnecessary list index lookup, use 'val' instead:HIGH
+unnecessary-list-index-lookup:137:10:137:22::Unnecessary list index lookup, use 'val' instead:HIGH


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`unnecessary-list-index-lookup` code wasn't taking into account the fact that `enumerate` could be called with a kwarg.

Closes #7770
