### PR TITLE
[test multiprocessing] Add regression test against removing dill for unpickable plugins

### DIFF
--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -249,10 +249,9 @@ class TestCheckParallelFramework:
         linter.load_plugin_modules(["pylint.extensions.overlapping_exceptions"])
         try:
             dill.dumps(linter)
-            # TODO: 3.0: Fix this test by raising this assertion again
-            # raise AssertionError(
-            #     "Plugins loaded were pickle-safe! This test needs altering"
-            # )
+            raise AssertionError(
+                "Plugins loaded were pickle-safe! This test needs altering"
+            )
         except (KeyError, TypeError, PickleError, NotImplementedError):
             pass
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

It was fixed previously I don't know when.
