### PR TITLE
Tighten design constraints

### DIFF
--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -104,6 +104,7 @@ def report_by_type_stats(
     sect.append(reporter_nodes.Table(children=lines, cols=6, rheaders=1))
 
 
+# pylint: disable-next = too-many-public-methods
 class BasicChecker(_BasicChecker):
     """Basic checker.
 

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1218,6 +1218,7 @@ a metaclass class method.",
                     pass
 
         # check if the method is hidden by an attribute
+        # pylint: disable = too-many-try-statements
         try:
             overridden = klass.instance_attr(node.name)[0]
             overridden_frame = overridden.frame(future=True)
@@ -2063,6 +2064,7 @@ a metaclass class method.",
                 and expr.expr.func.name == "super"
             ):
                 return
+            # pylint: disable = too-many-try-statements
             try:
                 for klass in expr.expr.infer():
                     if klass is astroid.Uninferable:

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1150,6 +1150,7 @@ a metaclass class method.",
                                 "attribute-defined-outside-init", args=attr, node=node
                             )
 
+    # pylint: disable = too-many-branches
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
         """Check method arguments, overriding."""
         # ignore actual functions

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -275,7 +275,7 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
     def process_module(self, node: nodes.Module) -> None:
         pass
 
-    # pylint: disable-next=too-many-return-statements
+    # pylint: disable-next = too-many-return-statements, too-many-branches
     def _check_keyword_parentheses(
         self, tokens: list[tokenize.TokenInfo], start: int
     ) -> None:

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -722,6 +722,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
         imports = [import_node for (import_node, _) in imports]
         return any(astroid.are_exclusive(import_node, node) for import_node in imports)
 
+    # pylint: disable = too-many-statements
     def _check_imports_order(
         self, _module_node: nodes.Module
     ) -> tuple[

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -854,6 +854,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         self._check_consider_get(node)
         self._check_consider_using_min_max_builtin(node)
 
+    # pylint: disable = too-many-branches
     def _check_consider_using_min_max_builtin(self, node: nodes.If) -> None:
         """Check if the given if node can be refactored as a min/max python builtin."""
         if self._is_actual_elif(node) or node.orelse:

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -474,6 +474,7 @@ class Similar:
         )
         return report
 
+    # pylint: disable = too-many-locals
     def _find_common(
         self, lineset1: LineSet, lineset2: LineSet
     ) -> Generator[Commonality, None, None]:

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -340,6 +340,7 @@ class SpellingChecker(BaseTokenChecker):
         )
         self.initialized = True
 
+    # pylint: disable = too-many-statements
     def _check_spelling(self, msgid: str, line: str, line_num: int) -> None:
         original_line = line
         try:

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -605,6 +605,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
 
         lru_cache_nodes: list[nodes.NodeNG] = []
         for d_node in node.decorators.nodes:
+            # pylint: disable = too-many-try-statements
             try:
                 for infered_node in d_node.infer():
                     q_name = infered_node.qname()

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -247,7 +247,7 @@ class StringFormatChecker(BaseChecker):
     name = "string"
     msgs = MSGS
 
-    # pylint: disable=too-many-branches
+    # pylint: disable = too-many-branches, too-many-locals
     @only_required_for_messages(
         "bad-format-character",
         "truncated-format-string",

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -247,7 +247,7 @@ class StringFormatChecker(BaseChecker):
     name = "string"
     msgs = MSGS
 
-    # pylint: disable = too-many-branches, too-many-locals
+    # pylint: disable = too-many-branches, too-many-locals, too-many-statements
     @only_required_for_messages(
         "bad-format-character",
         "truncated-format-string",
@@ -533,6 +533,7 @@ class StringFormatChecker(BaseChecker):
         self._detect_vacuous_formatting(node, positional_arguments)
         self._check_new_format_specifiers(node, fields, named_arguments)
 
+    # pylint: disable = too-many-statements
     def _check_new_format_specifiers(
         self,
         node: nodes.Call,

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -440,7 +440,7 @@ def _emit_no_member(
           AttributeError, Exception or bare except.
         * The node is guarded behind and `IF` or `IFExp` node
     """
-    # pylint: disable=too-many-return-statements
+    # pylint: disable = too-many-return-statements, too-many-branches
     if node_ignores_exception(node, AttributeError):
         return False
     if ignored_none and isinstance(owner, nodes.Const) and owner.value is None:
@@ -1035,6 +1035,7 @@ accessed. Python regular expressions are accepted.",
     def visit_delattr(self, node: nodes.DelAttr) -> None:
         self.visit_attribute(node)
 
+    # pylint: disable = too-many-branches
     @only_required_for_messages("no-member", "c-extension-no-member")
     def visit_attribute(
         self, node: nodes.Attribute | nodes.AssignAttr | nodes.DelAttr

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1399,7 +1399,7 @@ accessed. Python regular expressions are accepted.",
         if _is_invalid_isinstance_type(second_arg):
             self.add_message("isinstance-second-argument-not-valid-type", node=node)
 
-    # pylint: disable=too-many-branches,too-many-locals
+    # pylint: disable = too-many-branches, too-many-locals, too-many-statements
     def visit_call(self, node: nodes.Call) -> None:
         """Check that called functions/methods are inferred to callable objects,
         and that passed arguments match the parameters in the inferred function.

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -627,6 +627,7 @@ def collect_string_fields(format_string: str) -> Iterable[str | None]:
     It handles nested fields as well.
     """
     formatter = string.Formatter()
+    # pylint: disable = too-many-try-statements
     try:
         parseiterator = formatter.parse(format_string)
         for result in parseiterator:
@@ -1374,6 +1375,7 @@ def safe_infer(
     if value is not astroid.Uninferable:
         inferred_types.add(_get_python_type_of_node(value))
 
+    # pylint: disable = too-many-try-statements
     try:
         for inferred in infer_gen:
             inferred_type = _get_python_type_of_node(inferred)
@@ -2050,6 +2052,7 @@ def is_hashable(node: nodes.NodeNG) -> bool:
 
     When finding ambiguity, return True.
     """
+    # pylint: disable = too-many-try-statements
     try:
         for inferred in node.infer():
             if inferred is astroid.Uninferable or isinstance(inferred, nodes.ClassDef):

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -303,6 +303,7 @@ def is_defined_in_scope(
     return defnode_in_scope(var_node, varname, scope) is not None
 
 
+# pylint: disable = too-many-branches
 def defnode_in_scope(
     var_node: nodes.NodeNG,
     varname: str,

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2025,6 +2025,7 @@ class VariablesChecker(BaseChecker):
             parent = parent.parent
         return False
 
+    # pylint: disable = too-many-statements
     @staticmethod
     def _is_variable_violation(
         node: nodes.Name,

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1661,7 +1661,7 @@ class VariablesChecker(BaseChecker):
 
         return False
 
-    # pylint: disable=too-many-return-statements
+    # pylint: disable = too-many-return-statements, too-many-branches
     def _check_consumer(
         self,
         node: nodes.Name,
@@ -2025,7 +2025,7 @@ class VariablesChecker(BaseChecker):
             parent = parent.parent
         return False
 
-    # pylint: disable = too-many-statements
+    # pylint: disable = too-many-statements, too-many-branches
     @staticmethod
     def _is_variable_violation(
         node: nodes.Name,
@@ -2403,6 +2403,7 @@ class VariablesChecker(BaseChecker):
             and name in frame_locals
         )
 
+    # pylint: disable = too-many-branches
     def _loopvar_name(self, node: astroid.Name) -> None:
         # filter variables according to node's scope
         astmts = [s for s in node.lookup(node.name)[1] if hasattr(s, "assign_type")]
@@ -2547,6 +2548,7 @@ class VariablesChecker(BaseChecker):
             if not elements:
                 self.add_message("undefined-loop-variable", args=node.name, node=node)
 
+    # pylint: disable = too-many-branches
     def _check_is_unused(
         self,
         name: str,
@@ -3012,6 +3014,7 @@ class VariablesChecker(BaseChecker):
             for node in node_lst:
                 self.add_message("unused-variable", args=(name,), node=node)
 
+    # pylint: disable = too-many-branches
     def _check_imports(self, not_consumed: dict[str, list[nodes.NodeNG]]) -> None:
         local_names = _fix_dot_imports(not_consumed)
         checked = set()

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -61,7 +61,7 @@ def _is_ignored_file(
     )
 
 
-# pylint: disable = too-many-locals
+# pylint: disable = too-many-locals, too-many-statements
 def expand_modules(
     files_or_modules: Sequence[str],
     ignore_list: list[str],

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -61,6 +61,7 @@ def _is_ignored_file(
     )
 
 
+# pylint: disable = too-many-locals
 def expand_modules(
     files_or_modules: Sequence[str],
     ignore_list: list[str],

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -115,7 +115,7 @@ group are mutually exclusive.",
     Used by _PylintConfigRun to make the 'pylint-config' command work.
     """
 
-    # pylint: disable = too-many-statements
+    # pylint: disable = too-many-statements, too-many-branches
     def __init__(
         self,
         args: Sequence[str],

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -115,6 +115,7 @@ group are mutually exclusive.",
     Used by _PylintConfigRun to make the 'pylint-config' command work.
     """
 
+    # pylint: disable = too-many-statements
     def __init__(
         self,
         args: Sequence[str],

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -90,6 +90,7 @@ class OutputLine(NamedTuple):
         if isinstance(row, str):
             row = row.split(",")
         # noinspection PyBroadException
+        # pylint: disable = too-many-try-statements
         try:
             column = cls._get_column(row[2])
             if len(row) == 5:

--- a/pylint/utils/ast_walker.py
+++ b/pylint/utils/ast_walker.py
@@ -82,6 +82,7 @@ class ASTWalker:
         visit_events: Sequence[AstCallback] = self.visit_events.get(cid, ())
         leave_events: Sequence[AstCallback] = self.leave_events.get(cid, ())
 
+        # pylint: disable = too-many-try-statements
         try:
             if astroid.is_statement:
                 self.nbstatements += 1

--- a/pylintrc
+++ b/pylintrc
@@ -425,30 +425,11 @@ max-branches = 20
 # Maximum number of statements in function / method body
 max-statements = 50
 
-# Maximum number of parents for a class (see R0901).
-max-parents=7
-
-# List of qualified class names to ignore when counting class parents (see R0901).
-ignored-parents=
-
 # Maximum number of attributes for a class (see R0902).
 max-attributes=11
 
-# Minimum number of public methods for a class (see R0903).
-min-public-methods=2
-
-# Maximum number of public methods for a class (see R0904).
-max-public-methods=25
-
-# Maximum number of boolean expressions in an if statement (see R0916).
-max-bool-expr=5
-
 # Maximum number of statements in a try-block
 max-try-statements = 7
-
-# List of regular expressions of class ancestor names to
-# ignore when counting public methods (see R0903).
-exclude-too-few-public-methods=
 
 [CLASSES]
 

--- a/pylintrc
+++ b/pylintrc
@@ -414,7 +414,7 @@ max-spelling-suggestions=2
 max-args=10
 
 # Maximum number of locals for function / method body
-max-locals=25
+max-locals = 19
 
 # Maximum number of return / yield for function / method body
 max-returns=11

--- a/pylintrc
+++ b/pylintrc
@@ -420,7 +420,7 @@ max-locals = 19
 max-returns=11
 
 # Maximum number of branch for function / method body
-max-branches=27
+max-branches = 20
 
 # Maximum number of statements in function / method body
 max-statements = 50

--- a/pylintrc
+++ b/pylintrc
@@ -423,7 +423,7 @@ max-returns=11
 max-branches=27
 
 # Maximum number of statements in function / method body
-max-statements=100
+max-statements = 50
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7

--- a/pylintrc
+++ b/pylintrc
@@ -411,7 +411,7 @@ max-spelling-suggestions=2
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=10
+max-args = 9
 
 # Maximum number of locals for function / method body
 max-locals = 19

--- a/pylintrc
+++ b/pylintrc
@@ -444,7 +444,7 @@ max-public-methods=25
 max-bool-expr=5
 
 # Maximum number of statements in a try-block
-max-try-statements = 14
+max-try-statements = 7
 
 # List of regular expressions of class ancestor names to
 # ignore when counting public methods (see R0903).

--- a/tests/checkers/unittest_deprecated.py
+++ b/tests/checkers/unittest_deprecated.py
@@ -53,6 +53,7 @@ class _DeprecatedChecker(DeprecatedMixin, BaseChecker):
         return {".deprecated_decorator"}
 
 
+# pylint: disable-next = too-many-public-methods
 class TestDeprecatedChecker(CheckerTestCase):
     CHECKER_CLASS = _DeprecatedChecker
 

--- a/tests/checkers/unittest_format.py
+++ b/tests/checkers/unittest_format.py
@@ -165,6 +165,7 @@ def test_disable_global_option_end_of_line() -> None:
 1
     """
         )
+    # pylint: disable = too-many-try-statements
     try:
         linter = lint.PyLinter()
         checker = BasicChecker(linter)

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -979,6 +979,7 @@ def test_pylintrc() -> None:
     with fake_home():
         current_dir = getcwd()
         chdir(os.path.dirname(os.path.abspath(sys.executable)))
+        # pylint: disable = too-many-try-statements
         try:
             with pytest.warns(DeprecationWarning):
                 assert config.find_pylintrc() is None

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -781,6 +781,7 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (<unknown>, line 1)' (syntax-er
 
     @staticmethod
     def test_modify_sys_path() -> None:
+        # pylint: disable = too-many-statements
         cwd = "/tmp/pytest-of-root/pytest-0/test_do_not_import_files_from_0"
         default_paths = [
             "/usr/local/lib/python39.zip",


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This PR tightens a few of the design constraints in the config file. No code is changed, although a few disable comments are added.

The rationale for the numbers is that they should be as low as possible without raising too many warnings. This way only the worst offenders are flagged. For example, there are only a few functions with more than 50 statements, and more with between 40 and 50 statements. So 50 is the cutoff. I'm not wed to any of the numbers in particular, but I think they're about where they should be.

Observe that several functions raise multiple warnings. Such functions are prime candidates for refactoring.