### PR TITLE
[deprecation] 'Pylinter.check' now takes sequence of str only

### DIFF
--- a/doc/whatsnew/fragments/8463.internal
+++ b/doc/whatsnew/fragments/8463.internal
@@ -1,0 +1,3 @@
+Following a deprecation period, ``Pylinter.check`` now only work with sequences of strings, not strings.
+
+Refs #8463

--- a/tests/lint/test_pylinter.py
+++ b/tests/lint/test_pylinter.py
@@ -8,7 +8,6 @@ from typing import Any, NoReturn
 from unittest import mock
 from unittest.mock import patch
 
-from _pytest.recwarn import WarningsRecorder
 from pytest import CaptureFixture
 
 from pylint.lint.pylinter import PyLinter
@@ -32,12 +31,6 @@ def test_crash_in_file(
     assert len(files) == 1
     assert "pylint-crash-20" in str(files[0])
     assert any(m.symbol == "fatal" for m in linter.reporter.messages)
-
-
-def test_check_deprecation(linter: PyLinter, recwarn: WarningsRecorder) -> None:
-    linter.check("myfile.py")
-    msg = recwarn.pop()
-    assert "check function will only accept sequence" in str(msg)
 
 
 def test_crash_during_linting(


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Enacting planned deprecations.
