### PR TITLE
Cut oldstyle checks

### DIFF
--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -873,9 +873,6 @@ a metaclass class method.",
             self.add_message("inconsistent-mro", args=node.name, node=node)
         except astroid.DuplicateBasesError:
             self.add_message("duplicate-bases", args=node.name, node=node)
-        except NotImplementedError:
-            # Old style class, there's no mro so don't do anything.
-            pass
 
     def _check_proper_bases(self, node: nodes.ClassDef) -> None:
         """Detect that a class inherits something which is not

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -748,15 +748,8 @@ def _no_context_variadic(
 
 
 def _is_invalid_metaclass(metaclass: nodes.ClassDef) -> bool:
-    try:
-        mro = metaclass.mro()
-    except NotImplementedError:
-        # Cannot have a metaclass which is not a newstyle class.
-        return True
-    else:
-        if not any(is_builtin_object(cls) and cls.name == "type" for cls in mro):
-            return True
-    return False
+    mro = metaclass.mro()
+    return not any(is_builtin_object(cls) and cls.name == "type" for cls in mro)
 
 
 def _infer_from_metaclass_constructor(

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -950,9 +950,7 @@ def unimplemented_abstract_methods(
     A method can be considered abstract if the callback *is_abstract_cb*
     returns a ``True`` value. The check defaults to verifying that
     a method is decorated with abstract methods.
-    The function will work only for new-style classes. For old-style
-    classes, it will simply return an empty dictionary.
-    For the rest of them, it will return a dictionary of abstract method
+    It will return a dictionary of abstract method
     names and their inferred objects.
     """
     if is_abstract_cb is None:
@@ -960,9 +958,6 @@ def unimplemented_abstract_methods(
     visited: dict[str, nodes.FunctionDef] = {}
     try:
         mro = reversed(node.mro())
-    except NotImplementedError:
-        # Old style class, it will not have a mro.
-        return {}
     except astroid.ResolveError:
         # Probably inconsistent hierarchy, don't try to figure this out here.
         return {}


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Looking at the coverage report, I noticed these `except NotImplementedError` blocks weren't being hit. I think it's because they are holdovers from Python 2 days. Oldstyle classes aren't possible anymore, so I don't think it's possible to reach this code. So, delete it.