### PR TITLE
[Backport maintenance/2.16.x] Fix invalid type false positive (#8206)

### DIFF
--- a/doc/whatsnew/fragments/8205.false_positive
+++ b/doc/whatsnew/fragments/8205.false_positive
@@ -1,0 +1,3 @@
+Fix false positive for isinstance-second-argument-not-valid-type with union types.
+
+Closes #8205

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -18,6 +18,7 @@ from pylint.typing import MessageTypesFullName
 
 PY38_PLUS = sys.version_info[:2] >= (3, 8)
 PY39_PLUS = sys.version_info[:2] >= (3, 9)
+PY310_PLUS = sys.version_info[:2] >= (3, 10)
 
 IS_PYPY = platform.python_implementation() == "PyPy"
 

--- a/tests/functional/d/dataclass/dataclass_typecheck.txt
+++ b/tests/functional/d/dataclass/dataclass_typecheck.txt
@@ -9,4 +9,4 @@ unsupported-delete-operation:72:4:72:13::'obj.attr1' does not support item delet
 not-context-manager:97:0:98:8::Context manager 'str' doesn't implement __enter__ and __exit__.:UNDEFINED
 invalid-metaclass:105:0:105:11:Test2:Invalid metaclass 'Instance of builtins.int' used:UNDEFINED
 unhashable-member:111:0:111:2::'obj.attr5' is unhashable and can't be used as a key in a dict:INFERENCE
-isinstance-second-argument-not-valid-type:121:6:121:30::Second argument of isinstance is not a type:UNDEFINED
+isinstance-second-argument-not-valid-type:121:6:121:30::Second argument of isinstance is not a type:INFERENCE

--- a/tests/functional/ext/typing/redundant_typehint_argument.py
+++ b/tests/functional/ext/typing/redundant_typehint_argument.py
@@ -1,4 +1,4 @@
-""""Checks for redundant Union typehints in assignments"""
+"""Checks for redundant Union typehints in assignments"""
 # pylint: disable=deprecated-typing-alias,consider-alternative-union-syntax,consider-using-alias
 
 from __future__ import annotations

--- a/tests/functional/i/isinstance_second_argument.txt
+++ b/tests/functional/i/isinstance_second_argument.txt
@@ -1,5 +1,5 @@
-isinstance-second-argument-not-valid-type:27:0:27:23::Second argument of isinstance is not a type:UNDEFINED
-isinstance-second-argument-not-valid-type:28:0:28:19::Second argument of isinstance is not a type:UNDEFINED
-isinstance-second-argument-not-valid-type:29:0:29:34::Second argument of isinstance is not a type:UNDEFINED
-isinstance-second-argument-not-valid-type:30:0:30:54::Second argument of isinstance is not a type:UNDEFINED
-isinstance-second-argument-not-valid-type:31:0:31:18::Second argument of isinstance is not a type:UNDEFINED
+isinstance-second-argument-not-valid-type:27:0:27:23::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:28:0:28:19::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:29:0:29:34::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:30:0:30:54::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:31:0:31:18::Second argument of isinstance is not a type:INFERENCE

--- a/tests/functional/i/isinstance_second_argument_py310.py
+++ b/tests/functional/i/isinstance_second_argument_py310.py
@@ -1,0 +1,27 @@
+'''Tests for invalid isinstance with compound types'''
+
+# True negatives
+isinstance(0, int | str)
+isinstance(0, int | int | int)
+isinstance(0, int | str | list | float)
+isinstance(0, (int | str) | (list | float))
+
+IntOrStr = int | str
+isinstance(0, IntOrStr)
+ListOrDict = list | dict
+isinstance(0, (float | ListOrDict) | IntOrStr)
+
+# True positives
+isinstance(0, int | 5)  # [isinstance-second-argument-not-valid-type]
+isinstance(0, str | 5 | int)  # [isinstance-second-argument-not-valid-type]
+INT = 5
+isinstance(0, INT | int)  # [isinstance-second-argument-not-valid-type]
+
+
+# FALSE NEGATIVES
+
+# Parameterized generics will raise type errors at runtime.
+# Warnings should be raised, but aren't (yet).
+isinstance(0, list[int])
+ListOfInts = list[int]
+isinstance(0, ListOfInts)

--- a/tests/functional/i/isinstance_second_argument_py310.rc
+++ b/tests/functional/i/isinstance_second_argument_py310.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.10

--- a/tests/functional/i/isinstance_second_argument_py310.txt
+++ b/tests/functional/i/isinstance_second_argument_py310.txt
@@ -1,0 +1,3 @@
+isinstance-second-argument-not-valid-type:15:0:15:22::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:16:0:16:28::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:18:0:18:24::Second argument of isinstance is not a type:INFERENCE


### PR DESCRIPTION
(cherry picked from commit e64f0437388298c7f8514a6755c3c27a0d9a35f2)