### PR TITLE
Try new branch of `astroid` to see if change works

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies    = [
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/pylint-dev/astroid/issues/1341
-    "astroid>=3.3.5,<=4.0.0-dev0",
+    "astroid @ git+https://github.com/danielnoord/astroid.git@collections-fix",
     "isort>=4.2.5,<6,!=5.13.0",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==3.3.5  # Pinned to a specific version for tests
+astroid @ git+https://github.com/danielnoord/astroid.git@collections-fix
 typing-extensions~=4.12
 py~=1.11.0
 pytest~=8.3

--- a/tests/functional/n/no/no_member_imports.py
+++ b/tests/functional/n/no/no_member_imports.py
@@ -32,12 +32,6 @@ def test_ignored_modules_root_one_applies_as_well() -> None:
     argparse.submodule.THIS_does_not_EXIST
 
 
-def test_ignored_modules_patterns() -> None:
-    import collections
-
-    collections.abc.THIS_does_not_EXIST
-
-
 def test_ignored_classes_no_recursive_pattern() -> None:
     import sys
 

--- a/tests/functional/n/no/no_member_imports.rc
+++ b/tests/functional/n/no/no_member_imports.rc
@@ -1,3 +1,3 @@
 [TYPECHECK]
-ignored-modules=argparse,xml.etree.,collections.abc*
+ignored-modules=argparse,xml.etree.
 ignored-classes=sys*,optparse.Values,Option

--- a/tests/functional/n/no/no_member_imports.txt
+++ b/tests/functional/n/no/no_member_imports.txt
@@ -1,3 +1,3 @@
 no-member:10:4:10:28:test_no_member_in_getattr:Module 'math' has no 'THIS_does_not_EXIST' member:INFERENCE
 no-member:25:4:25:33:test_ignored_modules_invalid_pattern:Module 'xml.etree' has no 'THIS_does_not_EXIST' member:INFERENCE
-no-member:44:4:44:27:test_ignored_classes_no_recursive_pattern:Module 'sys' has no 'THIS_does_not_EXIST' member:INFERENCE
+no-member:38:4:38:27:test_ignored_classes_no_recursive_pattern:Module 'sys' has no 'THIS_does_not_EXIST' member:INFERENCE


### PR DESCRIPTION
Try https://github.com/pylint-dev/astroid/pull/2665 and see if it works.

It seemingly does?

I have removed one test that was added in https://github.com/pylint-dev/pylint/pull/5453/commits/255562a18562804ac85b8913771aa188a8a3cc32. I don't really see why it is needed (it clearly isn't a move, but a new test...). With the change for `collections.abc` it should now be `_collections_abc`. Anyway, `xml.etree.` seems to do the same? 