### PR TITLE
Fixes false positive for `try-except-raise` with multiple exceptions in one except statement

### DIFF
--- a/doc/whatsnew/fragments/8051.false_positive
+++ b/doc/whatsnew/fragments/8051.false_positive
@@ -1,0 +1,4 @@
+Fixes false positive for ``try-except-raise`` with multiple exceptions in one
+except statement if exception are in different namespace.
+
+Closes #8051

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -488,7 +488,7 @@ class ExceptionsChecker(checkers.BaseChecker):
                         {
                             exception
                             for exception in exceptions_in_handler.elts
-                            if isinstance(exception, nodes.Name)
+                            if isinstance(exception, (nodes.Name, nodes.Attribute))
                         }
                     )
                 elif exceptions_in_handler:

--- a/tests/functional/t/try_except_raise.py
+++ b/tests/functional/t/try_except_raise.py
@@ -1,5 +1,5 @@
 # pylint:disable=missing-docstring, unreachable, bad-except-order, bare-except, unnecessary-pass
-# pylint: disable=undefined-variable, broad-except, raise-missing-from
+# pylint: disable=undefined-variable, broad-except, raise-missing-from, too-few-public-methods
 try:
     int("9a")
 except:  # [try-except-raise]
@@ -79,6 +79,18 @@ try:
 except (FileNotFoundError, PermissionError):
     raise
 except OSError:
+    print("a failure")
+
+class NameSpace:
+    error1 = FileNotFoundError
+    error2 = PermissionError
+    parent_error=OSError
+
+try:
+    pass
+except (NameSpace.error1, NameSpace.error2):
+    raise
+except NameSpace.parent_error:
     print("a failure")
 
 # also consider tuples for subsequent exception handler instead of just bare except handler

--- a/tests/functional/t/try_except_raise.txt
+++ b/tests/functional/t/try_except_raise.txt
@@ -3,4 +3,4 @@ try-except-raise:16:0:18:29::The except handler raises immediately:UNDEFINED
 try-except-raise:53:4:54:13:ddd:The except handler raises immediately:UNDEFINED
 try-except-raise:67:0:68:9::The except handler raises immediately:UNDEFINED
 try-except-raise:72:0:73:9::The except handler raises immediately:UNDEFINED
-try-except-raise:94:0:95:9::The except handler raises immediately:UNDEFINED
+try-except-raise:106:0:107:9::The except handler raises immediately:UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fixes false positive for `try-except-raise` with multiple exceptions in one except statement if exceptions are in different namespace.

Closes #8051
