### PR TITLE
Revert "Fix crash when using ``enumerate`` with ``start`` and a class attribute (#7824)"

### DIFF
--- a/doc/whatsnew/fragments/7821.bugfix
+++ b/doc/whatsnew/fragments/7821.bugfix
@@ -1,3 +1,0 @@
-Fixes a crash in the ``unnecessary_list_index_lookup`` check when using ``enumerate`` with ``start`` and a class attribute.
-
-Closes #7821

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -2248,13 +2248,15 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         return False, confidence
 
     def _get_start_value(self, node: nodes.NodeNG) -> tuple[int | None, Confidence]:
-        if isinstance(node, (nodes.Name, nodes.Call, nodes.Attribute)):
+        confidence = HIGH
+
+        if isinstance(node, (nodes.Name, nodes.Call)):
             inferred = utils.safe_infer(node)
             start_val = inferred.value if inferred else None
-            return start_val, INFERENCE
-        if isinstance(node, nodes.UnaryOp):
-            return node.operand.value, HIGH
-        if isinstance(node, nodes.Const):
-            return node.value, HIGH
+            confidence = INFERENCE
+        elif isinstance(node, nodes.UnaryOp):
+            start_val = node.operand.value
+        else:
+            start_val = node.value
 
-        return None, HIGH
+        return start_val, confidence

--- a/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
+++ b/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
@@ -130,22 +130,3 @@ def return_start(start):
 
 for i, k in enumerate(series, return_start(20)):
     print(series[idx])
-
-for idx, val in enumerate(iterable=series, start=0):
-    print(series[idx])  # [unnecessary-list-index-lookup]
-
-result = [my_list[idx] for idx, val in enumerate(iterable=my_list)]  # [unnecessary-list-index-lookup]
-
-for idx, val in enumerate():
-    print(my_list[idx])
-
-class Command:
-    def _get_extra_attrs(self, extra_columns):
-        self.extra_rows_start = 8  # pylint: disable=attribute-defined-outside-init
-        for index, column in enumerate(extra_columns, start=self.extra_rows_start):
-            pass
-
-Y_START = 2
-nums = list(range(20))
-for y, x in enumerate(nums, start=Y_START + 1):
-    pass


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This reverts commit 86b8c649061f49c7d121843675ceefe6ff3a8113 which broke the test on the maintenance branch. Do you think this is fixable by cherry-picking something else first @clavedeluna ? Otherwise we can just wait for 2.16 to release the fix.
