### PR TITLE
[Reporter] Remove 'set_output' in favor of reporter.out

### DIFF
--- a/doc/whatsnew/fragments/8408.breaking
+++ b/doc/whatsnew/fragments/8408.breaking
@@ -1,0 +1,3 @@
+'Reporter.set_output' was removed in favor of 'reporter.out = stream'.
+
+Refs #8408

--- a/pylint/reporters/base_reporter.py
+++ b/pylint/reporters/base_reporter.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import os
 import sys
 from typing import TYPE_CHECKING, TextIO
-from warnings import warn
 
 from pylint.message import Message
 from pylint.reporters.ureports.nodes import Text
@@ -40,16 +39,6 @@ class BaseReporter:
     def handle_message(self, msg: Message) -> None:
         """Handle a new message triggered on the current file."""
         self.messages.append(msg)
-
-    def set_output(self, output: TextIO | None = None) -> None:
-        """Set output stream."""
-        # TODO: 3.0: Remove deprecated method
-        warn(
-            "'set_output' will be removed in 3.0, please use 'reporter.out = stream' instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.out = output or sys.stdout
 
     def writeln(self, string: str = "") -> None:
         """Write a line in the output buffer."""

--- a/tests/reporters/unittest_reporting.py
+++ b/tests/reporters/unittest_reporting.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import sys
 import warnings
 from contextlib import redirect_stdout
 from io import StringIO
@@ -15,7 +14,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TextIO
 
 import pytest
-from _pytest.recwarn import WarningsRecorder
 
 from pylint import checkers
 from pylint.interfaces import HIGH
@@ -126,16 +124,6 @@ def test_template_option_with_header(linter: PyLinter) -> None:
     out_lines = output.getvalue().split("\n")
     assert out_lines[1] == '{ "Category": "convention" }'
     assert out_lines[2] == '{ "Category": "convention" }'
-
-
-def test_deprecation_set_output(recwarn: WarningsRecorder) -> None:
-    """TODO remove in 3.0."""
-    reporter = BaseReporter()
-    # noinspection PyDeprecation
-    reporter.set_output(sys.stdout)
-    warning = recwarn.pop()
-    assert "set_output' will be removed in 3.0" in str(warning)
-    assert reporter.out == sys.stdout
 
 
 def test_parseable_output_deprecated() -> None:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description


