### PR TITLE
Improve performance for `pointless-exception-statement`

### DIFF
--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -287,6 +287,13 @@ Standard Checkers
 
 ``Basic`` **Checker**
 ---------------------
+--additional-exception-classes
+""""""""""""""""""""""""""""""
+*List of regular expressions of additional exception names to check for 'pointless-exception-statement*
+
+**Default:**  ``[]``
+
+
 --argument-naming-style
 """""""""""""""""""""""
 *Naming style matching correct argument names.*
@@ -522,6 +529,8 @@ Standard Checkers
 .. code-block:: toml
 
    [tool.pylint.basic]
+   additional-exception-classes = []
+
    argument-naming-style = "snake_case"
 
    # argument-rgx =

--- a/tests/functional/c/ctor_arguments.py
+++ b/tests/functional/c/ctor_arguments.py
@@ -78,11 +78,11 @@ class ClassWithMeta(with_metaclass(Metaclass)):
 ClassWithMeta()
 
 
-class BuiltinExc(Exception):
+class BuiltinError(Exception):
     def __init__(self, val=True):
         self.val = val
 
-BuiltinExc(42, 24, badarg=1) # [line-too-long,pointless-exception-statement,too-many-function-args,unexpected-keyword-arg]
+BuiltinError(42, 24, badarg=1) # [line-too-long,pointless-exception-statement,too-many-function-args,unexpected-keyword-arg]
 
 
 class Clsmethod:

--- a/tests/functional/c/ctor_arguments.txt
+++ b/tests/functional/c/ctor_arguments.txt
@@ -15,10 +15,10 @@ too-many-function-args:60:0:60:30::Too many positional arguments for constructor
 too-many-function-args:63:0:63:17::Too many positional arguments for constructor call:UNDEFINED
 no-value-for-parameter:64:0:64:15::No value for argument 'first_argument' in constructor call:UNDEFINED
 unexpected-keyword-arg:64:0:64:15::Unexpected keyword argument 'one' in constructor call:UNDEFINED
-line-too-long:85:0::::Line too long (122/100):UNDEFINED
-pointless-exception-statement:85:0:85:28::Exception statement has no effect:INFERENCE
-too-many-function-args:85:0:85:28::Too many positional arguments for constructor call:UNDEFINED
-unexpected-keyword-arg:85:0:85:28::Unexpected keyword argument 'badarg' in constructor call:UNDEFINED
+line-too-long:85:0:None:None::Line too long (124/100):UNDEFINED
+pointless-exception-statement:85:0:85:30::Exception statement has no effect:INFERENCE
+too-many-function-args:85:0:85:30::Too many positional arguments for constructor call:UNDEFINED
+unexpected-keyword-arg:85:0:85:30::Unexpected keyword argument 'badarg' in constructor call:UNDEFINED
 too-many-function-args:95:15:95:30:Clsmethod.from_nothing:Too many positional arguments for constructor call:UNDEFINED
 no-value-for-parameter:99:15:99:20:Clsmethod.from_nothing1:No value for argument 'first' in constructor call:UNDEFINED
 no-value-for-parameter:99:15:99:20:Clsmethod.from_nothing1:No value for argument 'second' in constructor call:UNDEFINED

--- a/tests/functional/s/statement_without_effect.py
+++ b/tests/functional/s/statement_without_effect.py
@@ -94,7 +94,7 @@ class ASomethingCustom(Exception):
 
 
 class BSomethingCustom:
-    """Custom class name.
+    """Custom class name but NOT inheriting from Exception.
 
     Instantiating should NOT raise 'pointless-exception-statement'.
     """

--- a/tests/functional/s/statement_without_effect.py
+++ b/tests/functional/s/statement_without_effect.py
@@ -38,6 +38,9 @@ GOOD_ATTRIBUTE_DOCSTRING = 42
 class ClassLevelAttributeTest:
     """ test attribute docstrings. """
 
+    class ClassLevelException(Exception):
+        """Exception defined for access as a class attribute."""
+
     good_attribute_docstring = 24
     """ class level attribute docstring is fine either. """
     second_good_attribute_docstring = 42
@@ -86,7 +89,31 @@ def raised_exception():
     raise ValueError()
 
 
+class ASomethingCustom(Exception):
+    """Custom class name inheriting from Exception."""
+
+
+class BSomethingCustom:
+    """Custom class name.
+
+    Instantiating should NOT raise 'pointless-exception-statement'.
+    """
+
+
+class SomethingElse(Exception):
+    """Custom exception not matching regex."""
+
+
 def unraised_exception():
     """Test that instantiating but not raising an exception is flagged as a pointless statement"""
     ValueError("pointless-statement")  # [pointless-exception-statement]
     ValueError(to_be())  # [pointless-exception-statement]
+    ClassLevelAttributeTest.ClassLevelException(to_be())  # [pointless-exception-statement]
+    ValueError("another-pointless-statement")  # [pointless-exception-statement]
+    ASomethingCustom()  # [pointless-exception-statement]
+
+    # Not inheriting from Exception
+    BSomethingCustom()
+
+    # Not matching regex
+    SomethingElse()

--- a/tests/functional/s/statement_without_effect.rc
+++ b/tests/functional/s/statement_without_effect.rc
@@ -1,0 +1,3 @@
+[Basic]
+additional-exception-classes =
+    .*SomethingCustom

--- a/tests/functional/s/statement_without_effect.txt
+++ b/tests/functional/s/statement_without_effect.txt
@@ -8,7 +8,10 @@ expression-not-assigned:23:0:23:18::"Expression ""list() and tuple()"" is assign
 expression-not-assigned:30:0:30:17::"Expression ""ANSWER == to_be()"" is assigned to nothing":UNDEFINED
 expression-not-assigned:32:0:32:22::"Expression ""to_be() or not to_be()"" is assigned to nothing":UNDEFINED
 expression-not-assigned:33:0:33:13::"Expression ""to_be().title"" is assigned to nothing":UNDEFINED
-pointless-string-statement:58:8:58:43:ClassLevelAttributeTest.__init__:String statement has no effect:UNDEFINED
-pointless-string-statement:65:8:65:55:ClassLevelAttributeTest.test:String statement has no effect:UNDEFINED
-pointless-exception-statement:91:4:91:37:unraised_exception:Exception statement has no effect:INFERENCE
-pointless-exception-statement:92:4:92:23:unraised_exception:Exception statement has no effect:INFERENCE
+pointless-string-statement:61:8:61:43:ClassLevelAttributeTest.__init__:String statement has no effect:UNDEFINED
+pointless-string-statement:68:8:68:55:ClassLevelAttributeTest.test:String statement has no effect:UNDEFINED
+pointless-exception-statement:109:4:109:37:unraised_exception:Exception statement has no effect:INFERENCE
+pointless-exception-statement:110:4:110:23:unraised_exception:Exception statement has no effect:INFERENCE
+pointless-exception-statement:111:4:111:56:unraised_exception:Exception statement has no effect:INFERENCE
+pointless-exception-statement:112:4:112:45:unraised_exception:Exception statement has no effect:INFERENCE
+pointless-exception-statement:113:4:113:22:unraised_exception:Exception statement has no effect:INFERENCE


### PR DESCRIPTION
## Description
Improve performance for `pointless-exception-statement` especially for large code bases.
Use 3 step approach outline in https://github.com/PyCQA/pylint/pull/7939#discussion_r1072865819 to catch almost all issues without the negative performance impact while still providing an option for users to check more / everything if they use a custom exception name pattern.

1. Check common names. Almost all exceptions contain one the these words: `Exception`, `Error`, or `Warning`.
2. Check not yet covered stdlib exceptions. https://docs.python.org/3/library/exceptions.html#exception-hierarchy
_If a 3rd party library has some other names, those could be added here as well. Although I would limit it to fairly popular ones, something like `requests` for example._
3. Allow users to define additional regex names to check.

Alternative to #8078
Closes #8073
