### PR TITLE
Drop dependency on py module

### DIFF
--- a/tests/config/test_per_directory_config.py
+++ b/tests/config/test_per_directory_config.py
@@ -2,17 +2,16 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
-
-from py._path.local import LocalPath
+from pathlib import Path
 
 from pylint.lint import Run
 
 
-def test_fall_back_on_base_config(tmpdir: LocalPath) -> None:
+def test_fall_back_on_base_config(tmp_path: Path) -> None:
     """Test that we correctly fall back on the base config."""
     # A file under the current dir should fall back to the highest level
     # For pylint this is ./pylintrc
-    test_file = tmpdir / "test.py"
+    test_file = tmp_path / "test.py"
     runner = Run([__name__], exit=False)
     assert id(runner.linter.config) == id(runner.linter._base_config)
 

--- a/tests/pyreverse/test_pyreverse_functional.py
+++ b/tests/pyreverse/test_pyreverse_functional.py
@@ -22,9 +22,7 @@ CLASS_DIAGRAM_TEST_IDS = [testfile.source.stem for testfile in CLASS_DIAGRAM_TES
     CLASS_DIAGRAM_TESTS,
     ids=CLASS_DIAGRAM_TEST_IDS,
 )
-def test_class_diagrams(
-    testfile: FunctionalPyreverseTestfile, tmp_path: Path
-) -> None:
+def test_class_diagrams(testfile: FunctionalPyreverseTestfile, tmp_path: Path) -> None:
     input_file = testfile.source
     for output_format in testfile.options["output_formats"]:
         with pytest.raises(SystemExit) as sys_exit:

--- a/tests/pyreverse/test_pyreverse_functional.py
+++ b/tests/pyreverse/test_pyreverse_functional.py
@@ -5,7 +5,6 @@
 from pathlib import Path
 
 import pytest
-from py._path.local import LocalPath
 
 from pylint.pyreverse.main import Run
 from pylint.testutils.pyreverse import (
@@ -24,16 +23,16 @@ CLASS_DIAGRAM_TEST_IDS = [testfile.source.stem for testfile in CLASS_DIAGRAM_TES
     ids=CLASS_DIAGRAM_TEST_IDS,
 )
 def test_class_diagrams(
-    testfile: FunctionalPyreverseTestfile, tmpdir: LocalPath
+    testfile: FunctionalPyreverseTestfile, tmp_path: Path
 ) -> None:
     input_file = testfile.source
     for output_format in testfile.options["output_formats"]:
         with pytest.raises(SystemExit) as sys_exit:
-            args = ["-o", f"{output_format}", "-d", str(tmpdir)]
+            args = ["-o", f"{output_format}", "-d", str(tmp_path)]
             args.extend(testfile.options["command_line_args"])
             args += [str(input_file)]
             Run(args)
         assert sys_exit.value.code == 0
         assert testfile.source.with_suffix(f".{output_format}").read_text(
             encoding="utf8"
-        ) == Path(tmpdir / f"classes.{output_format}").read_text(encoding="utf8")
+        ) == (tmp_path / f"classes.{output_format}").read_text(encoding="utf8")

--- a/tests/test_pylint_runners.py
+++ b/tests/test_pylint_runners.py
@@ -16,11 +16,11 @@ from typing import Any, NoReturn
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
-from py._path.local import LocalPath
 
 from pylint import run_epylint, run_pylint, run_pyreverse, run_symilar
 from pylint.lint import Run
 from pylint.testutils import GenericTestReporter as Reporter
+from pylint.testutils.utils import _test_cwd
 
 if sys.version_info >= (3, 8):
     from typing import Protocol
@@ -34,20 +34,20 @@ class _RunCallable(Protocol):  # pylint: disable=too-few-public-methods
 
 
 @pytest.mark.parametrize("runner", [run_pylint, run_pyreverse, run_symilar])
-def test_runner(runner: _RunCallable, tmpdir: LocalPath) -> None:
+def test_runner(runner: _RunCallable, tmp_path: pathlib.Path) -> None:
     filepath = os.path.abspath(__file__)
     testargs = ["", filepath]
-    with tmpdir.as_cwd():
+    with _test_cwd(tmp_path):
         with patch.object(sys, "argv", testargs):
             with pytest.raises(SystemExit) as err:
                 runner()
             assert err.value.code == 0
 
 
-def test_epylint(tmpdir: LocalPath) -> None:
+def test_epylint(tmp_path: pathlib.Path) -> None:
     """TODO: 3.0 delete with epylint."""
     filepath = os.path.abspath(__file__)
-    with tmpdir.as_cwd():
+    with _test_cwd(tmp_path):
         with patch.object(sys, "argv", ["", filepath]):
             with pytest.raises(SystemExit) as err:
                 with pytest.warns(DeprecationWarning):
@@ -56,21 +56,21 @@ def test_epylint(tmpdir: LocalPath) -> None:
 
 
 @pytest.mark.parametrize("runner", [run_pylint, run_pyreverse, run_symilar])
-def test_runner_with_arguments(runner: _RunCallable, tmpdir: LocalPath) -> None:
+def test_runner_with_arguments(runner: _RunCallable, tmp_path: pathlib.Path) -> None:
     """Check the runners with arguments as parameter instead of sys.argv."""
     filepath = os.path.abspath(__file__)
     testargs = [filepath]
-    with tmpdir.as_cwd():
+    with _test_cwd(tmp_path):
         with pytest.raises(SystemExit) as err:
             runner(testargs)
         assert err.value.code == 0
 
 
-def test_epylint_with_arguments(tmpdir: LocalPath) -> None:
+def test_epylint_with_arguments(tmp_path: pathlib.Path) -> None:
     """TODO: 3.0 delete with epylint."""
     filepath = os.path.abspath(__file__)
     testargs = [filepath]
-    with tmpdir.as_cwd():
+    with _test_cwd(tmp_path):
         with pytest.raises(SystemExit) as err:
             with pytest.warns(DeprecationWarning):
                 run_epylint(testargs)
@@ -78,7 +78,7 @@ def test_epylint_with_arguments(tmpdir: LocalPath) -> None:
 
 
 def test_pylint_argument_deduplication(
-    tmpdir: LocalPath, tests_directory: pathlib.Path
+    tmp_path: pathlib.Path, tests_directory: pathlib.Path
 ) -> None:
     """Check that the Pylint runner does not over-report on duplicate
     arguments.
@@ -90,7 +90,7 @@ def test_pylint_argument_deduplication(
     testargs = shlex.split("--report n --score n --max-branches 13")
     testargs.extend([filepath] * 4)
     exit_stack = contextlib.ExitStack()
-    exit_stack.enter_context(tmpdir.as_cwd())
+    exit_stack.enter_context(_test_cwd(tmp_path))
     exit_stack.enter_context(patch.object(sys, "argv", testargs))
     err = exit_stack.enter_context(pytest.raises(SystemExit))
     with exit_stack:
@@ -99,7 +99,7 @@ def test_pylint_argument_deduplication(
 
 
 def test_pylint_run_jobs_equal_zero_dont_crash_with_cpu_fraction(
-    tmpdir: LocalPath,
+    tmp_path: pathlib.Path,
 ) -> None:
     """Check that the pylint runner does not crash if `pylint.lint.run._query_cpu`
     determines only a fraction of a CPU core to be available.
@@ -122,7 +122,7 @@ def test_pylint_run_jobs_equal_zero_dont_crash_with_cpu_fraction(
 
     filepath = os.path.abspath(__file__)
     testargs = [filepath, "--jobs=0"]
-    with tmpdir.as_cwd():
+    with _test_cwd(tmp_path):
         with pytest.raises(SystemExit) as err:
             with patch("builtins.open", _mock_open):
                 with patch("pylint.lint.run.Path", _mock_path):

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -27,7 +27,6 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
-from py._path.local import LocalPath
 
 from pylint import extensions, modify_sys_path
 from pylint.constants import MAIN_CHECKER_NAME, MSG_TYPES_STATUS
@@ -162,7 +161,7 @@ class TestRunTC:
             assert unexpected_output.strip() not in actual_output.strip()
 
     def _test_output_file(
-        self, args: list[str], filename: LocalPath, expected_output: str
+        self, args: list[str], filename: Path, expected_output: str
     ) -> None:
         """Run Pylint with the ``output`` option set (must be included in
         the ``args`` passed to this method!) and check the file content afterwards.
@@ -555,8 +554,8 @@ class TestRunTC:
         self._runtest(["--from-stdin"], code=32)
 
     @pytest.mark.parametrize("write_bpy_to_disk", [False, True])
-    def test_relative_imports(self, write_bpy_to_disk: bool, tmpdir: LocalPath) -> None:
-        a = tmpdir.join("a")  # type: ignore[no-untyped-call]
+    def test_relative_imports(self, write_bpy_to_disk: bool, tmp_path: Path) -> None:
+        a = tmp_path / "a"
 
         b_code = textwrap.dedent(
             """
@@ -576,12 +575,12 @@ class TestRunTC:
         )
 
         a.mkdir()
-        a.join("__init__.py").write("")
+        (a / "__init__.py").write_text("")
         if write_bpy_to_disk:
-            a.join("b.py").write(b_code)
-        a.join("c.py").write(c_code)
+            (a / "b.py").write_text(b_code)
+        (a / "c.py").write_text(c_code)
 
-        with tmpdir.as_cwd():
+        with _test_cwd(tmp_path):
             # why don't we start pylint in a sub-process?
             expected = (
                 "************* Module a.b\n"
@@ -880,34 +879,34 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (<unknown>, line 1)' (syntax-er
         ],
     )
     def test_do_not_import_files_from_local_directory(
-        self, tmpdir: LocalPath, args: list[str]
+        self, tmp_path: Path, args: list[str]
     ) -> None:
         for path in ("astroid.py", "hmac.py"):
-            file_path = tmpdir / path
-            file_path.write("'Docstring'\nimport completely_unknown\n")
+            file_path = tmp_path / path
+            file_path.write_text("'Docstring'\nimport completely_unknown\n")
             pylint_call = [sys.executable, "-m", "pylint"] + args + [path]
-            with tmpdir.as_cwd():
-                subprocess.check_output(pylint_call, cwd=str(tmpdir))
+            with _test_cwd(tmp_path):
+                subprocess.check_output(pylint_call, cwd=str(tmp_path))
             new_python_path = os.environ.get("PYTHONPATH", "").strip(":")
-            with tmpdir.as_cwd(), _test_environ_pythonpath(f"{new_python_path}:"):
+            with _test_cwd(tmp_path), _test_environ_pythonpath(f"{new_python_path}:"):
                 # Appending a colon to PYTHONPATH should not break path stripping
                 # https://github.com/PyCQA/pylint/issues/3636
-                subprocess.check_output(pylint_call, cwd=str(tmpdir))
+                subprocess.check_output(pylint_call, cwd=str(tmp_path))
 
     @staticmethod
     def test_import_plugin_from_local_directory_if_pythonpath_cwd(
-        tmpdir: LocalPath,
+        tmp_path: Path,
     ) -> None:
-        p_plugin = tmpdir / "plugin.py"
-        p_plugin.write("# Some plugin content")
+        p_plugin = tmp_path / "plugin.py"
+        p_plugin.write_text("# Some plugin content")
         if sys.platform == "win32":
             python_path = "."
         else:
             python_path = f"{os.environ.get('PYTHONPATH', '').strip(':')}:."
-        with tmpdir.as_cwd(), _test_environ_pythonpath(python_path):
+        with _test_cwd(tmp_path), _test_environ_pythonpath(python_path):
             args = [sys.executable, "-m", "pylint", "--load-plugins", "plugin"]
             process = subprocess.run(
-                args, cwd=str(tmpdir), stderr=subprocess.PIPE, check=False
+                args, cwd=str(tmp_path), stderr=subprocess.PIPE, check=False
             )
             assert (
                 "AttributeError: module 'plugin' has no attribute 'register'"
@@ -915,18 +914,18 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (<unknown>, line 1)' (syntax-er
             )
 
     def test_allow_import_of_files_found_in_modules_during_parallel_check(
-        self, tmpdir: LocalPath
+        self, tmp_path: Path
     ) -> None:
-        test_directory = tmpdir / "test_directory"
+        test_directory = tmp_path / "test_directory"
         test_directory.mkdir()
         spam_module = test_directory / "spam.py"
-        spam_module.write("'Empty'")
+        spam_module.write_text("'Empty'")
 
         init_module = test_directory / "__init__.py"
-        init_module.write("'Empty'")
+        init_module.write_text("'Empty'")
 
         # For multiple jobs we could not find the `spam.py` file.
-        with tmpdir.as_cwd():
+        with _test_cwd(tmp_path):
             args = [
                 "-j2",
                 "--disable=missing-docstring, missing-final-newline",
@@ -935,7 +934,7 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (<unknown>, line 1)' (syntax-er
             self._runtest(args, code=0)
 
         # A single job should be fine as well
-        with tmpdir.as_cwd():
+        with _test_cwd(tmp_path):
             args = [
                 "-j1",
                 "--disable=missing-docstring, missing-final-newline",
@@ -944,11 +943,11 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (<unknown>, line 1)' (syntax-er
             self._runtest(args, code=0)
 
     @staticmethod
-    def test_can_list_directories_without_dunder_init(tmpdir: LocalPath) -> None:
-        test_directory = tmpdir / "test_directory"
+    def test_can_list_directories_without_dunder_init(tmp_path: Path) -> None:
+        test_directory = tmp_path / "test_directory"
         test_directory.mkdir()
         spam_module = test_directory / "spam.py"
-        spam_module.write("'Empty'")
+        spam_module.write_text("'Empty'")
 
         subprocess.check_output(
             [
@@ -958,7 +957,7 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (<unknown>, line 1)' (syntax-er
                 "--disable=missing-docstring, missing-final-newline",
                 "test_directory",
             ],
-            cwd=str(tmpdir),
+            cwd=str(tmp_path),
             stderr=subprocess.PIPE,
         )
 
@@ -976,9 +975,9 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (<unknown>, line 1)' (syntax-er
         )
         self._test_output([path, "-j2"], expected_output="")
 
-    def test_output_file_valid_path(self, tmpdir: LocalPath) -> None:
+    def test_output_file_valid_path(self, tmp_path: Path) -> None:
         path = join(HERE, "regrtest_data", "unused_variable.py")
-        output_file = tmpdir / "output.txt"
+        output_file = tmp_path / "output.txt"
         expected = "Your code has been rated at 7.50/10"
         self._test_output_file(
             [path, f"--output={output_file}"],
@@ -1058,10 +1057,10 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (<unknown>, line 1)' (syntax-er
         ],
     )
     def test_output_file_can_be_combined_with_output_format_option(
-        self, tmpdir: LocalPath, output_format: str, expected_output: str
+        self, tmp_path: Path, output_format: str, expected_output: str
     ) -> None:
         path = join(HERE, "regrtest_data", "unused_variable.py")
-        output_file = tmpdir / "output.txt"
+        output_file = tmp_path / "output.txt"
         self._test_output_file(
             [path, f"--output={output_file}", f"--output-format={output_format}"],
             output_file,
@@ -1069,10 +1068,10 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (<unknown>, line 1)' (syntax-er
         )
 
     def test_output_file_can_be_combined_with_custom_reporter(
-        self, tmpdir: LocalPath
+        self, tmp_path: Path
     ) -> None:
         path = join(HERE, "regrtest_data", "unused_variable.py")
-        output_file = tmpdir / "output.txt"
+        output_file = tmp_path / "output.txt"
         # It does not really have to be a truly custom reporter.
         # It is only important that it is being passed explicitly to ``Run``.
         myreporter = TextReporter()
@@ -1083,9 +1082,9 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (<unknown>, line 1)' (syntax-er
         )
         assert output_file.exists()
 
-    def test_output_file_specified_in_rcfile(self, tmpdir: LocalPath) -> None:
-        output_file = tmpdir / "output.txt"
-        rcfile = tmpdir / "pylintrc"
+    def test_output_file_specified_in_rcfile(self, tmp_path: Path) -> None:
+        output_file = tmp_path / "output.txt"
+        rcfile = tmp_path / "pylintrc"
         rcfile_contents = textwrap.dedent(
             f"""
         [MAIN]


### PR DESCRIPTION
pytest 7.2 no longer depends on py and py is kinda deprecated so it's better to drop it. `tmp_path` fixture is newer and uses `pathlib.Path` from stdlib instead of `LocalPath` from `py._path`.

An alternative for this is to add `py` into test dependencies.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |