### PR TITLE
[FileState] Deprecation enactment for 3.0.0

### DIFF
--- a/doc/whatsnew/fragments/8407.breaking
+++ b/doc/whatsnew/fragments/8407.breaking
@@ -1,0 +1,5 @@
+``modname`` and ``msg_store`` are now required to be given in ``FileState``.
+``collect_block_lines`` has also been removed. ``Pylinter.current_name``
+cannot be null anymore.
+
+Refs #8407

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -856,7 +856,7 @@ class SimilarChecker(BaseRawFileChecker, Similar):
                 DeprecationWarning,
             )
         with node.stream() as stream:
-            self.append_stream(self.linter.current_name, stream, node.file_encoding)  # type: ignore[arg-type]
+            self.append_stream(self.linter.current_name, stream, node.file_encoding)
 
     def close(self) -> None:
         """Compute and display similarities on closing (i.e. end of parsing)."""

--- a/pylint/lint/message_state_handler.py
+++ b/pylint/lint/message_state_handler.py
@@ -55,9 +55,8 @@ class _MessageStateHandler:
             "enable-msg": self._options_methods["enable"],
         }
         self._pragma_lineno: dict[str, int] = {}
-        # TODO: 3.0: Update key type to str when current_name is always str
         self._stashed_messages: defaultdict[
-            tuple[str | None, str], list[tuple[str | None, str]]
+            tuple[str, str], list[tuple[str | None, str]]
         ] = defaultdict(list)
         """Some messages in the options (for --enable and --disable) are encountered
         too early to warn about them.

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import functools
-import warnings
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any
@@ -42,7 +41,7 @@ def _worker_initialize(
     """Function called to initialize a worker for a Process within a concurrent Pool.
 
     :param linter: A linter-class (PyLinter) instance pickled with dill
-    :param extra_packages_paths: Extra entries to be added to sys.path
+    :param extra_packages_paths: Extra entries to be added to `sys.path`
     """
     global _worker_linter  # pylint: disable=global-statement
     _worker_linter = dill.loads(linter)
@@ -61,10 +60,9 @@ def _worker_check_single_file(
     file_item: FileItem,
 ) -> tuple[
     int,
-    # TODO: 3.0: Make this only str after deprecation has been removed
-    str | None,
     str,
-    str | None,
+    str,
+    str,
     list[Message],
     LinterStats,
     int,
@@ -82,14 +80,6 @@ def _worker_check_single_file(
     msgs = _worker_linter.reporter.messages
     assert isinstance(_worker_linter.reporter, reporters.CollectingReporter)
     _worker_linter.reporter.reset()
-    if _worker_linter.current_name is None:
-        warnings.warn(
-            (
-                "In pylint 3.0 the current_name attribute of the linter object should be a string. "
-                "If unknown it should be initialized as an empty string."
-            ),
-            DeprecationWarning,
-        )
     return (
         id(multiprocessing.current_process()),
         _worker_linter.current_name,

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -339,7 +339,7 @@ class PyLinter(
 
         # Attributes related to visiting files
         self.file_state = FileState("", self.msgs_store, is_base_filestate=True)
-        self.current_name: str | None = None
+        self.current_name: str = ""
         self.current_file: str | None = None
         self._ignore_file = False
         self._ignore_paths: list[Pattern[str]] = []
@@ -900,26 +900,13 @@ class PyLinter(
             self.add_message(key, args=message)
         return result
 
-    def set_current_module(
-        self, modname: str | None, filepath: str | None = None
-    ) -> None:
+    def set_current_module(self, modname: str, filepath: str | None = None) -> None:
         """Set the name of the currently analyzed module and
         init statistics for it.
         """
         if not modname and filepath is None:
             return
         self.reporter.on_set_current_module(modname or "", filepath)
-        if modname is None:
-            # TODO: 3.0: Remove all modname or ""'s in this method
-            warnings.warn(
-                (
-                    "In pylint 3.0 modname should be a string so that it can be used to "
-                    "correctly set the current_name attribute of the linter instance. "
-                    "If unknown it should be initialized as an empty string."
-                ),
-                DeprecationWarning,
-                stacklevel=2,
-            )
         self.current_name = modname
         self.current_file = filepath or modname
         self.stats.init_single_module(modname or "")
@@ -1219,12 +1206,7 @@ class PyLinter(
         msg_cat = MSG_TYPES[message_definition.msgid[0]]
         self.msg_status |= MSG_TYPES_STATUS[message_definition.msgid[0]]
         self.stats.increase_single_message_count(msg_cat, 1)
-        # TODO: 3.0 Should be removable after https://github.com/PyCQA/pylint/pull/5580
-        self.stats.increase_single_module_message_count(
-            self.current_name,  # type: ignore[arg-type]
-            msg_cat,
-            1,
-        )
+        self.stats.increase_single_module_message_count(self.current_name, msg_cat, 1)
         try:
             self.stats.by_msg[message_definition.symbol] += 1
         except KeyError:

--- a/pylint/utils/file_state.py
+++ b/pylint/utils/file_state.py
@@ -36,26 +36,12 @@ class FileState:
 
     def __init__(
         self,
-        modname: str | None = None,
-        msg_store: MessageDefinitionStore | None = None,
+        modname: str,
+        msg_store: MessageDefinitionStore,
         node: nodes.Module | None = None,
         *,
         is_base_filestate: bool = False,
     ) -> None:
-        if modname is None:
-            warnings.warn(
-                "FileState needs a string as modname argument. "
-                "This argument will be required in pylint 3.0",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        if msg_store is None:
-            warnings.warn(
-                "FileState needs a 'MessageDefinitionStore' as msg_store argument. "
-                "This argument will be required in pylint 3.0",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         self.base_name = modname
         self._module_msgs_state: MessageStateDict = {}
         self._raw_module_msgs_state: MessageStateDict = {}
@@ -230,10 +216,6 @@ class FileState:
     ) -> None:
         """Set status (enabled/disable) for a given message at a given line."""
         assert line > 0
-        assert self._module
-        # TODO: 3.0: Remove unnecessary assertion
-        assert self._msgs_store
-
         if scope != "line":
             # Expand the status to cover all relevant block lines
             self._set_state_on_block_lines(

--- a/pylint/utils/file_state.py
+++ b/pylint/utils/file_state.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import collections
 import sys
-import warnings
 from collections import defaultdict
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Dict
@@ -59,25 +58,6 @@ class FileState:
         """If this FileState is the base state made during initialization of
         PyLinter.
         """
-
-    def collect_block_lines(
-        self, msgs_store: MessageDefinitionStore, module_node: nodes.Module
-    ) -> None:
-        """Walk the AST to collect block level options line numbers."""
-        warnings.warn(
-            "'collect_block_lines' has been deprecated and will be removed in pylint 3.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        for msg, lines in self._module_msgs_state.items():
-            self._raw_module_msgs_state[msg] = lines.copy()
-        orig_state = self._module_msgs_state.copy()
-        self._module_msgs_state = {}
-        self._suppression_mapping = {}
-        self._effective_max_line_number = module_node.tolineno
-        for msgid, lines in orig_state.items():
-            for msgdef in msgs_store.get_message_definitions(msgid):
-                self._set_state_on_block_lines(msgs_store, module_node, msgdef, lines)
 
     def _set_state_on_block_lines(
         self,

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -9,13 +9,10 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from astroid import nodes
 
 from pylint import lint
 from pylint.checkers.mapreduce_checker import MapReduceMixin
 from pylint.lint import PyLinter
-from pylint.message import MessageDefinitionStore
-from pylint.utils import FileState
 
 
 def test_mapreducemixin() -> None:
@@ -30,24 +27,6 @@ def test_mapreducemixin() -> None:
 
     with pytest.warns(DeprecationWarning):
         MyChecker()
-
-
-def test_filestate() -> None:
-    """Test that FileState needs its arguments."""
-    with pytest.warns(DeprecationWarning):
-        FileState()
-    with pytest.warns(DeprecationWarning):
-        FileState("foo")
-    with pytest.warns(DeprecationWarning):
-        FileState(msg_store=MessageDefinitionStore())
-    FileState("foo", MessageDefinitionStore())
-
-
-def test_collectblocklines() -> None:
-    """Test FileState.collect_block_lines."""
-    state = FileState("foo", MessageDefinitionStore())
-    with pytest.warns(DeprecationWarning):
-        state.collect_block_lines(MessageDefinitionStore(), nodes.Module("foo"))
 
 
 def test_patch_sys_path() -> None:


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

``modname`` and ``msg_store`` are now required to be given in FileState, ``collect_block_lines`` has also been removed.
