### PR TITLE
Add ``content: write`` rights for backporting job

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   pull-requests: write
+  content: write
 
 jobs:
   backport:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -24,6 +24,6 @@ jobs:
         )
       )
     steps:
-      - uses: tibdex/backport@2e217641d82d02ba0603f46b1aeedefb258890ac
+      - uses: tibdex/backport@2e217641d82d02ba0603f46b1aeedefb258890ac # v2.0.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -4,14 +4,14 @@ on:
   push:
     branches:
       - main
-      - "maintenance/**"
   pull_request:
     paths:
       - "pylint/**"
       - "tests/primer/**"
       - "requirements*"
       - ".github/workflows/primer-test.yaml"
-
+    branches:
+      - main
 env:
   CACHE_VERSION: 1
   KEY_PREFIX: venv

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -16,6 +16,8 @@ on:
       - "!.github/workflows/primer_run_main.yaml"
       - "!.github/workflows/primer_comment.yaml"
       - "!tests/primer/packages_to_prime.json"
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

We need it to push to the backporting branch after cherry-picking. See https://github.com/PyCQA/pylint/pull/7810\#issuecomment-1324742960

Also include change we did on the maintenance branch to not run primers.

Refs #7804, #7815 #7810

