### PR TITLE
feat(6489): implement `positional-only-arguments-expected` checker

### DIFF
--- a/doc/data/messages/p/positional-only-arguments-expected/bad.py
+++ b/doc/data/messages/p/positional-only-arguments-expected/bad.py
@@ -1,0 +1,8 @@
+import random
+
+
+def pick_one(item1, item2, item3, /):
+    chosen_one = random.choice((item1, item2, item3))
+    print(f"The chosen item is: {chosen_one}")
+
+pick_one(item1="apple", item2="banana", item3="orange")  # [positional-only-arguments-expected]

--- a/doc/data/messages/p/positional-only-arguments-expected/bad.py
+++ b/doc/data/messages/p/positional-only-arguments-expected/bad.py
@@ -1,8 +1,5 @@
-import random
+def cube(n, /):
+    """Takes in a number n, returns the cube of n"""
+    return n**3
 
-
-def pick_one(item1, item2, item3, /):
-    chosen_one = random.choice((item1, item2, item3))
-    print(f"The chosen item is: {chosen_one}")
-
-pick_one(item1="apple", item2="banana", item3="orange")  # [positional-only-arguments-expected]
+cube(n=2) # [positional-only-arguments-expected]

--- a/doc/data/messages/p/positional-only-arguments-expected/good.py
+++ b/doc/data/messages/p/positional-only-arguments-expected/good.py
@@ -1,8 +1,5 @@
-import random
+def cube(n, /):
+    """Takes in a number n, returns the cube of n"""
+    return n**3
 
-
-def pick_one(item1, item2, item3, /):
-    chosen_one = random.choice((item1, item2, item3))
-    print(f"The chosen item is: {chosen_one}")
-
-pick_one("apple", "banana", "orange")
+cube(2)

--- a/doc/data/messages/p/positional-only-arguments-expected/good.py
+++ b/doc/data/messages/p/positional-only-arguments-expected/good.py
@@ -1,0 +1,8 @@
+import random
+
+
+def pick_one(item1, item2, item3, /):
+    chosen_one = random.choice((item1, item2, item3))
+    print(f"The chosen item is: {chosen_one}")
+
+pick_one("apple", "banana", "orange")

--- a/doc/data/messages/p/positional-only-arguments-expected/related.rst
+++ b/doc/data/messages/p/positional-only-arguments-expected/related.rst
@@ -1,0 +1,1 @@
+- `PEP 570 <https://peps.python.org/pep-570/>`_

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -474,7 +474,7 @@ Exceptions checker Messages
   program errors, use ``except Exception:`` (bare except is equivalent to
   ``except BaseException:``).
 :broad-exception-raised (W0719): *Raising too general exception: %s*
-  Raising exceptions that are too generic force you to catch exception
+  Raising exceptions that are too generic force you to catch exceptions
   generically too. It will force you to use a naked ``except Exception:``
   clause. You might then end up catching exceptions other than the ones you
   expect to catch. This can hide bugs or make it harder to debug programs when
@@ -643,6 +643,10 @@ See also :ref:`method_args checker's options' documentation <method_args-options
 
 Method Args checker Messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:positional-only-arguments-expected (E3102): *%s() got some positional-only arguments passed as keyword arguments: %s*
+  Emitted when positional-only arguments have been passed as keyword arguments.
+  Remove the keywords for the affected arguments in the function call. This
+  message can't be emitted when using Python < 3.8.
 :missing-timeout (W3101): *Missing timeout argument for method '%s' can cause your program to hang indefinitely*
   Used when a method needs a 'timeout' parameter in order to avoid waiting for
   a long time. If no timeout is specified explicitly the default value is used.

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -1258,7 +1258,7 @@ Standard Checkers
 
 --spelling-dict
 """""""""""""""
-*Spelling dictionary name. Available dictionaries: en (aspell), en_AU (aspell), en_CA (aspell), en_GB (aspell), en_US (aspell).*
+*Spelling dictionary name. Available dictionaries: none. To make it work, install the 'python-enchant' package.*
 
 **Default:** ``""``
 

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -1258,7 +1258,7 @@ Standard Checkers
 
 --spelling-dict
 """""""""""""""
-*Spelling dictionary name. Available dictionaries: none. To make it work, install the 'python-enchant' package.*
+*Spelling dictionary name. Available dictionaries: en (aspell), en_AU (aspell), en_CA (aspell), en_GB (aspell), en_US (aspell).*
 
 **Default:** ``""``
 

--- a/doc/user_guide/messages/messages_overview.rst
+++ b/doc/user_guide/messages/messages_overview.rst
@@ -137,6 +137,7 @@ All messages in the error category:
    error/not-context-manager
    error/not-in-loop
    error/notimplemented-raised
+   error/positional-only-arguments-expected
    error/potential-index-error
    error/raising-bad-type
    error/raising-non-exception

--- a/doc/whatsnew/fragments/6489.new_check
+++ b/doc/whatsnew/fragments/6489.new_check
@@ -1,0 +1,4 @@
+Add new checker ``positional-only-arguments-expected`` to check for cases when
+positional-only arguments have been passed as keyword arguments.
+
+Closes #6489

--- a/tests/functional/p/positional_only_arguments_expected.py
+++ b/tests/functional/p/positional_only_arguments_expected.py
@@ -1,0 +1,18 @@
+# pylint: disable=missing-docstring,unused-argument,pointless-statement
+# pylint: disable=too-few-public-methods
+
+class Gateaux:
+    def nihon(self, a, r, i, /, cheese=False):
+        return f"{a}{r}{i}gateaux" + " au fromage" if cheese else ""
+
+
+cake = Gateaux()
+# Should not emit error
+cake.nihon(1, 2, 3)
+cake.nihon(1, 2, 3, True)
+cake.nihon(1, 2, 3, cheese=True)
+# Emits error
+cake.nihon(1, 2, i=3)  # [positional-only-arguments-expected]
+cake.nihon(1, r=2, i=3)  # [positional-only-arguments-expected]
+cake.nihon(a=1, r=2, i=3)  # [positional-only-arguments-expected]
+cake.nihon(1, r=2, i=3, cheese=True)  # [positional-only-arguments-expected]

--- a/tests/functional/p/positional_only_arguments_expected.rc
+++ b/tests/functional/p/positional_only_arguments_expected.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.8

--- a/tests/functional/p/positional_only_arguments_expected.txt
+++ b/tests/functional/p/positional_only_arguments_expected.txt
@@ -1,0 +1,4 @@
+positional-only-arguments-expected:15:0:15:21::"`cake.nihon()` got some positional-only arguments passed as keyword arguments: 'i'":INFERENCE
+positional-only-arguments-expected:16:0:16:23::"`cake.nihon()` got some positional-only arguments passed as keyword arguments: 'r', 'i'":INFERENCE
+positional-only-arguments-expected:17:0:17:25::"`cake.nihon()` got some positional-only arguments passed as keyword arguments: 'a', 'r', 'i'":INFERENCE
+positional-only-arguments-expected:18:0:18:36::"`cake.nihon()` got some positional-only arguments passed as keyword arguments: 'r', 'i'":INFERENCE


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Write a good description on what the PR does.
- [x] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :scroll: Docs          |

## Description

### Background

This PR aims to implement a new checker `positional-only-arguments-expected` as requested.

### Scope
- [x] Implemented new *error* checker, `positional-only-arguments-expected` under `MethodArgsChecker` with id `E3102`
- [x] Added basic functional tests -- appreciate more examples
- [x] Added docs (news fragment, user_guide, good/bad examples) 


Closes #6489
