### PR TITLE
fix no-name-in-module when variable is same as module name

### DIFF
--- a/doc/whatsnew/fragments/8148.bugfix
+++ b/doc/whatsnew/fragments/8148.bugfix
@@ -1,0 +1,4 @@
+Fix ``no-name-in-module`` false positive raised when a package defines a variable with the
+same name as one of its submodules.
+
+Closes #8148

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2933,7 +2933,7 @@ class VariablesChecker(BaseChecker):
                 break
             try:
                 module = next(module.getattr(name)[0].infer())
-                if module is astroid.Uninferable:
+                if not isinstance(module, nodes.Module):
                     return None
             except astroid.NotFoundError:
                 if module.name in self._ignored_modules:

--- a/tests/regrtest_data/pkg_mod_imports/__init__.py
+++ b/tests/regrtest_data/pkg_mod_imports/__init__.py
@@ -1,0 +1,6 @@
+base = [
+    'Exchange',
+    'Precise',
+    'exchanges',
+    'decimal_to_precision',
+]

--- a/tests/regrtest_data/pkg_mod_imports/base/errors.py
+++ b/tests/regrtest_data/pkg_mod_imports/base/errors.py
@@ -1,0 +1,2 @@
+class SomeError(Exception):
+    pass

--- a/tests/regrtest_data/test_no_name_in_module.py
+++ b/tests/regrtest_data/test_no_name_in_module.py
@@ -1,0 +1,1 @@
+from pkg_mod_imports.base.errors import SomeError

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1293,6 +1293,15 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (<unknown>, line 1)' (syntax-er
             args, expected_output=expected, unexpected_output=not_expected
         )
 
+    def test_no_name_in_module(self) -> None:
+        """Test that a package with both a variable name `errors` and a module `errors`
+        does not emit a no-name-in-module msg."""
+        module = join(HERE, "regrtest_data", "test_no_name_in_module.py")
+        unexpected = "No name 'errors' in module 'list' (no-name-in-module)"
+        self._test_output(
+            [module, "-E"], expected_output="", unexpected_output=unexpected
+        )
+
 
 class TestCallbackOptions:
     """Test for all callback options we support."""

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1294,7 +1294,7 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (<unknown>, line 1)' (syntax-er
         )
 
     def test_no_name_in_module(self) -> None:
-        """Test that a package with both a variable name `errors` and a module `errors`
+        """Test that a package with both a variable name `base` and a module `base`
         does not emit a no-name-in-module msg."""
         module = join(HERE, "regrtest_data", "test_no_name_in_module.py")
         unexpected = "No name 'errors' in module 'list' (no-name-in-module)"


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Closes #8148

I was able to reproduce the original issue FP but also came up with a non-lib specific example that raised this issue.
