### PR TITLE
Prevent `used-before-assignment` for variables defined in assignment expressions

### DIFF
--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -738,13 +738,13 @@ scope_type : {self._atomic.scope_type}
         if any(node.nodes_of_class(nodes.Break)):
             return True
 
-        # If there is no else, then there is no collectively exhaustive set of paths
-        if not node.orelse:
-            return False
-
         # Is there an assignment in this node itself, e.g. in named expression?
         if NamesConsumer._defines_name_raises_or_returns(name, node):
             return True
+
+        # If there is no else, then there is no collectively exhaustive set of paths
+        if not node.orelse:
+            return False
 
         return NamesConsumer._branch_handles_name(
             name, node.body

--- a/tests/functional/u/undefined/undefined_variable_py38.py
+++ b/tests/functional/u/undefined/undefined_variable_py38.py
@@ -182,6 +182,7 @@ if (z := z):  # [used-before-assignment]
     z = z + 1
 
 
-if (never_defined := False):
-    pass
+if (defined := False):
+    never_defined = 1
+print(defined)
 print(never_defined)  # [used-before-assignment]

--- a/tests/functional/u/undefined/undefined_variable_py38.py
+++ b/tests/functional/u/undefined/undefined_variable_py38.py
@@ -183,6 +183,6 @@ if (z := z):  # [used-before-assignment]
 
 
 if (defined := False):
-    never_defined = 1
+    NEVER_DEFINED = 1
 print(defined)
-print(never_defined)  # [used-before-assignment]
+print(NEVER_DEFINED)  # [used-before-assignment]

--- a/tests/functional/u/undefined/undefined_variable_py38.txt
+++ b/tests/functional/u/undefined/undefined_variable_py38.txt
@@ -8,4 +8,4 @@ used-before-assignment:140:10:140:16:type_annotation_used_improperly_after_compr
 used-before-assignment:147:10:147:16:type_annotation_used_improperly_after_comprehension_2:Using variable 'my_int' before assignment:HIGH
 used-before-assignment:177:12:177:16:expression_in_ternary_operator_inside_container_wrong_position:Using variable 'val3' before assignment:HIGH
 used-before-assignment:181:9:181:10::Using variable 'z' before assignment:HIGH
-used-before-assignment:188:6:187:25::Using variable 'never_defined' before assignment:CONTROL_FLOW
+used-before-assignment:188:6:187:25::Using variable 'NEVER_DEFINED' before assignment:CONTROL_FLOW

--- a/tests/functional/u/undefined/undefined_variable_py38.txt
+++ b/tests/functional/u/undefined/undefined_variable_py38.txt
@@ -8,4 +8,4 @@ used-before-assignment:140:10:140:16:type_annotation_used_improperly_after_compr
 used-before-assignment:147:10:147:16:type_annotation_used_improperly_after_comprehension_2:Using variable 'my_int' before assignment:HIGH
 used-before-assignment:177:12:177:16:expression_in_ternary_operator_inside_container_wrong_position:Using variable 'val3' before assignment:HIGH
 used-before-assignment:181:9:181:10::Using variable 'z' before assignment:HIGH
-used-before-assignment:188:6:187:25::Using variable 'NEVER_DEFINED' before assignment:CONTROL_FLOW
+used-before-assignment:188:6:188:19::Using variable 'NEVER_DEFINED' before assignment:CONTROL_FLOW

--- a/tests/functional/u/undefined/undefined_variable_py38.txt
+++ b/tests/functional/u/undefined/undefined_variable_py38.txt
@@ -8,4 +8,4 @@ used-before-assignment:140:10:140:16:type_annotation_used_improperly_after_compr
 used-before-assignment:147:10:147:16:type_annotation_used_improperly_after_comprehension_2:Using variable 'my_int' before assignment:HIGH
 used-before-assignment:177:12:177:16:expression_in_ternary_operator_inside_container_wrong_position:Using variable 'val3' before assignment:HIGH
 used-before-assignment:181:9:181:10::Using variable 'z' before assignment:HIGH
-used-before-assignment:187:6:187:19::Using variable 'never_defined' before assignment:CONTROL_FLOW
+used-before-assignment:188:6:187:25::Using variable 'never_defined' before assignment:CONTROL_FLOW


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Fix an unreleased false positive noticed by Marc in https://github.com/PyCQA/pylint/pull/6677#discussion_r1031664559.
