### PR TITLE
Fix unreleased false positives with `used-before-assignment`

### DIFF
--- a/doc/whatsnew/fragments/7873.internal
+++ b/doc/whatsnew/fragments/7873.internal
@@ -1,4 +1,0 @@
-Fix unreleased false positives with ``used-before-assignment``
-relating to definitions under "always false" conditions.
-
-Closes #7873

--- a/doc/whatsnew/fragments/7873.internal
+++ b/doc/whatsnew/fragments/7873.internal
@@ -1,0 +1,4 @@
+Fix unreleased false positives with ``used-before-assignment``
+relating to definitions under "always false" conditions.
+
+Closes #7873

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -900,21 +900,16 @@ scope_type : {self._atomic.scope_type}
         if isinstance(node, nodes.Assign):
             for target in node.targets:
                 for elt in utils.get_all_elements(target):
+                    if isinstance(elt, nodes.Starred):
+                        elt = elt.value
                     if isinstance(elt, nodes.AssignName) and elt.name == name:
                         return True
         if isinstance(node, nodes.If):
-            # Check for assignments inside the test
-            if isinstance(node.test, nodes.NamedExpr) and node.test.target.name == name:
+            if any(
+                child_named_expr.target.name == name
+                for child_named_expr in node.nodes_of_class(nodes.NamedExpr)
+            ):
                 return True
-            if isinstance(node.test, nodes.Call):
-                for arg_or_kwarg in node.test.args + [
-                    kw.value for kw in node.test.keywords
-                ]:
-                    if (
-                        isinstance(arg_or_kwarg, nodes.NamedExpr)
-                        and arg_or_kwarg.target.name == name
-                    ):
-                        return True
         return False
 
     @staticmethod

--- a/tests/functional/u/undefined/undefined_variable_py38.py
+++ b/tests/functional/u/undefined/undefined_variable_py38.py
@@ -186,3 +186,7 @@ if (defined := False):
     NEVER_DEFINED = 1
 print(defined)
 print(NEVER_DEFINED)  # [used-before-assignment]
+
+if (still_defined := False) == 1:
+    NEVER_DEFINED_EITHER = 1
+print(still_defined)

--- a/tests/functional/u/used/used_before_assignment.py
+++ b/tests/functional/u/used/used_before_assignment.py
@@ -106,3 +106,13 @@ for num in [0, 1]:
     if VAR11:
         VAR12 = False
 print(VAR12)
+
+def turn_on2(**kwargs):
+    """https://github.com/PyCQA/pylint/issues/7873"""
+    if "brightness" in kwargs:
+        brightness = kwargs["brightness"]
+        var, *args = (1, "set_dimmer_state", brightness)
+    else:
+        var, *args = (1, "restore_dimmer_state")
+
+    print(var, *args)


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Fixes false positives relating to cases with `NamedExpr` and `Starred` not handled in https://github.com/PyCQA/pylint/pull/6677.

Thanks to @cdce8p for isolating and reporting.

Unreleased -- should _not_ need a backport.

Closes #7873