### PR TITLE
Only count obviously non-terminating while-loops as return-ended

### DIFF
--- a/doc/whatsnew/fragments/8280.false_negative
+++ b/doc/whatsnew/fragments/8280.false_negative
@@ -1,3 +1,3 @@
 Fix false negative for inconsistent-returns with while-loops.
 
-Closes 8280
+Closes #8280

--- a/doc/whatsnew/fragments/8280.false_negative
+++ b/doc/whatsnew/fragments/8280.false_negative
@@ -1,0 +1,3 @@
+Fix false negative for inconsistent-returns with while-loops.
+
+Closes 8280

--- a/pylint/checkers/base/basic_error_checker.py
+++ b/pylint/checkers/base/basic_error_checker.py
@@ -46,7 +46,7 @@ def _get_break_loop_node(break_node: nodes.Break) -> nodes.For | nodes.While | N
     return parent
 
 
-def _loop_exits_early(loop: nodes.For | nodes.While) -> bool:
+def loop_exits_early(loop: nodes.For | nodes.While) -> bool:
     """Returns true if a loop may end with a break statement.
 
     Args:
@@ -474,7 +474,7 @@ class BasicErrorChecker(_BasicChecker):
 
     def _check_else_on_loop(self, node: nodes.For | nodes.While) -> None:
         """Check that any loop with an else clause has a break statement."""
-        if node.orelse and not _loop_exits_early(node):
+        if node.orelse and not loop_exits_early(node):
             self.add_message(
                 "useless-else-on-loop",
                 node=node,

--- a/pylint/checkers/base/basic_error_checker.py
+++ b/pylint/checkers/base/basic_error_checker.py
@@ -46,7 +46,7 @@ def _get_break_loop_node(break_node: nodes.Break) -> nodes.For | nodes.While | N
     return parent
 
 
-def loop_exits_early(loop: nodes.For | nodes.While) -> bool:
+def _loop_exits_early(loop: nodes.For | nodes.While) -> bool:
     """Returns true if a loop may end with a break statement.
 
     Args:
@@ -474,7 +474,7 @@ class BasicErrorChecker(_BasicChecker):
 
     def _check_else_on_loop(self, node: nodes.For | nodes.While) -> None:
         """Check that any loop with an else clause has a break statement."""
-        if node.orelse and not loop_exits_early(node):
+        if node.orelse and not _loop_exits_early(node):
             self.add_message(
                 "useless-else-on-loop",
                 node=node,

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -20,7 +20,7 @@ from astroid.util import Uninferable
 
 from pylint import checkers
 from pylint.checkers import utils
-from pylint.checkers.base.basic_error_checker import loop_exits_early
+from pylint.checkers.base.basic_error_checker import _loop_exits_early
 from pylint.checkers.utils import node_frame_class
 from pylint.interfaces import HIGH, INFERENCE, Confidence
 
@@ -1949,7 +1949,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         if isinstance(node, nodes.While):
             # A while-loop is considered return-ended if it has a
             # truthy test and no break statements
-            return (node.test.bool_value() and not loop_exits_early(node)) or any(
+            return (node.test.bool_value() and not _loop_exits_early(node)) or any(
                 self._is_node_return_ended(child) for child in node.orelse
             )
         if isinstance(node, nodes.Raise):

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1945,10 +1945,10 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                     return True
             except astroid.InferenceError:
                 pass
-        # Avoid the check inside while loop as we don't know
-        # if they will be completed
         if isinstance(node, nodes.While):
-            return True
+            # A while-loop is considered return-ended if it has a
+            # truthy test and no break statements
+            return node.test.bool_value() and not any(node.nodes_of_class(nodes.Break))
         if isinstance(node, nodes.Raise):
             return self._is_raise_node_return_ended(node)
         if isinstance(node, nodes.If):

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -20,9 +20,9 @@ from astroid.util import Uninferable
 
 from pylint import checkers
 from pylint.checkers import utils
+from pylint.checkers.base.basic_error_checker import loop_exits_early
 from pylint.checkers.utils import node_frame_class
 from pylint.interfaces import HIGH, INFERENCE, Confidence
-from pylint.checkers.base.basic_error_checker import loop_exits_early
 
 if TYPE_CHECKING:
     from pylint.lint import PyLinter

--- a/tests/functional/i/inconsistent/inconsistent_returns.py
+++ b/tests/functional/i/inconsistent/inconsistent_returns.py
@@ -1,5 +1,5 @@
 #pylint: disable=missing-docstring, no-else-return, no-else-break, invalid-name, unused-variable, superfluous-parens, try-except-raise
-#pylint: disable=disallowed-name,too-few-public-methods,no-member,undefined-variable,useless-else-on-loop
+#pylint: disable=disallowed-name,too-few-public-methods,no-member,useless-else-on-loop
 """Testing inconsistent returns"""
 import math
 import sys
@@ -359,8 +359,8 @@ def bug_pylint_4019_wrong(x):  # [inconsistent-return-statements]
 class A:
     def get_the_answer(self):  # [inconsistent-return-statements]
         while self.is_running:
-            read_message()
-            if comunication_finished():
+            self.read_message()
+            if self.comunication_finished():
                 return "done"
 
 

--- a/tests/functional/i/inconsistent/inconsistent_returns.py
+++ b/tests/functional/i/inconsistent/inconsistent_returns.py
@@ -1,5 +1,5 @@
 #pylint: disable=missing-docstring, no-else-return, no-else-break, invalid-name, unused-variable, superfluous-parens, try-except-raise
-#pylint: disable=disallowed-name
+#pylint: disable=disallowed-name,too-few-public-methods,no-member,undefined-variable
 """Testing inconsistent returns"""
 import math
 import sys
@@ -353,3 +353,22 @@ def bug_pylint_4019_wrong(x):  # [inconsistent-return-statements]
     if x == 1:
         return 42
     assert True
+
+
+# https://github.com/PyCQA/pylint/issues/8280
+class A:
+    def get_the_answer(self):  # [inconsistent-return-statements]
+        while self.is_running:
+            read_message()
+            if comunication_finished():
+                return "done"
+
+
+def bug_1772_break():  # [inconsistent-return-statements]
+    counter = 1
+    while True:
+        counter += 1
+        if counter == 100:
+            return 7
+        if counter is None:
+            break

--- a/tests/functional/i/inconsistent/inconsistent_returns.py
+++ b/tests/functional/i/inconsistent/inconsistent_returns.py
@@ -1,5 +1,5 @@
 #pylint: disable=missing-docstring, no-else-return, no-else-break, invalid-name, unused-variable, superfluous-parens, try-except-raise
-#pylint: disable=disallowed-name,too-few-public-methods,no-member,undefined-variable
+#pylint: disable=disallowed-name,too-few-public-methods,no-member,undefined-variable,useless-else-on-loop
 """Testing inconsistent returns"""
 import math
 import sys
@@ -372,3 +372,33 @@ def bug_1772_break():  # [inconsistent-return-statements]
             return 7
         if counter is None:
             break
+
+
+def while_break_in_for():
+    counter = 1
+    while True:
+        counter += 1
+        if counter == 100:
+            return 7
+        for i in range(10):
+            if i == 5:
+                break
+
+
+def while_break_in_while():
+    counter = 1
+    while True:
+        counter += 1
+        if counter == 100:
+            return 7
+        while True:
+            if counter == 5:
+                break
+
+
+def wait_for_apps_ready(event, main_thread):
+    while main_thread.is_alive():
+        if event.wait(timeout=0.1):
+            return True
+    else:
+        return False

--- a/tests/functional/i/inconsistent/inconsistent_returns.txt
+++ b/tests/functional/i/inconsistent/inconsistent_returns.txt
@@ -15,3 +15,5 @@ inconsistent-return-statements:267:0:267:12:bug_3468:Either all return statement
 inconsistent-return-statements:277:0:277:20:bug_3468_variant:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
 inconsistent-return-statements:322:0:322:21:bug_pylint_3873_1:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
 inconsistent-return-statements:349:0:349:25:bug_pylint_4019_wrong:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
+inconsistent-return-statements:360:4:360:22:A.get_the_answer:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
+inconsistent-return-statements:367:0:367:18:bug_1772_break:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fixes false negative for `inconsistent-returns` by only counting `while` loops as return-ended when they are obviously non-terminating.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #8280 
