### PR TITLE
Fix FP for `invalid-name` with `typing.Annotated`

### DIFF
--- a/doc/whatsnew/fragments/10696.false_positive
+++ b/doc/whatsnew/fragments/10696.false_positive
@@ -1,0 +1,3 @@
+Fixed false positive for ``invalid-name`` with ``typing.Annotated``.
+
+Closes #10696

--- a/tests/functional/i/invalid/invalid_name/invalid_name_module_level.py
+++ b/tests/functional/i/invalid/invalid_name/invalid_name_module_level.py
@@ -51,3 +51,7 @@ try:
     VERSION = version("ty")  # uninferable
 except PackageNotFoundError:
     VERSION = "0.0.0"
+
+
+from typing import Annotated
+IntWithAnnotation = Annotated[int, "anything"]


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Closes #10696