### PR TITLE
Don't use ``self.config`` since it's deprecated

### DIFF
--- a/examples/custom.py
+++ b/examples/custom.py
@@ -50,7 +50,7 @@ class MyAstroidChecker(BaseChecker):
         if not (
             isinstance(node.func, nodes.Attribute)
             and isinstance(node.func.expr, nodes.Name)
-            and node.func.expr.name == self.config.store_locals_indicator
+            and node.func.expr.name == self.linter.config.store_locals_indicator
             and node.func.attrname == "create"
         ):
             return


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

The example lint rule references a deprecated attribute, so this changes the example to use the new recommended attribute.