### PR TITLE
Fix `used-before-assignment` false positive for walrus operator in dictionary

### DIFF
--- a/doc/whatsnew/fragments/8125.bugfix
+++ b/doc/whatsnew/fragments/8125.bugfix
@@ -1,0 +1,4 @@
+Fix ``used-before-assignment`` false positive when the walrus operator
+is used with a ternary operator in dictionary key/value initialization.
+
+Closes #8125

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2262,6 +2262,8 @@ class VariablesChecker(BaseChecker):
             return True
         if isinstance(value, nodes.Lambda) and isinstance(value.body, nodes.IfExp):
             return True
+        if isinstance(value, nodes.Dict) and any(isinstance(item[0], nodes.IfExp) or isinstance(item[1], nodes.IfExp) for item in value.items):
+            return True
         if not isinstance(value, nodes.Call):
             return False
         return any(

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2262,7 +2262,10 @@ class VariablesChecker(BaseChecker):
             return True
         if isinstance(value, nodes.Lambda) and isinstance(value.body, nodes.IfExp):
             return True
-        if isinstance(value, nodes.Dict) and any(isinstance(item[0], nodes.IfExp) or isinstance(item[1], nodes.IfExp) for item in value.items):
+        if isinstance(value, nodes.Dict) and any(
+            isinstance(item[0], nodes.IfExp) or isinstance(item[1], nodes.IfExp)
+            for item in value.items
+        ):
             return True
         if not isinstance(value, nodes.Call):
             return False

--- a/tests/functional/u/used/used_before_assignment_ternary.py
+++ b/tests/functional/u/used/used_before_assignment_ternary.py
@@ -29,6 +29,19 @@ def function_call_keyword_valid():
     var = foo(x=a if (a:='1') else '', y='', z='')
     var = foo(x='', y=foo(x='', y='', z=b if (b:='1') else ''), z='')
 
+def dictionary_items_valid():
+    """assignment as dictionary keys/values"""
+    var = {
+        0: w if (w:=input()) else "",
+    }
+    var = {
+        x if (x:=input()) else "": 0,
+    }
+    var = {
+        0: y if (y:=input()) else "",
+        z if (z:=input()) else "": 0,
+    }
+
 def complex_valid():
     """assignment within complex call expression"""
     var = str(bar(bar(a if (a:=1) else 0))).lower().upper()


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Fix false positive when the walrus operator is used with the ternary operator in dictionary key/value initialization.

Closes #8125 
