### PR TITLE
Reduce `max-locals` from 25 to 18

### DIFF
--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -483,11 +483,9 @@ class Similar:
             lineset2, self.namespace.min_similarity_lines
         )
 
-        hash_1: frozenset[LinesChunk] = frozenset(hash_to_index_1.keys())
-        hash_2: frozenset[LinesChunk] = frozenset(hash_to_index_2.keys())
-
         common_hashes: Iterable[LinesChunk] = sorted(
-            hash_1 & hash_2, key=lambda m: hash_to_index_1[m][0]
+            frozenset(hash_to_index_1.keys()) & frozenset(hash_to_index_2.keys()),
+            key=lambda m: hash_to_index_1[m][0],
         )
 
         # all_couples is a dict that links the couple of indices in both linesets that mark the beginning of
@@ -511,26 +509,26 @@ class Similar:
         remove_successive(all_couples)
 
         for cml_stripped_l, cmn_l in all_couples.items():
-            start_index_1 = cml_stripped_l.fst_lineset_index
-            start_index_2 = cml_stripped_l.snd_lineset_index
             nb_common_lines = cmn_l.effective_cmn_lines_nb
 
-            com = Commonality(
-                cmn_lines_nb=nb_common_lines,
-                fst_lset=lineset1,
-                fst_file_start=cmn_l.first_file.start,
-                fst_file_end=cmn_l.first_file.end,
-                snd_lset=lineset2,
-                snd_file_start=cmn_l.second_file.start,
-                snd_file_end=cmn_l.second_file.end,
-            )
-
             eff_cmn_nb = filter_noncode_lines(
-                lineset1, start_index_1, lineset2, start_index_2, nb_common_lines
+                lineset1,
+                cml_stripped_l.fst_lineset_index,
+                lineset2,
+                cml_stripped_l.snd_lineset_index,
+                nb_common_lines,
             )
 
             if eff_cmn_nb > self.namespace.min_similarity_lines:
-                yield com
+                yield Commonality(
+                    cmn_lines_nb=nb_common_lines,
+                    fst_lset=lineset1,
+                    fst_file_start=cmn_l.first_file.start,
+                    fst_file_end=cmn_l.first_file.end,
+                    snd_lset=lineset2,
+                    snd_file_start=cmn_l.second_file.start,
+                    snd_file_end=cmn_l.second_file.end,
+                )
 
     def _iter_sims(self) -> Generator[Commonality, None, None]:
         """Iterate on similarities among all files, by making a Cartesian

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -417,10 +417,17 @@ class SpellingChecker(BaseTokenChecker):
                 col += word_start_at
                 if starts_with_comment:
                     col += 1
-                indicator = (" " * col) + ("^" * len(word))
                 all_suggestion = "' or '".join(suggestions)
-                args = (word, original_line, indicator, f"'{all_suggestion}'")
-                self.add_message(msgid, line=line_num, args=args)
+                self.add_message(
+                    msgid,
+                    line=line_num,
+                    args=(
+                        word,
+                        original_line,
+                        (" " * col) + ("^" * len(word)),
+                        f"'{all_suggestion}'",
+                    ),
+                )
 
     def process_tokens(self, tokens: list[tokenize.TokenInfo]) -> None:
         if not self.initialized:

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -247,7 +247,7 @@ class StringFormatChecker(BaseChecker):
     name = "string"
     msgs = MSGS
 
-    # pylint: disable=too-many-branches
+    # pylint: disable = too-many-branches, too-many-locals
     @only_required_for_messages(
         "bad-format-character",
         "truncated-format-string",
@@ -346,8 +346,9 @@ class StringFormatChecker(BaseChecker):
                             args=(arg_type.pytype(), format_type),
                         )
             elif isinstance(args, (OTHER_NODES, nodes.Tuple)):
-                type_name = type(args).__name__
-                self.add_message("format-needs-mapping", node=node, args=type_name)
+                self.add_message(
+                    "format-needs-mapping", node=node, args=type(args).__name__
+                )
             # else:
             # The RHS of the format specifier is a name or
             # expression.  It may be a mapping object, so

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2338,19 +2338,21 @@ class VariablesChecker(BaseChecker):
                 return
 
             # Consider sequences.
-            sequences = (
-                nodes.List,
-                nodes.Tuple,
-                nodes.Dict,
-                nodes.Set,
-                astroid.objects.FrozenSet,
-            )
-            if not isinstance(inferred, sequences):
+            if not isinstance(
+                inferred,
+                (
+                    nodes.List,
+                    nodes.Tuple,
+                    nodes.Dict,
+                    nodes.Set,
+                    astroid.objects.FrozenSet,
+                ),
+            ):
                 self.add_message("undefined-loop-variable", args=node.name, node=node)
                 return
 
-            elements = getattr(inferred, "elts", getattr(inferred, "items", []))
-            if not elements:
+            # Consider elements.
+            if not getattr(inferred, "elts", getattr(inferred, "items", [])):
                 self.add_message("undefined-loop-variable", args=node.name, node=node)
 
     def _check_is_unused(

--- a/pylintrc
+++ b/pylintrc
@@ -416,7 +416,7 @@ max-spelling-suggestions=2
 max-args=10
 
 # Maximum number of locals for function / method body
-max-locals=25
+max-locals = 18
 
 # Maximum number of return / yield for function / method body
 max-returns=11


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This PR lowers the `max-locals` config value from 25 to 18. A few outlier functions with abnormally many local variables required some trimming. My approach was to cut any variable used only once and simply inline the value. After a little rearranging, there might even be some tiny performance improvements.

Why 18? Because `ImportsChecker._check_imports_order` stubbornly resisted my attempts to get rid of any of its variables :smile: