### PR TITLE
Use new Arguments.get_annotations() helper from astroid

### DIFF
--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1622,13 +1622,7 @@ def is_node_in_type_annotation_context(node: nodes.NodeNG) -> bool:
         match parent_node:
             case nodes.AnnAssign(annotation=ann) if ann == current_node:
                 return True
-            case nodes.Arguments() if current_node in (
-                *parent_node.annotations,
-                *parent_node.posonlyargs_annotations,
-                *parent_node.kwonlyargs_annotations,
-                parent_node.varargannotation,
-                parent_node.kwargannotation,
-            ):
+            case nodes.Arguments() if current_node in parent_node.get_annotations():
                 return True
             case nodes.FunctionDef(returns=ret) if ret == current_node:
                 return True

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2210,13 +2210,7 @@ class VariablesChecker(BaseChecker):
         in_annotation_or_default_or_decorator = False
         if isinstance(frame, nodes.FunctionDef) and node.statement() is frame:
             in_annotation_or_default_or_decorator = (
-                (
-                    node in frame.args.annotations
-                    or node in frame.args.posonlyargs_annotations
-                    or node in frame.args.kwonlyargs_annotations
-                    or node is frame.args.varargannotation
-                    or node is frame.args.kwargannotation
-                )
+                node in frame.args.get_annotations()
                 or frame.args.parent_of(node)
                 or (frame.decorators and frame.decorators.parent_of(node))
                 or (


### PR DESCRIPTION
Use new `Arguments.get_annotations()` helper added in https://github.com/pylint-dev/astroid/pull/2860
Requires astroid `>=4.1.0`, still unreleased.