### PR TITLE
Fix ``deprecated-method`` false positive

### DIFF
--- a/doc/whatsnew/fragments/5886.false_positive
+++ b/doc/whatsnew/fragments/5886.false_positive
@@ -1,0 +1,3 @@
+Fix ``deprecated-method`` false positive when alias for method is similar to name of deprecated method.
+
+Closes #5886

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -213,16 +213,7 @@ class DeprecatedMixin(BaseChecker):
             # Not interested in other nodes.
             return
 
-        if hasattr(inferred.parent, "qname") and inferred.parent.qname():
-            # Handling the situation when deprecated function is
-            # alias to existing function.
-            qnames = {
-                inferred.qname(),
-                f"{inferred.parent.qname()}.{func_name}",
-                func_name,
-            }
-        else:
-            qnames = {inferred.qname(), func_name}
+        qnames = {inferred.qname(), func_name}
         if any(name in self.deprecated_methods() for name in qnames):
             self.add_message("deprecated-method", node=node, args=(func_name,))
             return

--- a/tests/checkers/unittest_deprecated.py
+++ b/tests/checkers/unittest_deprecated.py
@@ -108,23 +108,22 @@ class TestDeprecatedChecker(CheckerTestCase):
 
     def test_deprecated_method_alias(self) -> None:
         # Tests detecting deprecated method defined as alias
-        # to existing method
         node = astroid.extract_node(
             """
         class Deprecated:
-            def _deprecated_method(self):
+            def deprecated_method(self):
                 pass
 
-            deprecated_method = _deprecated_method
+            new_name = deprecated_method
 
         d = Deprecated()
-        d.deprecated_method()
+        d.new_name()
         """
         )
         with self.assertAddsMessages(
             MessageTest(
                 msg_id="deprecated-method",
-                args=("deprecated_method",),
+                args=("new_name",),
                 node=node,
                 confidence=UNDEFINED,
                 line=9,
@@ -135,6 +134,22 @@ class TestDeprecatedChecker(CheckerTestCase):
         ):
             self.checker.visit_call(node)
 
+    def test_not_deprecated(self) -> None:
+        # Tests detecting method is NOT deprecated when alias name is a deprecated name
+        node = astroid.extract_node(
+            """
+        class Deprecated:
+            def not_deprecated(self):
+                pass
+
+            deprecated_method = not_deprecated
+
+        d = Deprecated()
+        d.deprecated_method()
+        """
+        )
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
     def test_no_message(self) -> None:
         # Tests not raising error when no deprecated functions/methods are present.
         node = astroid.extract_node(

--- a/tests/checkers/unittest_deprecated.py
+++ b/tests/checkers/unittest_deprecated.py
@@ -150,6 +150,7 @@ class TestDeprecatedChecker(CheckerTestCase):
         )
         with self.assertNoMessages():
             self.checker.visit_call(node)
+
     def test_no_message(self) -> None:
         # Tests not raising error when no deprecated functions/methods are present.
         node = astroid.extract_node(

--- a/tests/functional/d/deprecated/deprecated_methods_py38.py
+++ b/tests/functional/d/deprecated/deprecated_methods_py38.py
@@ -4,9 +4,9 @@ import base64
 import inspect
 import logging
 import nntplib
+import time
 import unittest
 import xml.etree.ElementTree
-
 
 class MyTest(unittest.TestCase):
     def test(self):
@@ -51,3 +51,7 @@ class Deprecated:  # pylint: disable=too-few-public-methods
 
 d = Deprecated()
 d.deprecated_method()  # [deprecated-method]
+
+def test(clock = time.time):
+    """time.clock is deprecated but time.time via an alias is not!"""
+    clock()


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Original PR that added this code https://github.com/PyCQA/pylint/pull/4619/files
it seems that the unit test that was added led the code, which is a good practice, except I believe the unit test itself was incorrect and confused the naming of `deprecated_method`. This wasn't a necessary change at all, and in fact led to a false positive. 

Closes #5886
