### PR TITLE
Fix incorrect preferred-modules matches

### DIFF
--- a/doc/whatsnew/fragments/8453.bugfix
+++ b/doc/whatsnew/fragments/8453.bugfix
@@ -1,0 +1,3 @@
+Fix a regression of ``preferred-modules`` where a partial match was used instead of the required full match.
+
+Closes #8453

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -922,7 +922,15 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             mod_compare = [f"{node.modname}.{name[0]}" for name in node.names]
 
         # find whether there are matches with the import vs preferred_modules keys
-        matches = [k for k in self.preferred_modules for mod in mod_compare if k in mod]
+        matches = [
+            k
+            for k in self.preferred_modules
+            for mod in mod_compare
+            # exact match
+            if k == mod
+            # checks for base module matches
+            or k in mod.split(".")[0]
+        ]
 
         # if we have matches, add message
         if matches:

--- a/tests/checkers/unittest_imports.py
+++ b/tests/checkers/unittest_imports.py
@@ -192,6 +192,23 @@ class TestImportsChecker(CheckerTestCase):
         # assert there were no errors
         assert len(errors) == 0
 
+        # Test for challenges with preferred modules indefinite matches
+        Run(
+            [
+                f"{os.path.join(REGR_DATA, 'preferred_module/unpreferred_submodule.py')}",
+                "-d all",
+                "-e preferred-module",
+                # prefer pathlib instead of random (testing to avoid regression)
+                # pathlib shouldn't match with path, which is in the test file
+                "--preferred-modules=random:pathlib",
+            ],
+            exit=False,
+        )
+        _, errors = capsys.readouterr()
+
+        # Assert there were no errors
+        assert len(errors) == 0
+
     @staticmethod
     def test_allow_reexport_package(capsys: CaptureFixture[str]) -> None:
         """Test --allow-reexport-from-package option."""


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This PR updates the preferred-modules functionality to avoid incorrect partial matches from the configuration, as highlighted by @ssbarnea via #8453. Also added is a new test to simulate the example partial match which was provided in the issue (`random` vs `getrandom`).

Closes #8453
