### PR TITLE
[deprecation] Make 'py_version' required for 'MessageDefinition.may_be_emitted'

### DIFF
--- a/doc/whatsnew/fragments/8473.internal
+++ b/doc/whatsnew/fragments/8473.internal
@@ -1,5 +1,5 @@
 Following a deprecation period, the ``py_version`` argument of the
-``MessageDefinition.may_be_emitted``  is now required. The most likely solution
+``MessageDefinition.may_be_emitted`` function is now required. The most likely solution
 is to use 'linter.config.py_version' if you need to keep using this
 function, or to use 'MessageDefinition.is_message_enabled' instead.
 

--- a/doc/whatsnew/fragments/8473.internal
+++ b/doc/whatsnew/fragments/8473.internal
@@ -1,0 +1,6 @@
+Following a deprecation period, the ``py_version`` argument of the
+``MessageDefinition.may_be_emitted``  is now required. The most likely solution
+is to use 'linter.config.py_version' if you need to keep using this
+function, or to use 'MessageDefinition.is_message_enabled' instead.
+
+Refs #8473

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import sys
-import warnings
 from typing import TYPE_CHECKING, Any
 
 from astroid import nodes
@@ -73,23 +72,8 @@ class MessageDefinition:
     def __str__(self) -> str:
         return f"{repr(self)}:\n{self.msg} {self.description}"
 
-    def may_be_emitted(
-        self,
-        py_version: tuple[int, ...] | sys._version_info | None = None,
-    ) -> bool:
-        """Return True if message may be emitted using the configured py_version."""
-        if py_version is None:
-            py_version = sys.version_info
-            # TODO: 3.0
-            warnings.warn(
-                "'py_version' will be a required parameter of "
-                "'MessageDefinition.may_be_emitted' in pylint 3.0. The most likely "
-                "solution is to use 'linter.config.py_version' if you need to keep "
-                "using this function, or to use 'MessageDefinition.is_message_enabled'"
-                " instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+    def may_be_emitted(self, py_version: tuple[int, ...] | sys._version_info) -> bool:
+        """May the message be emitted using the configured py_version?"""
         if self.minversion is not None and self.minversion > py_version:
             return False
         if self.maxversion is not None and self.maxversion <= py_version:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Enacting planned deprecation.
