### PR TITLE
Increase new primer timeout to 120m

### DIFF
--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -26,7 +26,7 @@ jobs:
   run-primer:
     name: Run / ${{ matrix.python-version }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       matrix:
         python-version: ["3.7", "3.11"]


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
The 3.7 primer job on main regularly takes about an hour and fails most of the time now, especially since we added `poetry-core`. Eventually, a better multiprocessing design will help. For now, bump the limit to the same as the workflow on PRs:

https://github.com/PyCQA/pylint/blob/b968fa062f801626426ef399401c4530e13fcc49/.github/workflows/primer_run_pr.yaml#L38
