### PR TITLE
[colorize_ansi] Remove the possibility to use anything else than a MessageStyle

### DIFF
--- a/doc/whatsnew/fragments/8412.breaking
+++ b/doc/whatsnew/fragments/8412.breaking
@@ -1,0 +1,3 @@
+``colorize_ansi`` now only accept a ``MessageStyle`` object.
+
+Refs #8412

--- a/pylint/reporters/text.py
+++ b/pylint/reporters/text.py
@@ -37,7 +37,7 @@ class MessageStyle(NamedTuple):
     style: tuple[str, ...] = ()
     """Tuple of style strings (see `ANSI_COLORS` for available values)."""
 
-    def get_ansi_code(self) -> str:
+    def _get_ansi_code(self) -> str:
         """Return ANSI escape code corresponding to color and style.
 
         :raise KeyError: if a nonexistent color or style identifier is given
@@ -93,7 +93,7 @@ def colorize_ansi(msg: str, msg_style: MessageStyle) -> str:
     if msg_style.color is None and len(msg_style.style) == 0:
         # If both color and style are not defined, then leave the text as is.
         return msg
-    escape_code = msg_style.get_ansi_code()
+    escape_code = msg_style._get_ansi_code()
     # If invalid (or unknown) color, don't wrap msg with ANSI codes
     if escape_code:
         return f"{escape_code}{msg}{ANSI_RESET}"

--- a/pylint/reporters/text.py
+++ b/pylint/reporters/text.py
@@ -15,7 +15,7 @@ import re
 import sys
 import warnings
 from dataclasses import asdict, fields
-from typing import TYPE_CHECKING, Dict, NamedTuple, Optional, TextIO, cast, overload
+from typing import TYPE_CHECKING, Dict, NamedTuple, Optional, TextIO, cast
 
 from pylint.message import Message
 from pylint.reporters import BaseReporter
@@ -36,6 +36,24 @@ class MessageStyle(NamedTuple):
     """
     style: tuple[str, ...] = ()
     """Tuple of style strings (see `ANSI_COLORS` for available values)."""
+
+    def get_ansi_code(self) -> str:
+        """Return ANSI escape code corresponding to color and style.
+
+        :raise KeyError: if a nonexistent color or style identifier is given
+
+        :return: the built escape code
+        """
+        ansi_code = [ANSI_STYLES[effect] for effect in self.style]
+        if self.color:
+            if self.color.isdigit():
+                ansi_code.extend(["38", "5"])
+                ansi_code.append(self.color)
+            else:
+                ansi_code.append(ANSI_COLORS[self.color])
+        if ansi_code:
+            return ANSI_PREFIX + ";".join(ansi_code) + ANSI_END
+        return ""
 
 
 ColorMappingDict = Dict[str, MessageStyle]
@@ -70,81 +88,12 @@ MESSAGE_FIELDS = {i.name for i in fields(Message)}
 """All fields of the Message class."""
 
 
-def _get_ansi_code(msg_style: MessageStyle) -> str:
-    """Return ANSI escape code corresponding to color and style.
-
-    :param msg_style: the message style
-
-    :raise KeyError: if a nonexistent color or style identifier is given
-
-    :return: the built escape code
-    """
-    ansi_code = [ANSI_STYLES[effect] for effect in msg_style.style]
-    if msg_style.color:
-        if msg_style.color.isdigit():
-            ansi_code.extend(["38", "5"])
-            ansi_code.append(msg_style.color)
-        else:
-            ansi_code.append(ANSI_COLORS[msg_style.color])
-    if ansi_code:
-        return ANSI_PREFIX + ";".join(ansi_code) + ANSI_END
-    return ""
-
-
-@overload
-def colorize_ansi(
-    msg: str,
-    msg_style: MessageStyle | None = ...,
-) -> str:
-    ...
-
-
-@overload
-def colorize_ansi(
-    msg: str,
-    msg_style: str | None = ...,
-    style: str = ...,
-    *,
-    color: str | None = ...,
-) -> str:
-    # Remove for pylint 3.0
-    ...
-
-
-def colorize_ansi(
-    msg: str,
-    msg_style: MessageStyle | str | None = None,
-    style: str = "",
-    **kwargs: str | None,
-) -> str:
-    r"""colorize message by wrapping it with ANSI escape codes
-
-    :param msg: the message string to colorize
-
-    :param msg_style: the message style
-        or color (for backwards compatibility): the color of the message style
-
-    :param style: the message's style elements, this will be deprecated
-
-    :param \**kwargs: used to accept `color` parameter while it is being deprecated
-
-    :return: the ANSI escaped string
-    """
-    # TODO: 3.0: Remove deprecated typing and only accept MessageStyle as parameter
-    if not isinstance(msg_style, MessageStyle):
-        warnings.warn(
-            "In pylint 3.0, the colorize_ansi function of Text reporters will only accept a "
-            "MessageStyle parameter",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        color = kwargs.get("color")
-        style_attrs = tuple(_splitstrip(style))
-        msg_style = MessageStyle(color or msg_style, style_attrs)
-    # If both color and style are not defined, then leave the text as is
+def colorize_ansi(msg: str, msg_style: MessageStyle) -> str:
+    """Colorize message by wrapping it with ANSI escape codes."""
     if msg_style.color is None and len(msg_style.style) == 0:
+        # If both color and style are not defined, then leave the text as is.
         return msg
-    escape_code = _get_ansi_code(msg_style)
+    escape_code = msg_style.get_ansi_code()
     # If invalid (or unknown) color, don't wrap msg with ANSI codes
     if escape_code:
         return f"{escape_code}{msg}{ANSI_RESET}"


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

I think we could be a lot more liberal with the breaking change for small internal things like that.