### PR TITLE
Add some test cases for redundant type check

### DIFF
--- a/tests/functional/ext/typing/redundant_typehint_argument.py
+++ b/tests/functional/ext/typing/redundant_typehint_argument.py
@@ -1,5 +1,5 @@
 """"Checks for redundant Union typehints in assignments"""
-# pylint: disable=deprecated-typing-alias,consider-alternative-union-syntax,consider-using-alias
+# pylint: disable=deprecated-typing-alias,consider-alternative-union-syntax,consider-using-alias,invalid-name,unused-argument,missing-function-docstring
 
 from __future__ import annotations
 from typing import Union, Optional, Sequence
@@ -19,3 +19,22 @@ ANSWER_9: str | int | None | int | bool = 9   # [redundant-typehint-argument]
 ANSWER_10: dict | list[int] | float | str | int | bool = 10
 #  +1: [redundant-typehint-argument]
 ANSWER_11: list[int] | dict[int] | dict[list[int]] | list[str] | list[str] = ['string']
+
+# Multiple warnings for the same repeated type
+#  +1: [redundant-typehint-argument, redundant-typehint-argument, redundant-typehint-argument]
+x: int | int | int | int
+
+# No warning for type alias
+Q = int | int
+QQ = Q | Q
+
+q: Q | Q  # [redundant-typehint-argument]
+
+# No warning for redundant types in compound type
+z: dict[int | int, str | str]
+
+#  +1: [redundant-typehint-argument]
+zz: dict[int | int, str | str] | dict[int | int, str | str]
+
+# No warnings for redundant types in function signature
+def f(p: int | int) -> str | str: ...

--- a/tests/functional/ext/typing/redundant_typehint_argument.py
+++ b/tests/functional/ext/typing/redundant_typehint_argument.py
@@ -24,11 +24,11 @@ ANSWER_11: list[int] | dict[int] | dict[list[int]] | list[str] | list[str] = ['s
 #  +1: [redundant-typehint-argument, redundant-typehint-argument, redundant-typehint-argument]
 x: int | int | int | int
 
-# No warning for redundant types in compound type
+# No warning for redundant types in compound type (yet !)
 z: dict[int | int, str | str]
 
 #  +1: [redundant-typehint-argument]
 zz: dict[int | int, str | str] | dict[int | int, str | str]
 
-# No warnings for redundant types in function signature
+# No warnings for redundant types in function signature (yet !)
 def f(p: int | int) -> str | str: ...

--- a/tests/functional/ext/typing/redundant_typehint_argument.txt
+++ b/tests/functional/ext/typing/redundant_typehint_argument.txt
@@ -7,3 +7,8 @@ redundant-typehint-argument:16:0:16:82::Type `list[str]` is used more than once 
 redundant-typehint-argument:17:0:17:23::Type `int` is used more than once in union type annotation. Remove redundant typehints.:HIGH
 redundant-typehint-argument:18:0:18:43::Type `int` is used more than once in union type annotation. Remove redundant typehints.:HIGH
 redundant-typehint-argument:21:0:21:87::Type `list[str]` is used more than once in union type annotation. Remove redundant typehints.:HIGH
+redundant-typehint-argument:25:0:25:24::Type `int` is used more than once in union type annotation. Remove redundant typehints.:HIGH
+redundant-typehint-argument:25:0:25:24::Type `int` is used more than once in union type annotation. Remove redundant typehints.:HIGH
+redundant-typehint-argument:25:0:25:24::Type `int` is used more than once in union type annotation. Remove redundant typehints.:HIGH
+redundant-typehint-argument:31:0:31:8::Type `Q` is used more than once in union type annotation. Remove redundant typehints.:HIGH
+redundant-typehint-argument:37:0:37:59::Type `dict[int | int, str | str]` is used more than once in union type annotation. Remove redundant typehints.:HIGH

--- a/tests/functional/ext/typing/redundant_typehint_argument_py310.py
+++ b/tests/functional/ext/typing/redundant_typehint_argument_py310.py
@@ -24,6 +24,12 @@ ANSWER_11: list[int] | dict[int] | dict[list[int]] | list[str] | list[str] = ['s
 #  +1: [redundant-typehint-argument, redundant-typehint-argument, redundant-typehint-argument]
 x: int | int | int | int
 
+# No warning for type alias
+Q = int | int
+QQ = Q | Q
+
+q: Q | Q  # [redundant-typehint-argument]
+
 # No warning for redundant types in compound type
 z: dict[int | int, str | str]
 

--- a/tests/functional/ext/typing/redundant_typehint_argument_py310.py
+++ b/tests/functional/ext/typing/redundant_typehint_argument_py310.py
@@ -24,17 +24,17 @@ ANSWER_11: list[int] | dict[int] | dict[list[int]] | list[str] | list[str] = ['s
 #  +1: [redundant-typehint-argument, redundant-typehint-argument, redundant-typehint-argument]
 x: int | int | int | int
 
-# No warning for type alias
+# No warning for type alias (yet !)
 Q = int | int
 QQ = Q | Q
 
 q: Q | Q  # [redundant-typehint-argument]
 
-# No warning for redundant types in compound type
+# No warning for redundant types in compound type (yet !)
 z: dict[int | int, str | str]
 
 #  +1: [redundant-typehint-argument]
 zz: dict[int | int, str | str] | dict[int | int, str | str]
 
-# No warnings for redundant types in function signature
+# No warnings for redundant types in function signature (yet !)
 def f(p: int | int) -> str | str: ...

--- a/tests/functional/ext/typing/redundant_typehint_argument_py310.rc
+++ b/tests/functional/ext/typing/redundant_typehint_argument_py310.rc
@@ -1,0 +1,6 @@
+[main]
+py-version=3.10
+load-plugins=pylint.extensions.typing
+
+[testoptions]
+min_pyver=3.10

--- a/tests/functional/ext/typing/redundant_typehint_argument_py310.txt
+++ b/tests/functional/ext/typing/redundant_typehint_argument_py310.txt
@@ -10,4 +10,5 @@ redundant-typehint-argument:21:0:21:87::Type `list[str]` is used more than once 
 redundant-typehint-argument:25:0:25:24::Type `int` is used more than once in union type annotation. Remove redundant typehints.:HIGH
 redundant-typehint-argument:25:0:25:24::Type `int` is used more than once in union type annotation. Remove redundant typehints.:HIGH
 redundant-typehint-argument:25:0:25:24::Type `int` is used more than once in union type annotation. Remove redundant typehints.:HIGH
-redundant-typehint-argument:31:0:31:59::Type `dict[int | int, str | str]` is used more than once in union type annotation. Remove redundant typehints.:HIGH
+redundant-typehint-argument:31:0:31:8::Type `Q` is used more than once in union type annotation. Remove redundant typehints.:HIGH
+redundant-typehint-argument:37:0:37:59::Type `dict[int | int, str | str]` is used more than once in union type annotation. Remove redundant typehints.:HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Testing   |

## Description

Adds a few test cases for the `redundant-typehint-argument` check, just to verify existing behavior.