### PR TITLE
[github actions] Fix the permissions in backporting job

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,7 +6,10 @@ on:
       - labeled
 
 permissions:
+  checks: read
   contents: write
+  pull-requests: write
+  statuses: read
 
 jobs:
   backport:

--- a/doc/development_guide/contributor_guide/release.md
+++ b/doc/development_guide/contributor_guide/release.md
@@ -55,6 +55,14 @@ branch:
 - Label the PR with `backport maintenance/X.Y-1.x`. (For example
   `backport maintenance/2.3.x`)
 - Squash the PR before merging (alternatively rebase if there's a single commit)
+- (If the automated cherry-pick has conflicts)
+  - Add a `Needs backport` label and do it manually.
+  - You might alternatively also:
+    - Cherry-pick the changes that create the conflict if it's not a new feature before
+      doing the original PR cherry-pick manually.
+    - Decide to wait for the next minor to release the PR
+    - In any case upgrade the milestones in the original PR and newly cherry-picked PR
+      to match reality.
 - Release a patch version
 
 ## Releasing a patch version


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The back-porting job needs to be able to create a cherry-pick on a branch and then open a pull request.