### PR TITLE
Upgrade the versions of astroid and dill

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   pull-requests: write
-  content: write
+  contents: write
 
 jobs:
   backport:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,7 @@ classifiers = [
 ]
 requires-python = ">=3.7.2"
 dependencies    = [
-    # TODO: Remove dill-pylint once dill 0.3.6 is released
-    "dill>=0.2;python_version<'3.11'",
-    "dill-pylint>=0.3.6.dev0;python_version>='3.11'",
+    "dill>=0.2",
     "platformdirs>=2.2.0",
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies    = [
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/PyCQA/astroid/issues/1341
-    "astroid>=2.12.12,<=2.14.0-dev0",
+    "astroid>=2.12.13,<=2.14.0-dev0",
     "isort>=4.2.5,<6",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 -e .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==2.12.12  # Pinned to a specific version for tests
+astroid==2.12.13  # Pinned to a specific version for tests
 typing-extensions~=4.4
 py~=1.11.0
 pytest~=7.2


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |


## Description

Make sure that we use the real version of dill on all interpreter now that dill released version 0.3.6. also explicitly use the latest astroid.
