### PR TITLE
[doc] Add details and related links for bare/broad-except

### DIFF
--- a/doc/data/messages/b/bare-except/bad.py
+++ b/doc/data/messages/b/bare-except/bad.py
@@ -2,9 +2,3 @@ try:
     import platform_specific_module
 except:  # [bare-except]
     platform_specific_module = None
-
-
-try:
-    1 / 0
-except:  # [bare-except]
-    pass

--- a/doc/data/messages/b/bare-except/bad.py
+++ b/doc/data/messages/b/bare-except/bad.py
@@ -1,4 +1,10 @@
 try:
+    import platform_specific_module
+except:  # [bare-except]
+    platform_specific_module = None
+
+
+try:
     1 / 0
 except:  # [bare-except]
     pass

--- a/doc/data/messages/b/bare-except/details.rst
+++ b/doc/data/messages/b/bare-except/details.rst
@@ -1,0 +1,7 @@
+A bare ``except:`` clause will catch ``SystemExit`` and ``KeyboardInterrupt`` exceptions, making it harder to interrupt
+a program with ``Control-C``, and can disguise other problems. If you want to catch all exceptions that signal
+program errors, use ``except Exception:`` (bare except is equivalent to ``except BaseException:``).
+
+A good rule of thumb is to limit use of bare ‘except’ clauses to two cases:
+- If the exception handler will be printing out or logging the traceback; at least the user will be aware that an error has occurred.
+- If the code needs to do some cleanup work, but then lets the exception propagate upwards with raise. ``try...finally`` can be a better way to handle this case.

--- a/doc/data/messages/b/bare-except/details.rst
+++ b/doc/data/messages/b/bare-except/details.rst
@@ -1,7 +1,3 @@
-A bare ``except:`` clause will catch ``SystemExit`` and ``KeyboardInterrupt`` exceptions, making it harder to interrupt
-a program with ``Control-C``, and can disguise other problems. If you want to catch all exceptions that signal
-program errors, use ``except Exception:`` (bare except is equivalent to ``except BaseException:``).
-
 A good rule of thumb is to limit use of bare ‘except’ clauses to two cases:
 - If the exception handler will be printing out or logging the traceback; at least the user will be aware that an error has occurred.
 - If the code needs to do some cleanup work, but then lets the exception propagate upwards with raise. ``try...finally`` can be a better way to handle this case.

--- a/doc/data/messages/b/bare-except/good.py
+++ b/doc/data/messages/b/bare-except/good.py
@@ -2,8 +2,3 @@ try:
     import platform_specific_module
 except ImportError:
     platform_specific_module = None
-
-try:
-    1 / 0
-except ZeroDivisionError:
-    pass

--- a/doc/data/messages/b/bare-except/good.py
+++ b/doc/data/messages/b/bare-except/good.py
@@ -1,4 +1,9 @@
 try:
+    import platform_specific_module
+except ImportError:
+    platform_specific_module = None
+
+try:
     1 / 0
 except ZeroDivisionError:
     pass

--- a/doc/data/messages/b/bare-except/related.rst
+++ b/doc/data/messages/b/bare-except/related.rst
@@ -1,0 +1,1 @@
+- `Programming recommendation in PEP8 <https://peps.python.org/pep-0008/#programming-recommendations>`_

--- a/doc/data/messages/b/broad-exception-caught/bad.py
+++ b/doc/data/messages/b/broad-exception-caught/bad.py
@@ -1,4 +1,10 @@
 try:
+    import platform_specific_module
+except Exception:  # [broad-exception-caught]
+    platform_specific_module = None
+
+
+try:
     1 / 0
 except Exception:  # [broad-exception-caught]
     pass

--- a/doc/data/messages/b/broad-exception-caught/bad.py
+++ b/doc/data/messages/b/broad-exception-caught/bad.py
@@ -2,9 +2,3 @@ try:
     import platform_specific_module
 except Exception:  # [broad-exception-caught]
     platform_specific_module = None
-
-
-try:
-    1 / 0
-except Exception:  # [broad-exception-caught]
-    pass

--- a/doc/data/messages/b/broad-exception-caught/details.rst
+++ b/doc/data/messages/b/broad-exception-caught/details.rst
@@ -1,0 +1,6 @@
+If you use a naked ``except Exception:`` clause, you might end up catching exceptions other than the ones you expect to catch
+This can hide bugs or make it harder to debug programs when they aren't doing what you expect.
+
+For example, you're trying to import a library with required system dependencies and you catch
+everything instead of only import errors, you will miss the error message telling you, that
+your code could work if you had installed the system dependencies.

--- a/doc/data/messages/b/broad-exception-caught/details.rst
+++ b/doc/data/messages/b/broad-exception-caught/details.rst
@@ -1,6 +1,3 @@
-If you use a naked ``except Exception:`` clause, you might end up catching exceptions other than the ones you expect to catch
-This can hide bugs or make it harder to debug programs when they aren't doing what you expect.
-
 For example, you're trying to import a library with required system dependencies and you catch
 everything instead of only import errors, you will miss the error message telling you, that
 your code could work if you had installed the system dependencies.

--- a/doc/data/messages/b/broad-exception-caught/good.py
+++ b/doc/data/messages/b/broad-exception-caught/good.py
@@ -2,8 +2,3 @@ try:
     import platform_specific_module
 except ImportError:
     platform_specific_module = None
-
-try:
-    1 / 0
-except ZeroDivisionError:
-    pass

--- a/doc/data/messages/b/broad-exception-caught/good.py
+++ b/doc/data/messages/b/broad-exception-caught/good.py
@@ -1,4 +1,9 @@
 try:
+    import platform_specific_module
+except ImportError:
+    platform_specific_module = None
+
+try:
     1 / 0
 except ZeroDivisionError:
     pass

--- a/doc/data/messages/b/broad-exception-caught/related.rst
+++ b/doc/data/messages/b/broad-exception-caught/related.rst
@@ -1,0 +1,1 @@
+- `Should I always specify an exception type in 'except' statements? <https://stackoverflow.com/a/14797508/2519059>`_

--- a/doc/data/messages/b/broad-exception-raised/related.rst
+++ b/doc/data/messages/b/broad-exception-raised/related.rst
@@ -1,0 +1,1 @@
+- `Programming recommendation in PEP8 <https://peps.python.org/pep-0008/#programming-recommendations>`_

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -447,8 +447,9 @@ Exceptions checker Messages
   Used when an except catches a type that was already caught by a previous
   handler.
 :broad-exception-caught (W0718): *Catching too general exception %s*
-  Used when an except catches a too general exception, possibly burying
-  unrelated errors.
+  If you use a naked ``except Exception:`` clause, you might end up catching
+  exceptions other than the ones you expect to catch. This can hide bugs or
+  make it harder to debug programs when unrelated errors are hidden.
 :raise-missing-from (W0707): *Consider explicitly re-raising using %s'%s from %s'*
   Python's exception chaining shows the traceback of the current exception, but
   also of the original exception. When you raise a new exception after another
@@ -467,9 +468,17 @@ Exceptions checker Messages
   valid for the exception in question. Usually emitted when having binary
   operations between exceptions in except handlers.
 :bare-except (W0702): *No exception type(s) specified*
-  Used when an except clause doesn't specify exceptions type to catch.
+  A bare ``except:`` clause will catch ``SystemExit`` and ``KeyboardInterrupt``
+  exceptions, making it harder to interrupt a program with ``Control-C``, and
+  can disguise other problems. If you want to catch all exceptions that signal
+  program errors, use ``except Exception:`` (bare except is equivalent to
+  ``except BaseException:``).
 :broad-exception-raised (W0719): *Raising too general exception: %s*
-  Used when an except raises a too general exception.
+  Raising exceptions that are too generic force you to catch exception
+  generically too. It will force you to use a naked ``except Exception:``
+  clause. You might then end up catching exceptions other than the ones you
+  expect to catch. This can hide bugs or make it harder to debug programs when
+  unrelated errors are hidden.
 :try-except-raise (W0706): *The except handler raises immediately*
   Used when an except handler uses raise as its first or only operator. This is
   useless because it raises back the exception immediately. Remove the raise

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -112,13 +112,18 @@ MSGS: dict[str, MessageDefinitionTuple] = {
     "W0702": (
         "No exception type(s) specified",
         "bare-except",
-        "Used when an except clause doesn't specify exceptions type to catch.",
+        "A bare ``except:`` clause will catch ``SystemExit`` and ``KeyboardInterrupt``"
+        " exceptions, making it harder to interrupt a program with ``Control-C``, and "
+        "can disguise other problems. If you want to catch all exceptions that signal "
+        "program errors, use ``except Exception:`` (bare except is equivalent to"
+        " ``except BaseException:``).",
     ),
     "W0718": (
         "Catching too general exception %s",
         "broad-exception-caught",
-        "Used when an except catches a too general exception, "
-        "possibly burying unrelated errors.",
+        "If you use a naked ``except Exception:`` clause, you might end up catching "
+        "exceptions other than the ones you expect to catch. This can hide bugs or "
+        "make it harder to debug programs when unrelated errors are hidden.",
         {"old_names": [("W0703", "broad-except")]},
     ),
     "W0705": (
@@ -168,7 +173,11 @@ MSGS: dict[str, MessageDefinitionTuple] = {
     "W0719": (
         "Raising too general exception: %s",
         "broad-exception-raised",
-        "Used when an except raises a too general exception.",
+        "Raising exceptions that are too generic force you to catch exception "
+        "generically too. It will force you to use a naked ``except Exception:``"
+        " clause. You might then end up catching exceptions other than the ones "
+        "you expect to catch. This can hide bugs or make it harder to debug programs"
+        " when unrelated errors are hidden.",
     ),
 }
 

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -174,10 +174,10 @@ MSGS: dict[str, MessageDefinitionTuple] = {
         "Raising too general exception: %s",
         "broad-exception-raised",
         "Raising exceptions that are too generic force you to catch exceptions "
-        "generically too. It will force you to use a naked ``except Exception:``"
-        " clause. You might then end up catching exceptions other than the ones "
-        "you expect to catch. This can hide bugs or make it harder to debug programs"
-        " when unrelated errors are hidden.",
+        "generically too. It will force you to use a naked ``except Exception:`` "
+        "clause. You might then end up catching exceptions other than the ones "
+        "you expect to catch. This can hide bugs or make it harder to debug programs "
+        "when unrelated errors are hidden.",
     ),
 }
 

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -173,7 +173,7 @@ MSGS: dict[str, MessageDefinitionTuple] = {
     "W0719": (
         "Raising too general exception: %s",
         "broad-exception-raised",
-        "Raising exceptions that are too generic force you to catch exception "
+        "Raising exceptions that are too generic force you to catch exceptions "
         "generically too. It will force you to use a naked ``except Exception:``"
         " clause. You might then end up catching exceptions other than the ones "
         "you expect to catch. This can hide bugs or make it harder to debug programs"

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -112,11 +112,11 @@ MSGS: dict[str, MessageDefinitionTuple] = {
     "W0702": (
         "No exception type(s) specified",
         "bare-except",
-        "A bare ``except:`` clause will catch ``SystemExit`` and ``KeyboardInterrupt``"
-        " exceptions, making it harder to interrupt a program with ``Control-C``, and "
-        "can disguise other problems. If you want to catch all exceptions that signal "
-        "program errors, use ``except Exception:`` (bare except is equivalent to"
-        " ``except BaseException:``).",
+        "A bare ``except:`` clause will catch ``SystemExit`` and "
+        "``KeyboardInterrupt`` exceptions, making it harder to interrupt a program "
+        "with ``Control-C``, and can disguise other problems. If you want to catch "
+        "all exceptions that signal program errors, use ``except Exception:`` (bare "
+        "except is equivalent to ``except BaseException:``).",
     ),
     "W0718": (
         "Catching too general exception %s",


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

All messages do not have a good/bad example yet but the next step is giving the rationale. This one was easy to do. I feel like the rationale are lacking right now we have a lot of "emitted when ..." type message, but **when** it's emitted is / should be shown by the example, what we really need is a rationale for **why** the message exists in pylint. There's a lot of work if we want to change this part of the message other the whole code base.
