### PR TITLE
Fix `used-before-assignment` false positive

### DIFF
--- a/doc/whatsnew/fragments/7779.false_positive
+++ b/doc/whatsnew/fragments/7779.false_positive
@@ -1,0 +1,4 @@
+Fixes ``used-before-assignment`` false positive when the walrus operator 
+is used in a ternary operator.
+
+Closes #7779

--- a/doc/whatsnew/fragments/7779.false_positive
+++ b/doc/whatsnew/fragments/7779.false_positive
@@ -1,4 +1,4 @@
-Fixes ``used-before-assignment`` false positive when the walrus operator 
+Fixes ``used-before-assignment`` false positive when the walrus operator
 is used in a ternary operator.
 
 Closes #7779

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2198,10 +2198,3 @@ def is_class_attr(name: str, klass: nodes.ClassDef) -> bool:
         return True
     except astroid.NotFoundError:
         return False
-
-def get_all_calls(node: nodes.NodeNG) -> list[nodes.Call]:
-    """Depth first search to get all call nodes under a node"""
-    calls = [node] if isinstance(node, nodes.Call) else []
-    for child in node.get_children():
-        calls.extend(get_all_calls(child))
-    return calls

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2198,3 +2198,10 @@ def is_class_attr(name: str, klass: nodes.ClassDef) -> bool:
         return True
     except astroid.NotFoundError:
         return False
+
+def get_all_calls(node: nodes.NodeNG) -> list[nodes.Call]:
+    """Depth first search to get all call nodes under a node"""
+    calls = [node] if isinstance(node, nodes.Call) else []
+    for child in node.get_children():
+        calls.extend(get_all_calls(child))
+    return calls

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2246,14 +2246,17 @@ class VariablesChecker(BaseChecker):
             return True
         if isinstance(value, nodes.Lambda) and isinstance(value.body, nodes.IfExp):
             return True
-        if isinstance(value, nodes.Call):
-            for call in value.nodes_of_class(klass=nodes.Call):
-                if (any(isinstance(kwarg.value, nodes.IfExp) for kwarg in call.keywords)
-                    or any(isinstance(arg, nodes.IfExp) for arg in call.args)
-                    or (isinstance(call.func, nodes.Attribute) and isinstance(call.func.expr, nodes.IfExp))
-                ):
-                    return True
-        return False
+        if not isinstance(value, nodes.Call):
+            return False
+        return any(
+            any(isinstance(kwarg.value, nodes.IfExp) for kwarg in call.keywords)
+            or any(isinstance(arg, nodes.IfExp) for arg in call.args)
+            or (
+                isinstance(call.func, nodes.Attribute)
+                and isinstance(call.func.expr, nodes.IfExp)
+            )
+            for call in value.nodes_of_class(klass=nodes.Call)
+        )
 
     def _is_only_type_assignment(
         self, node: nodes.Name, defstmt: nodes.Statement

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2247,7 +2247,7 @@ class VariablesChecker(BaseChecker):
         if isinstance(value, nodes.Lambda) and isinstance(value.body, nodes.IfExp):
             return True
         if isinstance(value, nodes.Call):
-            for call in utils.get_all_calls(value):
+            for call in value.nodes_of_class(klass=nodes.Call):
                 if (any(isinstance(kwarg.value, nodes.IfExp) for kwarg in call.keywords)
                     or any(isinstance(arg, nodes.IfExp) for arg in call.args)
                     or (isinstance(call.func, nodes.Attribute) and isinstance(call.func.expr, nodes.IfExp))

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2246,10 +2246,14 @@ class VariablesChecker(BaseChecker):
             return True
         if isinstance(value, nodes.Lambda) and isinstance(value.body, nodes.IfExp):
             return True
-        return isinstance(value, nodes.Call) and (
-            any(isinstance(kwarg.value, nodes.IfExp) for kwarg in value.keywords)
-            or any(isinstance(arg, nodes.IfExp) for arg in value.args)
-        )
+        if isinstance(value, nodes.Call):
+            for call in utils.get_all_calls(value):
+                if (any(isinstance(kwarg.value, nodes.IfExp) for kwarg in call.keywords)
+                    or any(isinstance(arg, nodes.IfExp) for arg in call.args)
+                    or (isinstance(call.func, nodes.Attribute) and isinstance(call.func.expr, nodes.IfExp))
+                ):
+                    return True
+        return False
 
     def _is_only_type_assignment(
         self, node: nodes.Name, defstmt: nodes.Statement

--- a/tests/functional/u/used/used_before_assignment_ternary.py
+++ b/tests/functional/u/used/used_before_assignment_ternary.py
@@ -1,0 +1,41 @@
+"""Tests for used-before-assignment false positive from ternary expression with walrus operator"""
+# pylint: disable=unnecessary-lambda-assignment, unused-variable, disallowed-name, invalid-name
+
+def invalid():
+    """invalid cases that will trigger used-before-assignment"""
+    var = foo(a, '', '')  # [used-before-assignment]
+    print(str(1 if (a:=-1) else 0))
+    var = bar(b)  # [used-before-assignment]
+    var = c*c  # [used-before-assignment]
+    var = 1 if (b:=-1) else 0
+    var = 1 if (c:=-1) else 0
+
+def attribute_call_valid():
+    """assignment with attribute calls"""
+    var = (a if (a:='a') else '').lower()
+    var = ('' if (b:='b') else b).lower()
+    var = (c if (c:='c') else c).upper().lower().replace('', '').strip()
+    var = ''.strip().replace('', '' + (e if (e:='e') else '').lower())
+
+def function_call_arg_valid():
+    """assignment as function call arguments"""
+    var = str(a if (a:='a') else '')
+    var = str('' if (b:='b') else b)
+    var = foo(1, c if (c:=1) else 0, 1)
+    print(foo('', '', foo('', str(int(d if (d:='1') else '')), '')))
+
+def function_call_keyword_valid():
+    """assignment as function call keywords"""
+    var = foo(x=a if (a:='1') else '', y='', z='')
+    var = foo(x='', y=foo(x='', y='', z=b if (b:='1') else ''), z='')
+
+def complex_valid():
+    """assignment within complex call expression"""
+    var = str(bar(bar(a if (a:=1) else 0))).lower().upper()
+    print(foo(x=foo(''.replace('', str(b if (b:=1) else 0).upper()), '', z=''), y='', z=''))
+
+def foo(x, y, z):
+    """helper function for tests"""
+    return x+y+z
+
+bar = lambda x : x

--- a/tests/functional/u/used/used_before_assignment_ternary.rc
+++ b/tests/functional/u/used/used_before_assignment_ternary.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.8

--- a/tests/functional/u/used/used_before_assignment_ternary.txt
+++ b/tests/functional/u/used/used_before_assignment_ternary.txt
@@ -1,0 +1,3 @@
+used-before-assignment:6:14:6:15:invalid:Using variable 'a' before assignment:HIGH
+used-before-assignment:8:14:8:15:invalid:Using variable 'b' before assignment:HIGH
+used-before-assignment:9:10:9:11:invalid:Using variable 'c' before assignment:HIGH


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

After investigation, there seems to be two main cases that trigger used-before-assignment false positives:

1. Ternary expression with walrus operator within attribute calls. Eg. `(foo if (foo:='foo') else 'bar').upper()`
2. Ternary expression with walrus operator nested in function calls. Eg. `str(str(foo if (foo:='foo') else 'bar'))`

This fix enforces a stricter check on whether a name may be assigned and used in the same statement.
<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #7779 
