### PR TITLE
[doc] Make sure that doc examples are of a reasonable length

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,13 @@ repos:
         additional_dependencies:
           [flake8-bugbear==23.1.20, flake8-typing-imports==1.14.0]
         exclude: *fixtures
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        name: line-length-doc
+        files: doc/data/messages
+        args: ["--config", "doc/data/.flake8"]
   - repo: local
     hooks:
       - id: pylint

--- a/doc/data/.flake8
+++ b/doc/data/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+select =
+    E501,
+# Reading ease is drastically reduced on read the doc after 103 chars
+# (Because of horizontal scrolling)
+max-line-length=103

--- a/doc/data/messages/b/bad-exception-cause/bad.py
+++ b/doc/data/messages/b/bad-exception-cause/bad.py
@@ -3,5 +3,6 @@ def divide(x, y):
     try:
         result = x / y
     except ZeroDivisionError:
-        raise ValueError(f"Division by zero when dividing {x} by {y} !") from result  # [bad-exception-cause]
+        # +1: [bad-exception-cause]
+        raise ValueError(f"Division by zero when dividing {x} by {y} !") from result
     return result

--- a/doc/data/messages/c/class-variable-slots-conflict/bad.py
+++ b/doc/data/messages/c/class-variable-slots-conflict/bad.py
@@ -1,5 +1,6 @@
 class Person:
-    __slots__ = ("age", "name", "say_hi",)  # [class-variable-slots-conflict, class-variable-slots-conflict, class-variable-slots-conflict]
+    # +1: [class-variable-slots-conflict, class-variable-slots-conflict, class-variable-slots-conflict]
+    __slots__ = ("age", "name", "say_hi")
     name = None
 
     def __init__(self, age, name):

--- a/doc/data/messages/c/consider-using-dict-comprehension/bad.py
+++ b/doc/data/messages/c/consider-using-dict-comprehension/bad.py
@@ -1,3 +1,4 @@
 NUMBERS = [1, 2, 3]
 
-DOUBLED_NUMBERS = dict([(number, number * 2) for number in NUMBERS])  # [consider-using-dict-comprehension]
+# +1: [consider-using-dict-comprehension]
+DOUBLED_NUMBERS = dict([(number, number * 2) for number in NUMBERS])

--- a/doc/data/messages/c/consider-using-dict-comprehension/details.rst
+++ b/doc/data/messages/c/consider-using-dict-comprehension/details.rst
@@ -1,0 +1,3 @@
+pyupgrade_ can fix this issue automatically.
+
+.. _pyupgrade: https://github.com/asottile/pyupgrade

--- a/doc/data/messages/c/consider-using-f-string/bad.py
+++ b/doc/data/messages/c/consider-using-f-string/bad.py
@@ -1,10 +1,16 @@
 from string import Template
 
-menu = ('eggs', 'spam', 42.4)
+menu = ("eggs", "spam", 42.4)
 
-old_order = "%s and %s: %.2f ¤" % menu # [consider-using-f-string]
+old_order = "%s and %s: %.2f ¤" % menu  # [consider-using-f-string]
 beginner_order = menu[0] + " and " + menu[1] + ": " + str(menu[2]) + " ¤"
 joined_order = " and ".join(menu[:2])
-format_order = "{} and {}: {:0.2f} ¤".format(menu[0], menu[1], menu[2]) # [consider-using-f-string]
-named_format_order = "{eggs} and {spam}: {price:0.2f} ¤".format(eggs=menu[0], spam=menu[1], price=menu[2]) # [consider-using-f-string]
-template_order = Template('$eggs and $spam: $price ¤').substitute(eggs=menu[0], spam=menu[1], price=menu[2])
+# +1: [consider-using-f-string]
+format_order = "{} and {}: {:0.2f} ¤".format(menu[0], menu[1], menu[2])
+# +1: [consider-using-f-string]
+named_format_order = "{eggs} and {spam}: {price:0.2f} ¤".format(
+    eggs=menu[0], spam=menu[1], price=menu[2]
+)
+template_order = Template("$eggs and $spam: $price ¤").substitute(
+    eggs=menu[0], spam=menu[1], price=menu[2]
+)

--- a/doc/data/messages/c/consider-using-set-comprehension/bad.py
+++ b/doc/data/messages/c/consider-using-set-comprehension/bad.py
@@ -1,3 +1,4 @@
 NUMBERS = [1, 2, 2, 3, 4, 4]
 
-UNIQUE_EVEN_NUMBERS = set([number for number in NUMBERS if number % 2 == 0])  # [consider-using-set-comprehension]
+# +1: [consider-using-set-comprehension]
+UNIQUE_EVEN_NUMBERS = set([number for number in NUMBERS if number % 2 == 0])

--- a/doc/data/messages/c/consider-using-set-comprehension/details.rst
+++ b/doc/data/messages/c/consider-using-set-comprehension/details.rst
@@ -1,0 +1,3 @@
+pyupgrade_ can fix this issue automatically.
+
+.. _pyupgrade: https://github.com/asottile/pyupgrade

--- a/doc/data/messages/l/line-too-long/bad.py
+++ b/doc/data/messages/l/line-too-long/bad.py
@@ -1,1 +1,2 @@
-FRUIT = ["apricot", "blackcurrant", "cantaloupe", "dragon fruit", "elderberry", "fig", "grapefruit"]  # [line-too-long]
+# +1: [line-too-long]
+FRUIT = ["apricot", "blackcurrant", "cantaloupe", "dragon fruit", "elderberry", "fig", "grapefruit", ]

--- a/doc/data/messages/l/line-too-long/pylintrc
+++ b/doc/data/messages/l/line-too-long/pylintrc
@@ -1,0 +1,2 @@
+[MAIN]
+max-line-length=100

--- a/doc/data/messages/n/no-self-use/details.rst
+++ b/doc/data/messages/n/no-self-use/details.rst
@@ -1,0 +1,2 @@
+If a function is not using any class attribute it can be a ``@staticmethod``,
+or a function outside the class.

--- a/doc/data/messages/n/no-self-use/good.py
+++ b/doc/data/messages/n/no-self-use/good.py
@@ -1,5 +1,3 @@
-"""If a function is not using any class attribute it can be a @staticmethod, or a function outside the class."""
-
 def developer_greeting():
     print("Greetings developer!")
 

--- a/doc/data/messages/t/too-many-boolean-expressions/bad.py
+++ b/doc/data/messages/t/too-many-boolean-expressions/bad.py
@@ -1,4 +1,5 @@
 def can_be_divided_by_two_and_are_not_zero(x, y, z):
     # Maximum number of boolean expressions in an if statement (by default 5)
-    if (x and y and z) and (x % 2 == 0 and y % 2 == 0 and z % 2 == 0):  # [too-many-boolean-expressions]
+    # +1: [too-many-boolean-expressions]
+    if (x and y and z) and (x % 2 == 0 and y % 2 == 0 and z % 2 == 0):
         pass

--- a/doc/data/messages/t/too-many-format-args/bad.py
+++ b/doc/data/messages/t/too-many-format-args/bad.py
@@ -1,1 +1,2 @@
-print("Today is {0}, so tomorrow will be {1}".format("Monday", "Tuesday", "Wednesday"))  # [too-many-format-args]
+# +1: [too-many-format-args]
+print("Today is {0}, so tomorrow will be {1}".format("Monday", "Tuesday", "Wednesday"))


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

And upgrade existing unreasonable length. Reading ease is drastically reduced on read the doc after 103 chars (Because of horizontal scrolling)
