### PR TITLE
[WIP] Expose `pylint.recommended` as default base message set

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -57,7 +57,7 @@ hint of what Pylint is going to ``pick on``: ::
     further processing.
 
 When Pylint is first run on a fresh piece of code, a common complaint is that it
-is too ``noisy``.  The default configuration enforce a lot of warnings.
+is too ``noisy``.  The default configuration enforces a lot of warnings.
 We'll use some of the options we noted above to make it suit your
 preferences a bit better.
 

--- a/pylint/__init__.py
+++ b/pylint/__init__.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 
 __all__ = [
     "__version__",
+    "core",
     "modify_sys_path",
+    "recommended",
     "run_pylint",
     "run_pyreverse",
     "run_symilar",
@@ -19,6 +21,7 @@ from collections.abc import Sequence
 from typing import NoReturn
 
 from pylint.__pkginfo__ import __version__
+from pylint.message_sets import core, recommended
 
 # pylint: disable=import-outside-toplevel
 

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -239,6 +239,8 @@ class _ArgumentsManager:
         """Write a configuration file according to the current configuration
         into the given stream or stdout.
         """
+        # If --message-sets is absent, maybe just go ahead and
+        # set --message-sets=pylint.recommended? or wait until pylint 5?
         options_by_section = {}
         sections = []
         for group in sorted(

--- a/pylint/config/callback_actions.py
+++ b/pylint/config/callback_actions.py
@@ -382,6 +382,24 @@ class _XableAction(_AccessLinterObjectAction):
         raise NotImplementedError  # pragma: no cover
 
 
+class _MessageSetsAction(_AccessLinterObjectAction):
+    """Callback action for setting message sets."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: str | Sequence[Any] | None,
+        option_string: str | None = "--disable",
+    ) -> None:
+        for msg_set in values or ():
+            actions = utils.utils._import_attribute(msg_set)
+            for enable in actions["enable"]:
+                self.linter.enable(enable)
+            for disable in actions["disable"]:
+                self.linter.disable(disable)
+
+
 class _DisableAction(_XableAction):
     """Callback action for disabling a message."""
 

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -26,6 +26,7 @@ from pylint.config.callback_actions import (
     _ListMessagesEnabledAction,
     _LongHelpAction,
     _MessageHelpAction,
+    _MessageSetsAction,
     _OutputFormatAction,
 )
 from pylint.typing import Options
@@ -179,6 +180,19 @@ def _make_linter_options(linter: PyLinter) -> Options:
                 "group": "Messages control",
                 "help": "Only show warnings with the listed confidence levels."
                 f" Leave empty to show all. Valid levels: {', '.join(interfaces.CONFIDENCE_LEVEL_NAMES)}.",
+            },
+        ),
+        (
+            "message-sets",
+            {
+                "action": _MessageSetsAction,
+                "callback": lambda x1, x2, x3, x4: x1,
+                "default": ("pylint.core"),  # pylint.recommended in v5
+                "metavar": "<msg ids>",
+                "short": "msg-sets",
+                "group": "Messages control",
+                "help": "",
+                "kwargs": {"linter": linter},
             },
         ),
         (

--- a/pylint/message_sets.py
+++ b/pylint/message_sets.py
@@ -1,0 +1,16 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+
+core: dict[str, set[str]] = {
+    "enable": set(),
+    "disable": set(),
+}
+
+recommended: dict[str, set[str]] = {
+    "enable": set(),
+    "disable": {
+        "duplicate-code",
+        # add others from issue...
+    },
+}

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -24,6 +24,7 @@ import tokenize
 import warnings
 from collections import deque
 from collections.abc import Iterable, Sequence
+from importlib import import_module
 from io import BufferedReader, BytesIO
 from re import Pattern
 from typing import TYPE_CHECKING, Any, Literal, TextIO, TypeVar
@@ -262,6 +263,18 @@ def _check_regexp_csv(value: list[str] | tuple[str] | str) -> Iterable[str]:
             else:
                 regexps[-1].append(char)
         yield from ("".join(regexp).strip() for regexp in regexps if regexp is not None)
+
+
+def _import_attribute(dotted_path: str) -> Any:
+    try:
+        module_path, attribute_name = dotted_path.rsplit(".", 1)
+    except ValueError as err:
+        raise ImportError(f"{dotted_path} doesn't look like a module path") from err
+
+    if not (module := sys.modules.get(module_path)):
+        module = import_module(module_path)
+
+    return getattr(module, attribute_name)
 
 
 def _comment(string: str) -> str:

--- a/pylintrc
+++ b/pylintrc
@@ -76,6 +76,8 @@ clear-cache-post-run=no
 # all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
 # confidence=
 
+message-sets=pylint.recommended
+
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description
Pylint is forbiddingly opinionated and noisy out of the box. For years there has been consensus to "get sane" somehow.

Here's a stab at a design inspired by eslint. Manual testing shows it works.

Provide a list of strings that can be imported from a module on your path. Default is `pylint.recommended`. It unpacks to a set of enables and disables that we apply before anything else.

Intended to close #3512 

We can change the "default" for this setting in 5, once we go through a cycle of verifying that this works and can be customized (e.g. `pylint_django.recommended` or whatever)