### PR TITLE
[doc] Add an example for suppressed-message

### DIFF
--- a/doc/data/messages/s/suppressed-message/bad.py
+++ b/doc/data/messages/s/suppressed-message/bad.py
@@ -1,1 +1,9 @@
-test = ["a" "b"]  # pylint: disable=implicit-str-concat # [suppressed-message]
+### This is a contrived example, to show how suppressed-message works.
+### First we enable all messages
+# pylint: enable=all
+
+### Here we disable two messages so we get two warnings
+# pylint: disable=locally-disabled, useless-suppression # [suppressed-message, suppressed-message]
+
+### Here we disable a message, so we get a warning for suppressed-message again.
+"A"  # pylint: disable=pointless-statement # [suppressed-message, suppressed-message]

--- a/doc/data/messages/s/suppressed-message/bad.py
+++ b/doc/data/messages/s/suppressed-message/bad.py
@@ -1,0 +1,1 @@
+test = ["a" "b"]  # pylint: disable=implicit-str-concat # [suppressed-message]

--- a/doc/data/messages/s/suppressed-message/details.rst
+++ b/doc/data/messages/s/suppressed-message/details.rst
@@ -1,1 +1,4 @@
-You can help us make the doc better `by contributing <https://github.com/PyCQA/pylint/issues/5953>`_ !
+``suppressed-message`` is simply a way to see messages that would be raised
+without the disable in your codebase. It should not be activated most
+of the time. See also ``useless-suppression`` if you want to see the message
+that are disabled for no reasons.

--- a/doc/data/messages/s/suppressed-message/good.py
+++ b/doc/data/messages/s/suppressed-message/good.py
@@ -1,1 +1,1 @@
-test = ["ab"]
+"""Instead of a single string somewhere in the file, write a module docstring!"""

--- a/doc/data/messages/s/suppressed-message/good.py
+++ b/doc/data/messages/s/suppressed-message/good.py
@@ -1,1 +1,1 @@
-# This is a placeholder for correct code for this message.
+test = ["ab"]

--- a/doc/test_messages_documentation.py
+++ b/doc/test_messages_documentation.py
@@ -106,7 +106,7 @@ class LintModuleTest:
         args = [
             str(full_path),
             "--disable=all",
-            f"--enable=F,implicit-str-concat,{msgid},astroid-error,syntax-error",
+            f"--enable=F,{msgid},astroid-error,syntax-error",
         ]
         print(f"Command used:\npylint {' '.join(args)}")
         _config_initialization(

--- a/doc/test_messages_documentation.py
+++ b/doc/test_messages_documentation.py
@@ -106,7 +106,7 @@ class LintModuleTest:
         args = [
             str(full_path),
             "--disable=all",
-            f"--enable=F,{msgid},astroid-error,syntax-error",
+            f"--enable=F,implicit-str-concat,{msgid},astroid-error,syntax-error",
         ]
         print(f"Command used:\npylint {' '.join(args)}")
         _config_initialization(


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

The message would not be triggered if implicit-str-concat is not activated too. I initially wanted to activate invalid-name so we follow pep8 in our examples but there's more than 50 violations right now. So 'implicit-str-concat' it is.

Refs #7897 #5953 

