### PR TITLE
Fix ``dangerous-default-value`` false negative when `*` is used.

### DIFF
--- a/doc/whatsnew/fragments/7818.false_negative
+++ b/doc/whatsnew/fragments/7818.false_negative
@@ -1,0 +1,3 @@
+Fix ``dangerous-default-value`` false negative when `*` is used.
+
+Closes #7818

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -572,7 +572,7 @@ class BasicChecker(_BasicChecker):
         def is_iterable(internal_node: nodes.NodeNG) -> bool:
             return isinstance(internal_node, (nodes.List, nodes.Set, nodes.Dict))
 
-        defaults = node.args.defaults or [] + node.args.kw_defaults or []
+        defaults = (node.args.defaults or []) + (node.args.kw_defaults or [])
         for default in defaults:
             if not default:
                 continue

--- a/tests/functional/d/dangerous_default_value.py
+++ b/tests/functional/d/dangerous_default_value.py
@@ -109,3 +109,14 @@ def function23(value=collections.UserList()):  # [dangerous-default-value]
 def function24(*, value=[]): # [dangerous-default-value]
     """dangerous default value in kwarg."""
     return value
+
+
+class Clazz:
+    # pylint: disable=too-few-public-methods
+    def __init__(  # [dangerous-default-value]
+        self,
+        arg: str = None,
+        *,
+        kk: dict = {},
+    ) -> None:
+        pass

--- a/tests/functional/d/dangerous_default_value.txt
+++ b/tests/functional/d/dangerous_default_value.txt
@@ -20,3 +20,4 @@ dangerous-default-value:97:0:97:14:function21:Dangerous default value defaultdic
 dangerous-default-value:101:0:101:14:function22:Dangerous default value UserDict() (collections.UserDict) as argument:UNDEFINED
 dangerous-default-value:105:0:105:14:function23:Dangerous default value UserList() (collections.UserList) as argument:UNDEFINED
 dangerous-default-value:109:0:109:14:function24:Dangerous default value [] as argument:UNDEFINED
+dangerous-default-value:116:4:116:16:Clazz.__init__:Dangerous default value {} as argument:UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Order of operation matters!! Turns out without the parens we weren't getting the default kwargs.

Closes #7818
