### PR TITLE
Update isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         args: [--py37-plus]
         exclude: *fixtures
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         exclude: doc/data/messages/(r/reimported|w/wrong-import-order|u/ungrouped-imports|m/misplaced-future|m/multiple-imports)/bad.py

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -5,5 +5,5 @@ black==23.1a1
 flake8>=5.0.0
 flake8-bugbear==23.1.20
 flake8-typing-imports==1.14.0
-isort==5.10.1
+isort==5.12.0
 mypy==0.991


### PR DESCRIPTION
## Description
Release notes: https://github.com/PyCQA/isort/releases/tag/5.12.0
Compare view: https://github.com/PyCQA/isort/compare/5.11.4...5.12.0

Necessary to fix isort with pre-commit.

--
Astroid: https://github.com/PyCQA/astroid/pull/1989