### PR TITLE
Don't consider ``Union`` to always be a type alias

### DIFF
--- a/doc/whatsnew/fragments/8487.false_positive
+++ b/doc/whatsnew/fragments/8487.false_positive
@@ -1,0 +1,3 @@
+No longer consider ``Union`` as type annotation as type alias for naming checks.
+
+Closes #8487

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -600,12 +600,10 @@ class NameChecker(_BasicChecker):
                 # Union is a special case because it can be used as a type alias
                 # or as a type annotation. We only want to check the former.
                 assert node is not None
-                if (
+                return not (
                     isinstance(node.parent, nodes.AnnAssign)
                     and node.parent.value is not None
-                ):
-                    return False
-                return True
+                )
         elif isinstance(inferred, nodes.FunctionDef):
             if inferred.qname() == "typing.TypeAlias":
                 return True

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -597,6 +597,14 @@ class NameChecker(_BasicChecker):
         inferred = utils.safe_infer(node)
         if isinstance(inferred, nodes.ClassDef):
             if inferred.qname() == ".Union":
+                # Union is a special case because it can be used as a type alias
+                # or as a type annotation. We only want to check the former.
+                assert node is not None
+                if (
+                    isinstance(node.parent, nodes.AnnAssign)
+                    and node.parent.value is not None
+                ):
+                    return False
                 return True
         elif isinstance(inferred, nodes.FunctionDef):
             if inferred.qname() == "typing.TypeAlias":

--- a/tests/functional/t/typealias_naming_style_default.py
+++ b/tests/functional/t/typealias_naming_style_default.py
@@ -21,3 +21,7 @@ BAD_NAME = Union[int, str]  # [invalid-name]
 _BAD_NAME = Union[int, str]  # [invalid-name]
 __BAD_NAME = Union[int, str]  # [invalid-name]
 ANOTHERBADNAME = Union[int, str]  # [invalid-name]
+
+# Regression tests
+# This is not a TypeAlias, and thus shouldn't flag the message
+x: Union[str, int] = 42


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes https://github.com/PyCQA/pylint/issues/8487.

Silly mistake in this logic.
