### PR TITLE
Fix FP for `used-before-assignment` when reimporting name used in type annotation

### DIFF
--- a/doc/whatsnew/fragments/7882.false_positive
+++ b/doc/whatsnew/fragments/7882.false_positive
@@ -1,0 +1,4 @@
+Fix a false positive for ``used-before-assignment`` after a variable
+annotated with a name guarded by ``if TYPE_CHECKING:``.
+
+Closes #7882

--- a/doc/whatsnew/fragments/7882.false_positive
+++ b/doc/whatsnew/fragments/7882.false_positive
@@ -1,4 +1,3 @@
-Fix a false positive for ``used-before-assignment`` after a variable
-annotated with a name guarded by ``if TYPE_CHECKING:``.
+Fix a false positive for ``used-before-assignment`` when a name guarded by ``if TYPE_CHECKING:`` is used as a type annotation in a function body and later re-imported in the same scope.
 
 Closes #7882

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1798,10 +1798,14 @@ class VariablesChecker(BaseChecker):
             elif base_scope_type != "lambda":
                 # E0601 may *not* occurs in lambda scope.
 
-                # Handle postponed evaluation of annotations
+                # Skip postponed evaluation of annotations
+                # and unevaluated annotations inside a function body
                 if not (
                     self._postponed_evaluation_enabled
                     and isinstance(stmt, (nodes.AnnAssign, nodes.FunctionDef))
+                ) and not (
+                    isinstance(stmt, nodes.AnnAssign)
+                    and utils.get_node_first_ancestor_of_type(stmt, nodes.FunctionDef)
                 ):
                     self.add_message(
                         "used-before-assignment",

--- a/tests/functional/u/used/used_before_assignment_typing.py
+++ b/tests/functional/u/used/used_before_assignment_typing.py
@@ -95,6 +95,7 @@ class VariableAnnotationsGuardedByTypeChecking:  # pylint: disable=too-few-publi
     local (function) variable annotations, which are not evaluated at runtime.
 
     See: https://github.com/PyCQA/pylint/issues/7609
+    and https://github.com/PyCQA/pylint/issues/7882
     """
 
     still_an_error: datetime.date  # [used-before-assignment]
@@ -102,6 +103,8 @@ class VariableAnnotationsGuardedByTypeChecking:  # pylint: disable=too-few-publi
     def print_date(self, date) -> None:
         date: datetime.date = date
         print(date)
+
+        import datetime  # pylint: disable=import-outside-toplevel
 
 
 class ConditionalImportGuardedWhenUsed:  # pylint: disable=too-few-public-methods

--- a/tests/functional/u/used/used_before_assignment_typing.txt
+++ b/tests/functional/u/used/used_before_assignment_typing.txt
@@ -2,4 +2,4 @@ undefined-variable:17:21:17:28:MyClass.incorrect_typing_method:Undefined variabl
 undefined-variable:22:26:22:33:MyClass.incorrect_nested_typing_method:Undefined variable 'MyClass':UNDEFINED
 undefined-variable:27:20:27:27:MyClass.incorrect_default_method:Undefined variable 'MyClass':UNDEFINED
 used-before-assignment:88:35:88:39:MyFourthClass.is_close:Using variable 'math' before assignment:HIGH
-used-before-assignment:100:20:100:28:VariableAnnotationsGuardedByTypeChecking:Using variable 'datetime' before assignment:HIGH
+used-before-assignment:101:20:101:28:VariableAnnotationsGuardedByTypeChecking:Using variable 'datetime' before assignment:HIGH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
## Description
Closes #7882
