### PR TITLE
Bump pylint to 4.0.1, update changelog

### DIFF
--- a/doc/whatsnew/4/4.0/index.rst
+++ b/doc/whatsnew/4/4.0/index.rst
@@ -74,6 +74,29 @@ to your liking.
 
 .. towncrier release notes start
 
+What's new in Pylint 4.0.1?
+---------------------------
+Release date: 2025-10-14
+
+
+False Positives Fixed
+---------------------
+
+- Exclude ``__all__`` and ``__future__.annotations`` from ``unused-variable``.
+
+  Closes #10019 (`#10019 <https://github.com/pylint-dev/pylint/issues/10019>`_)
+
+- Fix false-positive for ``bare-name-capture-pattern`` if a case guard is used.
+
+  Closes #10647 (`#10647 <https://github.com/pylint-dev/pylint/issues/10647>`_)
+
+- Check enums created with the ``Enum()`` functional syntax to pass against the
+  ``--class-rgx`` for the :ref:`invalid-name` check, like other enums.
+
+  Closes #10660 (`#10660 <https://github.com/pylint-dev/pylint/issues/10660>`_)
+
+
+
 What's new in Pylint 4.0.0?
 ---------------------------
 Release date: 2025-10-12

--- a/doc/whatsnew/fragments/10019.false_positive
+++ b/doc/whatsnew/fragments/10019.false_positive
@@ -1,3 +1,0 @@
-Exclude ``__all__`` and ``__future__.annotations`` from ``unused-variable``.
-
-Closes #10019

--- a/doc/whatsnew/fragments/10647.false_positive
+++ b/doc/whatsnew/fragments/10647.false_positive
@@ -1,3 +1,0 @@
-Fix false-positive for ``bare-name-capture-pattern`` if a case guard is used.
-
-Closes #10647

--- a/doc/whatsnew/fragments/10660.false_positive
+++ b/doc/whatsnew/fragments/10660.false_positive
@@ -1,4 +1,0 @@
-Check enums created with the ``Enum()`` functional syntax to pass against the
-``--class-rgx`` for the :ref:`invalid-name` check, like other enums.
-
-Closes #10660

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "4.0.0"
+current = "4.0.1"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's new in Pylint 4.0.1?
---------------------------
Release date: 2025-10-14


False Positives Fixed
---------------------

- Exclude ``__all__`` and ``__future__.annotations`` from ``unused-variable``.

  Closes #10019 

- Fix false-positive for ``bare-name-capture-pattern`` if a case guard is used.

  Closes #10647 

- Check enums created with the ``Enum()`` functional syntax to pass against the
  ``--class-rgx`` for the :ref:`invalid-name` check, like other enums.

  Closes #10660 