### PR TITLE
Add import-based submodule detection for preferred-modules

### DIFF
--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -993,7 +993,7 @@ Standard Checkers
 
 --preferred-modules
 """""""""""""""""""
-*Couples of modules and preferred modules, separated by a comma.*
+*Couples of modules and preferred modules, separated by a comma. Submodules may also be specified using '.' syntax (for ex. 'os.path').*
 
 **Default:**  ``()``
 

--- a/doc/whatsnew/fragments/7957.feature
+++ b/doc/whatsnew/fragments/7957.feature
@@ -1,0 +1,3 @@
+Adds new functionality with preferred-modules configuration to detect submodules.
+
+Refs #7957

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -914,11 +914,20 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
 
     def _check_preferred_module(self, node: ImportNode, mod_path: str) -> None:
         """Check if the module has a preferred replacement."""
-        if mod_path in self.preferred_modules:
+
+        if isinstance(node, astroid.nodes.node_classes.ImportFrom):
+            mod_compare = [f"{node.modname}.{name[0]}" for name in node.names]
+        else:
+            mod_compare = [mod_path]
+
+        if len(set(mod_compare).intersection(self.preferred_modules)) > 0:
+            mod_path_intersect = list(
+                set(mod_compare).intersection(self.preferred_modules)
+            )[0]
             self.add_message(
                 "preferred-module",
                 node=node,
-                args=(self.preferred_modules[mod_path], mod_path),
+                args=(self.preferred_modules[mod_path_intersect], mod_path_intersect),
             )
 
     def _check_import_as_rename(self, node: ImportNode) -> None:

--- a/tests/checkers/unittest_imports.py
+++ b/tests/checkers/unittest_imports.py
@@ -123,7 +123,7 @@ class TestImportsChecker(CheckerTestCase):
         # test preferred-modules case with base module import
         Run(
             [
-                f"{os.path.join(REGR_DATA, 'preferred_module')}",
+                f"{os.path.join(REGR_DATA, 'preferred_module/unpreferred_module.py')}",
                 "-d all",
                 "-e preferred-module",
                 # prefer sys instead of os (for triggering test)
@@ -135,6 +135,24 @@ class TestImportsChecker(CheckerTestCase):
 
         # assert that we saw preferred-modules triggered
         assert "Prefer importing 'sys' instead of 'os'" in output
+        # assert there were no errors
+        assert len(errors) == 0
+
+        # test preferred-modules case with submodules
+        Run(
+            [
+                f"{os.path.join(REGR_DATA, 'preferred_module/unpreferred_submodule.py')}",
+                "-d all",
+                "-e preferred-module",
+                # prefer sys instead of os (for triggering test)
+                "--preferred-modules=os.path:pathlib",
+            ],
+            exit=False,
+        )
+        output, errors = capsys.readouterr()
+
+        # assert that we saw preferred-modules triggered
+        assert "Prefer importing 'pathlib' instead of 'os.path'" in output
         # assert there were no errors
         assert len(errors) == 0
 

--- a/tests/checkers/unittest_imports.py
+++ b/tests/checkers/unittest_imports.py
@@ -55,7 +55,8 @@ class TestImportsChecker(CheckerTestCase):
             REGR_DATA, "beyond_top_two/namespace_package/top_level_function.py"
         )
         Run(
-            [top_level_function, "-d all", "-e relative-beyond-top-level"], exit=False,
+            [top_level_function, "-d all", "-e relative-beyond-top-level"],
+            exit=False,
         )
         output2, errors2 = capsys.readouterr()
 

--- a/tests/checkers/unittest_imports.py
+++ b/tests/checkers/unittest_imports.py
@@ -55,8 +55,7 @@ class TestImportsChecker(CheckerTestCase):
             REGR_DATA, "beyond_top_two/namespace_package/top_level_function.py"
         )
         Run(
-            [top_level_function, "-d all", "-e relative-beyond-top-level"],
-            exit=False,
+            [top_level_function, "-d all", "-e relative-beyond-top-level"], exit=False,
         )
         output2, errors2 = capsys.readouterr()
 
@@ -153,6 +152,24 @@ class TestImportsChecker(CheckerTestCase):
 
         # assert that we saw preferred-modules triggered
         assert "Prefer importing 'pathlib' instead of 'os.path'" in output
+        # assert there were no errors
+        assert len(errors) == 0
+
+        # test preferred-modules case for no trigger with submodule
+        Run(
+            [
+                f"{os.path.join(REGR_DATA, 'preferred_module/unpreferred_submodule.py')}",
+                "-d all",
+                "-e preferred-module",
+                # prefer sys instead of os (for triggering test)
+                "--preferred-modules=os:pathlib",
+            ],
+            exit=False,
+        )
+        output, errors = capsys.readouterr()
+
+        # assert that we did not see preferred-modules triggered
+        assert "Your code has been rated at 10.00/10" in output
         # assert there were no errors
         assert len(errors) == 0
 

--- a/tests/regrtest_data/preferred_module/unpreferred_submodule.py
+++ b/tests/regrtest_data/preferred_module/unpreferred_submodule.py
@@ -1,0 +1,3 @@
+from os import path
+
+path(".")

--- a/tests/regrtest_data/preferred_module/unpreferred_submodule.py
+++ b/tests/regrtest_data/preferred_module/unpreferred_submodule.py
@@ -1,3 +1,3 @@
-from os import path
+from os import path, getrandom
 
 path(".")


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Description

This PR adds new functionality with preferred-modules configuration to detect submodules (along with relevant documentation and tests). The focus was intended to enhance the existing design via the `imports.py` without losing the original functionality.

I very much appreciate any comments or suggestions towards improving the work in this PR!

Note: I feel that #7957 may still need more work to close beyond this change to possibly detect submodule implementation when a "parent" module has been imported (without a direct submodule import statement to reference). It felt that non-import-specific submodule detection might need to be referenced or implemented outside of `imports.py` but I wasn't sure exactly where this would fit. Thank you in advance for any thoughts or feedback on this topic specifically!

Refs #7957
