### PR TITLE
[test] Use an empty pylintrc so tests to not depend on system's conf

### DIFF
--- a/tests/checkers/unittest_imports.py
+++ b/tests/checkers/unittest_imports.py
@@ -206,7 +206,7 @@ class TestImportsChecker(CheckerTestCase):
             exit=False,
         )
         output, errors = capsys.readouterr()
-        assert len(output.split("\n")) == 7, f"Expected 5 line breaks in:{output}"
+        assert len(output.split("\n")) == 7, f"Expected 7 line breaks in:{output}"
         assert (
             "__init__.py:1:0: C0414: Import alias does not rename original package (useless-import-alias)"
             in output

--- a/tests/checkers/unittest_imports.py
+++ b/tests/checkers/unittest_imports.py
@@ -11,8 +11,8 @@ from pytest import CaptureFixture
 
 from pylint.checkers import imports
 from pylint.interfaces import UNDEFINED
-from pylint.lint import Run
 from pylint.testutils import CheckerTestCase, MessageTest
+from pylint.testutils._run import _Run as Run
 
 REGR_DATA = os.path.join(os.path.dirname(__file__), "..", "regrtest_data", "")
 
@@ -206,7 +206,7 @@ class TestImportsChecker(CheckerTestCase):
             exit=False,
         )
         output, errors = capsys.readouterr()
-        assert len(output.split("\n")) == 5, f"Expected 5 line breaks in:{output}"
+        assert len(output.split("\n")) == 7, f"Expected 5 line breaks in:{output}"
         assert (
             "__init__.py:1:0: C0414: Import alias does not rename original package (useless-import-alias)"
             in output
@@ -222,6 +222,7 @@ class TestImportsChecker(CheckerTestCase):
             [
                 f"{os.path.join(REGR_DATA, 'allow_reexport')}",
                 "--allow-reexport-from-package=yes",
+                "--disable=missing-module-docstring",
                 "-sn",
             ],
             exit=False,

--- a/tests/config/pylint_config/test_pylint_config_generate.py
+++ b/tests/config/pylint_config/test_pylint_config_generate.py
@@ -186,7 +186,15 @@ def test_writing_minimal_file(
         assert any(line.startswith("#") for line in captured.out.splitlines())
 
         # Check minimal doesn't have comments and no default values
-        Run(["--accept-no-return-doc=y", "generate", "--interactive"], exit=False)
+        Run(
+            [
+                "--load-plugins=pylint.extensions.docparams",
+                "--accept-no-return-doc=y",
+                "generate",
+                "--interactive",
+            ],
+            exit=False,
+        )
         captured = capsys.readouterr()
         assert not any(i.startswith("#") for i in captured.out.split("\n"))
         assert "accept-no-return-doc" not in captured.out

--- a/tests/config/test_per_directory_config.py
+++ b/tests/config/test_per_directory_config.py
@@ -4,7 +4,7 @@
 
 from pathlib import Path
 
-from pylint.lint import Run
+from pylint.testutils._run import _Run as Run
 
 
 def test_fall_back_on_base_config(tmp_path: Path) -> None:

--- a/tests/test_pylint_runners.py
+++ b/tests/test_pylint_runners.py
@@ -18,8 +18,8 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 from pylint import run_epylint, run_pylint, run_pyreverse, run_symilar
-from pylint.lint import Run
 from pylint.testutils import GenericTestReporter as Reporter
+from pylint.testutils._run import _Run as Run
 from pylint.testutils.utils import _test_cwd
 
 if sys.version_info >= (3, 8):


### PR DESCRIPTION

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #8342, and fix test that could create similar bugs with specifics configurations.
