### PR TITLE
Cancel previous tests when pushing to PRs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,10 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests-linux:
     name: run / ${{ matrix.python-version }} / Linux


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Closes #8285

Extends our [existing](https://github.com/PyCQA/pylint/blob/c356a3c99388a192dd57beea99c4d043e15cff2c/.github/workflows/primer-test.yaml#L19-L21) `concurrency` infrastructure that cancels some in-progress jobs when a PR is updated to cancel also the tests workflow and the codeql-analysis workflow.

Does not affect pushes to main.


## Demo
[Example cancelled run](https://github.com/jacobtylerwalls/pylint/actions/runs/4336747449)
![demo](https://user-images.githubusercontent.com/38668450/222970031-cf161c82-66ad-4da8-bd0b-6a006dfa8f5d.png)
