### PR TITLE
[deprecation] Message.location must be a 'MessageLocationTuple'

### DIFF
--- a/doc/whatsnew/fragments/8476.internal
+++ b/doc/whatsnew/fragments/8476.internal
@@ -1,0 +1,4 @@
+Following a deprecation period, the ``location`` argument of the
+``Message`` class must now be a ``MessageLocationTuple``.
+
+Refs #8476

--- a/doc/whatsnew/fragments/8477.internal
+++ b/doc/whatsnew/fragments/8477.internal
@@ -1,4 +1,4 @@
 Following a deprecation period, the ``location`` argument of the
 ``Message`` class must now be a ``MessageLocationTuple``.
 
-Refs #8476
+Refs #8477

--- a/pylint/message/message.py
+++ b/pylint/message/message.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from warnings import warn
 
 from pylint.constants import MSG_TYPES
 from pylint.interfaces import UNDEFINED, Confidence
@@ -35,27 +34,10 @@ class Message:  # pylint: disable=too-many-instance-attributes
         self,
         msg_id: str,
         symbol: str,
-        location: tuple[str, str, str, str, int, int] | MessageLocationTuple,
+        location: MessageLocationTuple,
         msg: str,
         confidence: Confidence | None,
     ) -> None:
-        if not isinstance(location, MessageLocationTuple):
-            warn(
-                "In pylint 3.0, Messages will only accept a MessageLocationTuple as location parameter",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            location = MessageLocationTuple(
-                location[0],
-                location[1],
-                location[2],
-                location[3],
-                location[4],
-                location[5],
-                None,
-                None,
-            )
-
         self.msg_id = msg_id
         self.symbol = symbol
         self.msg = msg


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Enacting planned deprecation.
