### PR TITLE
Fix `missing-kwoa` FP with With statements

### DIFF
--- a/doc/whatsnew/fragments/8100.false_positive
+++ b/doc/whatsnew/fragments/8100.false_positive
@@ -1,0 +1,3 @@
+Fix ``no-kwoa`` false positive for context managers.
+
+Closes #8100

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -691,13 +691,7 @@ def _no_context_variadic_keywords(node: nodes.Call, scope: nodes.Lambda) -> bool
     ):
         call = statement.value
         variadics = list(call.keywords or []) + call.kwargs
-    # elif isinstance(statement, nodes.With):
-    #     breakpoint()
-    #     calls = statement.items
-    #     if calls:
-    #         # only handle one call for now...
-    #         call = statement.items[0][0]
-    #         variadics = list(call.keywords or []) + call.kwargs
+
     return _no_context_variadic(node, scope.args.kwarg, nodes.Keyword, variadics)
 
 
@@ -1622,7 +1616,12 @@ accessed. Python regular expressions are accepted.",
                 and not has_no_context_keywords_variadic
                 and not overload_function
             ):
-                self.add_message("missing-kwoa", node=node, args=(name, callable_name))
+                self.add_message(
+                    "missing-kwoa",
+                    node=node,
+                    args=(name, callable_name),
+                    confidence=INFERENCE,
+                )
 
     @staticmethod
     def _keyword_argument_is_in_all_decorator_returns(

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -687,7 +687,12 @@ def _no_context_variadic_keywords(node: nodes.Call, scope: nodes.Lambda) -> bool
     ):
         call = statement.value
         variadics = list(call.keywords or []) + call.kwargs
-
+    elif isinstance(statement, nodes.With):
+        calls = statement.items
+        if calls:
+            # only handle one call for now...
+            call = statement.items[0][0]
+            variadics = list(call.keywords or []) + call.kwargs
     return _no_context_variadic(node, scope.args.kwarg, nodes.Keyword, variadics)
 
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -680,19 +680,24 @@ def _no_context_variadic_keywords(node: nodes.Call, scope: nodes.Lambda) -> bool
     statement = node.statement(future=True)
     variadics = []
 
-    if isinstance(scope, nodes.Lambda) and not isinstance(scope, nodes.FunctionDef):
+    if (
+        isinstance(scope, nodes.Lambda)
+        and not isinstance(scope, nodes.FunctionDef)
+        or isinstance(statement, nodes.With)
+    ):
         variadics = list(node.keywords or []) + node.kwargs
     elif isinstance(statement, (nodes.Return, nodes.Expr, nodes.Assign)) and isinstance(
         statement.value, nodes.Call
     ):
         call = statement.value
         variadics = list(call.keywords or []) + call.kwargs
-    elif isinstance(statement, nodes.With):
-        calls = statement.items
-        if calls:
-            # only handle one call for now...
-            call = statement.items[0][0]
-            variadics = list(call.keywords or []) + call.kwargs
+    # elif isinstance(statement, nodes.With):
+    #     breakpoint()
+    #     calls = statement.items
+    #     if calls:
+    #         # only handle one call for now...
+    #         call = statement.items[0][0]
+    #         variadics = list(call.keywords or []) + call.kwargs
     return _no_context_variadic(node, scope.args.kwarg, nodes.Keyword, variadics)
 
 

--- a/tests/functional/d/dataclass/dataclass_kw_only.txt
+++ b/tests/functional/d/dataclass/dataclass_kw_only.txt
@@ -1,4 +1,4 @@
-missing-kwoa:24:0:26:1::Missing mandatory keyword argument 'a' in constructor call:UNDEFINED
-missing-kwoa:24:0:26:1::Missing mandatory keyword argument 'b' in constructor call:UNDEFINED
+missing-kwoa:24:0:26:1::Missing mandatory keyword argument 'a' in constructor call:INFERENCE
+missing-kwoa:24:0:26:1::Missing mandatory keyword argument 'b' in constructor call:INFERENCE
 redundant-keyword-arg:24:0:26:1::Argument 'c' passed by position and keyword in constructor call:UNDEFINED
 too-many-function-args:24:0:26:1::Too many positional arguments for constructor call:UNDEFINED

--- a/tests/functional/m/missing/missing_kwoa.py
+++ b/tests/functional/m/missing/missing_kwoa.py
@@ -86,5 +86,7 @@ def test_context_managers(**kw):
     with run(**kw), run(**kw):
         pass
 
+    with run(**kw), run():  # [missing-kwoa]
+        pass
 
 test_context_managers(a=1)

--- a/tests/functional/m/missing/missing_kwoa.py
+++ b/tests/functional/m/missing/missing_kwoa.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-docstring,unused-argument,too-few-public-methods
+import contextlib
 import typing
-
 
 def target(pos, *, keyword):
     return pos + keyword
@@ -71,3 +71,20 @@ class Child(Parent):
             second):
         super().__init__(first=first, second=second)
         self._first = first + second
+
+
+@contextlib.contextmanager
+def run(*, a):
+    yield
+
+def test_context_managers(**kw):
+    run(**kw)
+
+    with run(**kw):
+        pass
+
+    with run(**kw), run(**kw):
+        pass
+
+
+test_context_managers(a=1)

--- a/tests/functional/m/missing/missing_kwoa.txt
+++ b/tests/functional/m/missing/missing_kwoa.txt
@@ -1,3 +1,4 @@
 missing-kwoa:21:4:21:17:not_forwarding_kwargs:Missing mandatory keyword argument 'keyword' in function call:UNDEFINED
 missing-kwoa:27:0:27:16::Missing mandatory keyword argument 'keyword' in function call:UNDEFINED
 too-many-function-args:27:0:27:16::Too many positional arguments for function call:UNDEFINED
+missing-kwoa:89:20:89:25:test_context_managers:Missing mandatory keyword argument 'a' in function call:UNDEFINED

--- a/tests/functional/m/missing/missing_kwoa.txt
+++ b/tests/functional/m/missing/missing_kwoa.txt
@@ -1,4 +1,4 @@
-missing-kwoa:21:4:21:17:not_forwarding_kwargs:Missing mandatory keyword argument 'keyword' in function call:UNDEFINED
-missing-kwoa:27:0:27:16::Missing mandatory keyword argument 'keyword' in function call:UNDEFINED
+missing-kwoa:21:4:21:17:not_forwarding_kwargs:Missing mandatory keyword argument 'keyword' in function call:INFERENCE
+missing-kwoa:27:0:27:16::Missing mandatory keyword argument 'keyword' in function call:INFERENCE
 too-many-function-args:27:0:27:16::Too many positional arguments for function call:UNDEFINED
-missing-kwoa:89:20:89:25:test_context_managers:Missing mandatory keyword argument 'a' in function call:UNDEFINED
+missing-kwoa:89:20:89:25:test_context_managers:Missing mandatory keyword argument 'a' in function call:INFERENCE


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Fix ``no-kwoa`` false positive for context managers.

Closes #8100
