### PR TITLE
Fix some doc about messages

### DIFF
--- a/doc/data/messages/b/bad-configuration-section/details.rst
+++ b/doc/data/messages/b/bad-configuration-section/details.rst
@@ -1,1 +1,2 @@
-You can help us make the doc better `by contributing <https://github.com/PyCQA/pylint/issues/5953>`_ !
+This error was raised when we encountered an unexpected value type in a toml
+configuration between pylint 2.12 and pylint 2.14 (before the argparse refactor).

--- a/doc/data/messages/b/bad-configuration-section/good.py
+++ b/doc/data/messages/b/bad-configuration-section/good.py
@@ -1,1 +1,0 @@
-# This is a placeholder for correct code for this message.

--- a/doc/data/messages/p/parse-error/good.py
+++ b/doc/data/messages/p/parse-error/good.py
@@ -1,1 +1,0 @@
-# This is a placeholder for correct code for this message.

--- a/doc/data/messages/u/using-f-string-in-unsupported-version/bad.py
+++ b/doc/data/messages/u/using-f-string-in-unsupported-version/bad.py
@@ -1,0 +1,1 @@
+f"python {3.5} is past end of life"  # [using-f-string-in-unsupported-version]

--- a/doc/data/messages/u/using-f-string-in-unsupported-version/details.rst
+++ b/doc/data/messages/u/using-f-string-in-unsupported-version/details.rst
@@ -1,1 +1,1 @@
-You can help us make the doc better `by contributing <https://github.com/PyCQA/pylint/issues/5953>`_ !
+You should upgrade to python 3.6 to use f-strings. Even python 3.6 is past end of life at this point.

--- a/doc/data/messages/u/using-f-string-in-unsupported-version/good.py
+++ b/doc/data/messages/u/using-f-string-in-unsupported-version/good.py
@@ -1,1 +1,1 @@
-# This is a placeholder for correct code for this message.
+"python {} is past end of life".format(3.5)

--- a/doc/data/messages/u/using-f-string-in-unsupported-version/pylintrc
+++ b/doc/data/messages/u/using-f-string-in-unsupported-version/pylintrc
@@ -1,0 +1,2 @@
+[main]
+py-version=3.5

--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -414,8 +414,8 @@ def _write_redirect_old_page(
     )
     content = f""".. _{old_name[0]}:
 
-{get_rst_title("/".join(old_name), "=")}
-"{old_name[0]} has been renamed. The new message can be found at:
+{get_rst_title(" / ".join(old_name), "=")}
+'{old_name[0]}' has been renamed. The new message can be found at:
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Saw some issue while reading the doc.

Before:
![image](https://user-images.githubusercontent.com/5493666/216167555-5167d4ff-454a-4785-984c-ffb8aace7fce.png)


After:
![image](https://user-images.githubusercontent.com/5493666/216167434-89470677-e364-4458-a348-9de77fac60c1.png)
