### PR TITLE
Run primer on 3.11

### DIFF
--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -16,7 +16,7 @@ env:
   # This needs to be the SAME as in the Main and PR job
   CACHE_VERSION: 1
   KEY_PREFIX: venv-primer
-  DEFAULT_PYTHON: "3.10"
+  DEFAULT_PYTHON: "3.11"
 
 permissions:
   contents: read

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.7", "3.11"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.1.0

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.7", "3.11"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.1.0


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Per https://github.com/PyCQA/pylint/pull/6756#issue-1253101349 we run the primer on the oldest and newest supported versions. 3.11 is the newest supported version.
