### PR TITLE
Switch back to upstream mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -131,8 +131,8 @@ repos:
         # TODO remove pydantic once 2.12.0 is released
         additional_dependencies:
           ["Sphinx==7.4.3", "pydantic>=2.12.0a1;python_version>='3.14'"]
-  - repo: https://github.com/cdce8p/mypy-dev-pre-commit
-    rev: v1.19.0a1
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.18.1
     hooks:
       - id: mypy
         name: mypy


### PR DESCRIPTION
Followup to https://github.com/pylint-dev/pylint/pull/10527

Mypy just released `1.18.1` which includes the required match statement fixes.
https://mypy-lang.blogspot.com/2025/09/mypy-1181-released.html