### PR TITLE
Define Protocol as abstract to prevent abstract-method FP

### DIFF
--- a/doc/whatsnew/fragments/7209.false_positive
+++ b/doc/whatsnew/fragments/7209.false_positive
@@ -1,0 +1,3 @@
+Fixes false positive ``abstract-method`` on Protocol classes.
+
+Closes #7209

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -2098,18 +2098,8 @@ a metaclass class method.",
             if node_frame_class(method) in parents_with_called_inits:
                 return
 
-            # Return if klass is protocol
-            if klass.qname() in utils.TYPING_PROTOCOLS:
+            if utils.is_protocol_class(klass):
                 return
-
-            # Return if any of the klass' first-order bases is protocol
-            for base in klass.bases:
-                try:
-                    for inf_base in base.infer():
-                        if inf_base.qname() in utils.TYPING_PROTOCOLS:
-                            return
-                except astroid.InferenceError:
-                    continue
 
             if decorated_with(node, ["typing.overload"]):
                 continue

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1167,6 +1167,10 @@ def class_is_abstract(node: nodes.ClassDef) -> bool:
     """Return true if the given class node should be considered as an abstract
     class.
     """
+    # Protocol classes are considered "abstract"
+    if is_protocol_class(node):
+        return True
+
     # Only check for explicit metaclass=ABCMeta on this specific class
     meta = node.declared_metaclass()
     if meta is not None:

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1657,14 +1657,23 @@ def is_protocol_class(cls: nodes.NodeNG) -> bool:
     """Check if the given node represents a protocol class.
 
     :param cls: The node to check
-    :returns: True if the node is a typing protocol class, false otherwise.
+    :returns: True if the node is or inherits from typing.Protocol directly, false otherwise.
     """
     if not isinstance(cls, nodes.ClassDef):
         return False
 
-    # Use .ancestors() since not all protocol classes can have
-    # their mro deduced.
-    return any(parent.qname() in TYPING_PROTOCOLS for parent in cls.ancestors())
+    # Return if klass is protocol
+    if cls.qname() in TYPING_PROTOCOLS:
+        return True
+
+    for base in cls.bases:
+        try:
+            for inf_base in base.infer():
+                if inf_base.qname() in TYPING_PROTOCOLS:
+                    return True
+        except astroid.InferenceError:
+            continue
+    return False
 
 
 def is_call_of_name(node: nodes.NodeNG, name: str) -> bool:

--- a/tests/functional/p/protocol_classes_abstract.py
+++ b/tests/functional/p/protocol_classes_abstract.py
@@ -1,5 +1,7 @@
 """Test that classes inheriting from protocols should not warn about abstract-method."""
+
 # pylint: disable=too-few-public-methods,disallowed-name,invalid-name
+
 from abc import abstractmethod
 from typing import Protocol, Literal
 
@@ -14,6 +16,7 @@ class FooProtocol(Protocol):
     def foo_no_abstract(self) -> Literal["foo"]:
         """foo not abstract method"""
 
+
 class BarProtocol(Protocol):
     """Bar Protocol"""
     @abstractmethod
@@ -21,9 +24,12 @@ class BarProtocol(Protocol):
         """bar method"""
 
 
-
 class FooBarProtocol(FooProtocol, BarProtocol, Protocol):
     """FooBar Protocol"""
+
+
+class IndirectProtocol(FooProtocol):
+    """Doesn't subclass typing.Protocol directly"""
 
 
 class FooBar(FooBarProtocol):

--- a/tests/functional/p/protocol_classes_abstract.py
+++ b/tests/functional/p/protocol_classes_abstract.py
@@ -1,0 +1,36 @@
+"""Test that classes inheriting from protocols should not warn about abstract-method."""
+# pylint: disable=too-few-public-methods,disallowed-name,invalid-name
+from abc import abstractmethod
+from typing import Protocol, Literal
+
+
+class FooProtocol(Protocol):
+    """Foo Protocol"""
+
+    @abstractmethod
+    def foo(self) -> Literal["foo"]:
+        """foo method"""
+
+    def foo_no_abstract(self) -> Literal["foo"]:
+        """foo not abstract method"""
+
+class BarProtocol(Protocol):
+    """Bar Protocol"""
+    @abstractmethod
+    def bar(self) -> Literal["bar"]:
+        """bar method"""
+
+
+
+class FooBarProtocol(FooProtocol, BarProtocol, Protocol):
+    """FooBar Protocol"""
+
+
+class FooBar(FooBarProtocol):
+    """FooBar object"""
+
+    def bar(self) -> Literal["bar"]:
+        return "bar"
+
+    def foo(self) -> Literal["foo"]:
+        return "foo"

--- a/tests/functional/p/protocol_classes_abstract.py
+++ b/tests/functional/p/protocol_classes_abstract.py
@@ -27,6 +27,8 @@ class BarProtocol(Protocol):
 class FooBarProtocol(FooProtocol, BarProtocol, Protocol):
     """FooBar Protocol"""
 
+class BarParent(BarProtocol): # [abstract-method]
+    """Doesn't subclass typing.Protocol directly"""
 
 class IndirectProtocol(FooProtocol):  # [abstract-method]
     """Doesn't subclass typing.Protocol directly"""

--- a/tests/functional/p/protocol_classes_abstract.py
+++ b/tests/functional/p/protocol_classes_abstract.py
@@ -1,8 +1,8 @@
-"""Test that classes inheriting from protocols should not warn about abstract-method."""
+"""Test that classes inheriting directly from Protocol should not warn about abstract-method."""
 
 # pylint: disable=too-few-public-methods,disallowed-name,invalid-name
 
-from abc import abstractmethod
+from abc import abstractmethod, ABCMeta
 from typing import Protocol, Literal
 
 
@@ -28,9 +28,11 @@ class FooBarProtocol(FooProtocol, BarProtocol, Protocol):
     """FooBar Protocol"""
 
 
-class IndirectProtocol(FooProtocol):
+class IndirectProtocol(FooProtocol):  # [abstract-method]
     """Doesn't subclass typing.Protocol directly"""
 
+class AbcProtocol(FooProtocol, metaclass=ABCMeta):
+    """Doesn't subclass typing.Protocol but uses metaclass directly"""
 
 class FooBar(FooBarProtocol):
     """FooBar object"""

--- a/tests/functional/p/protocol_classes_abstract.rc
+++ b/tests/functional/p/protocol_classes_abstract.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.8

--- a/tests/functional/p/protocol_classes_abstract.txt
+++ b/tests/functional/p/protocol_classes_abstract.txt
@@ -1,0 +1,1 @@
+abstract-method:31:0:31:22:IndirectProtocol:Method 'foo' is abstract in class 'FooProtocol' but is not overridden in child class 'IndirectProtocol':INFERENCE

--- a/tests/functional/p/protocol_classes_abstract.txt
+++ b/tests/functional/p/protocol_classes_abstract.txt
@@ -1,1 +1,2 @@
-abstract-method:31:0:31:22:IndirectProtocol:Method 'foo' is abstract in class 'FooProtocol' but is not overridden in child class 'IndirectProtocol':INFERENCE
+abstract-method:30:0:30:15:BarParent:Method 'bar' is abstract in class 'BarProtocol' but is not overridden in child class 'BarParent':INFERENCE
+abstract-method:33:0:33:22:IndirectProtocol:Method 'foo' is abstract in class 'FooProtocol' but is not overridden in child class 'IndirectProtocol':INFERENCE


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Closes #7209

I'm not sure if I just got lucky in this very short fix or I'm completely wrong here in adding a Protocol check to the is_abstract utility method....
