### PR TITLE
Add Python 3.8+ `asyncSetUp` to "defining-attr-methods" list

### DIFF
--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -626,7 +626,7 @@ Standard Checkers
 """""""""""""""""""""""
 *List of method names used to declare (i.e. assign) instance attributes.*
 
-**Default:**  ``('__init__', '__new__', 'setUp', '__post_init__')``
+**Default:**  ``('__init__', '__new__', 'setUp', 'asyncSetUp', '__post_init__')``
 
 
 --exclude-protected
@@ -663,7 +663,7 @@ Standard Checkers
    [tool.pylint.classes]
    check-protected-access-in-special-methods = false
 
-   defining-attr-methods = ["__init__", "__new__", "setUp", "__post_init__"]
+   defining-attr-methods = ["__init__", "__new__", "setUp", "asyncSetUp", "__post_init__"]
 
    exclude-protected = ["_asdict", "_fields", "_replace", "_source", "_make", "os._exit"]
 

--- a/doc/whatsnew/fragments/8403.false_positive
+++ b/doc/whatsnew/fragments/8403.false_positive
@@ -1,0 +1,5 @@
+Adds ``asyncSetUp`` to the default ``defining-attr-methods`` list to silence
+``attribute-defined-outside-init`` warning when using
+``unittest.IsolatedAsyncioTestCase``.
+
+Refs #8403

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -260,6 +260,7 @@ check-protected-access-in-special-methods=no
 defining-attr-methods=__init__,
                       __new__,
                       setUp,
+                      asyncSetUp,
                       __post_init__
 
 # List of member names, which should be excluded from the protected access

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -226,7 +226,7 @@ variable-naming-style = "snake_case"
 # check-protected-access-in-special-methods =
 
 # List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods = ["__init__", "__new__", "setUp", "__post_init__"]
+defining-attr-methods = ["__init__", "__new__", "setUp", "asyncSetUp", "__post_init__"]
 
 # List of member names, which should be excluded from the protected access
 # warning.

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -778,7 +778,13 @@ class ClassChecker(BaseChecker):
         (
             "defining-attr-methods",
             {
-                "default": ("__init__", "__new__", "setUp", "__post_init__"),
+                "default": (
+                    "__init__",
+                    "__new__",
+                    "setUp",
+                    "asyncSetUp",
+                    "__post_init__",
+                ),
                 "type": "csv",
                 "metavar": "<method names>",
                 "help": "List of method names used to declare (i.e. assign) \

--- a/tests/functional/a/attribute_defined_outside_init_py38.py
+++ b/tests/functional/a/attribute_defined_outside_init_py38.py
@@ -1,0 +1,9 @@
+# pylint: disable=missing-docstring
+
+import unittest
+
+
+class AsyncioTestCase(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.i = 42

--- a/tests/functional/a/attribute_defined_outside_init_py38.rc
+++ b/tests/functional/a/attribute_defined_outside_init_py38.rc
@@ -1,0 +1,5 @@
+[main]
+load-plugins=pylint.extensions.typing
+
+[testoptions]
+min_pyver=3.8


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|  | :sparkles: New feature |
|   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

This patch adds `unittest.IsolatedAsyncioTestCase` asynchronous "setUp" coroutine to the list of "defining-attr-methods", in order to silence "attribute-defined-outside-init" (W0201) false positive.

---

Feel free to edit this PR as needed; I'm not sure how we should handle Python 3.8+ constraint here.

Thanks, bye :wave: