### PR TITLE
[deprecation] Make 'OutputLine' require a fixed number of args

### DIFF
--- a/doc/whatsnew/fragments/8474.internal
+++ b/doc/whatsnew/fragments/8474.internal
@@ -1,0 +1,5 @@
+Following a deprecation period, the ``OutputLine`` class now requires
+the right number of argument all the time. The functional output can be
+regenerated automatically to achieve that easily.
+
+Refs #8474

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Sequence
 from typing import Any, NamedTuple, TypeVar
 
@@ -88,55 +87,20 @@ class OutputLine(NamedTuple):
         """
         if isinstance(row, str):
             row = row.split(",")
-        # noinspection PyBroadException
-        # pylint: disable = too-many-try-statements
         try:
+            line = int(row[1])
             column = cls._get_column(row[2])
-            if len(row) == 5:
-                # TODO: 3.0
-                warnings.warn(
-                    "In pylint 3.0 functional tests expected output should always include the "
-                    "expected confidence level, expected end_line and expected end_column. "
-                    "An OutputLine should thus have a length of 8.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                return cls(
-                    row[0],
-                    int(row[1]),
-                    column,
-                    None,
-                    None,
-                    row[3],
-                    row[4],
-                    UNDEFINED.name,
-                )
-            if len(row) == 6:
-                # TODO: 3.0
-                warnings.warn(
-                    "In pylint 3.0 functional tests expected output should always include the "
-                    "expected end_line and expected end_column. An OutputLine should thus have "
-                    "a length of 8.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                return cls(
-                    row[0], int(row[1]), column, None, None, row[3], row[4], row[5]
-                )
-            if len(row) == 8:
-                end_line = cls._get_py38_none_value(row[3], check_endline)
-                end_column = cls._get_py38_none_value(row[4], check_endline)
-                return cls(
-                    row[0],
-                    int(row[1]),
-                    column,
-                    cls._value_to_optional_int(end_line),
-                    cls._value_to_optional_int(end_column),
-                    row[5],
-                    row[6],
-                    row[7],
-                )
-            raise IndexError
+            end_line = cls._value_to_optional_int(
+                cls._get_py38_none_value(row[3], check_endline)
+            )
+            end_column = cls._value_to_optional_int(
+                cls._get_py38_none_value(row[4], check_endline)
+            )
+            # symbol, line, column, end_line, end_column, node, msg, confidences
+            assert len(row) == 8
+            return cls(
+                row[0], line, column, end_line, end_column, row[5], row[6], row[7]
+            )
         except Exception:  # pylint: disable=broad-except
             # We need this to not fail for the update script to work.
             return cls("", 0, 0, None, None, "", "", "")

--- a/tests/testutils/test_output_line.py
+++ b/tests/testutils/test_output_line.py
@@ -134,57 +134,11 @@ def test_output_line_to_csv(confidence: Confidence, message: _MessageCallable) -
     )
 
 
-@pytest.mark.parametrize(
-    "confidence,expected_confidence", [[None, "UNDEFINED"], ["INFERENCE", "INFERENCE"]]
-)
-def test_output_line_from_csv_deprecated(
-    confidence: str | None, expected_confidence: str
-) -> None:
-    """Test that the OutputLine NamedTuple is instantiated correctly with from_csv.
-    Test OutputLine's of length 5 or 6.
-    """
-    if confidence:
-        proper_csv = [
-            "missing-docstring",
-            "1",
-            "2",
-            "obj",
-            "msg",
-            confidence,
-        ]
-    else:
-        proper_csv = ["missing-docstring", "1", "2", "obj", "msg"]
-    with pytest.warns(DeprecationWarning) as records:
-        output_line = OutputLine.from_csv(proper_csv, True)
-        assert len(records) == 1
-
-    expected_column = 2 if PY38_PLUS else 0
-    assert output_line == OutputLine(
-        symbol="missing-docstring",
-        lineno=1,
-        column=expected_column,
-        end_lineno=None,
-        end_column=None,
-        object="obj",
-        msg="msg",
-        confidence=expected_confidence,
-    )
-
-
 def test_output_line_from_csv() -> None:
     """Test that the OutputLine NamedTuple is instantiated correctly with from_csv.
     Test OutputLine of length 8.
     """
-    proper_csv = [
-        "missing-docstring",
-        "1",
-        "2",
-        "1",
-        "None",
-        "obj",
-        "msg",
-        "HIGH",
-    ]
+    proper_csv = ["missing-docstring", "1", "2", "1", "None", "obj", "msg", "HIGH"]
     expected_column = 2 if PY38_PLUS else 0
 
     output_line = OutputLine.from_csv(proper_csv)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Enacting planned deprecation.
