### PR TITLE
[deprecation] Remove 'do_exit' from the 'Run' constructor

### DIFF
--- a/doc/whatsnew/fragments/8472.internal
+++ b/doc/whatsnew/fragments/8472.internal
@@ -1,0 +1,4 @@
+Following a deprecation period, the ``do_exit`` argument of the ``Run`` class (and of the ``_Run``
+class in testutils) were removed.
+
+Refs #8472

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -97,9 +97,6 @@ def _cpu_count() -> int:
     return cpu_count
 
 
-UNUSED_PARAM_SENTINEL = object()
-
-
 class Run:
     """Helper class to use as main for pylint with 'run(*sys.argv[1:])'."""
 

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -9,7 +9,7 @@ import sys
 import warnings
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import ClassVar
 
 from pylint import config
 from pylint.checkers.utils import clear_lru_caches
@@ -123,7 +123,6 @@ group are mutually exclusive.",
         args: Sequence[str],
         reporter: BaseReporter | None = None,
         exit: bool = True,  # pylint: disable=redefined-builtin
-        do_exit: Any = UNUSED_PARAM_SENTINEL,
     ) -> None:
         # Immediately exit if user asks for version
         if "--version" in args:
@@ -215,16 +214,6 @@ group are mutually exclusive.",
         else:
             linter.check(args)
             score_value = linter.generate_reports()
-
-        if do_exit is not UNUSED_PARAM_SENTINEL:
-            # TODO: 3.0
-            warnings.warn(
-                "do_exit is deprecated and it is going to be removed in a future version.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            exit = do_exit
-
         if linter.config.clear_cache_post_run:
             clear_lru_caches()
             MANAGER.clear_cache()

--- a/pylint/testutils/_run.py
+++ b/pylint/testutils/_run.py
@@ -10,10 +10,8 @@ This module is considered private and can change at any time.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
 
 from pylint.lint import Run as LintRun
-from pylint.lint.run import UNUSED_PARAM_SENTINEL
 from pylint.reporters.base_reporter import BaseReporter
 from pylint.testutils.lint_module_test import PYLINTRC
 
@@ -39,7 +37,6 @@ class _Run(LintRun):
         args: Sequence[str],
         reporter: BaseReporter | None = None,
         exit: bool = True,  # pylint: disable=redefined-builtin
-        do_exit: Any = UNUSED_PARAM_SENTINEL,
     ) -> None:
         args = _add_rcfile_default_pylintrc(list(args))
-        super().__init__(args, reporter, exit, do_exit)
+        super().__init__(args, reporter, exit)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Enacting planned deprecation.
