### PR TITLE
Fix ``missing-param-doc`` FP

### DIFF
--- a/doc/whatsnew/fragments/7827.false_positive
+++ b/doc/whatsnew/fragments/7827.false_positive
@@ -1,3 +1,3 @@
-Fix ``missing-param-doc`` false positive when function parameter has escaped underscore.
+Fix ``missing-param-doc`` false positive when function parameter has an escaped underscore.
 
 Closes #7827

--- a/doc/whatsnew/fragments/7827.false_positive
+++ b/doc/whatsnew/fragments/7827.false_positive
@@ -1,0 +1,3 @@
+Fix ``missing-param-doc`` false positive when function parameter has escaped underscore.
+
+Closes #7827

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -471,7 +471,7 @@ class GoogleDocstring(Docstring):
 
     re_param_line = re.compile(
         rf"""
-        \s*  ((?:\\?\*{{0,2}})?\w+)     # identifier potentially with asterisks
+        \s*  ((?:\\?\*{{0,2}})?[\w\\]+) # identifier potentially with asterisks or escaped `\`
         \s*  ( [(]
             {re_multiple_type}
             (?:,\s+optional)?
@@ -645,12 +645,16 @@ class GoogleDocstring(Docstring):
         entries.extend(self._parse_section(self.re_keyword_param_section))
         for entry in entries:
             # Remove escape characters necessary for asterisks and trailing underscores
-            entry = entry.replace("\\", "")
             match = self.re_param_line.match(entry)
             if not match:
                 continue
 
-            param_name, param_type, param_desc = match.groups()
+            param_name = match.group(1)
+            # Remove escape characters necessary for asterisks
+            param_name = param_name.replace("\\", "")
+
+            param_type = match.group(2)
+            param_desc = match.group(3)
 
             if param_type:
                 params_with_type.add(param_name)

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -644,7 +644,6 @@ class GoogleDocstring(Docstring):
         entries = self._parse_section(self.re_param_section)
         entries.extend(self._parse_section(self.re_keyword_param_section))
         for entry in entries:
-            # Remove escape characters necessary for asterisks and trailing underscores
             match = self.re_param_line.match(entry)
             if not match:
                 continue

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -644,7 +644,7 @@ class GoogleDocstring(Docstring):
         entries = self._parse_section(self.re_param_section)
         entries.extend(self._parse_section(self.re_keyword_param_section))
         for entry in entries:
-            match = self.re_param_line.match(entry)
+            match = self.re_param_line.match(entry.replace("\\", ""))
             if not match:
                 continue
 

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -644,16 +644,13 @@ class GoogleDocstring(Docstring):
         entries = self._parse_section(self.re_param_section)
         entries.extend(self._parse_section(self.re_keyword_param_section))
         for entry in entries:
-            match = self.re_param_line.match(entry.replace("\\", ""))
+            # Remove escape characters necessary for asterisks and trailing underscores
+            entry = entry.replace("\\", "")
+            match = self.re_param_line.match(entry)
             if not match:
                 continue
 
-            param_name = match.group(1)
-            # Remove escape characters necessary for asterisks
-            param_name = param_name.replace("\\", "")
-
-            param_type = match.group(2)
-            param_desc = match.group(3)
+            param_name, param_type, param_desc = match.groups()
 
             if param_type:
                 params_with_type.add(param_name)

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Google.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Google.py
@@ -433,3 +433,15 @@ def test_finds_multiple_complex_types_google(
         named_arg_nine,
         named_arg_ten,
     )
+
+def test_escape_underscore(something: int, raise_: bool = False) -> bool:
+    """Tests param with _ is handled correctly.
+
+    Args:
+        something: the something
+        raise\\_: the other
+
+    Returns:
+        something
+    """
+    return something and raise_

--- a/tests/functional/ext/docparams/parameter/missing_param_doc_required_Google.py
+++ b/tests/functional/ext/docparams/parameter/missing_param_doc_required_Google.py
@@ -435,7 +435,7 @@ def test_finds_multiple_complex_types_google(
     )
 
 def test_escape_underscore(something: int, raise_: bool = False) -> bool:
-    """Tests param with _ is handled correctly.
+    """Tests param with escaped _ is handled correctly.
 
     Args:
         something: the something


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

As mentioned in linked issue, if this is too a hacky solution, we can reject the PR and attempt to update the `re_param_line` regex.

Closes #7827
