### PR TITLE
Bump pylint to 4.0.2, update changelog

### DIFF
--- a/doc/whatsnew/4/4.0/index.rst
+++ b/doc/whatsnew/4/4.0/index.rst
@@ -74,6 +74,30 @@ to your liking.
 
 .. towncrier release notes start
 
+What's new in Pylint 4.0.2?
+--------------------------------
+Release date: 2025-10-20
+
+
+False Positives Fixed
+---------------------
+
+- Fix false positive for :ref:`invalid-name` on a partially uninferable module-level constant.
+
+  Closes #10652 (`#10652 <https://github.com/pylint-dev/pylint/issues/10652>`_)
+
+- Fix a false positive for :ref:`invalid-name` on exclusive module-level assignments
+  composed of three or more branches. We won't raise :ref:`disallowed-name` on module-level names that can't be inferred
+  until a further refactor to remove this false negative is done.
+
+  Closes #10664 (`#10664 <https://github.com/pylint-dev/pylint/issues/10664>`_)
+
+- Fix false positive for :ref:`invalid-name` for ``TypedDict`` instances.
+
+  Closes #10672 (`#10672 <https://github.com/pylint-dev/pylint/issues/10672>`_)
+
+
+
 What's new in Pylint 4.0.1?
 ---------------------------
 Release date: 2025-10-14

--- a/doc/whatsnew/fragments/10652.false_positive
+++ b/doc/whatsnew/fragments/10652.false_positive
@@ -1,3 +1,0 @@
-Fix false positive for ``invalid-name`` on a partially uninferable module-level constant.
-
-Closes #10652

--- a/doc/whatsnew/fragments/10664.false_positive
+++ b/doc/whatsnew/fragments/10664.false_positive
@@ -1,5 +1,0 @@
-Fix a false positive for ``invalid-name`` on exclusive module-level assignments
-composed of three or more branches. We won't raise ``disallowed-name`` on module-level names that can't be inferred
-until a further refactor to remove this false negative is done.
-
-Closes #10664

--- a/doc/whatsnew/fragments/10672.false_positive
+++ b/doc/whatsnew/fragments/10672.false_positive
@@ -1,3 +1,0 @@
-Fix false positive for ``invalid-name`` for ``TypedDict`` instances.
-
-Closes #10672

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "4.0.1"
+__version__ = "4.0.2"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "4.0.1"
+current = "4.0.2"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
False Positives Fixed
---------------------

- Fix false positive for ``invalid-name`` on a partially uninferable module-level constant.

  Closes #10652

- Fix a false positive for ``invalid-name`` on exclusive module-level assignments
  composed of three or more branches. We won't raise ``disallowed-name`` on module-level names that can't be inferred
  until a further refactor to remove this false negative is done.

  Closes #10664

- Fix false positive for ``invalid-name`` for ``TypedDict`` instances.

  Closes #10672