### PR TITLE
[deprecation] end_line and end_col_offset required in functional tests

### DIFF
--- a/doc/whatsnew/fragments/8465.user_action
+++ b/doc/whatsnew/fragments/8465.user_action
@@ -2,4 +2,4 @@ Following a deprecation period, it's no longer possible to use ``MASTER``
 or ``master`` as configuration section in ``setup.cfg`` or ``tox.ini``. It's bad practice
 to not start sections titles with the tool name. Please use ``pylint.main`` instead.
 
-Refs #8464
+Refs #8465

--- a/doc/whatsnew/fragments/8466.internal
+++ b/doc/whatsnew/fragments/8466.internal
@@ -1,0 +1,5 @@
+Following a deprecation period, ``MessageTest``'s ``end_line`` and ``end_col_offset``
+must be accurate in functional tests (for python 3.8 or above on cpython, and for
+python 3.9 or superior on pypy).
+
+Refs #8466

--- a/pylint/testutils/checker_test_case.py
+++ b/pylint/testutils/checker_test_case.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import contextlib
-import warnings
 from collections.abc import Generator, Iterator
 from typing import Any
 
@@ -78,23 +77,8 @@ class CheckerTestCase:
             assert expected_msg.line == gotten_msg.line, msg
             assert expected_msg.col_offset == gotten_msg.col_offset, msg
             if PY38_PLUS and not IS_PYPY or PY39_PLUS:
-                # TODO: 3.0: Remove deprecated missing arguments and remove the warning
-                if not expected_msg.end_line == gotten_msg.end_line:
-                    warnings.warn(  # pragma: no cover
-                        f"The end_line attribute of {gotten_msg} does not match "
-                        f"the expected value in {expected_msg}. In pylint 3.0 correct end_line "
-                        "attributes will be required for MessageTest.",
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-                if not expected_msg.end_col_offset == gotten_msg.end_col_offset:
-                    warnings.warn(  # pragma: no cover
-                        f"The end_col_offset attribute of {gotten_msg} does not match "
-                        f"the expected value in {expected_msg}. In pylint 3.0 correct end_col_offset "
-                        "attributes will be required for MessageTest.",
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
+                assert expected_msg.end_line == gotten_msg.end_line, msg
+                assert expected_msg.end_col_offset == gotten_msg.end_col_offset, msg
 
     def walk(self, node: nodes.NodeNG) -> None:
         """Recursive walk on the given node."""


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

Enacting planned deprecation.
