### PR TITLE
[pre-commit] Transition from flake8/autoflake to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,23 +15,19 @@ repos:
             doc/data/messages/t/trailing-newlines/bad.py|
             doc/data/messages/m/missing-final-newline/bad.py|
           )$
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.0.1
-    hooks:
-      - id: autoflake
-        exclude: &fixtures tests(/\w*)*/functional/|tests/input|doc/data/messages|tests(/\w*)*data/
-        args:
-          - --in-place
-          - --remove-all-unused-imports
-          - --expand-star-imports
-          - --remove-duplicate-keys
-          - --remove-unused-variables
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: "v0.0.253"
     hooks:
       - id: ruff
         args: ["--fix"]
-        exclude: *fixtures
+        exclude: &fixtures tests(/\w*)*/functional/|tests/input|doc/data/messages|tests(/\w*)*data/
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.253"
+    hooks:
+      - id: ruff
+        name: line-length-doc
+        files: doc/data/messages
+        args: ["--config", "doc/data/ruff.toml"]
   - repo: https://github.com/Pierre-Sassoulas/copyright_notice_precommit
     rev: 0.1.2
     hooks:
@@ -60,20 +56,6 @@ repos:
     rev: v1.1.3
     hooks:
       - id: black-disable-checker
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          [flake8-bugbear==23.1.20, flake8-typing-imports==1.14.0]
-        exclude: *fixtures
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        name: line-length-doc
-        files: doc/data/messages
-        args: ["--config", "doc/data/.flake8"]
   - repo: local
     hooks:
       - id: pylint

--- a/doc/data/ruff.toml
+++ b/doc/data/ruff.toml
@@ -1,6 +1,5 @@
-[flake8]
-select =
-    E501,
+ignore = []
 # Reading ease is drastically reduced on read the doc after 103 chars
 # (Because of horizontal scrolling)
-max-line-length=103
+line-length = 103
+select = ["E501"]

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -125,9 +125,10 @@ def _config_initialization(
     # All other options have been removed from the list.
     return list(
         chain.from_iterable(
-            # NOTE: 'or [arg]' is needed in the case the input file or directory does not exist and 'glob(arg)' cannot
-            # find anything. Without this we would not be able to output the fatal import error for this module later
-            # on, as it would get silently ignored.
+            # NOTE: 'or [arg]' is needed in the case the input file or directory does
+            # not exist and 'glob(arg)' cannot find anything. Without this we would
+            # not be able to output the fatal import error for this module later on,
+            # as it would get silently ignored.
             glob(arg, recursive=True) or [arg]
             for arg in parsed_args_list
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,10 +130,13 @@ module = [
     "pytest",
     "sphinx.*",
 ]
+
 [tool.ruff]
-select = ["E", "F", "B"]
+select = ["E", "F", "W", "B"]
 ignore = [
     "B905", # Not enforced previousely
 ]
-fixable = ["E", "F", "B"]
-line-length = 125
+fixable = ["E", "F", "W", "B"]
+# ruff is less lenient than pylint and does not make any exceptions
+# (for docstrings, strings and comments in particular).
+line-length = 115

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,19 +7,3 @@
 license_files =
     LICENSE
     CONTRIBUTORS.txt
-
-[flake8]
-# Incompatible with black see https://github.com/ambv/black/issues/315
-# E203: Whitespace before ':'
-# W503: Line break occurred before a binary operator
-# B028: consider using the `!r` conversion flag
-ignore =
-    E203,
-    W503,
-    B028,
-# Flake8 is less lenient than pylint and does not make any exceptions
-# (for docstrings, strings and comments in particular).
-max-line-length=115
-# Required for flake8-typing-imports (v1.12.0)
-# The plugin doesn't yet read the value from pyproject.toml
-min_python_version = 3.7.2


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

ruff is faster and support pyproject.toml and python 3.7. flake8-typing-import is not implemented but it checks for things in python version < 3.7.2 that we do not support. Fix main following #8362 that broke it.
