### PR TITLE
[doc] Add an example for 'missing-format-string-key'

### DIFF
--- a/doc/data/messages/m/missing-format-string-key/bad.py
+++ b/doc/data/messages/m/missing-format-string-key/bad.py
@@ -1,7 +1,7 @@
+# +1: [missing-format-string-key]
 fruit_prices = """
 Apple: %(apple_price)d ¤
 Orange: %(orange_price)d ¤
 """ % {
-    "apple_price": 42,
-    "orange_price": 87,
+    "apple_price": 42
 }

--- a/doc/data/messages/m/missing-format-string-key/details.rst
+++ b/doc/data/messages/m/missing-format-string-key/details.rst
@@ -1,1 +1,0 @@
-You can help us make the doc better `by contributing <https://github.com/PyCQA/pylint/issues/5953>`_ !


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Refs #5953
