### PR TITLE
[cyclic-import] Break cycle between pylint.checkers.util / variables

### DIFF
--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2277,13 +2277,13 @@ def overridden_method(
         return None
     try:
         meth_node = parent[name]
-    except KeyError:
+    except KeyError:  # pragma: no-cover
         # We have found an ancestor defining <name> but it's not in the local
         # dictionary. This may happen with astroid built from living objects.
         return None
     if isinstance(meth_node, nodes.FunctionDef):
         return meth_node
-    return None
+    return None  # pragma: no-cover
 
 
 def clear_lru_caches() -> None:

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2266,11 +2266,28 @@ def not_condition_as_string(
     return msg
 
 
+@lru_cache(maxsize=1000)
+def overridden_method(
+    klass: nodes.LocalsDictNodeNG, name: str | None
+) -> nodes.FunctionDef | None:
+    """Get overridden method if any."""
+    try:
+        parent = next(klass.local_attr_ancestors(name))
+    except (StopIteration, KeyError):
+        return None
+    try:
+        meth_node = parent[name]
+    except KeyError:
+        # We have found an ancestor defining <name> but it's not in the local
+        # dictionary. This may happen with astroid built from living objects.
+        return None
+    if isinstance(meth_node, nodes.FunctionDef):
+        return meth_node
+    return None
+
+
 def clear_lru_caches() -> None:
     """Clear caches holding references to AST nodes."""
-    # pylint: disable-next=import-outside-toplevel
-    from pylint.checkers.variables import overridden_method
-
     caches_holding_node_references: list[_lru_cache_wrapper[Any]] = [
         in_for_else_branch,
         infer_all,

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2277,13 +2277,13 @@ def overridden_method(
         return None
     try:
         meth_node = parent[name]
-    except KeyError:  # pragma: no-cover
+    except KeyError:  # pragma: no cover
         # We have found an ancestor defining <name> but it's not in the local
         # dictionary. This may happen with astroid built from living objects.
         return None
     if isinstance(meth_node, nodes.FunctionDef):
         return meth_node
-    return None  # pragma: no-cover
+    return None  # pragma: no cover
 
 
 def clear_lru_caches() -> None:

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -15,7 +15,6 @@ import sys
 from collections import defaultdict
 from collections.abc import Generator, Iterable, Iterator
 from enum import Enum
-from functools import lru_cache
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 import astroid
@@ -28,6 +27,7 @@ from pylint.checkers.utils import (
     in_type_checking_block,
     is_postponed_evaluation_enabled,
     is_sys_guard,
+    overridden_method,
 )
 from pylint.constants import PY39_PLUS, TYPING_NEVER, TYPING_NORETURN
 from pylint.interfaces import CONTROL_FLOW, HIGH, INFERENCE, INFERENCE_FAILURE
@@ -148,26 +148,6 @@ def _is_from_future_import(stmt: nodes.ImportFrom, name: str) -> bool | None:
     for local_node in module.locals.get(name, []):
         if isinstance(local_node, nodes.ImportFrom) and local_node.modname == FUTURE:
             return True
-    return None
-
-
-@lru_cache(maxsize=1000)
-def overridden_method(
-    klass: nodes.LocalsDictNodeNG, name: str | None
-) -> nodes.FunctionDef | None:
-    """Get overridden method if any."""
-    try:
-        parent = next(klass.local_attr_ancestors(name))
-    except (StopIteration, KeyError):
-        return None
-    try:
-        meth_node = parent[name]
-    except KeyError:
-        # We have found an ancestor defining <name> but it's not in the local
-        # dictionary. This may happen with astroid built from living objects.
-        return None
-    if isinstance(meth_node, nodes.FunctionDef):
-        return meth_node
     return None
 
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Seen when adding ruff specific checks, it suddenly appeared following unrelated changes, I don't know why.
