### PR TITLE
Add mypy config for local tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,6 +273,11 @@ module = [
   "sphinx.*",
 ]
 
+# For local tests: Enable follow_untyped_imports overwrite for astroid
+# [[tool.mypy.overrides]]
+# module = ["astroid.*"]
+# follow_untyped_imports = true
+
 [tool.pyright]
 include = [
   "pylint",


### PR DESCRIPTION
Astroid isn't fully typed yet and thus doesn't have a `py.typed` file yet. Sometimes it's helpful to check the mypy output as if astroid would have a `py.typed` file. Mypy does have an option for it `follow_untyped_imports = true`. This PR adds it to the config as a comment. If necessary devs can simply uncomment that section and run mypy without having to lookup the correct config value again.

https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-library-stubs-or-py-typed-marker
https://mypy.readthedocs.io/en/stable/config_file.html#confval-follow_untyped_imports

_Unfortunately there are still over 900 errors with that setting enabled, so I don't think we'll be adding `py.typed` to astroid any time soon._