### PR TITLE
Remove workaround for pre-commit check with Python 3.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -128,9 +128,7 @@ repos:
       - id: rstcheck
         args: ["--report-level=warning"]
         files: ^(doc/(.*/)*.*\.rst)
-        # TODO remove pydantic once 2.12.0 is released
-        additional_dependencies:
-          ["Sphinx==7.4.3", "pydantic>=2.12.0a1;python_version>='3.14'"]
+        additional_dependencies: ["Sphinx==7.4.3"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.18.2
     hooks:


### PR DESCRIPTION
The workaround added in #10500 is no longer necessary as pydantic `2.12.0` was released last week with support for Python 3.14.