### PR TITLE
Fix inconsistent argument exit code when argparse exit with its own error code

### DIFF
--- a/doc/whatsnew/fragments/7931.bugfix
+++ b/doc/whatsnew/fragments/7931.bugfix
@@ -1,3 +1,3 @@
-Fix exit code when argparse raises SystemExit due to bad arguments.
+When pylint exit due to bad arguments being provided the exit code will now be the expected ``32``.
 
 Refs #7931

--- a/doc/whatsnew/fragments/7931.bugfix
+++ b/doc/whatsnew/fragments/7931.bugfix
@@ -1,0 +1,3 @@
+Fix exit code when argparse raises SystemExit due to bad arguments.
+
+Refs #7931

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -256,9 +256,12 @@ class _ArgumentsManager:
 
     def _parse_configuration_file(self, arguments: list[str]) -> None:
         """Parse the arguments found in a configuration file into the namespace."""
-        self.config, parsed_args = self._arg_parser.parse_known_args(
-            arguments, self.config
-        )
+        try:
+            self.config, parsed_args = self._arg_parser.parse_known_args(
+                arguments, self.config
+            )
+        except SystemExit:
+            sys.exit(32)
         unrecognized_options: list[str] = []
         for opt in parsed_args:
             if opt.startswith("--"):

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -87,7 +87,10 @@ def _config_initialization(
             unrecognized_options.append(opt[1:])
     if unrecognized_options:
         msg = ", ".join(unrecognized_options)
-        linter._arg_parser.error(f"Unrecognized option found: {msg}")
+        try:
+            linter._arg_parser.error(f"Unrecognized option found: {msg}")
+        except SystemExit:
+            sys.exit(32)
 
     # Now that config file and command line options have been loaded
     # with all disables, it is safe to emit messages

--- a/tests/lint/test_run_pylint.py
+++ b/tests/lint/test_run_pylint.py
@@ -1,0 +1,18 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+
+import pytest
+from _pytest.capture import CaptureFixture
+
+from pylint import run_pylint
+
+
+def test_run_pylint_with_invalid_argument(capsys: CaptureFixture[str]) -> None:
+    """Check that appropriate exit code is used with invalid argument."""
+    with pytest.raises(SystemExit) as ex:
+        run_pylint(["--never-use-this"])
+    captured = capsys.readouterr()
+    assert captured.err.startswith("usage: pylint [options]")
+    assert ex.value.code == 32

--- a/tests/lint/test_run_pylint.py
+++ b/tests/lint/test_run_pylint.py
@@ -2,6 +2,7 @@
 # For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
 
+from pathlib import Path
 
 import pytest
 from _pytest.capture import CaptureFixture
@@ -13,6 +14,23 @@ def test_run_pylint_with_invalid_argument(capsys: CaptureFixture[str]) -> None:
     """Check that appropriate exit code is used with invalid argument."""
     with pytest.raises(SystemExit) as ex:
         run_pylint(["--never-use-this"])
+    captured = capsys.readouterr()
+    assert captured.err.startswith("usage: pylint [options]")
+    assert ex.value.code == 32
+
+
+def test_run_pylint_with_invalid_argument_in_config(
+    capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    """Check that appropriate exit code is used with an ambiguous
+    argument in a config file.
+    """
+    test_file = tmp_path / "testpylintrc"
+    with open(test_file, "w", encoding="utf-8") as f:
+        f.write("[MASTER]\nno=")
+
+    with pytest.raises(SystemExit) as ex:
+        run_pylint(["--rcfile", f"{test_file}"])
     captured = capsys.readouterr()
     assert captured.err.startswith("usage: pylint [options]")
     assert ex.value.code == 32

--- a/tests/lint/unittest_expand_modules.py
+++ b/tests/lint/unittest_expand_modules.py
@@ -69,6 +69,14 @@ test_utils = {
     "path": str(TEST_DIRECTORY / "lint/test_utils.py"),
 }
 
+test_run_pylint = {
+    "basename": "lint",
+    "basepath": INIT_PATH,
+    "isarg": False,
+    "name": "lint.test_run_pylint",
+    "path": str(TEST_DIRECTORY / "lint/test_run_pylint.py"),
+}
+
 test_pylinter = {
     "basename": "lint",
     "basepath": INIT_PATH,
@@ -102,6 +110,7 @@ def _list_expected_package_modules(
         init_of_package,
         test_caching,
         test_pylinter,
+        test_run_pylint,
         test_utils,
         this_file_from_init_deduplicated if deduplicating else this_file_from_init,
         unittest_lint,


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

We were bitten by this causing us to think that pylint was completing successfully when in fact a typo in a configuration file was causing argparse to exit with exit code 2. This didn't happen in older versions of pylint for whatever reason. The [documentation for pylint](https://pylint.pycqa.org/en/latest/user_guide/usage/run.html#exit-codes) suggests that this means "error message issued" but that pylint executed properly when this is not the case.

It feels a bit clumsy to just add in `try..except`, but on the other hand it's perhaps unexpected that argparse will raise a `SystemExit`. I'm open to any suggestions to improve this.
