### PR TITLE
Fix news fragment after incorrect auto-merge

### DIFF
--- a/doc/whatsnew/fragments/8485.false_positive
+++ b/doc/whatsnew/fragments/8485.false_positive
@@ -1,4 +1,4 @@
-``invalid-name`` now allows for integers in ``typealias`` names: 
+``invalid-name`` now allows for integers in ``typealias`` names:
 - now valid: ``Good2Name``, ``GoodName2``.
 - still invalid: ``_1BadName``.
 


### PR DESCRIPTION
Follow up to https://github.com/PyCQA/pylint/pull/8488.

I'm making ``pre-commit`` a required check to avoid this in the future.