### PR TITLE
class attrs should not emit assigning-non-slot msg

### DIFF
--- a/doc/whatsnew/fragments/6001.false_positive
+++ b/doc/whatsnew/fragments/6001.false_positive
@@ -1,0 +1,3 @@
+Fix false positive ``assigning-non-slot`` when a class attribute is re-assigned.
+
+Closes #6001

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1629,7 +1629,9 @@ a metaclass class method.",
                     # Properties circumvent the slots mechanism,
                     # so we should not emit a warning for them.
                     return
-                if self._is_class_attribute(node.attrname, klass):
+                if node.attrname != "__class__" and utils.is_class_attr(
+                    node.attrname, klass
+                ):
                     return
                 if node.attrname in klass.locals:
                     for local_name in klass.locals.get(node.attrname):
@@ -1786,7 +1788,7 @@ a metaclass class method.",
                 if (
                     self._is_classmethod(node.frame(future=True))
                     and self._is_inferred_instance(node.expr, klass)
-                    and self._is_class_attribute(attrname, klass)
+                    and self._is_class_or_instance_attribute(attrname, klass)
                 ):
                     return
 
@@ -1833,7 +1835,7 @@ a metaclass class method.",
         return inferred._proxied is klass
 
     @staticmethod
-    def _is_class_attribute(name: str, klass: nodes.ClassDef) -> bool:
+    def _is_class_or_instance_attribute(name: str, klass: nodes.ClassDef) -> bool:
         """Check if the given attribute *name* is a class or instance member of the
         given *klass*.
 
@@ -1841,11 +1843,8 @@ a metaclass class method.",
         ``False`` otherwise.
         """
 
-        try:
-            klass.getattr(name)
+        if utils.is_class_attr(name, klass):
             return True
-        except astroid.NotFoundError:
-            pass
 
         try:
             klass.instance_attr(name)

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1646,7 +1646,12 @@ a metaclass class method.",
                     slots, node.parent.value
                 ):
                     return
-                self.add_message("assigning-non-slot", args=(node.attrname,), node=node)
+                self.add_message(
+                    "assigning-non-slot",
+                    args=(node.attrname,),
+                    node=node,
+                    confidence=INFERENCE,
+                )
 
     @only_required_for_messages(
         "protected-access", "no-classmethod-decorator", "no-staticmethod-decorator"

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1621,6 +1621,7 @@ a metaclass class method.",
             for ancestor in klass.ancestors()
         ):
             return
+
         if not any(slot.value == node.attrname for slot in slots):
             # If we have a '__dict__' in slots, then
             # assigning any name is valid.

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1621,7 +1621,6 @@ a metaclass class method.",
             for ancestor in klass.ancestors()
         ):
             return
-
         if not any(slot.value == node.attrname for slot in slots):
             # If we have a '__dict__' in slots, then
             # assigning any name is valid.
@@ -1629,6 +1628,8 @@ a metaclass class method.",
                 if _is_attribute_property(node.attrname, klass):
                     # Properties circumvent the slots mechanism,
                     # so we should not emit a warning for them.
+                    return
+                if self._is_class_attribute(node.attrname, klass):
                     return
                 if node.attrname in klass.locals:
                     for local_name in klass.locals.get(node.attrname):

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2190,3 +2190,11 @@ def is_terminating_func(node: nodes.Call) -> bool:
         pass
 
     return False
+
+
+def is_class_attr(name: str, klass: nodes.ClassDef) -> bool:
+    try:
+        klass.getattr(name)
+        return True
+    except astroid.NotFoundError:
+        return False

--- a/tests/functional/a/assigning/assigning_non_slot.py
+++ b/tests/functional/a/assigning/assigning_non_slot.py
@@ -147,7 +147,7 @@ class ClassReassingingInvalidLayoutClass:
     __slots__ = []
 
     def release(self):
-        self.__class__ = ClassWithSlots
+        self.__class__ = ClassWithSlots  # [assigning-non-slot]
 
 
 # pylint: disable=attribute-defined-outside-init

--- a/tests/functional/a/assigning/assigning_non_slot.py
+++ b/tests/functional/a/assigning/assigning_non_slot.py
@@ -2,6 +2,8 @@
 will trigger assigning-non-slot warning.
 """
 # pylint: disable=too-few-public-methods, missing-docstring, import-error, redundant-u-string-prefix, unnecessary-dunder-call
+# pylint: disable=attribute-defined-outside-init
+
 from collections import deque
 
 from missing import Unknown
@@ -148,6 +150,7 @@ class ClassReassingingInvalidLayoutClass:
 
     def release(self):
         self.__class__ = ClassWithSlots  # [assigning-non-slot]
+        self.test = 'test'  # [assigning-non-slot]
 
 
 # pylint: disable=attribute-defined-outside-init

--- a/tests/functional/a/assigning/assigning_non_slot.py
+++ b/tests/functional/a/assigning/assigning_non_slot.py
@@ -206,9 +206,33 @@ class ColorCls:
     COLOR = "red"
 
 
-class Repro(ColorCls):
+class Child(ColorCls):
+    __slots__ = ()
+
+
+repro = Child()
+Child.COLOR = "blue"
+
+class MyDescriptor:
+    """Basic descriptor."""
+
+    def __get__(self, instance, owner):
+        return 42
+
+    def __set__(self, instance, value):
+        pass
+
+
+# Regression test from https://github.com/PyCQA/pylint/issues/6001
+class Base:
+    __slots__ = ()
+
+    attr2 = MyDescriptor()
+
+
+class Repro(Base):
     __slots__ = ()
 
 
 repro = Repro()
-Repro.COLOR = "blue"
+repro.attr2 = "anything"

--- a/tests/functional/a/assigning/assigning_non_slot.py
+++ b/tests/functional/a/assigning/assigning_non_slot.py
@@ -129,7 +129,7 @@ def dont_emit_for_descriptors():
     # This should not emit, because attr is
     # a data descriptor
     inst.data_descriptor = 'foo'
-    inst.non_data_descriptor = 'lala' # [assigning-non-slot]
+    inst.non_data_descriptor = 'lala'
 
 
 class ClassWithSlots:
@@ -147,7 +147,7 @@ class ClassReassingingInvalidLayoutClass:
     __slots__ = []
 
     def release(self):
-        self.__class__ = ClassWithSlots # [assigning-non-slot]
+        self.__class__ = ClassWithSlots
 
 
 # pylint: disable=attribute-defined-outside-init
@@ -200,3 +200,15 @@ def dont_emit_for_defined_setattr():
 
     child = ClassWithParentDefiningSetattr()
     child.non_existent = "non-existent"
+
+class ColorCls:
+    __slots__ = ()
+    COLOR = "red"
+
+
+class Repro(ColorCls):
+    __slots__ = ()
+
+
+repro = Repro()
+Repro.COLOR = "blue"

--- a/tests/functional/a/assigning/assigning_non_slot.txt
+++ b/tests/functional/a/assigning/assigning_non_slot.txt
@@ -1,5 +1,3 @@
 assigning-non-slot:18:8:18:20:Bad.__init__:Assigning to attribute 'missing' not defined in class slots:UNDEFINED
 assigning-non-slot:26:8:26:20:Bad2.__init__:Assigning to attribute 'missing' not defined in class slots:UNDEFINED
 assigning-non-slot:36:8:36:20:Bad3.__init__:Assigning to attribute 'missing' not defined in class slots:UNDEFINED
-assigning-non-slot:132:4:132:28:dont_emit_for_descriptors:Assigning to attribute 'non_data_descriptor' not defined in class slots:UNDEFINED
-assigning-non-slot:150:8:150:22:ClassReassingingInvalidLayoutClass.release:Assigning to attribute '__class__' not defined in class slots:UNDEFINED

--- a/tests/functional/a/assigning/assigning_non_slot.txt
+++ b/tests/functional/a/assigning/assigning_non_slot.txt
@@ -1,4 +1,5 @@
-assigning-non-slot:18:8:18:20:Bad.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
-assigning-non-slot:26:8:26:20:Bad2.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
-assigning-non-slot:36:8:36:20:Bad3.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
-assigning-non-slot:150:8:150:22:ClassReassingingInvalidLayoutClass.release:Assigning to attribute '__class__' not defined in class slots:INFERENCE
+assigning-non-slot:20:8:20:20:Bad.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
+assigning-non-slot:28:8:28:20:Bad2.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
+assigning-non-slot:38:8:38:20:Bad3.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
+assigning-non-slot:152:8:152:22:ClassReassingingInvalidLayoutClass.release:Assigning to attribute '__class__' not defined in class slots:INFERENCE
+assigning-non-slot:153:8:153:17:ClassReassingingInvalidLayoutClass.release:Assigning to attribute 'test' not defined in class slots:INFERENCE

--- a/tests/functional/a/assigning/assigning_non_slot.txt
+++ b/tests/functional/a/assigning/assigning_non_slot.txt
@@ -1,3 +1,4 @@
 assigning-non-slot:18:8:18:20:Bad.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
 assigning-non-slot:26:8:26:20:Bad2.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
 assigning-non-slot:36:8:36:20:Bad3.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
+assigning-non-slot:150:8:150:22:ClassReassingingInvalidLayoutClass.release:Assigning to attribute '__class__' not defined in class slots:INFERENCE

--- a/tests/functional/a/assigning/assigning_non_slot.txt
+++ b/tests/functional/a/assigning/assigning_non_slot.txt
@@ -1,3 +1,3 @@
-assigning-non-slot:18:8:18:20:Bad.__init__:Assigning to attribute 'missing' not defined in class slots:UNDEFINED
-assigning-non-slot:26:8:26:20:Bad2.__init__:Assigning to attribute 'missing' not defined in class slots:UNDEFINED
-assigning-non-slot:36:8:36:20:Bad3.__init__:Assigning to attribute 'missing' not defined in class slots:UNDEFINED
+assigning-non-slot:18:8:18:20:Bad.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
+assigning-non-slot:26:8:26:20:Bad2.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
+assigning-non-slot:36:8:36:20:Bad3.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE

--- a/tests/functional/a/assigning/assigning_non_slot_4509.txt
+++ b/tests/functional/a/assigning/assigning_non_slot_4509.txt
@@ -1,1 +1,1 @@
-assigning-non-slot:18:8:18:17:Foo.__init__:Assigning to attribute '_bar' not defined in class slots:UNDEFINED
+assigning-non-slot:18:8:18:17:Foo.__init__:Assigning to attribute '_bar' not defined in class slots:INFERENCE


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Pylint was raising  ``assigning-non-slot`` when a class attribute was re-assigned, which I believe is incorrect given that `__slots__` is meant for instance attrs.

Closes #6001
