### PR TITLE
Documentation: Order of messages

### DIFF
--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -84,7 +84,7 @@ def _get_example_code(data_path: Path) -> str:
     )
 
     _check_placeholders(data_path, bad_code, details, related)
-    return "\n".join((good_code, bad_code, pylintrc, details, related)) + "\n"
+    return "\n".join((bad_code, good_code, pylintrc, details, related)) + "\n"
 
 
 def _get_pylintrc_code(data_path: Path) -> str:
@@ -307,7 +307,7 @@ def _generate_single_message_body(message: MessageData) -> str:
 {get_rst_title(f"{message.name} / {message.id}", "=")}
 **Message emitted:**
 
-{message.definition.msg}
+``{message.definition.msg}``
 
 **Description:**
 

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -386,7 +386,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
             "By default, the first parameter is the group param, not the target param.",
         ),
         "W1507": (
-            "Using copy.copy(os.environ). Use os.environ.copy() instead. ",
+            "Using copy.copy(os.environ). Use os.environ.copy() instead.",
             "shallow-copy-environ",
             "os.environ is not a dict object but proxy object, so "
             "shallow copy has still effects on original object. "

--- a/tests/functional/s/shallow_copy_environ.txt
+++ b/tests/functional/s/shallow_copy_environ.txt
@@ -1,2 +1,2 @@
-shallow-copy-environ:7:0:7:21::Using copy.copy(os.environ). Use os.environ.copy() instead. :UNDEFINED
-shallow-copy-environ:17:0:17:18::Using copy.copy(os.environ). Use os.environ.copy() instead. :UNDEFINED
+shallow-copy-environ:7:0:7:21::Using copy.copy(os.environ). Use os.environ.copy() instead.:UNDEFINED
+shallow-copy-environ:17:0:17:18::Using copy.copy(os.environ). Use os.environ.copy() instead.:UNDEFINED


### PR DESCRIPTION
In https://github.com/PyCQA/pylint/pull/7162, "we decreed" that the `bad_code` goes first, then the `good_code`.

Fixup current changes, to revert "back to standards".

Additionally, tackle the comment here
https://github.com/PyCQA/pylint/pull/8287#issuecomment-1437983737

"Message emitted" is technically still code (`%-formatting`); let us make it stand out properly.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

Refs https://github.com/PyCQA/pylint/pull/8287

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes https://github.com/PyCQA/pylint/issues/8321
