### PR TITLE
Prevent `used-before-assignment` in pattern matching with a guard

### DIFF
--- a/doc/whatsnew/fragments/5327.false_positive
+++ b/doc/whatsnew/fragments/5327.false_positive
@@ -1,0 +1,4 @@
+Fix false-positive for ``used-before-assignment`` in pattern matching
+with a guard.
+
+Closes #5327

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2139,6 +2139,7 @@ class VariablesChecker(BaseChecker):
                             nodes.AugAssign,
                             nodes.Expr,
                             nodes.Return,
+                            nodes.Match,
                         ),
                     )
                     and VariablesChecker._maybe_used_and_assigned_at_once(defstmt)
@@ -2239,6 +2240,8 @@ class VariablesChecker(BaseChecker):
         """Check if `defstmt` has the potential to use and assign a name in the
         same statement.
         """
+        if isinstance(defstmt, nodes.Match):
+            return any(case.guard for case in defstmt.cases)
         if isinstance(defstmt.value, nodes.BaseContainer) and defstmt.value.elts:
             # The assignment must happen as part of the first element
             # e.g. "assert (x:= True), x"

--- a/tests/functional/u/used/used_before_assignment_py310.py
+++ b/tests/functional/u/used/used_before_assignment_py310.py
@@ -1,0 +1,7 @@
+"""Tests for used-before-assignment with python 3.10's pattern matching"""
+
+match ("example", "one"):
+    case (x, y) if x == "example":
+        print("x used to cause used-before-assignment!")
+    case _:
+        print("good thing it doesn't now!")

--- a/tests/functional/u/used/used_before_assignment_py310.rc
+++ b/tests/functional/u/used/used_before_assignment_py310.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.10


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Closes #5327

Supersedes #7793