### PR TITLE
Document ignoring pragmas for calculating line length

### DIFF
--- a/doc/data/messages/l/line-too-long/details.rst
+++ b/doc/data/messages/l/line-too-long/details.rst
@@ -1,3 +1,5 @@
+Pragma controls such as ``# pylint: disable=all`` are not counted toward line length for the purposes of this message.
+
 If you attempt to disable this message via ``# pylint: disable=line-too-long`` in a module with no code, you may receive a message for ``useless-suppression``. This is a false positive of ``useless-suppression`` we can't easily fix.
 
 See https://github.com/PyCQA/pylint/issues/3368 for more information.


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description
Closes #4802 with a doc update as described there.