### PR TITLE
Create additional namespaces for subdirectories with pylint configs

### DIFF
--- a/.pyenchant_pylint_custom_dict.txt
+++ b/.pyenchant_pylint_custom_dict.txt
@@ -61,6 +61,7 @@ codecs
 col's
 conf
 config
+configs
 const
 Const
 contextlib
@@ -310,11 +311,13 @@ str
 stringified
 subclasses
 subcommands
+subconfigs
 subdicts
 subgraphs
 sublists
 submodule
 submodules
+subpackage
 subparsers
 subparts
 subprocess

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -216,6 +216,20 @@ Standard Checkers
 **Default:**  ``False``
 
 
+--use-local-configs
+"""""""""""""""""""
+*When some of the linted files or modules have pylint config in the same directory, use their local configs for checking these files.*
+
+**Default:**  ``False``
+
+
+--use-parent-configs
+""""""""""""""""""""
+*Search for local pylint configs up until current working directory or root.*
+
+**Default:**  ``False``
+
+
 
 .. raw:: html
 
@@ -284,6 +298,10 @@ Standard Checkers
    suggestion-mode = true
 
    unsafe-load-any-extension = false
+
+   use-local-configs = false
+
+   use-parent-configs = false
 
 
 

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -218,14 +218,7 @@ Standard Checkers
 
 --use-local-configs
 """""""""""""""""""
-*When some of the linted files or modules have pylint config in the same directory, use their local configs for checking these files.*
-
-**Default:**  ``False``
-
-
---use-parent-configs
-""""""""""""""""""""
-*Search for local pylint configs up until current working directory or root.*
+*When some of the linted modules have a pylint config in the same directory (or one of the parent directories), use this config for checking these files.*
 
 **Default:**  ``False``
 
@@ -300,8 +293,6 @@ Standard Checkers
    unsafe-load-any-extension = false
 
    use-local-configs = false
-
-   use-parent-configs = false
 
 
 

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -218,7 +218,7 @@ Standard Checkers
 
 --use-local-configs
 """""""""""""""""""
-*When some of the linted modules have a pylint config in the same directory (or one of the parent directories), use this config for checking these files.*
+*When some of the modules to be linted have a pylint config in their directory or any of their parent directories, all checkers use this local config to check those modules. If present, local config replaces entirely a config from current working directory (cwd). Modules that don't have local pylint config are still checked using config from cwd. When pylint starts, it always loads base config from the cwd first. Some options in base config can prevent local configs from loading (e.g. disable=all). Some options for Main checker will work only in base config: evaluation, exit_zero, fail_under, from_stdin, jobs, persistent, recursive, reports, score.*
 
 **Default:**  ``False``
 

--- a/doc/whatsnew/fragments/618.feature
+++ b/doc/whatsnew/fragments/618.feature
@@ -1,0 +1,15 @@
+Add 2 new command line options: use-local-configs and use-parent-configs.
+
+use-local-configs enables searching for local pylint configurations in the same directory where linted file is located.
+For example:
+if there exists package/pylintrc, then
+pylint --use-local-configs=y package/file.py
+will use package/pylintrc instead of default config from $PWD.
+
+use-parent-configs enables searching for local pylint configurations upwards from the directory where linted file is located.
+For example:
+if there exists package/pylintrc, and doesn't exist package/subpackage/pylintrc, then
+pylint --use-local-configs=y --use-parent-configs=y package/subpackage/file.py
+will use package/pylintrc instead of default config from $PWD.
+
+Closes #618

--- a/doc/whatsnew/fragments/618.feature
+++ b/doc/whatsnew/fragments/618.feature
@@ -1,6 +1,6 @@
 Add new command line option: use-local-configs.
 
-use-local-configs enables searching for local pylint configurations in the same directory where linted file is located and upwards until $PWD or root.
+use-local-configs enables loading of local pylint configurations in addition to the base pylint config from $PWD. Local configurations are searched in the same directories where linted files are located and upwards until $PWD or root.
 For example:
 if there exists package/pylintrc, then
 pylint --use-local-configs=y package/file.py

--- a/doc/whatsnew/fragments/618.feature
+++ b/doc/whatsnew/fragments/618.feature
@@ -1,15 +1,13 @@
-Add 2 new command line options: use-local-configs and use-parent-configs.
+Add new command line option: use-local-configs.
 
-use-local-configs enables searching for local pylint configurations in the same directory where linted file is located.
+use-local-configs enables searching for local pylint configurations in the same directory where linted file is located and upwards until $PWD or root.
 For example:
 if there exists package/pylintrc, then
 pylint --use-local-configs=y package/file.py
 will use package/pylintrc instead of default config from $PWD.
 
-use-parent-configs enables searching for local pylint configurations upwards from the directory where linted file is located.
-For example:
 if there exists package/pylintrc, and doesn't exist package/subpackage/pylintrc, then
-pylint --use-local-configs=y --use-parent-configs=y package/subpackage/file.py
+pylint --use-local-configs=y package/subpackage/file.py
 will use package/pylintrc instead of default config from $PWD.
 
 Closes #618

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -81,6 +81,9 @@ class _ArgumentsManager:
         self._directory_namespaces: DirectoryNamespaceDict = {}
         """Mapping of directories and their respective namespace objects."""
 
+        self._cli_args: list[str] = []
+        """Options that were passed as command line arguments and have highest priority."""
+
     @property
     def config(self) -> argparse.Namespace:
         """Namespace for all options."""
@@ -226,6 +229,8 @@ class _ArgumentsManager:
     ) -> list[str]:
         """Parse the arguments found on the command line into the namespace."""
         arguments = sys.argv[1:] if arguments is None else arguments
+        if not self._cli_args:
+            self._cli_args = list(arguments)
 
         self.config, parsed_args = self._arg_parser.parse_known_args(
             arguments, self.config

--- a/pylint/config/config_file_parser.py
+++ b/pylint/config/config_file_parser.py
@@ -106,7 +106,7 @@ class _RawConfParser:
             raise OSError(f"The config file {file_path} doesn't exist!")
 
         if verbose:
-            print(f"Using config file {file_path}", file=sys.stderr)
+            print(f"Loading config file {file_path}", file=sys.stderr)
 
         if file_path.suffix == ".toml":
             return _RawConfParser.parse_toml_file(file_path)

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -83,6 +83,9 @@ def _config_initialization(
     args_list = _order_all_first(args_list, joined=True)
     parsed_args_list = linter._parse_command_line_configuration(args_list)
 
+    # save preprocessed Runner.verbose to config
+    linter.config.verbose = verbose_mode
+
     # Remove the positional arguments separator from the list of arguments if it exists
     try:
         parsed_args_list.remove("--")

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
 
+# pylint: disable = too-many-statements
 def _config_initialization(
     linter: PyLinter,
     args_list: list[str],
@@ -141,7 +142,8 @@ def _config_initialization(
     linter._parse_error_mode()
 
     # Link the base Namespace object on the current directory
-    linter._directory_namespaces[Path(".").resolve()] = (linter.config, {})
+    if Path(".").resolve() not in linter._directory_namespaces:
+        linter._directory_namespaces[Path(".").resolve()] = (linter.config, {})
 
     # parsed_args_list should now only be a list of inputs to lint.
     # All other options have been removed from the list.

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -83,7 +83,7 @@ def _config_initialization(
     args_list = _order_all_first(args_list, joined=True)
     parsed_args_list = linter._parse_command_line_configuration(args_list)
 
-    # save preprocessed Runner.verbose to config
+    # save Runner.verbose to make this preprocessed option visible from other modules
     linter.config.verbose = verbose_mode
 
     # Remove the positional arguments separator from the list of arguments if it exists

--- a/pylint/config/find_default_config_files.py
+++ b/pylint/config/find_default_config_files.py
@@ -64,17 +64,19 @@ def _cfg_has_config(path: Path | str) -> bool:
     return any(section.startswith("pylint.") for section in parser.sections())
 
 
-def _yield_default_files() -> Iterator[Path]:
+def _yield_default_files(basedir: Path | str = ".") -> Iterator[Path]:
     """Iterate over the default config file names and see if they exist."""
+    basedir = Path(basedir)
     for config_name in CONFIG_NAMES:
+        config_file = basedir / config_name
         try:
-            if config_name.is_file():
-                if config_name.suffix == ".toml" and not _toml_has_config(config_name):
+            if config_file.is_file():
+                if config_file.suffix == ".toml" and not _toml_has_config(config_file):
                     continue
-                if config_name.suffix == ".cfg" and not _cfg_has_config(config_name):
+                if config_file.suffix == ".cfg" and not _cfg_has_config(config_file):
                     continue
 
-                yield config_name.resolve()
+                yield config_file.resolve()
         except OSError:
             pass
 
@@ -142,3 +144,8 @@ def find_default_config_files() -> Iterator[Path]:
             yield Path("/etc/pylintrc").resolve()
     except OSError:
         pass
+
+
+def find_subdirectory_config_files(basedir: Path | str) -> Iterator[Path]:
+    """Find config file in arbitrary subdirectory."""
+    yield from _yield_default_files(basedir)

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -414,6 +414,25 @@ def _make_linter_options(linter: PyLinter) -> Options:
                 "Useful if running pylint in a server-like mode.",
             },
         ),
+        (
+            "use-local-configs",
+            {
+                "default": False,
+                "type": "yn",
+                "metavar": "<y or n>",
+                "help": "When some of the linted files or modules have pylint config in the same directory, "
+                "use their local configs for checking these files.",
+            },
+        ),
+        (
+            "use-parent-configs",
+            {
+                "default": False,
+                "type": "yn",
+                "metavar": "<y or n>",
+                "help": "Search for local pylint configs up until current working directory or root.",
+            },
+        ),
     )
 
 

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -420,17 +420,8 @@ def _make_linter_options(linter: PyLinter) -> Options:
                 "default": False,
                 "type": "yn",
                 "metavar": "<y or n>",
-                "help": "When some of the linted files or modules have pylint config in the same directory, "
-                "use their local configs for checking these files.",
-            },
-        ),
-        (
-            "use-parent-configs",
-            {
-                "default": False,
-                "type": "yn",
-                "metavar": "<y or n>",
-                "help": "Search for local pylint configs up until current working directory or root.",
+                "help": "When some of the linted modules have a pylint config in the same directory "
+                "(or one of the parent directories), use this config for checking these files.",
             },
         ),
     )

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -420,8 +420,15 @@ def _make_linter_options(linter: PyLinter) -> Options:
                 "default": False,
                 "type": "yn",
                 "metavar": "<y or n>",
-                "help": "When some of the linted modules have a pylint config in the same directory "
-                "(or one of the parent directories), use this config for checking these files.",
+                "help": "When some of the modules to be linted have a pylint config in their directory "
+                "or any of their parent directories, all checkers use this local config to check "
+                "those modules. "
+                "If present, local config replaces entirely a config from current working directory (cwd). "
+                "Modules that don't have local pylint config are still checked using config from cwd. "
+                "When pylint starts, it always loads base config from the cwd first. Some options in "
+                "base config can prevent local configs from loading (e.g. disable=all). "
+                "Some options for Main checker will work only in base config: "
+                "evaluation, exit_zero, fail_under, from_stdin, jobs, persistent, recursive, reports, score.",
             },
         ),
     )

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -638,7 +638,9 @@ class PyLinter(
                 # existing self.config, so we need to save original self.config to restore it later
                 original_config_ref = self.config
                 self.config = copy.deepcopy(self.config)
-                _config_initialization(self, self._cli_args, config_file=local_conf)
+                _config_initialization(
+                    self, self._cli_args, reporter=self.reporter, config_file=local_conf
+                )
                 self._directory_namespaces[basedir.resolve()] = (self.config, {})
                 # keep dict keys reverse-sorted so that
                 # iteration over keys in _get_namespace_for_file gets the most nested path first
@@ -775,6 +777,7 @@ class PyLinter(
 
         initialize() should be called before calling this method
         """
+        self.set_current_module(file.name, file.filepath)
         with self._astroid_module_checker() as check_astroid_module:
             self._check_file(self.get_ast, check_astroid_module, file)
 

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -630,7 +630,7 @@ class PyLinter(
         elif _is_relative_to(basedir, Path(os.getcwd())):
             scan_root_dir = Path(os.getcwd())
         else:
-            scan_root_dir = Path("/")
+            scan_root_dir = Path(basedir.parts[0])
 
         while basedir.resolve() not in self._directory_namespaces and _is_relative_to(
             basedir, scan_root_dir

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -624,10 +624,7 @@ class PyLinter(
         else:
             basedir = Path(os.path.dirname(file_or_dir))
 
-        if self.config.use_parent_configs is False:
-            # exit loop after first iteration
-            scan_root_dir = basedir
-        elif _is_relative_to(basedir, Path(os.getcwd())):
+        if _is_relative_to(basedir, Path(os.getcwd())):
             scan_root_dir = Path(os.getcwd())
         else:
             scan_root_dir = Path(basedir.parts[0])

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,3 +9,4 @@ six
 # Type packages for mypy
 types-pkg_resources==0.1.3
 tox>=3
+pre-commit

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -178,7 +178,7 @@ def test_short_verbose(capsys: CaptureFixture) -> None:
     """Check that we correctly handle the -v flag."""
     Run([str(EMPTY_MODULE), "-v"], exit=False)
     output = capsys.readouterr()
-    assert "Using config file" in output.err
+    assert "Loading config file" in output.err
 
 
 def test_argument_separator() -> None:

--- a/tests/config/test_per_directory_config.py
+++ b/tests/config/test_per_directory_config.py
@@ -32,28 +32,34 @@ def test_fall_back_on_base_config(tmp_path: Path) -> None:
 
 
 @pytest.fixture
-def _create_subconfig_test_fs(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+def _create_subconfig_test_fs(tmp_path: Path) -> tuple[Path, ...]:
     level1_dir = tmp_path / "level1_dir"
     level1_init = level1_dir / "__init__.py"
     conf_file1 = level1_dir / "pylintrc"
     test_file1 = level1_dir / "a.py"
     test_file3 = level1_dir / "z.py"
+    level1_dir_without_config = tmp_path / "level1_dir_without_config"
+    level1_init2 = level1_dir_without_config / "__init__.py"
+    test_file4 = level1_dir_without_config / "aa.py"
     subdir = level1_dir / "sub"
     level2_init = subdir / "__init__.py"
     conf_file2 = subdir / "pylintrc"
     test_file2 = subdir / "b.py"
+    os.makedirs(level1_dir_without_config)
     os.makedirs(subdir)
     level1_init.touch()
+    level1_init2.touch()
     level2_init.touch()
     test_file_text = "#LEVEL1\n#LEVEL2\n#ALL_LEVELS\n#TODO\n"
     test_file1.write_text(test_file_text)
     test_file2.write_text(test_file_text)
     test_file3.write_text(test_file_text)
+    test_file4.write_text(test_file_text)
     conf1 = "[MISCELLANEOUS]\nnotes=LEVEL1,ALL_LEVELS"
     conf2 = "[MISCELLANEOUS]\nnotes=LEVEL2,ALL_LEVELS"
     conf_file1.write_text(conf1)
     conf_file2.write_text(conf2)
-    return level1_dir, test_file1, test_file2, test_file3
+    return level1_dir, test_file1, test_file2, test_file3, test_file4
 
 
 # check that use-parent-configs doesn't break anything
@@ -61,10 +67,12 @@ def _create_subconfig_test_fs(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
     "local_config_args",
     [["--use-local-configs=y"], ["--use-local-configs=y", "--use-parent-configs=y"]],
 )
-# check files and configs from top-level package or subpackage
+# check modules and use of configuration files from top-level package or subpackage
 @pytest.mark.parametrize("test_file_index", [0, 1, 2])
 # check cases when cwd contains pylintrc or not
-@pytest.mark.parametrize("start_dir_modificator", [".", ".."])
+@pytest.mark.parametrize(
+    "start_dir_modificator", [".", "..", "../level1_dir_without_config"]
+)
 def test_subconfig_vs_root_config(
     _create_subconfig_test_fs: tuple[Path, ...],
     capsys: CaptureFixture,
@@ -80,7 +88,7 @@ def test_subconfig_vs_root_config(
     start_dir = (level1_dir / start_dir_modificator).resolve()
 
     orig_cwd = os.getcwd()
-    output = [f"{start_dir = }, {test_file = }"]
+    output = [f"{start_dir = }\n{test_file = }\n"]
     os.chdir(start_dir)
     for _ in range(2):
         # _Run adds --rcfile, which overrides config from cwd, so we need original Run here
@@ -90,28 +98,70 @@ def test_subconfig_vs_root_config(
         test_file = test_file.parent
     os.chdir(orig_cwd)
 
-    expected_note = f"LEVEL{(test_file_index%2)+1}"
-    assert (
-        expected_note in output[1]
-    ), f"readable debug output:\n{output[0]}\n{output[1]}"
-    assert (
-        expected_note in output[2]
-    ), f"readable debug output:\n{output[0]}\n{output[2]}"
+    expected_note = "LEVEL1"
+    if test_file_index == 1:
+        expected_note = "LEVEL2"
+    assert_message = f"Wrong note after checking FILE. Readable debug output:\n{output[0]}\n{output[1]}"
+    assert expected_note in output[1], assert_message
+    assert_message = f"Wrong note after checking DIRECTORY. Readable debug output:\n{output[0]}\n{output[2]}"
+    assert expected_note in output[2], assert_message
 
     if test_file_index == 0:
         # 'pylint level1_dir/' should use config from subpackage when checking level1_dir/sub/b.py
-        assert (
-            "LEVEL2" in output[2]
-        ), f"readable debug output:\n{output[0]}\n{output[2]}"
+        assert_message = f"Wrong note after checking DIRECTORY. Readable debug output:\n{output[0]}\n{output[2]}"
+        assert "LEVEL2" in output[2], assert_message
     if test_file_index == 1:
         # 'pylint level1_dir/sub/b.py' and 'pylint level1_dir/sub/' should use
         # level1_dir/sub/pylintrc, not level1_dir/pylintrc
-        assert (
-            "LEVEL1" not in output[1]
-        ), f"readable debug output:\n{output[0]}\n{output[1]}"
-        assert (
-            "LEVEL1" not in output[2]
-        ), f"readable debug output:\n{output[0]}\n{output[2]}"
+        assert_message = f"Wrong note after checking FILE. Readable debug output:\n{output[0]}\n{output[1]}"
+        assert "LEVEL1" not in output[1], assert_message
+        assert_message = f"Wrong note after checking DIRECTORY. Readable debug output:\n{output[0]}\n{output[2]}"
+        assert "LEVEL1" not in output[2], assert_message
+
+
+# check that use-parent-configs doesn't break anything
+@pytest.mark.parametrize(
+    "local_config_args",
+    [["--use-local-configs=y"], ["--use-local-configs=y", "--use-parent-configs=y"]],
+)
+# check cases when test_file without local config belongs to cwd subtree or not
+@pytest.mark.parametrize(
+    "start_dir_modificator", [".", "..", "../level1_dir_without_config"]
+)
+def test_missing_local_config(
+    _create_subconfig_test_fs: tuple[Path, ...],
+    capsys: CaptureFixture,
+    local_config_args: list[str],
+    start_dir_modificator: str,
+) -> None:
+    """Test that when checked file or module doesn't have config
+    in its own directory, it uses default config or config from cwd.
+    """
+    level1_dir, *tmp_files = _create_subconfig_test_fs
+    # file from level1_dir_without_config
+    test_file = tmp_files[3]
+    start_dir = (level1_dir / start_dir_modificator).resolve()
+
+    orig_cwd = os.getcwd()
+    output = [f"{start_dir = }\n{test_file = }\n"]
+    os.chdir(start_dir)
+    for _ in range(2):
+        # _Run adds --rcfile, which overrides config from cwd, so we need original Run here
+        LintRun([*local_config_args, str(test_file)], exit=False)
+        output.append(capsys.readouterr().out.replace("\\n", "\n"))
+
+        test_file = test_file.parent
+    os.chdir(orig_cwd)
+
+    # from default config
+    expected_note = "TODO"
+    if start_dir_modificator == ".":
+        # from config in level1_dir
+        expected_note = "LEVEL1"
+    assert_message = f"Wrong note after checking FILE. Readable debug output:\n{output[0]}\n{output[1]}"
+    assert expected_note in output[1], assert_message
+    assert_message = f"Wrong note after checking DIRECTORY. Readable debug output:\n{output[0]}\n{output[2]}"
+    assert expected_note in output[2], assert_message
 
 
 @pytest.mark.parametrize("test_file_index", [0, 1])
@@ -120,7 +170,7 @@ def test_subconfig_vs_cli_arg(
     capsys: CaptureFixture,
     test_file_index: int,
 ) -> None:
-    """Test that cli args have priority over subconfigs."""
+    """Test that CLI arguments have priority over subconfigs."""
     test_root, *tmp_files = _create_subconfig_test_fs
     test_file = tmp_files[test_file_index]
     orig_cwd = os.getcwd()
@@ -129,9 +179,9 @@ def test_subconfig_vs_cli_arg(
     output = capsys.readouterr().out.replace("\\n", "\n")
     os.chdir(orig_cwd)
 
-    # check that cli arg overrides default value
+    # check that CLI argument overrides default value
     assert "TODO" not in output
-    # notes=FIXME in cli should override all pylintrc configs
+    # notes=FIXME in arguments should override all pylintrc configs
     assert "ALL_LEVELS" not in output
 
 
@@ -162,3 +212,18 @@ def test_subconfig_in_parent(tmp_path: Path, capsys: CaptureFixture) -> None:
     # check that file is linted with config from ../, which is not a cwd
     assert "TODO" not in output1
     assert "LEVEL1" in output1
+
+
+def test_register_local_config_accepts_directory(
+    _create_subconfig_test_fs: tuple[Path, ...]
+) -> None:
+    """Test that register_local_config can handle directory as argument."""
+    level1_dir, *tmp_files = _create_subconfig_test_fs
+    # init linter without local configs
+    linter = LintRun([str(tmp_files[0])], exit=False).linter
+    assert level1_dir not in linter._directory_namespaces
+
+    # call register_local_config with directory as argument
+    assert level1_dir.is_dir()
+    linter.register_local_config(str(level1_dir))
+    assert level1_dir in linter._directory_namespaces

--- a/tests/config/test_per_directory_config.py
+++ b/tests/config/test_per_directory_config.py
@@ -2,8 +2,16 @@
 # For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
+import os
+import os.path
 from pathlib import Path
 
+import pytest
+from pytest import CaptureFixture
+
+from pylint.lint import Run as LintRun
 from pylint.testutils._run import _Run as Run
 
 
@@ -21,3 +29,136 @@ def test_fall_back_on_base_config(tmp_path: Path) -> None:
         f.write("1")
     Run([str(test_file)], exit=False)
     assert id(runner.linter.config) == id(runner.linter._base_config)
+
+
+@pytest.fixture
+def _create_subconfig_test_fs(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    level1_dir = tmp_path / "level1_dir"
+    level1_init = level1_dir / "__init__.py"
+    conf_file1 = level1_dir / "pylintrc"
+    test_file1 = level1_dir / "a.py"
+    test_file3 = level1_dir / "z.py"
+    subdir = level1_dir / "sub"
+    level2_init = subdir / "__init__.py"
+    conf_file2 = subdir / "pylintrc"
+    test_file2 = subdir / "b.py"
+    os.makedirs(subdir)
+    level1_init.touch()
+    level2_init.touch()
+    test_file_text = "#LEVEL1\n#LEVEL2\n#ALL_LEVELS\n#TODO\n"
+    test_file1.write_text(test_file_text)
+    test_file2.write_text(test_file_text)
+    test_file3.write_text(test_file_text)
+    conf1 = "[MISCELLANEOUS]\nnotes=LEVEL1,ALL_LEVELS"
+    conf2 = "[MISCELLANEOUS]\nnotes=LEVEL2,ALL_LEVELS"
+    conf_file1.write_text(conf1)
+    conf_file2.write_text(conf2)
+    return level1_dir, test_file1, test_file2, test_file3
+
+
+# check that use-parent-configs doesn't break anything
+@pytest.mark.parametrize(
+    "local_config_args",
+    [["--use-local-configs=y"], ["--use-local-configs=y", "--use-parent-configs=y"]],
+)
+# check files and configs from top-level package or subpackage
+@pytest.mark.parametrize("test_file_index", [0, 1, 2])
+# check cases when cwd contains pylintrc or not
+@pytest.mark.parametrize("start_dir_modificator", [".", ".."])
+def test_subconfig_vs_root_config(
+    _create_subconfig_test_fs: tuple[Path, ...],
+    capsys: CaptureFixture,
+    test_file_index: int,
+    local_config_args: list[str],
+    start_dir_modificator: str,
+) -> None:
+    """Test that each checked file or module uses config
+    from its own directory.
+    """
+    level1_dir, *tmp_files = _create_subconfig_test_fs
+    test_file = tmp_files[test_file_index]
+    start_dir = (level1_dir / start_dir_modificator).resolve()
+
+    orig_cwd = os.getcwd()
+    output = [f"{start_dir = }, {test_file = }"]
+    os.chdir(start_dir)
+    for _ in range(2):
+        # _Run adds --rcfile, which overrides config from cwd, so we need original Run here
+        LintRun([*local_config_args, str(test_file)], exit=False)
+        output.append(capsys.readouterr().out.replace("\\n", "\n"))
+
+        test_file = test_file.parent
+    os.chdir(orig_cwd)
+
+    expected_note = f"LEVEL{(test_file_index%2)+1}"
+    assert (
+        expected_note in output[1]
+    ), f"readable debug output:\n{output[0]}\n{output[1]}"
+    assert (
+        expected_note in output[2]
+    ), f"readable debug output:\n{output[0]}\n{output[2]}"
+
+    if test_file_index == 0:
+        # 'pylint level1_dir/' should use config from subpackage when checking level1_dir/sub/b.py
+        assert (
+            "LEVEL2" in output[2]
+        ), f"readable debug output:\n{output[0]}\n{output[2]}"
+    if test_file_index == 1:
+        # 'pylint level1_dir/sub/b.py' and 'pylint level1_dir/sub/' should use
+        # level1_dir/sub/pylintrc, not level1_dir/pylintrc
+        assert (
+            "LEVEL1" not in output[1]
+        ), f"readable debug output:\n{output[0]}\n{output[1]}"
+        assert (
+            "LEVEL1" not in output[2]
+        ), f"readable debug output:\n{output[0]}\n{output[2]}"
+
+
+@pytest.mark.parametrize("test_file_index", [0, 1])
+def test_subconfig_vs_cli_arg(
+    _create_subconfig_test_fs: tuple[Path, ...],
+    capsys: CaptureFixture,
+    test_file_index: int,
+) -> None:
+    """Test that cli args have priority over subconfigs."""
+    test_root, *tmp_files = _create_subconfig_test_fs
+    test_file = tmp_files[test_file_index]
+    orig_cwd = os.getcwd()
+    os.chdir(test_root)
+    LintRun(["--notes=FIXME", "--use-local-configs=y", str(test_file)], exit=False)
+    output = capsys.readouterr().out.replace("\\n", "\n")
+    os.chdir(orig_cwd)
+
+    # check that cli arg overrides default value
+    assert "TODO" not in output
+    # notes=FIXME in cli should override all pylintrc configs
+    assert "ALL_LEVELS" not in output
+
+
+def _create_parent_subconfig_fs(tmp_path: Path) -> Path:
+    level1_dir = tmp_path / "package"
+    conf_file = level1_dir / "pylintrc"
+    subdir = level1_dir / "sub"
+    test_file = subdir / "b.py"
+    os.makedirs(subdir)
+    test_file_text = "#LEVEL1\n#LEVEL2\n#TODO\n"
+    test_file.write_text(test_file_text)
+    conf = "[MISCELLANEOUS]\nnotes=LEVEL1,LEVEL2"
+    conf_file.write_text(conf)
+    return test_file
+
+
+def test_subconfig_in_parent(tmp_path: Path, capsys: CaptureFixture) -> None:
+    """Test that searching local configs in parent directories works."""
+    test_file = _create_parent_subconfig_fs(tmp_path)
+    orig_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    LintRun(
+        ["--use-parent-configs=y", "--use-local-configs=y", str(test_file)], exit=False
+    )
+    output1 = capsys.readouterr().out.replace("\\n", "\n")
+    os.chdir(orig_cwd)
+
+    # check that file is linted with config from ../, which is not a cwd
+    assert "TODO" not in output1
+    assert "LEVEL1" in output1

--- a/tests/config/test_per_directory_config.py
+++ b/tests/config/test_per_directory_config.py
@@ -240,3 +240,13 @@ def test_register_local_config_accepts_directory(
     assert level1_dir.is_dir()
     linter.register_local_config(str(level1_dir))
     assert level1_dir in linter._directory_namespaces.keys()
+
+
+def test_local_config_verbose(
+    _create_subconfig_test_fs: tuple[Path, ...], capsys: CaptureFixture
+) -> None:
+    """Check --verbose flag prints message about current config for each file."""
+    level1_dir, *tmp_files = _create_subconfig_test_fs
+    LintRun(["--verbose", "--use-local-configs=y", str(tmp_files[1])], exit=False)
+    output = capsys.readouterr()
+    assert f"Using config from {level1_dir / 'sub'}" in output.err

--- a/tests/config/test_per_directory_config.py
+++ b/tests/config/test_per_directory_config.py
@@ -62,10 +62,9 @@ def _create_subconfig_test_fs(tmp_path: Path) -> tuple[Path, ...]:
     return level1_dir, test_file1, test_file2, test_file3, test_file4
 
 
-# check that use-parent-configs doesn't break anything
 @pytest.mark.parametrize(
     "local_config_args",
-    [["--use-local-configs=y"], ["--use-local-configs=y", "--use-parent-configs=y"]],
+    [["--use-local-configs=y"]],
 )
 # check modules and use of configuration files from top-level package or subpackage
 @pytest.mark.parametrize("test_file_index", [0, 1, 2])
@@ -119,10 +118,9 @@ def test_subconfig_vs_root_config(
         assert "LEVEL1" not in output[2], assert_message
 
 
-# check that use-parent-configs doesn't break anything
 @pytest.mark.parametrize(
     "local_config_args",
-    [["--use-local-configs=y"], ["--use-local-configs=y", "--use-parent-configs=y"]],
+    [["--use-local-configs=y"]],
 )
 # check cases when test_file without local config belongs to cwd subtree or not
 @pytest.mark.parametrize(
@@ -203,9 +201,7 @@ def test_subconfig_in_parent(tmp_path: Path, capsys: CaptureFixture) -> None:
     test_file = _create_parent_subconfig_fs(tmp_path)
     orig_cwd = os.getcwd()
     os.chdir(tmp_path)
-    LintRun(
-        ["--use-parent-configs=y", "--use-local-configs=y", str(test_file)], exit=False
-    )
+    LintRun(["--use-local-configs=y", str(test_file)], exit=False)
     output1 = capsys.readouterr().out.replace("\\n", "\n")
     os.chdir(orig_cwd)
 
@@ -226,4 +222,4 @@ def test_register_local_config_accepts_directory(
     # call register_local_config with directory as argument
     assert level1_dir.is_dir()
     linter.register_local_config(str(level1_dir))
-    assert level1_dir in linter._directory_namespaces
+    assert level1_dir in linter._directory_namespaces.keys()


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

This pr is based on changes by [DanielNoord](https://github.com/DanielNoord) and makes possible to use different configuration files for different directories. This behavior is enabled with 2 new options, described in docs. Default behavior stays the same as before.

Also I have a few concerns related to the changes I'm proposing. Could someone direct me to the right place to consult about them, if it's not here? My questions are:
1. Should I enable use-local-configs automatically when use-parent-configs is given? Or it would be better to generate a warning that use-parent-configs does nothing without use-local-configs? Or do something else?
2. Calling _get_namespace_for_file recursively on nested dictionaries can have performance benefits for repositories with a big number of nested pylint configs. But with the bottom-up approach that I realized in register_local_config it was not trivial to store configs in a tree structure. So, my pr just stores all paths in one plain dict, and I suppose that performance optimization, allowing _get_namespace_for_file to work more effectively, can be done in another issue/pr if needed.
3. Also, it may be a bit off-topic, but I included here adding pre-commit to the requirements_test.txt, because without it I got the following error each time I run tests with python -m tox:
```
formatting: commands[0]> pre-commit run --all-files
formatting: failed with pre-commit is not allowed, use allowlist_externals to allow it
```
I can move it to another pr or cancel this change entirely if it was only my local problem.
<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #618 
