### PR TITLE
Fix ``logging-fstring-interpolation`` FP

### DIFF
--- a/doc/whatsnew/fragments/4984.false_positive
+++ b/doc/whatsnew/fragments/4984.false_positive
@@ -1,0 +1,3 @@
+Fix ``logging-fstring-interpolation`` false positive raised when logging and f-string with ``%s`` formatting.
+
+Closes #4984

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -105,12 +105,7 @@ CHECKED_CONVENIENCE_FUNCTIONS = {
     "warning",
 }
 
-MOST_COMMON_FORMATTING = {
-    "%s",
-    "%d",
-    "%f",
-    "%r",
-}
+MOST_COMMON_FORMATTING = frozenset("%s", "%d", "%f", "%r")
 
 
 def is_method_call(

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -403,7 +403,7 @@ def _count_supplied_tokens(args: list[nodes.NodeNG]) -> int:
     return sum(1 for arg in args if not isinstance(arg, nodes.Keyword))
 
 
-def str_formatting_in_f_string(node: nodes.NodeNG) -> bool:
+def str_formatting_in_f_string(node: nodes.JoinedStr) -> bool:
     """Determine whether the node represents an f-string with string formatting.
 
     For example: `f'Hello %s'`
@@ -416,6 +416,5 @@ def str_formatting_in_f_string(node: nodes.NodeNG) -> bool:
     )
 
 
-# Detect % formatting inside an f-string, such as `f'Hello %s'`
 def register(linter: PyLinter) -> None:
     linter.register_checker(LoggingChecker(linter))

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -105,7 +105,7 @@ CHECKED_CONVENIENCE_FUNCTIONS = {
     "warning",
 }
 
-MOST_COMMON_FORMATTING = frozenset("%s", "%d", "%f", "%r")
+MOST_COMMON_FORMATTING = frozenset(["%s", "%d", "%f", "%r"])
 
 
 def is_method_call(

--- a/tests/functional/l/logging/logging_fstring_interpolation_py37.py
+++ b/tests/functional/l/logging/logging_fstring_interpolation_py37.py
@@ -8,3 +8,4 @@ WORLD = "world"
 logging.error(f'Hello {WORLD}')  # [logging-fstring-interpolation]
 
 logging.error(f'Hello %s', 'World!')  # [f-string-without-interpolation]
+logging.error(f'Hello %d', 1)  # [f-string-without-interpolation]

--- a/tests/functional/l/logging/logging_fstring_interpolation_py37.py
+++ b/tests/functional/l/logging/logging_fstring_interpolation_py37.py
@@ -3,3 +3,8 @@ import logging
 
 VAR = "string"
 logging.error(f"{VAR}")  # [logging-fstring-interpolation]
+
+WORLD = "world"
+logging.error(f'Hello {WORLD}')  # [logging-fstring-interpolation]
+
+logging.error(f'Hello %s', 'World!')  # [f-string-without-interpolation]

--- a/tests/functional/l/logging/logging_fstring_interpolation_py37.txt
+++ b/tests/functional/l/logging/logging_fstring_interpolation_py37.txt
@@ -1,3 +1,4 @@
 logging-fstring-interpolation:5:0:5:23::Use lazy % formatting in logging functions:UNDEFINED
 logging-fstring-interpolation:8:0:8:31::Use lazy % formatting in logging functions:UNDEFINED
 f-string-without-interpolation:10:14:10:25::Using an f-string that does not have any interpolated variables:UNDEFINED
+f-string-without-interpolation:11:14:11:25::Using an f-string that does not have any interpolated variables:UNDEFINED

--- a/tests/functional/l/logging/logging_fstring_interpolation_py37.txt
+++ b/tests/functional/l/logging/logging_fstring_interpolation_py37.txt
@@ -1,1 +1,3 @@
 logging-fstring-interpolation:5:0:5:23::Use lazy % formatting in logging functions:UNDEFINED
+logging-fstring-interpolation:8:0:8:31::Use lazy % formatting in logging functions:UNDEFINED
+f-string-without-interpolation:10:14:10:25::Using an f-string that does not have any interpolated variables:UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

``logging-fstring-interpolation`` should not be raised if logging with an f-str that also has %s formatting.

Closes #4984
