### PR TITLE
Add version option to `pyreverse`

### DIFF
--- a/doc/whatsnew/fragments/7851.feature
+++ b/doc/whatsnew/fragments/7851.feature
@@ -1,0 +1,3 @@
+Add `--version` option to `pyreverse`.
+
+Refs #7851

--- a/pylint/pyreverse/main.py
+++ b/pylint/pyreverse/main.py
@@ -256,6 +256,12 @@ class Run(_ArgumentsManager, _ArgumentsProvider):
     name = "pyreverse"
 
     def __init__(self, args: Sequence[str]) -> NoReturn:
+        # Immediately exit if user asks for version
+        if "--version" in args:
+            print("pyreverse is included in pylint:")
+            print(constants.full_version)
+            sys.exit(0)
+
         _ArgumentsManager.__init__(self, prog="pyreverse", description=__doc__)
         _ArgumentsProvider.__init__(self, self)
 

--- a/tests/pyreverse/test_main.py
+++ b/tests/pyreverse/test_main.py
@@ -189,3 +189,16 @@ def test_class_command(
     )
     assert "data.clientmodule_test.Ancestor" in runner.config.classes
     assert "data.property_pattern.PropertyPatterns" in runner.config.classes
+
+
+def test_version_info(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Test that it is possible to display the version information."""
+    test_full_version = "1.2.3.4"
+    monkeypatch.setattr(main.constants, "full_version", test_full_version)  # type: ignore[attr-defined]
+    with pytest.raises(SystemExit):
+        main.Run(["--version"])
+    out, _ = capsys.readouterr()
+    assert "pyreverse is included in pylint" in out
+    assert test_full_version in out


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Add the `--version` option to `pyreverse`.
Note that this does not yet fix the crash mentioned in the referenced issue if somebody passes some other unknown version.

```console
% pyreverse --version
pyreverse is included in pylint:
pylint 2.17.0-dev0
astroid 2.14.1
Python 3.10.4 (main, May 15 2022, 08:21:46) [Clang 12.0.5 (clang-1205.0.22.9)]
```

Refs #7851
