### PR TITLE
Fix invalid type false positive

### DIFF
--- a/doc/whatsnew/fragments/8205.false_positive
+++ b/doc/whatsnew/fragments/8205.false_positive
@@ -1,0 +1,3 @@
+Fix false positive for isinstance-second-argument-not-valid-type with union types.
+
+Closes #8205

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -24,6 +24,7 @@ import astroid.helpers
 from astroid import arguments, bases, nodes
 from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
+from pylint.constants import PY310_PLUS
 from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import (
     decorated_with,
@@ -86,9 +87,6 @@ class VERSION_COMPATIBLE_OVERLOAD:
 
 
 VERSION_COMPATIBLE_OVERLOAD_SENTINEL = VERSION_COMPATIBLE_OVERLOAD()
-
-
-PY310_PLUS = sys.version_info >= (3, 10)
 
 
 def _unflatten(iterable: Iterable[_T]) -> Iterator[_T]:

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -796,6 +796,10 @@ def _is_c_extension(module_node: InferenceResult) -> bool:
 
 def _is_invalid_isinstance_type(arg: nodes.NodeNG) -> bool:
     # Return True if we are sure that arg is not a type
+    if isinstance(arg, nodes.BinOp) and arg.op == "|":
+        return _is_invalid_isinstance_type(arg.left) or _is_invalid_isinstance_type(
+            arg.right
+        )
     inferred = utils.safe_infer(arg)
     if not inferred:
         # Cannot infer it so skip it.
@@ -806,10 +810,6 @@ def _is_invalid_isinstance_type(arg: nodes.NodeNG) -> bool:
         return False
     if isinstance(inferred, astroid.Instance) and inferred.qname() == BUILTIN_TUPLE:
         return False
-    if isinstance(arg, nodes.BinOp) and arg.op == "|":
-        return _is_invalid_isinstance_type(arg.left) or _is_invalid_isinstance_type(
-            arg.right
-        )
     return True
 
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1407,7 +1407,11 @@ accessed. Python regular expressions are accepted.",
 
         second_arg = node.args[1]
         if _is_invalid_isinstance_type(second_arg):
-            self.add_message("isinstance-second-argument-not-valid-type", node=node)
+            self.add_message(
+                "isinstance-second-argument-not-valid-type",
+                node=node,
+                confidence=INFERENCE,
+            )
 
     # pylint: disable = too-many-branches, too-many-locals, too-many-statements
     def visit_call(self, node: nodes.Call) -> None:

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -24,7 +24,6 @@ import astroid.helpers
 from astroid import arguments, bases, nodes
 from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
-from pylint.constants import PY310_PLUS
 from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import (
     decorated_with,
@@ -49,6 +48,7 @@ from pylint.checkers.utils import (
     supports_membership_test,
     supports_setitem,
 )
+from pylint.constants import PY310_PLUS
 from pylint.interfaces import HIGH, INFERENCE
 from pylint.typing import MessageDefinitionTuple
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -810,6 +810,10 @@ def _is_invalid_isinstance_type(arg: nodes.NodeNG) -> bool:
         return False
     if isinstance(inferred, astroid.Instance) and inferred.qname() == BUILTIN_TUPLE:
         return False
+    if isinstance(inferred, bases.UnionType):
+        return _is_invalid_isinstance_type(
+            inferred.left
+        ) or _is_invalid_isinstance_type(inferred.right)
     return True
 
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -806,6 +806,10 @@ def _is_invalid_isinstance_type(arg: nodes.NodeNG) -> bool:
         return False
     if isinstance(inferred, astroid.Instance) and inferred.qname() == BUILTIN_TUPLE:
         return False
+    if isinstance(arg, nodes.BinOp) and arg.op == "|":
+        return _is_invalid_isinstance_type(arg.left) and _is_invalid_isinstance_type(
+            arg.right
+        )
     return True
 
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -807,7 +807,7 @@ def _is_invalid_isinstance_type(arg: nodes.NodeNG) -> bool:
     if isinstance(inferred, astroid.Instance) and inferred.qname() == BUILTIN_TUPLE:
         return False
     if isinstance(arg, nodes.BinOp) and arg.op == "|":
-        return _is_invalid_isinstance_type(arg.left) and _is_invalid_isinstance_type(
+        return _is_invalid_isinstance_type(arg.left) or _is_invalid_isinstance_type(
             arg.right
         )
     return True

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -88,6 +88,9 @@ class VERSION_COMPATIBLE_OVERLOAD:
 VERSION_COMPATIBLE_OVERLOAD_SENTINEL = VERSION_COMPATIBLE_OVERLOAD()
 
 
+PY310_PLUS = sys.version_info >= (3, 10)
+
+
 def _unflatten(iterable: Iterable[_T]) -> Iterator[_T]:
     for index, elem in enumerate(iterable):
         if isinstance(elem, Sequence) and not isinstance(elem, str):
@@ -796,7 +799,7 @@ def _is_c_extension(module_node: InferenceResult) -> bool:
 
 def _is_invalid_isinstance_type(arg: nodes.NodeNG) -> bool:
     # Return True if we are sure that arg is not a type
-    if isinstance(arg, nodes.BinOp) and arg.op == "|":
+    if PY310_PLUS and isinstance(arg, nodes.BinOp) and arg.op == "|":
         return _is_invalid_isinstance_type(arg.left) or _is_invalid_isinstance_type(
             arg.right
         )
@@ -810,7 +813,7 @@ def _is_invalid_isinstance_type(arg: nodes.NodeNG) -> bool:
         return False
     if isinstance(inferred, astroid.Instance) and inferred.qname() == BUILTIN_TUPLE:
         return False
-    if isinstance(inferred, bases.UnionType):
+    if PY310_PLUS and isinstance(inferred, bases.UnionType):
         return _is_invalid_isinstance_type(
             inferred.left
         ) or _is_invalid_isinstance_type(inferred.right)

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -18,6 +18,7 @@ from pylint.typing import MessageTypesFullName
 
 PY38_PLUS = sys.version_info[:2] >= (3, 8)
 PY39_PLUS = sys.version_info[:2] >= (3, 9)
+PY310_PLUS = sys.version_info[:2] >= (3, 10)
 
 IS_PYPY = platform.python_implementation() == "PyPy"
 

--- a/tests/functional/d/dataclass/dataclass_typecheck.txt
+++ b/tests/functional/d/dataclass/dataclass_typecheck.txt
@@ -9,4 +9,4 @@ unsupported-delete-operation:72:4:72:13::'obj.attr1' does not support item delet
 not-context-manager:97:0:98:8::Context manager 'str' doesn't implement __enter__ and __exit__.:UNDEFINED
 invalid-metaclass:105:0:105:11:Test2:Invalid metaclass 'Instance of builtins.int' used:UNDEFINED
 unhashable-member:111:0:111:2::'obj.attr5' is unhashable and can't be used as a key in a dict:INFERENCE
-isinstance-second-argument-not-valid-type:121:6:121:30::Second argument of isinstance is not a type:UNDEFINED
+isinstance-second-argument-not-valid-type:121:6:121:30::Second argument of isinstance is not a type:INFERENCE

--- a/tests/functional/ext/typing/redundant_typehint_argument.py
+++ b/tests/functional/ext/typing/redundant_typehint_argument.py
@@ -1,4 +1,4 @@
-""""Checks for redundant Union typehints in assignments"""
+"""Checks for redundant Union typehints in assignments"""
 # pylint: disable=deprecated-typing-alias,consider-alternative-union-syntax,consider-using-alias,invalid-name,unused-argument,missing-function-docstring
 
 from __future__ import annotations

--- a/tests/functional/ext/typing/redundant_typehint_argument_py310.py
+++ b/tests/functional/ext/typing/redundant_typehint_argument_py310.py
@@ -1,4 +1,4 @@
-""""Checks for redundant Union typehints in assignments"""
+"""Checks for redundant Union typehints in assignments"""
 # pylint: disable=deprecated-typing-alias,consider-alternative-union-syntax,consider-using-alias,invalid-name,unused-argument,missing-function-docstring
 
 from __future__ import annotations

--- a/tests/functional/i/isinstance_second_argument.txt
+++ b/tests/functional/i/isinstance_second_argument.txt
@@ -1,5 +1,5 @@
-isinstance-second-argument-not-valid-type:27:0:27:23::Second argument of isinstance is not a type:UNDEFINED
-isinstance-second-argument-not-valid-type:28:0:28:19::Second argument of isinstance is not a type:UNDEFINED
-isinstance-second-argument-not-valid-type:29:0:29:34::Second argument of isinstance is not a type:UNDEFINED
-isinstance-second-argument-not-valid-type:30:0:30:54::Second argument of isinstance is not a type:UNDEFINED
-isinstance-second-argument-not-valid-type:31:0:31:18::Second argument of isinstance is not a type:UNDEFINED
+isinstance-second-argument-not-valid-type:27:0:27:23::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:28:0:28:19::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:29:0:29:34::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:30:0:30:54::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:31:0:31:18::Second argument of isinstance is not a type:INFERENCE

--- a/tests/functional/i/isinstance_second_argument_py310.py
+++ b/tests/functional/i/isinstance_second_argument_py310.py
@@ -1,4 +1,4 @@
-'''Tests for isinstance with compound types'''
+'''Tests for invalid isinstance with compound types'''
 
 # True negatives
 isinstance(0, int | str)
@@ -6,18 +6,16 @@ isinstance(0, int | int | int)
 isinstance(0, int | str | list | float)
 isinstance(0, (int | str) | (list | float))
 
+IntOrStr = int | str
+isinstance(0, IntOrStr)
+ListOrDict = list | dict
+isinstance(0, (float | ListOrDict) | IntOrStr)
+
 # True positives
 isinstance(0, int | 5)  # [isinstance-second-argument-not-valid-type]
 isinstance(0, str | 5 | int)  # [isinstance-second-argument-not-valid-type]
-
-
-# FALSE POSITIVES
-
-# Type aliases cannot be inferred
-IntOrStr = int | str
-isinstance(0, IntOrStr)  # [isinstance-second-argument-not-valid-type]
-ListOrDict = list | dict
-isinstance(0, (float | ListOrDict) | IntOrStr)  # [isinstance-second-argument-not-valid-type]
+INT = 5
+isinstance(0, INT | int)  # [isinstance-second-argument-not-valid-type]
 
 
 # FALSE NEGATIVES

--- a/tests/functional/i/isinstance_second_argument_py310.py
+++ b/tests/functional/i/isinstance_second_argument_py310.py
@@ -1,5 +1,29 @@
-# pylint: disable = missing-docstring
+'''Tests for isinstance with compound types'''
+
+# True negatives
 isinstance(0, int | str)
 isinstance(0, int | int | int)
 isinstance(0, int | str | list | float)
 isinstance(0, (int | str) | (list | float))
+
+# True positives
+isinstance(0, int | 5)  # [isinstance-second-argument-not-valid-type]
+isinstance(0, str | 5 | int)  # [isinstance-second-argument-not-valid-type]
+
+
+# FALSE POSITIVES
+
+# Type aliases cannot be inferred
+IntOrStr = int | str
+isinstance(0, IntOrStr)  # [isinstance-second-argument-not-valid-type]
+ListOrDict = list | dict
+isinstance(0, (float | ListOrDict) | IntOrStr)  # [isinstance-second-argument-not-valid-type]
+
+
+# FALSE NEGATIVES
+
+# Parameterized generics will raise type errors at runtime.
+# Warnings should be raised, but aren't (yet).
+isinstance(0, list[int])
+ListOfInts = list[int]
+isinstance(0, ListOfInts)

--- a/tests/functional/i/isinstance_second_argument_py310.py
+++ b/tests/functional/i/isinstance_second_argument_py310.py
@@ -1,0 +1,5 @@
+# pylint: disable = missing-docstring
+isinstance(0, int | str)
+isinstance(0, int | int | int)
+isinstance(0, int | str | list | float)
+isinstance(0, (int | str) | (list | float))

--- a/tests/functional/i/isinstance_second_argument_py310.rc
+++ b/tests/functional/i/isinstance_second_argument_py310.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.10

--- a/tests/functional/i/isinstance_second_argument_py310.txt
+++ b/tests/functional/i/isinstance_second_argument_py310.txt
@@ -1,0 +1,4 @@
+isinstance-second-argument-not-valid-type:10:0:10:22::Second argument of isinstance is not a type:UNDEFINED
+isinstance-second-argument-not-valid-type:11:0:11:28::Second argument of isinstance is not a type:UNDEFINED
+isinstance-second-argument-not-valid-type:18:0:18:23::Second argument of isinstance is not a type:UNDEFINED
+isinstance-second-argument-not-valid-type:20:0:20:46::Second argument of isinstance is not a type:UNDEFINED

--- a/tests/functional/i/isinstance_second_argument_py310.txt
+++ b/tests/functional/i/isinstance_second_argument_py310.txt
@@ -1,4 +1,3 @@
-isinstance-second-argument-not-valid-type:10:0:10:22::Second argument of isinstance is not a type:UNDEFINED
-isinstance-second-argument-not-valid-type:11:0:11:28::Second argument of isinstance is not a type:UNDEFINED
-isinstance-second-argument-not-valid-type:18:0:18:23::Second argument of isinstance is not a type:UNDEFINED
-isinstance-second-argument-not-valid-type:20:0:20:46::Second argument of isinstance is not a type:UNDEFINED
+isinstance-second-argument-not-valid-type:15:0:15:22::Second argument of isinstance is not a type:UNDEFINED
+isinstance-second-argument-not-valid-type:16:0:16:28::Second argument of isinstance is not a type:UNDEFINED
+isinstance-second-argument-not-valid-type:18:0:18:24::Second argument of isinstance is not a type:UNDEFINED

--- a/tests/functional/i/isinstance_second_argument_py310.txt
+++ b/tests/functional/i/isinstance_second_argument_py310.txt
@@ -1,3 +1,3 @@
-isinstance-second-argument-not-valid-type:15:0:15:22::Second argument of isinstance is not a type:UNDEFINED
-isinstance-second-argument-not-valid-type:16:0:16:28::Second argument of isinstance is not a type:UNDEFINED
-isinstance-second-argument-not-valid-type:18:0:18:24::Second argument of isinstance is not a type:UNDEFINED
+isinstance-second-argument-not-valid-type:15:0:15:22::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:16:0:16:28::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:18:0:18:24::Second argument of isinstance is not a type:INFERENCE


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fixes false positive for `isinstance-second-argument-not-valid-type` with union types.

Closes #8205
