### PR TITLE
Prevent `pyreverse` crash when processing attributes assigned via tuple unpacking

### DIFF
--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -365,7 +365,7 @@ class AbstractAssociationHandler(AssociationHandlerInterface):
 
 class AggregationsHandler(AbstractAssociationHandler):
     def handle(self, node: nodes.AssignAttr, parent: nodes.ClassDef) -> None:
-        if isinstance(node.parent.value, astroid.node_classes.Name):
+        if isinstance(node.parent, (nodes.AnnAssign, nodes.Assign)) and isinstance(node.parent.value, astroid.node_classes.Name):
             current = set(parent.aggregations_type[node.attrname])
             parent.aggregations_type[node.attrname] = list(
                 current | utils.infer_node(node)

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -365,7 +365,9 @@ class AbstractAssociationHandler(AssociationHandlerInterface):
 
 class AggregationsHandler(AbstractAssociationHandler):
     def handle(self, node: nodes.AssignAttr, parent: nodes.ClassDef) -> None:
-        if isinstance(node.parent, (nodes.AnnAssign, nodes.Assign)) and isinstance(node.parent.value, astroid.node_classes.Name):
+        if isinstance(node.parent, (nodes.AnnAssign, nodes.Assign)) and isinstance(
+            node.parent.value, astroid.node_classes.Name
+        ):
             current = set(parent.aggregations_type[node.attrname])
             parent.aggregations_type[node.attrname] = list(
                 current | utils.infer_node(node)

--- a/tests/pyreverse/functional/class_diagrams/regression/regression_8031.mmd
+++ b/tests/pyreverse/functional/class_diagrams/regression/regression_8031.mmd
@@ -1,0 +1,5 @@
+classDiagram
+  class MyClass {
+    a
+    b
+  }

--- a/tests/pyreverse/functional/class_diagrams/regression/regression_8031.py
+++ b/tests/pyreverse/functional/class_diagrams/regression/regression_8031.py
@@ -1,0 +1,4 @@
+class MyClass:
+
+    def __init__(self, a, b):
+        self.a, self.b = a, b


### PR DESCRIPTION

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
If multiple attributes are assigned using tuple unpacking, `pyreverse` crashed with an `AttributeError`.
This only occurs on the current main branch (2.16.0-dev).

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #8031
