### PR TITLE
Use fail-on-cache-miss option [ci]

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -99,25 +99,17 @@ jobs:
         uses: actions/cache@v3.2.4
         with:
           path: venv
+          fail-on-cache-miss: true
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.prepare-base.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
       - name: Restore pre-commit environment
         id: cache-precommit
         uses: actions/cache@v3.2.4
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
+          fail-on-cache-miss: true
           key: ${{ runner.os }}-${{ needs.prepare-base.outputs.pre-commit-key }}
-      - name: Fail job if pre-commit cache restore failed
-        if: steps.cache-precommit.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore pre-commit environment from cache"
-          exit 1
       - name: Install enchant and aspell
         run: |
           sudo apt-get update
@@ -148,14 +140,10 @@ jobs:
         uses: actions/cache@v3.2.4
         with:
           path: venv
+          fail-on-cache-miss: true
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.prepare-base.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
       - name: Run spelling checks
         run: |
           . venv/bin/activate
@@ -180,14 +168,10 @@ jobs:
         uses: actions/cache@v3.2.4
         with:
           path: venv
+          fail-on-cache-miss: true
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.prepare-base.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
       - name: Install tox
         run: |
           pip install -U tox

--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -86,14 +86,10 @@ jobs:
         uses: actions/cache@v3.2.4
         with:
           path: venv
+          fail-on-cache-miss: true
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.prepare-tests-linux.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
       - name: Run pytest
         run: |
           . venv/bin/activate
@@ -122,14 +118,10 @@ jobs:
         uses: actions/cache@v3.2.4
         with:
           path: venv
+          fail-on-cache-miss: true
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.prepare-tests-linux.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
       - name: Run pytest
         run: |
           . venv/bin/activate

--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -44,15 +44,11 @@ jobs:
         uses: actions/cache@v3.2.4
         with:
           path: venv
+          fail-on-cache-miss: true
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ hashFiles('pyproject.toml',
             'requirements_test.txt', 'requirements_test_min.txt') }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
 
       - name: Download outputs
         uses: actions/github-script@v6.4.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -95,14 +95,10 @@ jobs:
         uses: actions/cache@v3.2.4
         with:
           path: venv
+          fail-on-cache-miss: true
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.tests-linux.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v3.0.2
       - name: Combine coverage results
@@ -139,14 +135,10 @@ jobs:
         uses: actions/cache@v3.2.4
         with:
           path: venv
+          fail-on-cache-miss: true
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.tests-linux.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
       - name: Run pytest
         run: |
           . venv/bin/activate


### PR DESCRIPTION
## Description
New option for `actions/cache` released with [`v3.2.4`](https://github.com/actions/cache/releases/tag/v3.2.4) a few hours ago.
https://github.com/actions/cache/blob/main/restore/README.md#exit-workflow-on-cache-miss