### PR TITLE
[deprecation] Remove ``get_message_definitions`` from ``BaseChecker``

### DIFF
--- a/doc/whatsnew/fragments/8401.breaking
+++ b/doc/whatsnew/fragments/8401.breaking
@@ -1,0 +1,4 @@
+``get_message_definition`` was removed from the base checker API. You can access
+message definitions through the ``MessageStore``.
+
+Refs #8401

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -234,20 +234,6 @@ class BaseChecker(_ArgumentsProvider):
             for msgid, msg_tuple in sorted(self.msgs.items())
         ]
 
-    def get_message_definition(self, msgid: str) -> MessageDefinition:
-        # TODO: 3.0: Remove deprecated method
-        warnings.warn(
-            "'get_message_definition' is deprecated and will be removed in 3.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        for message_definition in self.messages:
-            if message_definition.msgid == msgid:
-                return message_definition
-        error_msg = f"MessageDefinition for '{msgid}' does not exists. "
-        error_msg += f"Choose from {[m.msgid for m in self.messages]}."
-        raise InvalidMessageError(error_msg)
-
     def open(self) -> None:
         """Called before visiting project (i.e. set of modules)."""
 

--- a/tests/checkers/unittest_base_checker.py
+++ b/tests/checkers/unittest_base_checker.py
@@ -132,16 +132,5 @@ def test_base_checker_ordering() -> None:
 
 def test_base_checker_invalid_message() -> None:
     linter = PyLinter()
-
     with pytest.raises(InvalidMessageError):
         linter.register_checker(MissingFieldsChecker(linter))
-
-
-def test_get_message_definition() -> None:
-    checker = LessBasicChecker()
-    with pytest.warns(DeprecationWarning):
-        with pytest.raises(InvalidMessageError):
-            checker.get_message_definition("W123")
-
-    with pytest.warns(DeprecationWarning):
-        assert checker.get_message_definition("W0001")


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description


