### PR TITLE
Fix `used-before-assignment` if conditional imports guarded again when used

### DIFF
--- a/doc/whatsnew/fragments/7979.false_positive
+++ b/doc/whatsnew/fragments/7979.false_positive
@@ -1,0 +1,4 @@
+Prevent ``used-before-assignment`` when imports guarded by ``if TYPE_CHECKING``
+are guarded again when used.
+
+Closes #7979

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2193,6 +2193,7 @@ class VariablesChecker(BaseChecker):
                 isinstance(defstmt, (nodes.Import, nodes.ImportFrom))
                 and isinstance(defstmt.parent, nodes.If)
                 and in_type_checking_block(defstmt)
+                and not in_type_checking_block(node)
             ):
                 defstmt_parent = defstmt.parent
 

--- a/tests/functional/u/used/used_before_assignment_typing.py
+++ b/tests/functional/u/used/used_before_assignment_typing.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     if True:  # pylint: disable=using-constant-test
         import math
     import datetime
+    from urllib.request import urlopen
 
 class MyClass:
     """Type annotation or default values for first level methods can't refer to their own class"""
@@ -101,3 +102,9 @@ class VariableAnnotationsGuardedByTypeChecking:  # pylint: disable=too-few-publi
     def print_date(self, date) -> None:
         date: datetime.date = date
         print(date)
+
+
+class ConditionalImportGuardedWhenUsed:  # pylint: disable=too-few-public-methods
+    """Conditional imports also guarded by TYPE_CHECKING when used."""
+    if TYPE_CHECKING:
+        print(urlopen)

--- a/tests/functional/u/used/used_before_assignment_typing.txt
+++ b/tests/functional/u/used/used_before_assignment_typing.txt
@@ -1,5 +1,5 @@
-undefined-variable:16:21:16:28:MyClass.incorrect_typing_method:Undefined variable 'MyClass':UNDEFINED
-undefined-variable:21:26:21:33:MyClass.incorrect_nested_typing_method:Undefined variable 'MyClass':UNDEFINED
-undefined-variable:26:20:26:27:MyClass.incorrect_default_method:Undefined variable 'MyClass':UNDEFINED
-used-before-assignment:87:35:87:39:MyFourthClass.is_close:Using variable 'math' before assignment:HIGH
-used-before-assignment:99:20:99:28:VariableAnnotationsGuardedByTypeChecking:Using variable 'datetime' before assignment:HIGH
+undefined-variable:17:21:17:28:MyClass.incorrect_typing_method:Undefined variable 'MyClass':UNDEFINED
+undefined-variable:22:26:22:33:MyClass.incorrect_nested_typing_method:Undefined variable 'MyClass':UNDEFINED
+undefined-variable:27:20:27:27:MyClass.incorrect_default_method:Undefined variable 'MyClass':UNDEFINED
+used-before-assignment:88:35:88:39:MyFourthClass.is_close:Using variable 'math' before assignment:HIGH
+used-before-assignment:100:20:100:28:VariableAnnotationsGuardedByTypeChecking:Using variable 'datetime' before assignment:HIGH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #7979 

See regression test; fixes false positive in `music21`.