### PR TITLE
Prevent emitting ``invalid-name``

### DIFF
--- a/doc/whatsnew/fragments/8307.bugfix
+++ b/doc/whatsnew/fragments/8307.bugfix
@@ -1,0 +1,3 @@
+Prevent emitting ``invalid-name`` for the line on which a ``global`` statement is declared.
+
+Closes #8307

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -388,11 +388,6 @@ class NameChecker(_BasicChecker):
 
     visit_asyncfunctiondef = visit_functiondef
 
-    @utils.only_required_for_messages("disallowed-name", "invalid-name")
-    def visit_global(self, node: nodes.Global) -> None:
-        for name in node.names:
-            self._check_name("const", name, node)
-
     @utils.only_required_for_messages(
         "disallowed-name",
         "invalid-name",

--- a/tests/functional/g/globals.py
+++ b/tests/functional/g/globals.py
@@ -102,3 +102,12 @@ def init_connection_state(alias):
     global RAN_DB_DICT  # [global-variable-not-assigned]
     RAN_DB_SET.add(alias)
     return RAN_DB_DICT.setdefault("color", "Palomino")
+
+
+# Prevent emitting `invalid-name` for the line on which `global` is declared
+# https://github.com/PyCQA/pylint/issues/8307
+
+_foo: str = "tomato"
+def setup_shared_foo():
+    global _foo  # [global-statement]
+    _foo = "potato"

--- a/tests/functional/g/globals.txt
+++ b/tests/functional/g/globals.txt
@@ -14,3 +14,4 @@ global-statement:81:4:81:15:override_func:Using the global statement:HIGH
 global-statement:91:4:91:16:override_class:Using the global statement:HIGH
 global-variable-not-assigned:101:4:101:21:init_connection_state:Using global for 'RAN_DB_SET' but no assignment is done:HIGH
 global-variable-not-assigned:102:4:102:22:init_connection_state:Using global for 'RAN_DB_DICT' but no assignment is done:HIGH
+global-statement:112:4:112:15:setup_shared_foo:Using the global statement:HIGH

--- a/tests/functional/n/name/name_styles.py
+++ b/tests/functional/n/name/name_styles.py
@@ -94,7 +94,7 @@ NOT_CORRECT = CorrectClassName  # [invalid-name]
 def test_globals():
     """Names in global statements are also checked."""
     global NOT_CORRECT
-    global AlsoCorrect  # [invalid-name]
+    global AlsoCorrect
     NOT_CORRECT = 1
     AlsoCorrect = 2
 

--- a/tests/functional/n/name/name_styles.txt
+++ b/tests/functional/n/name/name_styles.txt
@@ -10,7 +10,6 @@ invalid-name:53:4:53:38:CorrectClassName.__DunDER_IS_not_free_for_all__:"Method 
 invalid-name:83:0:83:18::"Class name ""BAD_NAME_FOR_CLASS"" doesn't conform to PascalCase naming style":HIGH
 invalid-name:84:0:84:23::"Class name ""NEXT_BAD_NAME_FOR_CLASS"" doesn't conform to PascalCase naming style":HIGH
 invalid-name:91:0:91:11::"Class name ""NOT_CORRECT"" doesn't conform to PascalCase naming style":HIGH
-invalid-name:97:4:97:22:test_globals:"Constant name ""AlsoCorrect"" doesn't conform to UPPER_CASE naming style":HIGH
 invalid-name:110:4:110:21:FooClass.PROPERTY_NAME:"Attribute name ""PROPERTY_NAME"" doesn't conform to snake_case naming style":INFERENCE
 invalid-name:116:4:116:30:FooClass.ABSTRACT_PROPERTY_NAME:"Attribute name ""ABSTRACT_PROPERTY_NAME"" doesn't conform to snake_case naming style":INFERENCE
 invalid-name:121:4:121:28:FooClass.PROPERTY_NAME_SETTER:"Attribute name ""PROPERTY_NAME_SETTER"" doesn't conform to snake_case naming style":INFERENCE


### PR DESCRIPTION
Prevent emitting ``invalid-name`` for the line on which a ``global`` statement is declared.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
The `visit_global` function seems to be redundant because the `visit_assignname` method is already running the [self._check_name("const", node.name, node)](https://github.com/PyCQA/pylint/blob/main/pylint/checkers/base/name_checker/checker.py#L446) method on the node representing the module-level assignment.

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #8307
