### PR TITLE
[contributors.txt] Fix aliases and name that were actually emails

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -230,11 +230,9 @@ contributors:
 - Aurelien Campeas <aurelien.campeas@logilab.fr>
 - Alexander Pervakov <frost.nzcr4@jagmort.com>
 - Alain Leufroy <alain.leufroy@logilab.fr>
-- Adam Williamson <<awilliam@redhat.com>>
+- Adam Williamson <awilliam@redhat.com>
 - xmo-odoo <xmo-odoo@users.noreply.github.com>
-- root@clnstor.am.local <root@clnstor.am.local>
 - omarandlorraine <64254276+omarandlorraine@users.noreply.github.com>
-- grizzly.nyo@gmail.com <grizzly.nyo@gmail.com>
 - craig-sh <craig-sh@users.noreply.github.com>
 - bernie gray <bfgray3@users.noreply.github.com>
 - Wes Turner <westurner@google.com> (Google): added new check 'inconsistent-quotes'
@@ -276,6 +274,7 @@ contributors:
 - Hugues Bruant <hugues.bruant@affirm.com>
 - Harut <yes@harutune.name>
 - Grygorii Iermolenko <gyermolenko@gmail.com>
+- Grizzly Nyo <grizzly.nyo@gmail.com>
 - Gabriel R. Sezefredo <g@briel.dev>: Fixed "exception-escape" false positive with generators
 - Filipe Brandenburger <filbranden@google.com>
 - Fantix King <fantix@uchicago.edu> (UChicago)
@@ -308,13 +307,11 @@ contributors:
 - tbennett0 <tbennett0@users.noreply.github.com>
 - syutbai <syutbai@gmail.com>
 - sdet_liang <liangway@users.noreply.github.com>
-- pyves@crater.logilab.fr <pyves@crater.logilab.fr>
 - paschich <millen@gridium.com>
 - oittaa <8972248+oittaa@users.noreply.github.com>
 - nyabkun <75878387+nyabkun@users.noreply.github.com>
 - moxian <aleftmail@inbox.ru>
 - mar-chi-pan <mar.polatoglou@gmail.com>
-- ludal@logilab.fr <ludal@logilab.fr>
 - lrjball <50599110+lrjball@users.noreply.github.com>
 - laike9m <laike9m@users.noreply.github.com>
 - jaydesl <35102795+jaydesl@users.noreply.github.com>
@@ -331,7 +328,6 @@ contributors:
 - cordis-dev <darius@adroiti.com>
 - bluesheeptoken <louis.fruleux1@gmail.com>
 - anatoly techtonik <techtonik@gmail.com>
-- amdev@AMDEV-WS01.cisco.com <amdev@AMDEV-WS01.cisco.com>
 - agutole <toldo_carp@hotmail.com>
 - Zeckie <49095968+Zeckie@users.noreply.github.com>
 - Zeb Nicholls <zebedee.nicholls@climate-energy-college.org>
@@ -562,6 +558,7 @@ contributors:
 - Ramon Saraiva <ramonsaraiva@gmail.com>
 - Osher De Paz <odepaz@redhat.com>
 - Lumír 'Frenzy' Balhar <frenzy.madness@gmail.com>
+- Ludovic Aubry <ludal@logilab.fr>
 - James Addison <55152140+jayaddison@users.noreply.github.com>
 - Eddie Darling <eddie.darling@genapsys.com>
 - David Lawson <dmrlawson@gmail.com>

--- a/script/.contributors_aliases.json
+++ b/script/.contributors_aliases.json
@@ -338,6 +338,10 @@
     "mails": ["glenn@e-dad.net", "glmatthe@cisco.com"],
     "name": "Glenn Matthews"
   },
+  "grizzly.nyo@gmail.com": {
+    "mails": ["grizzly.nyo@gmail.com"],
+    "name": "Grizzly Nyo"
+  },
   "guillaume.peillex@gmail.com": {
     "mails": ["guillaume.peillex@gmail.com", "guillaume.peillex@gmail.col"],
     "name": "Hippo91",
@@ -428,6 +432,10 @@
     "mails": ["luigi.cristofolini@q-ctrl.com", "lucristofolini@gmail.com"],
     "name": "Luigi Bertaco Cristofolini"
   },
+  "ludal@logilab.fr": {
+    "mails": ["ludal@logilab.fr"],
+    "name": "Ludovic Aubry"
+  },
   "m.fesenko@corp.vk.com": {
     "mails": ["m.fesenko@corp.vk.com", "proggga@gmail.com"],
     "name": "Mikhail Fesenko"
@@ -502,6 +510,10 @@
   "peter.kolbus@gmail.com": {
     "mails": ["peter.kolbus@gmail.com", "peter.kolbus@garmin.com"],
     "name": "Peter Kolbus"
+  },
+  "pierre-yves.david@logilab.fr": {
+    "mails": ["pyves@crater.logilab.fr", "pierre-yves.david@logilab.fr"],
+    "name": "Pierre-Yves David"
   },
   "pierre.sassoulas@gmail.com": {
     "mails": [


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description

The idea is to automate more for easier release in #7362, so first we need to normalize. I made a web search to get the real name of Logilab employee from the email.
