### PR TITLE
Regression tests for false positive ``no-member`` in decorated manager

### DIFF
--- a/tests/functional/r/regression_02/regression_2567.py
+++ b/tests/functional/r/regression_02/regression_2567.py
@@ -1,0 +1,33 @@
+"""
+Regression test for `no-member`.
+See: https://github.com/PyCQA/pylint/issues/2567
+"""
+
+# pylint: disable=missing-docstring,too-few-public-methods
+
+import contextlib
+
+
+@contextlib.contextmanager
+def context_manager():
+    try:
+        yield
+    finally:
+        pass
+
+
+cm = context_manager()
+cm.__enter__()
+cm.__exit__(None, None, None)
+
+
+@contextlib.contextmanager
+def other_context_manager():
+    try:
+        yield
+    finally:
+        pass
+
+
+with other_context_manager():  # notice the function call
+    pass


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

This is fixed in astroid 2.13.2, it failed with astroid 2.12.14.

Closes #2567, depends on #8030 
