### PR TITLE
fix: bump dill to >= 0.3.6, prevents tests hanging with python3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = ">=3.7.2"
 dependencies    = [
-    "dill>=0.2",
+    "dill>=0.3.6",
     "platformdirs>=2.2.0",
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ classifiers = [
 ]
 requires-python = ">=3.7.2"
 dependencies    = [
-    "dill>=0.3.6",
+    "dill>=0.2;python_version<'3.11'",
+    "dill>=0.3.6;python_version>='3.11'",
     "platformdirs>=2.2.0",
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -2,7 +2,7 @@
 # in .pre-commit-config.yaml
 bandit==1.7.4
 black==22.10.0
-flake8==6.0.0
+flake8>=5.0.0
 flake8-bugbear==22.10.27
 flake8-typing-imports==1.14.0
 isort==5.10.1


### PR DESCRIPTION
Fixes #7916