### PR TITLE
Do not crash if next()` is called

### DIFF
--- a/doc/whatsnew/fragments/7828.bugfix
+++ b/doc/whatsnew/fragments/7828.bugfix
@@ -1,0 +1,3 @@
+Fixes a crash in ``stop-iteration-return`` when the ``next`` builtin is called without arguments.
+
+Closes #7828

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1135,6 +1135,11 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             # A next() method, which is now what we want.
             return
 
+        if len(node.args) == 0:
+            # handle case when builtin.next is called without args.
+            # see https://github.com/PyCQA/pylint/issues/7828
+            return
+
         inferred = utils.safe_infer(node.func)
 
         if (

--- a/tests/functional/s/stop_iteration_inside_generator.py
+++ b/tests/functional/s/stop_iteration_inside_generator.py
@@ -175,3 +175,13 @@ def other_safeiter(it):
     it = iter(it)
     while True:
         yield next(1, 2)
+
+def data(filename):
+    """
+    Ensure pylint doesn't crash if `next` is incorrectly called without args
+    See https://github.com/PyCQA/pylint/issues/7828
+    """
+    with open(filename, encoding="utf8") as file:
+        next() # attempt to skip header but this is incorrect code
+        for line in file:
+            yield line


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Pylint should not crash if `next()` is called, even tho that's incorrect python!

Closes #7828
