### PR TITLE
[testutil] More information in output for functional test fail

### DIFF
--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -287,12 +287,7 @@ class LintModuleTest:
     ) -> str:
         missing = set(expected_lines) - set(received_lines)
         unexpected = set(received_lines) - set(expected_lines)
-        error_msg = (
-            f"Wrong output for '{self._test_file.base}.txt':\n"
-            "You can update the expected output automatically with: '"
-            f"python tests/test_functional.py {UPDATE_OPTION} -k "
-            f'"test_functional[{self._test_file.base}]"\'\n\n'
-        )
+        error_msg = f"Wrong output for '{self._test_file.base}.txt':"
         sort_by_line_number = operator.attrgetter("lineno")
         if missing:
             error_msg += "\n- Missing lines:\n"
@@ -302,6 +297,17 @@ class LintModuleTest:
             error_msg += "\n- Unexpected lines:\n"
             for line in sorted(unexpected, key=sort_by_line_number):
                 error_msg += f"{line}\n"
+            error_msg += (
+                "\nYou can update the expected output automatically with:\n'"
+                f"python tests/test_functional.py {UPDATE_OPTION} -k "
+                f'"test_functional[{self._test_file.base}]"\'\n\n'
+                "Here's the update text in case you can't:\n"
+            )
+            expected_csv = StringIO()
+            writer = csv.writer(expected_csv, dialect="test")
+            for line in sorted(received_lines, key=sort_by_line_number):
+                writer.writerow(line.to_csv())
+            error_msg += expected_csv.getvalue()
         return error_msg
 
     def _check_output_text(


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

In order to help when the target interpreter is not installed locally and you can't update automatically yourself (pypy/old interpreters like python 3.7).

Done for: Refs #7945

Old:
```
Wrong output for 'postponed_evaluation_pep585.txt':
You can update the expected output automatically with: 'python tests/test_functional.py --update-functional-output -k "test_functional[postponed_evaluation_pep585]"'


- Missing lines:
OutputLine(symbol='unsubscriptable-object', lineno=96, column=15, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=97, column=21, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=98, column=15, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=99, column=19, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=100, column=15, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=101, column=9, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=101, column=14, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=121, column=20, end_lineno=None, end_column=None, object='func3', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=123, column=33, end_lineno=None, end_column=None, object='func3', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=126, column=14, end_lineno=None, end_column=None, object='func4', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=129, column=32, end_lineno=None, end_column=None, object='func5', msg="Value 'set' is unsubscriptable", confidence='UNDEFINED')

- Unexpected lines:
OutputLine(symbol='unsubscriptable-object', lineno=104, column=15, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=105, column=21, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=106, column=15, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=107, column=19, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=108, column=15, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=109, column=9, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=109, column=14, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=129, column=20, end_lineno=None, end_column=None, object='func3', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=131, column=33, end_lineno=None, end_column=None, object='func3', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=134, column=14, end_lineno=None, end_column=None, object='func4', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=137, column=32, end_lineno=None, end_column=None, object='func5', msg="Value 'set' is unsubscriptable", confidence='UNDEFINED')
```

New:
```
Wrong output for 'postponed_evaluation_pep585.txt':
- Missing lines:
OutputLine(symbol='unsubscriptable-object', lineno=96, column=15, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=97, column=21, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=98, column=15, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=99, column=19, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=100, column=15, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=101, column=9, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=101, column=14, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=121, column=20, end_lineno=None, end_column=None, object='func3', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=123, column=33, end_lineno=None, end_column=None, object='func3', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=126, column=14, end_lineno=None, end_column=None, object='func4', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=129, column=32, end_lineno=None, end_column=None, object='func5', msg="Value 'set' is unsubscriptable", confidence='UNDEFINED')

- Unexpected lines:
OutputLine(symbol='unsubscriptable-object', lineno=104, column=15, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=105, column=21, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=106, column=15, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=107, column=19, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=108, column=15, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=109, column=9, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=109, column=14, end_lineno=None, end_column=None, object='', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=129, column=20, end_lineno=None, end_column=None, object='func3', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=131, column=33, end_lineno=None, end_column=None, object='func3', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=134, column=14, end_lineno=None, end_column=None, object='func4', msg="Value 'list' is unsubscriptable", confidence='UNDEFINED')
OutputLine(symbol='unsubscriptable-object', lineno=137, column=32, end_lineno=None, end_column=None, object='func5', msg="Value 'set' is unsubscriptable", confidence='UNDEFINED')

You can update the expected output automatically with:
'python tests/test_functional.py --update-functional-output -k "test_functional[postponed_evaluation_pep585]"'

Here's the update text in case you can't:
unsubscriptable-object:23:15:None:None::Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:28:25:None:None:CustomIntListError:Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:32:28:None:None::Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:34:24:None:None::Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:36:14:None:None::Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:41:36:None:None::Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:51:54:None:None::Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:53:60:None:None::Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:104:15:None:None::Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:105:21:None:None::Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:106:15:None:None::Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:107:19:None:None::Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:108:15:None:None::Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:109:9:None:None::Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:109:14:None:None::Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:129:20:None:None:func3:Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:131:33:None:None:func3:Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:134:14:None:None:func4:Value 'list' is unsubscriptable:UNDEFINED
unsubscriptable-object:137:32:None:None:func5:Value 'set' is unsubscriptable:UNDEFINED
```
