### PR TITLE
Emit a ``UserWarning`` and crash pylint if run in parallel and with custom plugin

### DIFF
--- a/doc/whatsnew/fragments/3232.bugfix
+++ b/doc/whatsnew/fragments/3232.bugfix
@@ -1,3 +1,3 @@
-Emit a ``UserWarning`` if pylint is run in parallel and with custom plugins.
+Exit immediately with a ``UserWarning`` if pylint is run in parallel and with custom plugins. This can lead to inconsistent behaviors, and the multiprocessing is not very efficient due to most of the parsing our internal code representation generation not being parallelized anyway. Use ``--job=1`` instead.
 
 Closes #3232

--- a/doc/whatsnew/fragments/3232.bugfix
+++ b/doc/whatsnew/fragments/3232.bugfix
@@ -1,0 +1,3 @@
+Emit a ``UserWarning`` if pylint is run in parallel and with custom plugins.
+
+Closes #3232

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -229,18 +229,19 @@ group are mutually exclusive.",
 
         if self.linter.config.jobs != 1:
             # Validate if jobs is 0 or positive num other than 1
-            if self._plugins:
-                warnings.warn(
-                    "Running pylint in parallel with custom plugins is not currently supported.",
-                    UserWarning,
-                )
-                sys.exit(32)
             if multiprocessing is None:
                 print(
                     "Multiprocessing library is missing, fallback to single process",
                     file=sys.stderr,
                 )
                 self.linter.set_option("jobs", 1)
+            elif self._plugins:
+                warnings.warn(
+                    "Running pylint in parallel with custom plugins is not currently supported.",
+                    UserWarning,
+                )
+                sys.exit(32)
+
             elif self.linter.config.jobs == 0:
                 self.linter.config.jobs = _cpu_count()
 

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -20,6 +20,7 @@ from os import chdir, getcwd
 from os.path import abspath, dirname, join, sep
 from pathlib import Path
 from shutil import copy, rmtree
+from unittest.mock import patch
 
 import platformdirs
 import pytest
@@ -1078,6 +1079,16 @@ def test_custom_should_analyze_file() -> None:
         messages = reporter.messages
         assert len(messages) == 1
         assert "invalid syntax" in messages[0].msg
+
+
+def test_multiprocessing_missing() -> None:
+    with patch("pylint.lint.run.multiprocessing", None):
+        run = Run(
+            ["--jobs", "2", join(REGRTEST_DATA_DIR, "empty.py")],
+            exit=False,
+        )
+
+    assert run.linter.config.jobs == 1
 
 
 # we do the check with jobs=1 as well, so that we are sure that the duplicates

--- a/tests/test_pylint_runners.py
+++ b/tests/test_pylint_runners.py
@@ -129,9 +129,17 @@ def test_pylint_run_jobs_equal_zero_dont_crash_with_cpu_fraction(
                     Run(testargs, reporter=Reporter())
         assert err.value.code == 0
 
-def test_pylint_run_jobs_and_plugins_warns_and_exits(
-    tmpdir: LocalPath,
-) -> None:
+
+def test_pylint_run_negative_jobs(tmp_path: pathlib.Path) -> None:
+    filepath = os.path.abspath(__file__)
+    testargs = [filepath, "--jobs=-1"]
+    with _test_cwd(tmp_path):
+        with pytest.raises(SystemExit) as err:
+            run_pylint(testargs)
+        assert err.value.code == 32
+
+
+def test_pylint_run_jobs_and_plugins_warns_and_exits(tmp_path: pathlib.Path) -> None:
     """Test that pylint will raise a warning and exit if user runs it
     in parallel with jobs and with custom plugins.
 
@@ -139,7 +147,7 @@ def test_pylint_run_jobs_and_plugins_warns_and_exits(
     """
     filepath = os.path.abspath(__file__)
     testargs = [filepath, "--jobs=10", "--load-plugins=fake_plugin"]
-    with tmpdir.as_cwd():
+    with _test_cwd(tmp_path):
         with pytest.raises(SystemExit) as err:
             with pytest.warns(UserWarning):
                 run_pylint(testargs)

--- a/tests/test_pylint_runners.py
+++ b/tests/test_pylint_runners.py
@@ -128,3 +128,19 @@ def test_pylint_run_jobs_equal_zero_dont_crash_with_cpu_fraction(
                 with patch("pylint.lint.run.Path", _mock_path):
                     Run(testargs, reporter=Reporter())
         assert err.value.code == 0
+
+def test_pylint_run_jobs_and_plugins_warns_and_exits(
+    tmpdir: LocalPath,
+) -> None:
+    """Test that pylint will raise a warning and exit if user runs it
+    in parallel with jobs and with custom plugins.
+
+    See https://pylint.pycqa.org/en/latest/user_guide/usage/run.html#parallel-execution
+    """
+    filepath = os.path.abspath(__file__)
+    testargs = [filepath, "--jobs=10", "--load-plugins=fake_plugin"]
+    with tmpdir.as_cwd():
+        with pytest.raises(SystemExit) as err:
+            with pytest.warns(UserWarning):
+                run_pylint(testargs)
+        assert err.value.code == 32


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Closes #3232

As issue an as [pylint docs](state), users should not run pylint in parallel AND with custom plugins.

Looks like this now:
```
/Users/xxx/pylint/pylint/lint/run.py:189: UserWarning: Running pylint in parallel with custom plugins is not currently supported.
  warnings.warn(
```
and pylint then stops execution