### PR TITLE
ci: parallelise primer run pr on modules

### DIFF
--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -98,7 +98,6 @@ jobs:
                archive_format: "zip",
             });
             fs.writeFileSync("primer_pr_number.zip", Buffer.from(downloadThree.data));
-      - run: sudo apt install -y jq
       - run: unzip primer_main_output.zip
       - run:
           jq -n 'reduce inputs as $item ({}; . *= $item)' output_${{

--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -98,9 +98,17 @@ jobs:
                archive_format: "zip",
             });
             fs.writeFileSync("primer_pr_number.zip", Buffer.from(downloadThree.data));
+      - run: sudo apt install -y jq
       - run: unzip primer_main_output.zip
-      - run: unzip primer_pr_output.zip
+      - run:
+          jq -n 'reduce inputs as $item ({}; . *= $item)' output_${{
+          steps.python.outputs.python-version }}_main*.txt > output_${{
+          steps.python.outputs.python-version }}_main.txt
       - run: unzip primer_pr_number.zip
+      - run:
+          jq -n 'reduce inputs as $item ({}; . *= $item)' output_${{
+          steps.python.outputs.python-version }}_pr*.txt > output_${{
+          steps.python.outputs.python-version }}_pr.txt
       - name: Compare outputs
         run: |
           . venv/bin/activate

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
-      - run: sudo apt install -y jq
       - name: Generate matrix
         id: set-matrix
         run:

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -23,13 +23,32 @@ permissions:
   contents: read
 
 jobs:
-  run-primer:
-    name: Run / ${{ matrix.python-version }}
+  matrix-prep-packages:
+    name: Generate matrix of packages to prime
     runs-on: ubuntu-latest
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: 0
+      - run: sudo apt install -y jq
+      - name: Generate matrix
+        id: set-matrix
+        run:
+          echo "matrix=$(jq 'keys' tests/primer/packages_to_prime.json -c)" >>
+          $GITHUB_OUTPUT
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+  run-primer:
+    name: Run / ${{ matrix.python-version }} / ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    needs: matrix-prep-packages
     timeout-minutes: 60
     strategy:
       matrix:
         python-version: ["3.7", "3.11"]
+        package: ${{ fromJson(needs.matrix-prep-packages.outputs.matrix) }}
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.3.0
@@ -90,7 +109,7 @@ jobs:
         run: |
           . venv/bin/activate
           pip install -e .
-          python tests/primer/__main__.py run --type=main 2>warnings.txt
+          python tests/primer/__main__.py run --type=main --package=${{ matrix.package }} 2>warnings.txt
           WARNINGS=$(head -c 65000 < warnings.txt)
           if [[ $WARNINGS ]]
           then echo "::warning ::$WARNINGS"
@@ -101,4 +120,4 @@ jobs:
           name: primer_output
           path: >-
             tests/.pylint_primer_tests/output_${{ steps.python.outputs.python-version
-            }}_main.txt
+            }}_main_${{ matrix.package }}.txt

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -40,7 +40,6 @@ jobs:
         uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
-      - run: sudo apt install -y jq
       - name: Generate matrix
         id: set-matrix
         run:

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -32,13 +32,32 @@ permissions:
   contents: read
 
 jobs:
-  run-primer:
-    name: Run / ${{ matrix.python-version }}
+  matrix-prep-packages:
+    name: Generate matrix of packages to prime
     runs-on: ubuntu-latest
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: 0
+      - run: sudo apt install -y jq
+      - name: Generate matrix
+        id: set-matrix
+        run:
+          echo "matrix=$(jq 'keys' tests/primer/packages_to_prime.json -c)" >>
+          $GITHUB_OUTPUT
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+  run-primer:
+    name: Run / ${{ matrix.python-version }} / ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    needs: matrix-prep-packages
     timeout-minutes: 120
     strategy:
       matrix:
         python-version: ["3.7", "3.11"]
+        package: ${{ fromJson(needs.matrix-prep-packages.outputs.matrix) }}
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.3.0
@@ -155,7 +174,7 @@ jobs:
         run: |
           . venv/bin/activate
           pip install -e .
-          python tests/primer/__main__.py run --type=pr 2>warnings.txt
+          python tests/primer/__main__.py run --type=pr --package=${{ matrix.package }} 2>warnings.txt
           WARNINGS=$(head -c 65000 < warnings.txt)
           if [[ $WARNINGS ]]
           then echo "::warning ::$WARNINGS"
@@ -166,7 +185,7 @@ jobs:
           name: primer_output_pr
           path:
             tests/.pylint_primer_tests/output_${{ steps.python.outputs.python-version
-            }}_pr.txt
+            }}_pr_${{ matrix.package }}.txt
       - name: Upload output of 'main'
         uses: actions/upload-artifact@v3.1.2
         with:

--- a/pylint/testutils/_primer/primer.py
+++ b/pylint/testutils/_primer/primer.py
@@ -8,6 +8,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 from pylint.testutils._primer import PackageToLint
 from pylint.testutils._primer.primer_command import PrimerCommand
@@ -56,6 +57,11 @@ class Primer:
         run_parser.add_argument(
             "--type", choices=["main", "pr"], required=True, help="Type of primer run."
         )
+        run_parser.add_argument(
+            "--package",
+            help="If set, only run for specified package",
+            default="",
+        )
 
         # All arguments for the compare parser
         compare_parser = self._subparsers.add_parser("compare")
@@ -77,8 +83,9 @@ class Primer:
 
         # Storing arguments
         self.config = self._argument_parser.parse_args()
-
-        self.packages = self._get_packages_to_lint_from_json(json_path)
+        self.packages = self._get_packages_to_lint_from_json(
+            json_path, getattr(self.config, "package", None)
+        )
         """All packages to prime."""
 
         if self.config.command == "prepare":
@@ -101,10 +108,13 @@ class Primer:
         return min_python_tuple <= sys.version_info[:2]
 
     @staticmethod
-    def _get_packages_to_lint_from_json(json_path: Path) -> dict[str, PackageToLint]:
+    def _get_packages_to_lint_from_json(
+        json_path: Path, filter_package: Any | None = ""
+    ) -> dict[str, PackageToLint]:
         with open(json_path, encoding="utf8") as f:
             return {
                 name: PackageToLint(**package_data)
                 for name, package_data in json.load(f).items()
                 if Primer._minimum_python_supported(package_data)
+                and (not filter_package or name == filter_package)
             }

--- a/pylint/testutils/_primer/primer_run_command.py
+++ b/pylint/testutils/_primer/primer_run_command.py
@@ -35,9 +35,12 @@ class RunCommand(PrimerCommand):
             fatal_msgs += p_fatal_msgs
             local_commit = Repo(data.clone_directory).head.object.hexsha
             packages[package] = PackageData(commit=local_commit, messages=messages)
+        ext_path = ""
+        if self.config.package:
+            ext_path = f"_{self.config.package}"
         path = (
             self.primer_directory
-            / f"output_{'.'.join(str(i) for i in sys.version_info[:3])}_{self.config.type}.txt"
+            / f"output_{'.'.join(str(i) for i in sys.version_info[:3])}_{self.config.type}{ext_path}.txt"
         )
         print(f"Writing result in {path}")
         with open(path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature (?)|

## Description

CI improvements to speed up primer runs by dynamically populating a matrix and adding mechanism to run primer tests per package.

### Test results
Initial tests on own repo yielded 22m for entire primer run -- which usually takes 45m or more
![image](https://user-images.githubusercontent.com/36848472/215272805-14b692b5-3b26-4b73-a3b6-7dd11ff4c289.png)

- `Primer/comment` job works with merging all test artifacts with jq but output seems wonky: https://github.com/yushao2/pylint/pull/4#issuecomment-1407426487
