### PR TITLE
Fix `bandit` high-severity warnings:

### DIFF
--- a/pylint/graph.py
+++ b/pylint/graph.py
@@ -13,7 +13,6 @@ import codecs
 import os
 import shutil
 import subprocess
-import sys
 import tempfile
 from collections.abc import Sequence
 from typing import Any
@@ -113,9 +112,8 @@ class DotBackend:
                     "executable not found. Install graphviz, or specify a `.gv` "
                     "outputfile to produce the DOT source code."
                 )
-            use_shell = sys.platform == "win32"
             if mapfile:
-                subprocess.call(
+                subprocess.run(
                     [
                         self.renderer,
                         "-Tcmapx",
@@ -127,12 +125,12 @@ class DotBackend:
                         "-o",
                         outputfile,
                     ],
-                    shell=use_shell,
+                    check=True
                 )
             else:
-                subprocess.call(
+                subprocess.run(
                     [self.renderer, "-T", target, dot_sourcepath, "-o", outputfile],
-                    shell=use_shell,
+                    check=True
                 )
             os.unlink(dot_sourcepath)
         return outputfile

--- a/pylint/pyreverse/dot_printer.py
+++ b/pylint/pyreverse/dot_printer.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import sys
 import tempfile
 from enum import Enum
 from pathlib import Path
@@ -164,10 +163,9 @@ class DotPrinter(Printer):
         with open(dot_sourcepath, "w", encoding="utf8") as outfile:
             outfile.writelines(self.lines)
         if target not in graphviz_extensions:
-            use_shell = sys.platform == "win32"
-            subprocess.call(
+            subprocess.run(
                 ["dot", "-T", target, dot_sourcepath, "-o", outputfile],
-                shell=use_shell,
+                check=True
             )
             os.unlink(dot_sourcepath)
 


### PR DESCRIPTION
Remove `shell=True` argument of `subprocess.call`.

Refactor: Use `subprocess.run` instead of `subprocess.call`.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
|    | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
Running `bandit` against the `pylint` repository yields 3 high-severity warnings.
This merge-request attempts to fix those.
In addition `subprocess.run` is used in favour of `subprocess.call`.

[Documentation](https://docs.python.org/3.11/library/subprocess.html#module-subprocess) regarding the `shell=True` argument for Windows:
_On Windows with shell=True, the COMSPEC environment variable specifies the default shell. The only time you need to specify shell=True on Windows is when the command you wish to execute is built into the shell (e.g. dir or copy). You do not need shell=True to run a batch file or console-based executable._

[Documentation](https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module) regarding using `subprocess.run`:
_The recommended approach to invoking subprocesses is to use the [run()](https://docs.python.org/3/library/subprocess.html#subprocess.run) function for all use cases it can handle. For more advanced use cases, the underlying [Popen](https://docs.python.org/3/library/subprocess.html#subprocess.Popen) interface can be used directly._

[subprocess.call is considered part of the older API.](https://docs.python.org/3/library/subprocess.html#older-high-level-api)

<details>
<summary>Output of the bandit command:</summary>
(venv310) Marks-MacBook-Air-2:programming markbyrne$ bandit -r -lll pylint/pylint

[main]	INFO	profile include tests: None
[main]	INFO	profile exclude tests: None
[main]	INFO	cli include tests: None
[main]	INFO	cli exclude tests: None
[main]	INFO	running on Python 3.10.4
182 [0.. 50.. 100.. 150.. ]
Run started:2022-12-08 13:55:02.702590

Test results:
>> Issue: [B602:subprocess_popen_with_shell_equals_true] subprocess call with shell=True identified, security issue.
   Severity: High   Confidence: High
   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
   Location: pylint/pylint/graph.py:130:16
   More Info: https://bandit.readthedocs.io/en/1.7.4/plugins/b602_subprocess_popen_with_shell_equals_true.html
129	                    ],
130	                    shell=use_shell,
131	                )
132	            else:
133	                subprocess.call(
134	                    [self.renderer, "-T", target, dot_sourcepath, "-o", outputfile],
135	                    shell=use_shell,
136	                )
137	            os.unlink(dot_sourcepath)
138	        return outputfile
139	
140	    def emit(self, line: str) -> None:
141	        """Adds <line> to final output."""
142	        self.lines.append(line)
143	

--------------------------------------------------
>> Issue: [B602:subprocess_popen_with_shell_equals_true] subprocess call with shell=True identified, security issue.
   Severity: High   Confidence: High
   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
   Location: pylint/pylint/graph.py:135:16
   More Info: https://bandit.readthedocs.io/en/1.7.4/plugins/b602_subprocess_popen_with_shell_equals_true.html
134	                    [self.renderer, "-T", target, dot_sourcepath, "-o", outputfile],
135	                    shell=use_shell,
136	                )
137	            os.unlink(dot_sourcepath)
138	        return outputfile

--------------------------------------------------
>> Issue: [B602:subprocess_popen_with_shell_equals_true] subprocess call with shell=True identified, security issue.
   Severity: High   Confidence: High
   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
   Location: pylint/pylint/pyreverse/dot_printer.py:170:12
   More Info: https://bandit.readthedocs.io/en/1.7.4/plugins/b602_subprocess_popen_with_shell_equals_true.html
169	                ["dot", "-T", target, dot_sourcepath, "-o", outputfile],
170	                shell=use_shell,
171	            )
172	            os.unlink(dot_sourcepath)
173	

--------------------------------------------------

Code scanned:
	Total lines of code: 37969
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 94
		Medium: 5
		High: 3
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 3
		High: 99
Files skipped (0):
</details>
