### PR TITLE
Fix crash when using ``enumerate`` with ``start`` and a class attribute

### DIFF
--- a/doc/whatsnew/fragments/7821.bugfix
+++ b/doc/whatsnew/fragments/7821.bugfix
@@ -1,0 +1,3 @@
+Fixes bug that resulted in crash during ``unnecessary_list_index_lookup`` check.
+
+Closes #7821

--- a/doc/whatsnew/fragments/7821.bugfix
+++ b/doc/whatsnew/fragments/7821.bugfix
@@ -1,3 +1,3 @@
-Fixes bug that resulted in crash during ``unnecessary_list_index_lookup`` check.
+Fixes a crash in the ``unnecessary_list_index_lookup`` check when using ``enumerate`` with ``start`` and a class attribute.
 
 Closes #7821

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -2301,15 +2301,13 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         return False, confidence
 
     def _get_start_value(self, node: nodes.NodeNG) -> tuple[int | None, Confidence]:
-        confidence = HIGH
-
-        if isinstance(node, (nodes.Name, nodes.Call)):
+        if isinstance(node, (nodes.Name, nodes.Call, nodes.Attribute)):
             inferred = utils.safe_infer(node)
             start_val = inferred.value if inferred else None
-            confidence = INFERENCE
-        elif isinstance(node, nodes.UnaryOp):
-            start_val = node.operand.value
-        else:
-            start_val = node.value
+            return start_val, INFERENCE
+        if isinstance(node, nodes.UnaryOp):
+            return node.operand.value, HIGH
+        if isinstance(node, nodes.Const):
+            return node.value, HIGH
 
-        return start_val, confidence
+        return None, HIGH

--- a/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
+++ b/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
@@ -138,3 +138,9 @@ result = [my_list[idx] for idx, val in enumerate(iterable=my_list)]  # [unnecess
 
 for idx, val in enumerate():
     print(my_list[idx])
+
+class Command:
+    def _get_extra_attrs(self, extra_columns):
+        self.extra_rows_start = 8  # pylint: disable=attribute-defined-outside-init
+        for index, column in enumerate(extra_columns, start=self.extra_rows_start):
+            pass

--- a/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
+++ b/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
@@ -144,3 +144,8 @@ class Command:
         self.extra_rows_start = 8  # pylint: disable=attribute-defined-outside-init
         for index, column in enumerate(extra_columns, start=self.extra_rows_start):
             pass
+
+Y_START = 2
+nums = list(range(20))
+for y, x in enumerate(nums, start=Y_START + 1):
+    pass


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

fixes
```
    start_val = node.value
AttributeError: 'Attribute' object has no attribute 'value'
```

Closes #7821
