### PR TITLE
Fix consistency in ``subprocess-run-check`` and add rational

### DIFF
--- a/doc/data/messages/s/subprocess-run-check/good.py
+++ b/doc/data/messages/s/subprocess-run-check/good.py
@@ -1,3 +1,3 @@
 import subprocess
 
-proc = subprocess.run(["ls"], check=True)
+proc = subprocess.run(["ls"], check=False)

--- a/doc/data/messages/s/subprocess-run-check/related.rst
+++ b/doc/data/messages/s/subprocess-run-check/related.rst
@@ -1,0 +1,1 @@
+- `subprocess.run documentation <https://docs.python.org/3/library/subprocess.html#subprocess.run>`_

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -968,6 +968,11 @@ Stdlib checker Messages
   instance will never need to be garbage collected (singleton) it is
   recommended to refactor code to avoid this pattern or add a maxsize to the
   cache. The default value for maxsize is 128.
+:subprocess-run-check (W1510): *'subprocess.run' used without explicitly defining the value for 'check'.*
+  The ``check`` keyword is set to False by default. It means the process
+  launched by ``subprocess.run`` can exit with a non-zero exit code and fail
+  silently. It's better to set it explicitly to make clear what the error-
+  handling behavior is.
 :forgotten-debug-statement (W1515): *Leaving functions creating breakpoints in production code is not recommended*
   Calls to breakpoint(), sys.breakpointhook() and pdb.set_trace() should be
   removed from code that is not actively being debugged.
@@ -1001,10 +1006,6 @@ Stdlib checker Messages
   your application. The child process could deadlock before exec is called. If
   you must use it, keep it trivial! Minimize the number of libraries you call
   into. See https://docs.python.org/3/library/subprocess.html#popen-constructor
-:subprocess-run-check (W1510): *Using subprocess.run without explicitly set `check` is not recommended.*
-  The check parameter should always be used with explicitly set `check` keyword
-  to make clear what the error-handling behavior is. See
-  https://docs.python.org/3/library/subprocess.html#subprocess.run
 :bad-thread-instantiation (W1506): *threading.Thread needs the target function*
   The warning is emitted when a threading.Thread class is instantiated without
   the target function being passed as a kwarg or as a second argument. By

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -429,11 +429,12 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
             "See https://docs.python.org/3/library/subprocess.html#popen-constructor",
         ),
         "W1510": (
-            "Using subprocess.run without explicitly set `check` is not recommended.",
+            "'subprocess.run' used without explicitly defining the value for 'check'.",
             "subprocess-run-check",
-            "The check parameter should always be used with explicitly set "
-            "`check` keyword to make clear what the error-handling behavior is. "
-            "See https://docs.python.org/3/library/subprocess.html#subprocess.run",
+            "The ``check`` keyword  is set to False by default. It means the process "
+            "launched by ``subprocess.run`` can exit with a non-zero exit code and "
+            "fail silently. It's better to set it explicitly to make clear what the "
+            "error-handling behavior is.",
         ),
         "W1514": (
             "Using open without explicitly specifying an encoding",

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -16,6 +16,7 @@ from astroid.typing import InferenceResult
 
 from pylint import interfaces
 from pylint.checkers import BaseChecker, DeprecatedMixin, utils
+from pylint.interfaces import INFERENCE
 from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
@@ -507,7 +508,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
     def _check_for_check_kw_in_run(self, node: nodes.Call) -> None:
         kwargs = {keyword.arg for keyword in (node.keywords or ())}
         if "check" not in kwargs:
-            self.add_message("subprocess-run-check", node=node)
+            self.add_message("subprocess-run-check", node=node, confidence=INFERENCE)
 
     def _check_shallow_copy_environ(self, node: nodes.Call) -> None:
         arg = utils.get_argument_from_call(node, position=0)

--- a/tests/functional/s/subprocess_run_check.txt
+++ b/tests/functional/s/subprocess_run_check.txt
@@ -1,1 +1,1 @@
-subprocess-run-check:6:0:6:16::Using subprocess.run without explicitly set `check` is not recommended.:UNDEFINED
+subprocess-run-check:6:0:6:16::'subprocess.run' used without explicitly defining the value for 'check'.:UNDEFINED

--- a/tests/functional/s/subprocess_run_check.txt
+++ b/tests/functional/s/subprocess_run_check.txt
@@ -1,1 +1,1 @@
-subprocess-run-check:6:0:6:16::'subprocess.run' used without explicitly defining the value for 'check'.:UNDEFINED
+subprocess-run-check:6:0:6:16::'subprocess.run' used without explicitly defining the value for 'check'.:INFERENCE


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Closes #7973 
