### PR TITLE
[test] Remove 'test_pylint_config_attr'

### DIFF
--- a/tests/test_regr.py
+++ b/tests/test_regr.py
@@ -16,7 +16,6 @@ from collections.abc import Callable, Iterator
 from os.path import abspath, dirname, join
 from typing import cast
 
-import astroid
 import pytest
 
 from pylint import testutils
@@ -120,28 +119,6 @@ def test_check_package___init__(finalize_linter: PyLinter) -> None:
     finalize_linter.check(["__init__"])
     checked = list(finalize_linter.stats.by_module.keys())
     assert checked == ["__init__"]
-
-
-# TODO: 3.0: Test are broken because of property shenanigans of config attribute
-# Re-enable after some of the old attributes have been removed after deprecation period
-@pytest.mark.xfail
-def test_pylint_config_attr() -> None:
-    mod = astroid.MANAGER.ast_from_module_name("pylint.lint.pylinter")
-    pylinter = mod["PyLinter"]
-    expect = [
-        "_ArgumentsManager",
-        "object",
-        "ReportsHandlerMixIn",
-        "BaseTokenChecker",
-        "BaseChecker",
-        "_ArgumentsProvider",
-    ]
-    assert [c.name for c in pylinter.ancestors()] == expect
-    assert list(astroid.Instance(pylinter).getattr("config"))
-    inferred = list(astroid.Instance(pylinter).igetattr("config"))
-    assert len(inferred) >= 1
-    assert inferred[0].root().name == "argparse"
-    assert inferred[0].name == "Namespace"
 
 
 @pytest.mark.timeout(30)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Enacting deprecation, but I'm not sure it's supposed to still be broken.
