### PR TITLE
Avoid hanging forever after a parallel job was killed

### DIFF
--- a/doc/whatsnew/fragments/3899.bugfix
+++ b/doc/whatsnew/fragments/3899.bugfix
@@ -1,0 +1,4 @@
+Pylint will no longer deadlock if a parallel job is killed but fail
+immediately instead.
+
+Closes #3899

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -31,7 +31,7 @@ except ImportError:
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
-# PyLinter object used by worker processes when checking files using multiprocessing
+# PyLinter object used by worker processes when checking files using parallel mode
 # should only be used by the worker processes
 _worker_linter: PyLinter | None = None
 
@@ -39,8 +39,7 @@ _worker_linter: PyLinter | None = None
 def _worker_initialize(
     linter: bytes, arguments: None | str | Sequence[str] = None
 ) -> None:
-    """Function called to initialize a worker for a Process within a multiprocessing
-    Pool.
+    """Function called to initialize a worker for a Process within a concurrent Pool.
 
     :param linter: A linter-class (PyLinter) instance pickled with dill
     :param arguments: File or module name(s) to lint and to be added to sys.path

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -8,7 +8,6 @@ import functools
 import warnings
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
-from concurrent.futures import ProcessPoolExecutor
 from typing import TYPE_CHECKING, Any
 
 import dill
@@ -23,6 +22,11 @@ try:
     import multiprocessing
 except ImportError:
     multiprocessing = None  # type: ignore[assignment]
+
+try:
+    from concurrent.futures import ProcessPoolExecutor
+except ImportError:
+    ProcessPoolExecutor = None  # type: ignore[assignment,misc]
 
 if TYPE_CHECKING:
     from pylint.lint import PyLinter

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -139,7 +139,7 @@ def check_parallel(
     # a custom PyLinter object can be used.
     initializer = functools.partial(_worker_initialize, arguments=arguments)
     with ProcessPoolExecutor(
-        max_workers=jobs, initializer=initializer, initargs=(dill.dumps(linter))
+        max_workers=jobs, initializer=initializer, initargs=(dill.dumps(linter),)
     ) as executor:
         linter.open()
         all_stats = []

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -30,6 +30,11 @@ try:
 except ImportError:
     multiprocessing = None  # type: ignore[assignment]
 
+try:
+    from concurrent.futures import ProcessPoolExecutor
+except ImportError:
+    ProcessPoolExecutor = None  # type: ignore[assignment,misc]
+
 
 def _query_cpu() -> int | None:
     """Try to determine number of CPUs allotted in a docker container.
@@ -185,9 +190,9 @@ group are mutually exclusive.",
             )
             sys.exit(32)
         if linter.config.jobs > 1 or linter.config.jobs == 0:
-            if multiprocessing is None:
+            if ProcessPoolExecutor is None:
                 print(
-                    "Multiprocessing library is missing, fallback to single process",
+                    "concurrent.futures module is missing, fallback to single process",
                     file=sys.stderr,
                 )
                 linter.set_option("jobs", 1)

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -579,7 +579,7 @@ class TestCheckParallel:
             stats_check_parallel.by_msg
         ), "Single-proc and check_parallel() should return the same thing"
 
-    @pytest.mark.timeout(1)
+    @pytest.mark.timeout(5)
     def test_no_deadlock_due_to_initializer_error(self) -> None:
         """Tests that an error in the initializer for the parallel jobs doesn't
         lead to a deadlock.

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 
 import argparse
 import os
-from concurrent.futures import ProcessPoolExecutor
-from concurrent.futures.process import BrokenProcessPool
 from pickle import PickleError
 
 import dill
@@ -28,6 +26,13 @@ from pylint.lint.parallel import check_parallel
 from pylint.testutils import GenericTestReporter as Reporter
 from pylint.typing import FileItem
 from pylint.utils import LinterStats, ModuleStats
+
+try:
+    from concurrent.futures import ProcessPoolExecutor
+    from concurrent.futures.process import BrokenProcessPool
+except ImportError:
+    ProcessPoolExecutor = None  # type: ignore[assignment,misc]
+    BrokenProcessPool = None  # type: ignore[assignment,misc]
 
 
 def _gen_file_data(idx: int = 0) -> FileItem:

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import argparse
 import os
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from pickle import PickleError
 
 import dill
@@ -26,9 +28,6 @@ from pylint.lint.parallel import check_parallel
 from pylint.testutils import GenericTestReporter as Reporter
 from pylint.typing import FileItem
 from pylint.utils import LinterStats, ModuleStats
-
-from concurrent.futures import ProcessPoolExecutor
-from concurrent.futures.process import BrokenProcessPool
 
 
 def _gen_file_data(idx: int = 0) -> FileItem:

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -27,12 +27,8 @@ from pylint.testutils import GenericTestReporter as Reporter
 from pylint.typing import FileItem
 from pylint.utils import LinterStats, ModuleStats
 
-try:
-    from concurrent.futures import ProcessPoolExecutor
-    from concurrent.futures.process import BrokenProcessPool
-except ImportError:
-    ProcessPoolExecutor = None  # type: ignore[assignment,misc]
-    BrokenProcessPool = None  # type: ignore[assignment,misc]
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 
 
 def _gen_file_data(idx: int = 0) -> FileItem:

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -9,8 +9,9 @@
 from __future__ import annotations
 
 import argparse
-import multiprocessing
 import os
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from pickle import PickleError
 
 import dill
@@ -182,10 +183,10 @@ class TestCheckParallelFramework:
         """
         linter = PyLinter(reporter=Reporter())
         linter.attribute = argparse.ArgumentParser()  # type: ignore[attr-defined]
-        with multiprocessing.Pool(
-            2, initializer=worker_initialize, initargs=[dill.dumps(linter)]
-        ) as pool:
-            pool.imap_unordered(print, [1, 2])
+        with ProcessPoolExecutor(
+            max_workers=2, initializer=worker_initialize, initargs=(dill.dumps(linter),)
+        ) as executor:
+            executor.map(print, [1, 2])
 
     def test_worker_check_single_file_uninitialised(self) -> None:
         pylint.lint.parallel._worker_linter = None
@@ -577,3 +578,27 @@ class TestCheckParallel:
         assert str(stats_single_proc.by_msg) == str(
             stats_check_parallel.by_msg
         ), "Single-proc and check_parallel() should return the same thing"
+
+    @pytest.mark.timeout(1)
+    def test_no_deadlock_due_to_initializer_error(self) -> None:
+        """Tests that an error in the initializer for the parallel jobs doesn't
+        lead to a deadlock.
+        """
+        linter = PyLinter(reporter=Reporter())
+
+        linter.register_checker(SequentialTestChecker(linter))
+
+        # Create a dummy file, the actual contents of which will be ignored by the
+        # register test checkers, but it will trigger at least a single-job to be run.
+        single_file_container = _gen_file_datas(count=1)
+
+        # The error in the initializer should trigger a BrokenProcessPool exception
+        with pytest.raises(BrokenProcessPool):
+            check_parallel(
+                linter,
+                jobs=1,
+                files=iter(single_file_container),
+                # This will trigger an exception in the initializer for the parallel jobs
+                # because arguments has to be an Iterable.
+                arguments=1,  # type: ignore[arg-type]
+            )


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Replace `multiprocessing.pool` with [concurrent.futures.ProcessPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#processpoolexecutor) to avoid deadlocks.

In a `multiprocessing.pool`, if a process terminates in a non-clean fashion (for example, due to OOM or a segmentation fault), the pool will silently replace said process, but the work that the process was supposed to do will never be done, causing pylint to hang indefinitely. The `concurrent.futures.ProcessPoolExecutor` will raise a [BrokenProcessPool exception](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.process.BrokenProcessPool) in that case, avoiding the hang.

See https://github.com/PyCQA/pylint/issues/3899#issuecomment-732712793 for reproduction instructions.

The hangs caused by this issue ate up quite a few CI minutes for us over time. Although this doesn't fix the underlying sporadic issue (which is likely due to OOM) at least pylint will fail early instead of hanging forever.

A followup could be to recover from this type of error by catching the `BrokenProcessPool` exception and then instantiating a new `ProcessPoolExecutor` to continue the linting.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes https://github.com/PyCQA/pylint/issues/3899
