### PR TITLE
Add rational for ``consider-using-sys-exit``

### DIFF
--- a/doc/user_guide/checkers/extensions.rst
+++ b/doc/user_guide/checkers/extensions.rst
@@ -714,3 +714,4 @@ While Used checker Messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 :while-used (W0149): *Used `while` loop*
   Unbounded `while` loops can often be rewritten as bounded `for` loops.
+  Exceptions can be made for cases such as event loops, listeners, etc.

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -764,6 +764,9 @@ Refactoring checker Messages
 :consider-using-min-builtin (R1730): *Consider using '%s' instead of unnecessary if block*
   Using the min builtin instead of a conditional improves readability and
   conciseness.
+:consider-using-sys-exit (R1722): *Consider using 'sys.exit' instead*
+  Contrary to 'exit()' or 'quit()', 'sys.exit' does not rely on the site module
+  being available (as the 'sys' module is always available).
 :consider-using-with (R1732): *Consider using 'with' for resource-allocating operations*
   Emitted if a resource-allocating assignment or call may be replaced by a
   'with' block. By using 'with' the release of the allocated resources is
@@ -793,8 +796,6 @@ Refactoring checker Messages
 :consider-using-join (R1713): *Consider using str.join(sequence) for concatenating strings from an iterable*
   Using str.join(sequence) is faster, uses less memory and increases
   readability compared to for-loop iteration.
-:consider-using-sys-exit (R1722): *Consider using sys.exit()*
-  Instead of using exit() or quit(), consider using the sys.exit().
 :consider-using-ternary (R1706): *Consider using ternary (%s)*
   Used when one of known pre-python 2.5 ternary syntax is used.
 :consider-swap-variables (R1712): *Consider using tuple unpacking for swapping variables*

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -405,9 +405,10 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             "It is faster and simpler.",
         ),
         "R1722": (
-            "Consider using sys.exit()",
+            "Consider using 'sys.exit' instead",
             "consider-using-sys-exit",
-            "Instead of using exit() or quit(), consider using the sys.exit().",
+            "Contrary to 'exit()' or 'quit()', 'sys.exit' does not rely on the "
+            "site module being available (as the 'sys' module is always available).",
         ),
         "R1723": (
             'Unnecessary "%s" after "break", %s',
@@ -1121,7 +1122,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                 node.root()
             ):
                 return
-            self.add_message("consider-using-sys-exit", node=node)
+            self.add_message("consider-using-sys-exit", node=node, confidence=HIGH)
 
     def _check_super_with_arguments(self, node: nodes.Call) -> None:
         if not isinstance(node.func, nodes.Name) or node.func.name != "super":

--- a/tests/functional/c/consider/consider_using_sys_exit.txt
+++ b/tests/functional/c/consider/consider_using_sys_exit.txt
@@ -1,3 +1,3 @@
-consider-using-sys-exit:5:4:5:10:foo:Consider using sys.exit():UNDEFINED
-consider-using-sys-exit:8:4:8:10:foo_1:Consider using sys.exit():UNDEFINED
-consider-using-sys-exit:14:0:14:6::Consider using sys.exit():UNDEFINED
+consider-using-sys-exit:5:4:5:10:foo:Consider using 'sys.exit' instead:HIGH
+consider-using-sys-exit:8:4:8:10:foo_1:Consider using 'sys.exit' instead:HIGH
+consider-using-sys-exit:14:0:14:6::Consider using 'sys.exit' instead:HIGH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

I wanted to copy paste the rational from the doc, but the rational was lacking. Also added confidence in the process and fixed the generated doc.