### PR TITLE
Fix `valid-metaclass-classmethod-first-arg` default value

### DIFF
--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -620,7 +620,7 @@ Standard Checkers
 """""""""""""""""""""""""""""""""""""""
 *List of valid names for the first argument in a metaclass class method.*
 
-**Default:**  ``('cls',)``
+**Default:**  ``('mcs',)``
 
 
 
@@ -642,7 +642,7 @@ Standard Checkers
 
    valid-classmethod-first-arg = ["cls"]
 
-   valid-metaclass-classmethod-first-arg = ["cls"]
+   valid-metaclass-classmethod-first-arg = ["mcs"]
 
 
 

--- a/doc/whatsnew/fragments/7782.bugfix
+++ b/doc/whatsnew/fragments/7782.bugfix
@@ -1,0 +1,4 @@
+Fix ``valid-metaclass-classmethod-first-arg`` default config value from "cls" to "mcs"
+which would cause both a false-positive and false-negative.
+
+Closes #7782

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -260,7 +260,7 @@ exclude-protected=_asdict,
 valid-classmethod-first-arg=cls
 
 # List of valid names for the first argument in a metaclass class method.
-valid-metaclass-classmethod-first-arg=cls
+valid-metaclass-classmethod-first-arg=mcs
 
 
 [DESIGN]

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -222,7 +222,7 @@ exclude-protected = ["_asdict", "_fields", "_replace", "_source", "_make"]
 valid-classmethod-first-arg = ["cls"]
 
 # List of valid names for the first argument in a metaclass class method.
-valid-metaclass-classmethod-first-arg = ["cls"]
+valid-metaclass-classmethod-first-arg = ["mcs"]
 
 [tool.pylint.design]
 # List of regular expressions of class ancestor names to ignore when counting

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -792,7 +792,7 @@ a class method.",
         (
             "valid-metaclass-classmethod-first-arg",
             {
-                "default": ("cls",),
+                "default": ("mcs",),
                 "type": "csv",
                 "metavar": "<argument names>",
                 "help": "List of valid names for the first argument in \

--- a/tests/functional/c/class_members_py30.py
+++ b/tests/functional/c/class_members_py30.py
@@ -37,7 +37,7 @@ class TestMetaclass(metaclass=ABCMeta):
 class Metaclass(type):
     """ metaclass """
     @classmethod
-    def test(cls):
+    def test(mcs):
         """ classmethod """
 
 class UsingMetaclass(metaclass=Metaclass):

--- a/tests/functional/c/ctor_arguments.py
+++ b/tests/functional/c/ctor_arguments.py
@@ -65,8 +65,8 @@ ClassNew(one=2)  # [no-value-for-parameter,unexpected-keyword-arg]
 
 
 class Metaclass(type):
-    def __new__(cls, name, bases, namespace):
-        return type.__new__(cls, name, bases, namespace)
+    def __new__(mcs, name, bases, namespace):
+        return type.__new__(mcs, name, bases, namespace)
 
 def with_metaclass(meta, base=object):
     """Create a new type that can be used as a metaclass."""

--- a/tests/functional/f/first_arg.py
+++ b/tests/functional/f/first_arg.py
@@ -31,7 +31,7 @@ class Meta(type):
         pass
 
     # C0205, metaclass classmethod
-    def class1(cls):
+    def class1(mcs):
         pass
     class1 = classmethod(class1)  # [no-classmethod-decorator]
 

--- a/tests/functional/f/first_arg.txt
+++ b/tests/functional/f/first_arg.txt
@@ -2,8 +2,8 @@ bad-classmethod-argument:8:4:8:15:Obj.__new__:Class method __new__ should have '
 no-classmethod-decorator:14:4:14:10:Obj:Consider using a decorator instead of calling classmethod:UNDEFINED
 bad-classmethod-argument:16:4:16:14:Obj.class2:Class method class2 should have 'cls' as first argument:UNDEFINED
 no-classmethod-decorator:18:4:18:10:Obj:Consider using a decorator instead of calling classmethod:UNDEFINED
-bad-mcs-classmethod-argument:23:4:23:15:Meta.__new__:Metaclass class method __new__ should have 'cls' as first argument:UNDEFINED
+bad-mcs-classmethod-argument:23:4:23:15:Meta.__new__:Metaclass class method __new__ should have 'mcs' as first argument:UNDEFINED
 bad-mcs-method-argument:30:4:30:15:Meta.method2:Metaclass method method2 should have 'cls' as first argument:UNDEFINED
 no-classmethod-decorator:36:4:36:10:Meta:Consider using a decorator instead of calling classmethod:UNDEFINED
-bad-mcs-classmethod-argument:38:4:38:14:Meta.class2:Metaclass class method class2 should have 'cls' as first argument:UNDEFINED
+bad-mcs-classmethod-argument:38:4:38:14:Meta.class2:Metaclass class method class2 should have 'mcs' as first argument:UNDEFINED
 no-classmethod-decorator:40:4:40:10:Meta:Consider using a decorator instead of calling classmethod:UNDEFINED

--- a/tests/functional/r/regression_02/regression_too_many_arguments_2335.py
+++ b/tests/functional/r/regression_02/regression_too_many_arguments_2335.py
@@ -7,5 +7,5 @@ from abc import ABCMeta
 
 
 class NodeCheckMetaClass(ABCMeta):
-    def __new__(cls, name, bases, namespace, **kwargs):
-        return ABCMeta.__new__(cls, name, bases, namespace)
+    def __new__(mcs, name, bases, namespace, **kwargs):
+        return ABCMeta.__new__(mcs, name, bases, namespace)

--- a/tests/functional/u/undefined/undefined_variable_py30.py
+++ b/tests/functional/u/undefined/undefined_variable_py30.py
@@ -89,9 +89,9 @@ def used_before_assignment(*, arg): return arg + 1
 # Test for #4021
 # https://github.com/PyCQA/pylint/issues/4021
 class MetaClass(type):
-    def __new__(cls, *args, parameter=None, **kwargs):
+    def __new__(mcs, *args, parameter=None, **kwargs):
         print(parameter)
-        return super().__new__(cls, *args, **kwargs)
+        return super().__new__(mcs, *args, **kwargs)
 
 
 class InheritingClass(metaclass=MetaClass, parameter=variable):  # [undefined-variable]


### PR DESCRIPTION
## Type of Changes

|     | Type                  |
| --- | --------------- |
| ✓   | :bug: Bug fix     |
| ✓   | :scroll: Docs      |

## Description
This PR fixes the `valid-metaclass-classmethod-first-arg` default config value, which would cause `bad-mcs-classmethod-argument` ([C0204](https://pylint.pycqa.org/en/latest/user_guide/messages/convention/bad-mcs-classmethod-argument.html)) to have a false-positive on metaclass classmethods (using `mcs`), and a false-negative (using `cls`).

Some functional tests failed after introducing this change, due to either using the `classmethod()` decorator or the `__new__` dunder in a metaclass with a `cls` first method argument.

Along with fixing any now-failing tests, I updated documentation to reflect changes.


Closes #7782
