### PR TITLE
improving test_pragma_parser

### DIFF
--- a/tests/test_pragma_parser.py
+++ b/tests/test_pragma_parser.py
@@ -91,6 +91,14 @@ def test_unknown_keyword_with_messages() -> None:
         list(parse_pragma(match.group(2)))
 
 
+def test_unknown_keyword_with_missing_messages() -> None:
+    comment = "#pylint: unknown-keyword = "
+    match = OPTION_PO.search(comment)
+    assert match
+    with pytest.raises(UnRecognizedOptionError):
+        list(parse_pragma(match.group(2)))
+
+
 def test_unknown_keyword_without_messages() -> None:
     comment = "#pylint: unknown-keyword"
     match = OPTION_PO.search(comment)


### PR DESCRIPTION
This PR improves test_pragma_parser by adding the test `test_unknown_keyword_with_missing_messages`.
I believe this case is missing in test_pragma_parser.

In fact, we have some similar ones: `test_unknown_keyword_with_messages` and `test_unknown_keyword_without_messages`, but we do not check the case of unknown_keyword with missing messages:

```
"#pylint: unknown-keyword = missing-docstring" OK: test_unknown_keyword_with_messages
"#pylint: unknown-keyword = " missing test
"#pylint: unknown-keyword" OK: test_unknown_keyword_without_messages
```