### PR TITLE
Fix `used-before-assignment` false positive for `TYPE_CHECKING` elif branch imports 

### DIFF
--- a/doc/whatsnew/fragments/8437.bugfix
+++ b/doc/whatsnew/fragments/8437.bugfix
@@ -1,0 +1,4 @@
+Fix a ``used-before-assignment`` false positive when imports 
+are made under the ``TYPE_CHECKING`` else if branch.
+
+Closes #8437

--- a/tests/functional/u/used/used_before_assignment_typing.py
+++ b/tests/functional/u/used/used_before_assignment_typing.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     import types
     import zoneinfo
 elif input():
-    import calendar, bisect  # pylint: disable=multiple-imports
+    import calendar, bisect, dbm  # pylint: disable=multiple-imports
     if input() + 1:
         import heapq
     else:
@@ -168,6 +168,7 @@ class TypeCheckingMultiBranch:  # pylint: disable=too-few-public-methods,unused-
     """Test for defines in TYPE_CHECKING if/elif/else branching"""
     def defined_in_elif_branch(self) -> calendar.Calendar:
         print(bisect)
+        print(dbm)
         return calendar.Calendar()
 
     def defined_in_else_branch(self) -> urlopen:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

This PR resolves false positives when imports are made in the `TYPE_CHECKING` else if branch.

The issue lies in `is_variable_violation()`. The logic is supposed to rely on the usage of the `TYPE_CHECKING` `if` statement node, but it is relying on the `elif` statement node for such cases.

This solution searches the import node ancestors for the `TYPE_CHECKING` base branch.

Additionally, a new static function `_is_variable_annotation_in_function()` is introduced to refactor the related logic and reduce nesting levels.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #8437 
