### PR TITLE
Fix ModuleNotFoundError when using pylint_django

### DIFF
--- a/doc/whatsnew/fragments/7938.bugfix
+++ b/doc/whatsnew/fragments/7938.bugfix
@@ -1,0 +1,3 @@
+Fixes a ``ModuleNotFound`` exception when running pylint on a Django project with the ``pylint_django`` plugin enabled.
+
+Closes #7938

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -697,8 +697,8 @@ class PyLinter(
                 data = None
 
         # The contextmanager also opens all checkers and sets up the PyLinter class
-        with self._astroid_module_checker() as check_astroid_module:
-            with fix_import_path(files_or_modules):
+        with fix_import_path(files_or_modules):
+            with self._astroid_module_checker() as check_astroid_module:
                 # 4) Get the AST for each FileItem
                 ast_per_fileitem = self._get_asts(fileitems, data)
 


### PR DESCRIPTION
|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Ensure that the import path is fixed up before calling `._astroid_module_checker()` so that the `pylint_django` plugin can successfully import the Django settings module when its checkers are initialized.

Closes #7938