### PR TITLE
pointless-exception-statement: performance: filter to call nodes that reference named functions

### DIFF
--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -452,7 +452,7 @@ class BasicChecker(_BasicChecker):
             return
 
         # Warn W0133 for exceptions that are used as statements
-        if isinstance(expr, nodes.Call):
+        if isinstance(expr, nodes.Call) and isinstance(expr.func, nodes.Name):
             inferred = utils.safe_infer(expr)
             if isinstance(inferred, objects.ExceptionInstance):
                 self.add_message(


### PR DESCRIPTION
Adds an additional preconditional check to the `pointless-exception-statement` message logic so that `astroid`'s inference functionality is called only when the identified `Call` node includes a [named](https://pylint.pycqa.org/projects/astroid/en/latest/api/astroid.nodes.html#astroid.nodes.Name) function reference.

Some comparative (local, single-machine, limited sample-size) benchmark performance testing against the Home Assistant `core.git` repository (at commit https://github.com/home-assistant/core/commit/a44e44b7d01c2a10e0b84e22fbd2b20012024159):

```
pylint.git $ git checkout 89a20e2ccdb2927ac370f7c6663fc83318988e10
HEAD is now at 89a20e2cc Add new check "pointless-exception-statement" (#7939)

pylint.git $ time find home-assistant/core.git/ -name '*.py' -exec python3 -m pylint -j2 --output /dev/null {} +

real    12m33.726s
user    23m25.588s
sys     0m47.887s

pylint.git $ rm -rf ~/.cache/pylint/
pylint.git $ git checkout 56121344f6c9c223d8e4477c0cdb58c46c840b4b
HEAD is now at 56121344f [pre-commit.ci] pre-commit autoupdate (#8016)

pylint.git $ time find home-assistant/core.git/ -name '*.py' -exec python3 -m pylint -j2 --output /dev/null {} +

real    11m59.741s
user    22m58.198s
sys     0m46.425s

pylint.git $ rm -rf ~/.cache/pylint/
pylint.git $ git checkout 29d39b66d7b7c17b076638e46772472e9a5c73fc
HEAD is now at 29d39b66d pointless-exception-statement: performance: filter to call nodes that reference named functions

pylint.git $ time find .venv/lib/core/ -name '*.py' -exec python3 -m pylint -j2 --output /dev/null {} +

real	12m9.042s
user	23m3.343s
sys	0m46.171s
```

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|     | :bug: Bug fix          |
|     | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

Refs #7939.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

May resolve #8073.