### PR TITLE
Rephrase Functional tests section in writing_test docs page

### DIFF
--- a/doc/development_guide/contributor_guide/tests/writing_test.rst
+++ b/doc/development_guide/contributor_guide/tests/writing_test.rst
@@ -34,13 +34,13 @@ the unittests.
 Functional tests
 ----------------
 
-These are residing under ``/pylint/test/functional`` and they are formed of multiple
+These are located under ``/pylint/test/functional`` and they are formed of multiple
 components. First, each Python file is considered to be a test case and it
-should be accompanied by a .txt file, having the same name, with the messages
+should be accompanied by a `.txt` file, having the same name. The `.txt` file contains the `pylint` messages
 that are supposed to be emitted by the given test file.
 
-In the Python file, each line for which Pylint is supposed to emit a message
-has to be annotated with a comment in the form ``# [message_symbol]``, as in::
+In your `.py` test file, each line for which Pylint is supposed to emit a message
+has to be annotated with a comment following this pattern ``# [message_symbol]``, as in::
 
     a, b, c = 1 # [unbalanced-tuple-unpacking]
 
@@ -48,14 +48,15 @@ If multiple messages are expected on the same line, then this syntax can be used
 
     a, b, c = 1.test # [unbalanced-tuple-unpacking, no-member]
 
-You can also use ``# +n: [`` with n an integer if the above syntax would make the line too long or other reasons::
+You can also use  ``# +n: [`` where `n` is an integer to deal with special cases, e.g., where the above regular syntax makes the line too long::
 
-    # +1: [empty-comment]
-    #
+    A = 5
+    # +1: [singleton-comparison]
+    B = A == None  # The test will look for the `singleton-comparison` message in this line
 
-If you need special control over Pylint's configuration, you can also create a .rc file, which
-can have sections of Pylint's configuration.
-The .rc file can also contain a section ``[testoptions]`` to pass options for the functional
+If you need special control over Pylint's configuration, you can also create a `.rc` file, which
+can set sections of Pylint's configuration.
+The `.rc` file can also contain a section ``[testoptions]`` to pass options for the functional
 test runner. The following options are currently supported:
 
 - "min_pyver": Minimal python version required to run the test

--- a/doc/development_guide/contributor_guide/tests/writing_test.rst
+++ b/doc/development_guide/contributor_guide/tests/writing_test.rst
@@ -36,10 +36,10 @@ Functional tests
 
 These are located under ``/pylint/test/functional`` and they are formed of multiple
 components. First, each Python file is considered to be a test case and it
-should be accompanied by a `.txt` file, having the same name. The `.txt` file contains the `pylint` messages
+should be accompanied by a ``.txt`` file, having the same name. The ``.txt`` file contains the ``pylint`` messages
 that are supposed to be emitted by the given test file.
 
-In your `.py` test file, each line for which Pylint is supposed to emit a message
+In your ``.py`` test file, each line for which Pylint is supposed to emit a message
 has to be annotated with a comment following this pattern ``# [message_symbol]``, as in::
 
     a, b, c = 1 # [unbalanced-tuple-unpacking]
@@ -48,15 +48,15 @@ If multiple messages are expected on the same line, then this syntax can be used
 
     a, b, c = 1.test # [unbalanced-tuple-unpacking, no-member]
 
-You can also use  ``# +n: [`` where `n` is an integer to deal with special cases, e.g., where the above regular syntax makes the line too long::
+You can also use  ``# +n: [`` where ``n`` is an integer to deal with special cases, e.g., where the above regular syntax makes the line too long::
 
     A = 5
     # +1: [singleton-comparison]
     B = A == None  # The test will look for the `singleton-comparison` message in this line
 
-If you need special control over Pylint's configuration, you can also create a `.rc` file, which
+If you need special control over Pylint's configuration, you can also create a ``.rc`` file, which
 can set sections of Pylint's configuration.
-The `.rc` file can also contain a section ``[testoptions]`` to pass options for the functional
+The ``.rc`` file can also contain a section ``[testoptions]`` to pass options for the functional
 test runner. The following options are currently supported:
 
 - "min_pyver": Minimal python version required to run the test


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [V] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

The `Functional tests` section in the [Writing Test docs page](https://pylint.pycqa.org/en/latest/development_guide/contributor_guide/tests/writing_test.html) is unclear in the example for the `n` lines option:

```
# +1: [empty-comment]
#
```

The second line with `#` can be easily mistaken for being part of the syntax, or meaning some line, where the true meaning is the `empty-comment` error itself..
This PR offers a much better example, which doesn't mix up the syntax of what the example trying the show and the example itself.

see discussion in [the comment here](https://github.com/PyCQA/pylint/pull/7745#discussion_r1034965689).

<!-- If this PR references an issue without fixing it: -->

Refs #7745.
