### PR TITLE
Bump pylint to 2.16.0-b1, update changelog

### DIFF
--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "2.16.0b0"
+__version__ = "2.16.0b1"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies    = [
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/PyCQA/astroid/issues/1341
-    "astroid>=2.13.2,<=2.15.0-dev0",
+    "astroid>=2.13.3,<=2.15.0-dev0",
     "isort>=4.2.5,<6",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 -e .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==2.13.2  # Pinned to a specific version for tests
+astroid==2.13.3  # Pinned to a specific version for tests
 typing-extensions~=4.4
 py~=1.11.0
 pytest~=7.2

--- a/script/bump_changelog.py
+++ b/script/bump_changelog.py
@@ -49,7 +49,7 @@ def main() -> None:
     if "dev" in args.version:
         print("'-devXY' will be cut from version in towncrier.toml")
     match = re.match(
-        r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-\w+\d*)*", args.version
+        r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-?\w+\d*)*", args.version
     )
     if not match:
         print(

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/PyCQA/pylint"
 
 [version]
-current = "2.16.0b0"
+current = "2.16.0b1"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
We were not able to release on wednesday and we found a false positive recentely with #8088 so let's release another beta version and wait until the 30th to release 2.16.0 to see if anything else comes up.

Text for release note:
New beta release following a performance fix in the new pointless exception statement checks in https://github.com/PyCQA/pylint/issues/8073 and a false positive fixed in the unreleased ``consider-using-augmented-assign`` check in https://github.com/PyCQA/pylint/pull/8088. We're also using the latest version of astroid (2.13.3).
