### PR TITLE
[doc] Add the breaking change requiring user actions for 4.0

### DIFF
--- a/pylint/config/_breaking_changes.py
+++ b/pylint/config/_breaking_changes.py
@@ -35,7 +35,7 @@ class Condition(enum.Enum):
 class Information(NamedTuple):
     msgid_or_symbol: str | None = None
     extension: str | None = None
-    option: str | None = None
+    option: list[str] | str | None = None
     description: str | None = None
 
 
@@ -84,6 +84,7 @@ SUGGESTION_MODE_REMOVED = Information(
 )
 
 INVALID_NAME_CONST_BEHAVIOR = Information(
+    option=["const-rgx", "const-naming-style"],
     description="""\
 In 'invalid-name', module-level constants that are reassigned are now treated
 as variables and checked against ``--variable-rgx`` rather than ``--const-rgx``.


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Updating the data structure that still don't have a script to auto-upgrade yet for 4.0 breaking changes. The breaking change not included do not require user intervention (async checker, message name changed but we have the "old msgid" mechanism so I'm not even sure it should be a breaking change).


