### PR TITLE
Use `reversed()` for reverse iteration instead of in-place list reversal

### DIFF
--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1933,8 +1933,7 @@ a metaclass class method.",
         outer_klass = klass
         callee = node.expr.as_string()
         parents_callee = callee.split(".")
-        parents_callee.reverse()
-        for callee in parents_callee:
+        for callee in reversed(parents_callee):
             if not outer_klass or callee != outer_klass.name:
                 inside_klass = False
                 break

--- a/pylint/pyreverse/utils.py
+++ b/pylint/pyreverse/utils.py
@@ -47,9 +47,7 @@ def get_default_options() -> list[str]:
 
 def insert_default_options() -> None:
     """Insert default options to sys.argv."""
-    options = get_default_options()
-    options.reverse()
-    for arg in options:
+    for arg in reversed(get_default_options()):
         sys.argv.insert(1, arg)
 
 

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -112,8 +112,7 @@ def get_module_and_frameid(node: nodes.NodeNG) -> tuple[str, str]:
             frame = frame.parent.frame()
         except AttributeError:
             break
-    obj.reverse()
-    return module, ".".join(obj)
+    return module, ".".join(reversed(obj))
 
 
 def get_rst_title(title: str, character: str) -> str:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] ~Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``~
- [x] ~Relate your change to an issue in the tracker if such an issue exists~
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [x] ~If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``~
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Thanks to this change, the iteration in the loops will happen along a reversed iterator and not a concrete list as before. This _might_ improve the performance.

Note the variable shadowing of `callee` in `class_checker.py` - it seems that this is intended (fix feels like out of scope for this PR) - cf. https://github.com/pylint-dev/pylint/pull/10547#issuecomment-3279359001