### PR TITLE
Add flag `--clear-cache-post-run` to support server-like usage

### DIFF
--- a/doc/whatsnew/fragments/5401.feature
+++ b/doc/whatsnew/fragments/5401.feature
@@ -1,0 +1,4 @@
+Added configuration option ``clear-cache-post-run`` to support server-like usage.
+Use this flag if you expect the linted files to be altered between runs.
+
+Refs #5401

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -5,6 +5,10 @@
 # only in one or another interpreter, leading to false positives when analysed.
 analyse-fallback-blocks=no
 
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint in
+# a server-like mode.
+clear-cache-post-run=no
+
 # Load and enable all available extensions. Use --list-extensions to see a list
 # all available extensions.
 #enable-all-extensions=

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -4,6 +4,10 @@
 # one or another interpreter, leading to false positives when analysed.
 # analyse-fallback-blocks =
 
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint in
+# a server-like mode.
+# clear-cache-post-run =
+
 # Always return a 0 (non-error) status code, even if lint errors are found. This
 # is primarily useful in continuous integration scripts.
 # exit-zero =

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -391,6 +391,16 @@ def _make_linter_options(linter: PyLinter) -> Options:
                 "positives when analysed.",
             },
         ),
+        (
+            "clear-cache-post-run",
+            {
+                "default": False,
+                "type": "yn",
+                "metavar": "<y or n>",
+                "help": "Clear in-memory caches upon conclusion of linting. "
+                "Useful if running pylint in a server-like mode.",
+            },
+        ),
     )
 
 

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -21,7 +21,7 @@ from pylint.config.exceptions import ArgumentPreprocessingError
 from pylint.config.utils import _preprocess_options
 from pylint.constants import full_version
 from pylint.lint.base_options import _make_run_options
-from pylint.lint.pylinter import PyLinter
+from pylint.lint.pylinter import MANAGER, PyLinter
 from pylint.reporters.base_reporter import BaseReporter
 
 try:
@@ -213,6 +213,9 @@ group are mutually exclusive.",
                 DeprecationWarning,
             )
             exit = do_exit
+
+        if linter.config.clear_cache_post_run:
+            MANAGER.clear_cache()
 
         if exit:
             if linter.config.exit_zero:

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -57,7 +57,6 @@ GLOBAL_OPTION_BOOL = Literal[
     "suggestion-mode",
     "analyse-fallback-blocks",
     "allow-global-unused-variables",
-    "clear-cache-post-run",
 ]
 GLOBAL_OPTION_INT = Literal["max-line-length", "docstring-min-length"]
 GLOBAL_OPTION_LIST = Literal["ignored-modules"]

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -57,6 +57,7 @@ GLOBAL_OPTION_BOOL = Literal[
     "suggestion-mode",
     "analyse-fallback-blocks",
     "allow-global-unused-variables",
+    "clear-cache-post-run",
 ]
 GLOBAL_OPTION_INT = Literal["max-line-length", "docstring-min-length"]
 GLOBAL_OPTION_LIST = Literal["ignored-modules"]

--- a/pylintrc
+++ b/pylintrc
@@ -67,6 +67,10 @@ fail-under=10.0
 # specified are enabled, while categories only check already-enabled messages.
 fail-on=
 
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint in
+# a server-like mode.
+clear-cache-post-run=no
+
 
 [MESSAGES CONTROL]
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 from pytest import CaptureFixture
 
 from pylint.interfaces import CONFIDENCE_LEVEL_NAMES
 from pylint.lint import Run as LintRun
+from pylint.testutils import create_files
 from pylint.testutils._run import _Run as Run
 from pylint.testutils.configuration_test import run_using_a_configuration_file
 
@@ -155,3 +157,19 @@ def test_argument_separator() -> None:
     """
     runner = Run(["--", str(EMPTY_MODULE)], exit=False)
     assert not runner.linter.stats.by_msg
+
+
+def test_clear_cache_post_run() -> None:
+    modname = "changing.py"
+    with TemporaryDirectory() as tmp_dir:
+        create_files([modname], tmp_dir)
+        module = tmp_dir + os.sep + modname
+        # Run class does not produce the wanted failure
+        # must use LintRun to get pylint.lint.Run
+        runBeforeEdit = LintRun([module, "--clear-cache-post-run=y"], exit=False)
+        with open(module, mode="a", encoding="utf-8") as f:
+            f.write("undefined\n")
+        runAfterEdit = LintRun([module, "--clear-cache-post-run=y"], exit=False)
+
+    assert not runBeforeEdit.linter.stats.by_msg
+    assert runAfterEdit.linter.stats.by_msg

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -166,10 +166,10 @@ def test_clear_cache_post_run() -> None:
         module = tmp_dir + os.sep + modname
         # Run class does not produce the wanted failure
         # must use LintRun to get pylint.lint.Run
-        runBeforeEdit = LintRun([module, "--clear-cache-post-run=y"], exit=False)
+        run_before_edit = LintRun([module, "--clear-cache-post-run=y"], exit=False)
         with open(module, mode="a", encoding="utf-8") as f:
             f.write("undefined\n")
-        runAfterEdit = LintRun([module, "--clear-cache-post-run=y"], exit=False)
+        run_after_edit = LintRun([module, "--clear-cache-post-run=y"], exit=False)
 
-    assert not runBeforeEdit.linter.stats.by_msg
-    assert runAfterEdit.linter.stats.by_msg
+    assert not run_before_edit.linter.stats.by_msg
+    assert run_after_edit.linter.stats.by_msg


### PR DESCRIPTION
Use this flag if you expect the linted files to be altered between runs, for instance, if using pylint in a server-like mode. The flag clears astroid's in-memory caches.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Description

Refs https://github.com/microsoft/vscode-pylint/issues/129