### PR TITLE
Better regex for private attribute check

### DIFF
--- a/doc/whatsnew/fragments/8081.bugfix
+++ b/doc/whatsnew/fragments/8081.bugfix
@@ -1,0 +1,3 @@
+Use better regex to check for private attributes.
+
+Refs #8081

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -729,7 +729,7 @@ def is_attr_private(attrname: str) -> Match[str] | None:
     """Check that attribute name is private (at least two leading underscores,
     at most one trailing underscore).
     """
-    regex = re.compile("^_{2,}.*[^_]+_?$")
+    regex = re.compile("^_{2,10}.*[^_]+_?$")
     return regex.match(attrname)
 
 


### PR DESCRIPTION
## Description

Prevent regex timeout issues for methods with unreasonable many leading underscores (> 80T).