### PR TITLE
Minor improvement to unittest_utils.py

### DIFF
--- a/tests/utils/unittest_utils.py
+++ b/tests/utils/unittest_utils.py
@@ -18,6 +18,17 @@ def test_decoding_stream_unknown_encoding() -> None:
     assert ret == ["foo\n", "bar"]
 
 
+def test_decoding_stream_empty_encoding() -> None:
+    """Decoding_stream should fall back to *some* decoding when given an
+    empty encoding.
+    """
+    binary_io = io.BytesIO(b"foo\nbar")
+    stream = utils.decoding_stream(binary_io, "")
+    # should still act like a StreamReader
+    ret = stream.readlines()
+    assert ret == ["foo\n", "bar"]
+
+
 def test_decoding_stream_known_encoding() -> None:
     binary_io = io.BytesIO("€".encode("cp1252"))
     stream = utils.decoding_stream(binary_io, "cp1252")


### PR DESCRIPTION
Function `decoding_stream` may receive an empty encoding (see line 173):

https://github.com/PyCQA/pylint/blob/a57edea63fa7a1edfcb63074f9e2a373ebabb7cd/pylint/utils/utils.py#L167-L176

... but this case is untested `unittest_utils.py`.

Actually, the test `unittest_utils.py` checks two cases:
- test_decoding_stream_unknown_encoding
- test_decoding_stream_known_encoding 

Thus, this PR tests the untested case in `test_decoding_stream_empty_encoding`.