### PR TITLE
fix(4857): fix false positive for `use-maxsplit-arg` with custom spli…

### DIFF
--- a/doc/whatsnew/fragments/4857.false_positive
+++ b/doc/whatsnew/fragments/4857.false_positive
@@ -1,0 +1,3 @@
+Fix false positive for ``use-maxsplit-arg`` with custom split method.
+
+Closes #4857

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -121,6 +121,12 @@ class RecommendationChecker(checkers.BaseChecker):
             and isinstance(utils.safe_infer(node.func), astroid.BoundMethod)
         ):
             return
+        inferred_expr = utils.safe_infer(node.func.expr)
+        if not (
+            isinstance(inferred_expr, nodes.Const)
+            and not set(inferred_expr.nodes_of_class(nodes.ClassDef))
+        ):
+            return
 
         try:
             sep = utils.get_argument_from_call(node, 0, "sep")

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -123,7 +123,7 @@ class RecommendationChecker(checkers.BaseChecker):
             return
         inferred_expr = utils.safe_infer(node.func.expr)
         if isinstance(inferred_expr, astroid.Instance) and any(
-            i for i in inferred_expr.nodes_of_class(nodes.ClassDef)
+            inferred_expr.nodes_of_class(nodes.ClassDef)
         ):
             return
 

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -122,9 +122,8 @@ class RecommendationChecker(checkers.BaseChecker):
         ):
             return
         inferred_expr = utils.safe_infer(node.func.expr)
-        if not isinstance(inferred_expr, nodes.Const) and (
-            isinstance(inferred_expr, astroid.Instance)
-            and set(inferred_expr.nodes_of_class(nodes.ClassDef))
+        if isinstance(inferred_expr, astroid.Instance) and set(
+            inferred_expr.nodes_of_class(nodes.ClassDef)
         ):
             return
 

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -122,7 +122,7 @@ class RecommendationChecker(checkers.BaseChecker):
         ):
             return
         inferred_expr = utils.safe_infer(node.func.expr)
-        if isinstance(inferred_expr, astroid.Instance) and set(
+        if isinstance(inferred_expr, astroid.Instance) and any(i for i in
             inferred_expr.nodes_of_class(nodes.ClassDef)
         ):
             return

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -124,7 +124,7 @@ class RecommendationChecker(checkers.BaseChecker):
         inferred_expr = utils.safe_infer(node.func.expr)
         if not (
             isinstance(inferred_expr, nodes.Const)
-            and not set(inferred_expr.nodes_of_class(nodes.ClassDef))
+            or not set(inferred_expr.nodes_of_class(nodes.ClassDef))
         ):
             return
 

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -122,9 +122,9 @@ class RecommendationChecker(checkers.BaseChecker):
         ):
             return
         inferred_expr = utils.safe_infer(node.func.expr)
-        if not (
-            isinstance(inferred_expr, nodes.Const)
-            or not set(inferred_expr.nodes_of_class(nodes.ClassDef))
+        if not isinstance(inferred_expr, nodes.Const) and (
+            isinstance(inferred_expr, astroid.Instance) 
+            and set(inferred_expr.nodes_of_class(nodes.ClassDef))
         ):
             return
 

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -122,8 +122,8 @@ class RecommendationChecker(checkers.BaseChecker):
         ):
             return
         inferred_expr = utils.safe_infer(node.func.expr)
-        if isinstance(inferred_expr, astroid.Instance) and any(i for i in
-            inferred_expr.nodes_of_class(nodes.ClassDef)
+        if isinstance(inferred_expr, astroid.Instance) and any(
+            i for i in inferred_expr.nodes_of_class(nodes.ClassDef)
         ):
             return
 

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -123,7 +123,7 @@ class RecommendationChecker(checkers.BaseChecker):
             return
         inferred_expr = utils.safe_infer(node.func.expr)
         if not isinstance(inferred_expr, nodes.Const) and (
-            isinstance(inferred_expr, astroid.Instance) 
+            isinstance(inferred_expr, astroid.Instance)
             and set(inferred_expr.nodes_of_class(nodes.ClassDef))
         ):
             return

--- a/tests/functional/u/use/use_maxsplit_arg.py
+++ b/tests/functional/u/use/use_maxsplit_arg.py
@@ -94,3 +94,11 @@ for j in range(5):
 # Test for crash when sep is given by keyword
 # https://github.com/PyCQA/pylint/issues/5737
 get_last = SEQ.split(sep=None)[-1]  # [use-maxsplit-arg]
+
+
+class FalsePositive4857:
+    def split(self, point):
+        return point
+
+obj = FalsePositive4857()
+obj = obj.split((0, 0))[0]


### PR DESCRIPTION
…t method

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Write a good description on what the PR does.
- [x] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Refer to linked issue. This PR resolves the false positive arising from custom defined `split` methods. This is accomplished by adding an additional check to ensure that the expression used before the `.split()` is inferred as a `Const` node with a `String` type value

Closes #4857
