### PR TITLE
Don't use deprecated attribute in example test

### DIFF
--- a/doc/development_guide/how_tos/custom_checkers.rst
+++ b/doc/development_guide/how_tos/custom_checkers.rst
@@ -167,7 +167,7 @@ Now we know how to use the astroid node, we can implement our check.
           return
       for other_return in self._function_stack[-1]:
           if node.value.value == other_return.value.value and not (
-              self.config.ignore_ints and node.value.pytype() == int
+              self.linter.config.ignore_ints and node.value.pytype() == int
           ):
               self.add_message("non-unique-returns", node=node)
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Don't use deprecated attribute in example test. Wish I'd caught this in my earlier PR 🤷 . Probably this could use a lint rule or something, but that's beyond my purview for the time being.