### PR TITLE
Fix a crash when `TYPE_CHECKING` is used without importing it

### DIFF
--- a/doc/whatsnew/fragments/8434.bugfix
+++ b/doc/whatsnew/fragments/8434.bugfix
@@ -1,0 +1,3 @@
+Fix a crash when ``TYPE_CHECKING`` is used without importing it.
+
+Closes #8434

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1918,7 +1918,10 @@ def in_type_checking_block(node: nodes.NodeNG) -> bool:
         if isinstance(ancestor.test, nodes.Name):
             if ancestor.test.name != "TYPE_CHECKING":
                 continue
-            maybe_import_from = ancestor.test.lookup(ancestor.test.name)[1][0]
+            lookup_result = ancestor.test.lookup(ancestor.test.name)[1]
+            if not lookup_result:
+                return False
+            maybe_import_from = lookup_result[0]
             if (
                 isinstance(maybe_import_from, nodes.ImportFrom)
                 and maybe_import_from.modname == "typing"

--- a/tests/checkers/unittest_utils.py
+++ b/tests/checkers/unittest_utils.py
@@ -446,6 +446,16 @@ def test_if_typing_guard() -> None:
     assert utils.is_typing_guard(code[3]) is False
 
 
+def test_in_type_checking_block() -> None:
+    code = astroid.extract_node(
+        """
+    if TYPE_CHECKING:  # don't import this!
+        import math  #@
+    """
+    )
+    assert utils.in_type_checking_block(code) is False
+
+
 def test_is_empty_literal() -> None:
     list_node = astroid.extract_node("a = []")
     assert utils.is_base_container(list_node.value)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Closes #8434
