### PR TITLE
Add `--allow-reexport-from-package` option

### DIFF
--- a/doc/data/messages/u/useless-import-alias/details.rst
+++ b/doc/data/messages/u/useless-import-alias/details.rst
@@ -1,8 +1,8 @@
 Known issue
 -----------
 
-If you prefer to use "from-as" to explicitly reexport in API (`from fruit import orange as orange`)
-instead of using `__all__` this message will be a false positive.
+If you prefer to use "from-as" to explicitly reexport in API (``from fruit import orange as orange``)
+instead of using ``__all__`` this message will be a false positive.
 
-If that's the case use `pylint: disable=useless-import-alias` before your imports in your API files.
-`False positive 'useless-import-alias' error for mypy-compatible explicit re-exports #6006 <https://github.com/PyCQA/pylint/issues/6006>`_
+Use ``--allow-reexport-from-package`` to allow explicit reexports by alias
+in package ``__init__`` files.

--- a/doc/data/messages/u/useless-import-alias/related.rst
+++ b/doc/data/messages/u/useless-import-alias/related.rst
@@ -1,3 +1,4 @@
+- :ref:`--allow-reexport-from-package<imports-options>`
 - `PEP 8, Import Guideline <https://peps.python.org/pep-0008/#imports>`_
 - :ref:`Pylint block-disable <block_disables>`
 - `mypy --no-implicit-reexport <https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport>`_

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -474,7 +474,7 @@ Exceptions checker Messages
   program errors, use ``except Exception:`` (bare except is equivalent to
   ``except BaseException:``).
 :broad-exception-raised (W0719): *Raising too general exception: %s*
-  Raising exceptions that are too generic force you to catch exception
+  Raising exceptions that are too generic force you to catch exceptions
   generically too. It will force you to use a naked ``except Exception:``
   clause. You might then end up catching exceptions other than the ones you
   expect to catch. This can hide bugs or make it harder to debug programs when

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -935,6 +935,13 @@ Standard Checkers
 **Default:**  ``()``
 
 
+--allow-reexport-from-package
+"""""""""""""""""""""""""""""
+*Allow explicit reexports by alias from a package __init__.*
+
+**Default:**  ``False``
+
+
 --allow-wildcard-with-all
 """""""""""""""""""""""""
 *Allow wildcard imports from modules that define __all__.*
@@ -1003,6 +1010,8 @@ Standard Checkers
 
    [tool.pylint.imports]
    allow-any-import-level = []
+
+   allow-reexport-from-package = false
 
    allow-wildcard-with-all = false
 

--- a/doc/whatsnew/fragments/6006.feature
+++ b/doc/whatsnew/fragments/6006.feature
@@ -1,0 +1,5 @@
+Add ``--allow-reexport-from-package`` option to configure the
+``useless-import-alias`` check not to emit a warning if a name
+is reexported from a package.
+
+Closes #6006

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -936,7 +936,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
                 self._allow_reexport_package is False
                 or self._current_module_package is False
             ):
-                self.add_message("useless-import-alias", node=node)
+                self.add_message("useless-import-alias", node=node, confidence=HIGH)
             elif len(splitted_packages) == 2:
                 self.add_message(
                     "consider-using-from-import",

--- a/pylintrc
+++ b/pylintrc
@@ -477,6 +477,9 @@ allow-any-import-level=
 # Allow wildcard imports from modules that define __all__.
 allow-wildcard-with-all=no
 
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
 # Analyse import fallback blocks. This can be used to support both Python 2 and
 # 3 compatible code, which means that the block might have code that exists
 # only in one or another interpreter, leading to false positives when analysed.

--- a/tests/checkers/unittest_imports.py
+++ b/tests/checkers/unittest_imports.py
@@ -154,13 +154,11 @@ class TestImportsChecker(CheckerTestCase):
         output, errors = capsys.readouterr()
         assert len(output.split("\n")) == 5
         assert (
-            "tests/regrtest_data/allow_reexport/__init__.py:1:0: C0414: "
-            "Import alias does not rename original package (useless-import-alias)"
+            "__init__.py:1:0: C0414: Import alias does not rename original package (useless-import-alias)"
             in output
         )
         assert (
-            "tests/regrtest_data/allow_reexport/file.py:2:0: C0414: "
-            "Import alias does not rename original package (useless-import-alias)"
+            "file.py:2:0: C0414: Import alias does not rename original package (useless-import-alias)"
             in output
         )
         assert len(errors) == 0
@@ -176,10 +174,9 @@ class TestImportsChecker(CheckerTestCase):
         )
         output, errors = capsys.readouterr()
         assert len(output.split("\n")) == 3
-        assert "tests/regrtest_data/allow_reexport/__init__.py" not in output
+        assert "__init__.py" not in output
         assert (
-            "tests/regrtest_data/allow_reexport/file.py:2:0: C0414: "
-            "Import alias does not rename original package (useless-import-alias)"
+            "file.py:2:0: C0414: Import alias does not rename original package (useless-import-alias)"
             in output
         )
         assert len(errors) == 0

--- a/tests/functional/i/import_aliasing.txt
+++ b/tests/functional/i/import_aliasing.txt
@@ -1,10 +1,10 @@
-useless-import-alias:6:0:6:50::Import alias does not rename original package:UNDEFINED
+useless-import-alias:6:0:6:50::Import alias does not rename original package:HIGH
 consider-using-from-import:8:0:8:22::Use 'from os import path' instead:UNDEFINED
 consider-using-from-import:10:0:10:31::Use 'from foo.bar import foobar' instead:UNDEFINED
-useless-import-alias:14:0:14:24::Import alias does not rename original package:UNDEFINED
-useless-import-alias:17:0:17:28::Import alias does not rename original package:UNDEFINED
-useless-import-alias:18:0:18:38::Import alias does not rename original package:UNDEFINED
-useless-import-alias:20:0:20:38::Import alias does not rename original package:UNDEFINED
-useless-import-alias:21:0:21:38::Import alias does not rename original package:UNDEFINED
-useless-import-alias:23:0:23:36::Import alias does not rename original package:UNDEFINED
+useless-import-alias:14:0:14:24::Import alias does not rename original package:HIGH
+useless-import-alias:17:0:17:28::Import alias does not rename original package:HIGH
+useless-import-alias:18:0:18:38::Import alias does not rename original package:HIGH
+useless-import-alias:20:0:20:38::Import alias does not rename original package:HIGH
+useless-import-alias:21:0:21:38::Import alias does not rename original package:HIGH
+useless-import-alias:23:0:23:36::Import alias does not rename original package:HIGH
 relative-beyond-top-level:26:0:26:27::Attempted relative import beyond top-level package:UNDEFINED

--- a/tests/regrtest_data/allow_reexport/__init__.py
+++ b/tests/regrtest_data/allow_reexport/__init__.py
@@ -1,0 +1,1 @@
+import os as os

--- a/tests/regrtest_data/allow_reexport/file.py
+++ b/tests/regrtest_data/allow_reexport/file.py
@@ -1,0 +1,2 @@
+# pylint: disable=unused-import
+import os as os


### PR DESCRIPTION
## Description
Add option to reduce amount of false-positives for `useless-import-alias` when choosing to use explicit reexports.

~Test might be a bit difficult as the result depends on the filename (if it's `__init__.py`). Not sure it's worth it.~

Closes #6006
