### PR TITLE
[pre-commit] Configure ruff to sort import in the doc examples

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     rev: "v0.0.254"
     hooks:
       - id: ruff
-        name: line-length-doc
+        name: ruff-doc
         files: doc/data/messages
         args: ["--config", "doc/data/ruff.toml"]
   - repo: https://github.com/Pierre-Sassoulas/copyright_notice_precommit
@@ -45,7 +45,7 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        exclude: doc/data/messages/(r/reimported|w/wrong-import-order|u/ungrouped-imports|m/misplaced-future|m/multiple-imports)/bad.py
+        exclude: doc/data/messages/
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:

--- a/doc/data/ruff.toml
+++ b/doc/data/ruff.toml
@@ -2,4 +2,12 @@ ignore = []
 # Reading ease is drastically reduced on read the doc after 103 chars
 # (Because of horizontal scrolling)
 line-length = 103
-select = ["E501"]
+select = ["E501", "I"]
+
+
+[per-file-ignores]
+"doc/data/messages/r/reimported/bad.py" = ["I"]
+"doc/data/messages/w/wrong-import-order/bad.py" = ["I"]
+"doc/data/messages/u/ungrouped-imports/bad.py" = ["I"]
+"doc/data/messages/m/misplaced-future/bad.py" = ["I"]
+"doc/data/messages/m/multiple-imports/bad.py" = ["I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,11 +132,27 @@ module = [
 ]
 
 [tool.ruff]
-select = ["E", "F", "W", "B"]
-ignore = [
-    "B905", # Not enforced previousely
-]
-fixable = ["E", "F", "W", "B"]
+
 # ruff is less lenient than pylint and does not make any exceptions
 # (for docstrings, strings and comments in particular).
 line-length = 115
+
+select = [
+    "E",  # pycodestyle
+    "F",  # pyflakes
+    "W",  # pycodestyle
+    "B",  # bugbear
+    "I",  # isort
+]
+
+ignore = [
+    "B905", # `zip()` without an explicit `strict=` parameter
+]
+
+fixable = [
+    "E",  # pycodestyle
+    "F",  # pyflakes
+    "W",  # pycodestyle
+    "B",  # bugbear
+    "I",  # isort
+]

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -4,7 +4,7 @@ pre-commit~=3.1;python_version>='3.8'
 bandit==1.7.4
 black==23.1.0
 flake8==6.0.0;python_version>='3.8'
-ruff
+ruff==0.0.254
 flake8-typing-imports==1.14.0;python_version>='3.8'
 isort==5.12.0;python_version>='3.8'
 mypy==1.0.1

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,10 +1,10 @@
-# Everything in this file should reflect the pre-commit configuration
-# in .pre-commit-config.yaml
-pre-commit~=3.1;python_version>='3.8'
-bandit==1.7.4
-black==23.1.0
-flake8==6.0.0;python_version>='3.8'
-ruff==0.0.254
-flake8-typing-imports==1.14.0;python_version>='3.8'
-isort==5.12.0;python_version>='3.8'
-mypy==1.0.1
+# This file is accurate as long as the version in pre-commit configuration
+# is the latest. We don't want to pin and have to upgrade all the time.
+pre-commit
+bandit
+black
+flake8
+ruff
+flake8-typing-imports
+isort
+mypy


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Faster, but I'm not sure if ruff handle first party / third parties correctly. It's good enough for the doc example anyway, and the per file configuration is better than a regex...