### PR TITLE
Cover missing line in dict-init-mutate test

### DIFF
--- a/tests/functional/ext/dict_init_mutate.py
+++ b/tests/functional/ext/dict_init_mutate.py
@@ -36,3 +36,6 @@ def update_dict(di):
     di["one"] = 1
 
 update_dict(config)
+
+config = {}
+globals()["config"]["dir"] = "bin"


### PR DESCRIPTION
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This covers a missing line from the dict-init-mutate extension test.