### PR TITLE
Fix `invalid-name` for `typing_extensions.TypeVar`

### DIFF
--- a/doc/whatsnew/fragments/8089.false_positive
+++ b/doc/whatsnew/fragments/8089.false_positive
@@ -1,0 +1,3 @@
+Fix ``invalid-name`` errors for ``typing_extension.TypeVar``.
+
+Refs #8089

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -44,7 +44,12 @@ DEFAULT_PATTERNS = {
 }
 
 BUILTIN_PROPERTY = "builtins.property"
-TYPING_TYPE_VAR_QNAME = "typing.TypeVar"
+TYPE_VAR_QNAME = frozenset(
+    (
+        "typing.TypeVar",
+        "typing_extensions.TypeVar",
+    )
+)
 
 
 class TypeVarVariance(Enum):
@@ -555,7 +560,7 @@ class NameChecker(_BasicChecker):
             inferred = utils.safe_infer(node.func)
             if (
                 isinstance(inferred, astroid.ClassDef)
-                and inferred.qname() == TYPING_TYPE_VAR_QNAME
+                and inferred.qname() in TYPE_VAR_QNAME
             ):
                 return True
         return False

--- a/tests/functional/t/typevar_naming_style_default.py
+++ b/tests/functional/t/typevar_naming_style_default.py
@@ -1,7 +1,7 @@
 """Test case for typevar-name-incorrect-variance with default settings"""
 # pylint: disable=too-few-public-methods,line-too-long
-
 from typing import TypeVar
+import typing_extensions as te
 
 # PascalCase names with prefix
 GoodNameT = TypeVar("GoodNameT")
@@ -55,3 +55,10 @@ GoodName_co, a_BadName_contra = TypeVar(  # [invalid-name]
     "GoodName_co", covariant=True
 ), TypeVar("a_BadName_contra", contravariant=True)
 GoodName_co, VAR = TypeVar("GoodName_co", covariant=True), "a string"
+
+
+# -- typing_extensions.TypeVar --
+GoodNameT = te.TypeVar("GoodNameT")
+GoodNameT_co = te.TypeVar("GoodNameT_co", covariant=True)
+badName = te.TypeVar("badName")  # [invalid-name]
+T_co = te.TypeVar("T_co", covariant=True, contravariant=True)  # [typevar-double-variance,typevar-name-incorrect-variance]

--- a/tests/functional/t/typevar_naming_style_default.txt
+++ b/tests/functional/t/typevar_naming_style_default.txt
@@ -16,3 +16,6 @@ invalid-name:51:4:51:13::"Type variable name ""a_BadName"" doesn't conform to pr
 invalid-name:52:4:52:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to predefined naming style":HIGH
 typevar-name-incorrect-variance:52:4:52:26::"Type variable name does not reflect variance. ""a_BadNameWithoutContra"" is contravariant, use ""a_BadNameWithoutContra_contra"" instead":INFERENCE
 invalid-name:54:13:54:29::"Type variable name ""a_BadName_contra"" doesn't conform to predefined naming style":HIGH
+invalid-name:63:0:63:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
+typevar-double-variance:64:0:64:4::TypeVar cannot be both covariant and contravariant:INFERENCE
+typevar-name-incorrect-variance:64:0:64:4::Type variable name does not reflect variance:INFERENCE

--- a/tests/functional/t/typevar_naming_style_rgx.py
+++ b/tests/functional/t/typevar_naming_style_rgx.py
@@ -1,6 +1,6 @@
 """Test case for typevar-name-missing-variance with non-default settings"""
-
 from typing import TypeVar
+import typing_extensions as te
 
 # Name set by regex pattern
 TypeVarsShouldBeLikeThis = TypeVar("TypeVarsShouldBeLikeThis")
@@ -13,3 +13,9 @@ TypeVarsShouldBeLikeThis_co = TypeVar("TypeVarsShouldBeLikeThis_co", covariant=T
 GoodNameT = TypeVar("GoodNameT")  # [invalid-name]
 GoodNameT_co = TypeVar("GoodNameT_co", covariant=True)  # [invalid-name]
 GoodNameT_contra = TypeVar("GoodNameT_contra", contravariant=True)  # [invalid-name]
+
+
+# -- typing_extensions.TypeVar --
+TypeVarsShouldBeLikeThis = te.TypeVar("TypeVarsShouldBeLikeThis")
+GoodNameT = te.TypeVar("GoodNameT")  # [invalid-name]
+GoodNameT_co = te.TypeVar("GoodNameT_co", covariant=True)  # [invalid-name]

--- a/tests/functional/t/typevar_naming_style_rgx.txt
+++ b/tests/functional/t/typevar_naming_style_rgx.txt
@@ -1,3 +1,5 @@
 invalid-name:13:0:13:9::"Type variable name ""GoodNameT"" doesn't conform to 'TypeVarsShouldBeLikeThis(_co(ntra)?)?$' pattern":HIGH
 invalid-name:14:0:14:12::"Type variable name ""GoodNameT_co"" doesn't conform to 'TypeVarsShouldBeLikeThis(_co(ntra)?)?$' pattern":HIGH
 invalid-name:15:0:15:16::"Type variable name ""GoodNameT_contra"" doesn't conform to 'TypeVarsShouldBeLikeThis(_co(ntra)?)?$' pattern":HIGH
+invalid-name:20:0:20:9::"Type variable name ""GoodNameT"" doesn't conform to 'TypeVarsShouldBeLikeThis(_co(ntra)?)?$' pattern":HIGH
+invalid-name:21:0:21:12::"Type variable name ""GoodNameT_co"" doesn't conform to 'TypeVarsShouldBeLikeThis(_co(ntra)?)?$' pattern":HIGH


### PR DESCRIPTION
## Description
`typing_extensions` recently added it's own version of `TypeVar` and no longer aliases `typing.TypeVar`. Adjust name check for that.
https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-440-october-6-2022