### PR TITLE
Fix crash when a variable annotation is used as `if` test expression

### DIFF
--- a/doc/whatsnew/fragments/10707.bugfix
+++ b/doc/whatsnew/fragments/10707.bugfix
@@ -1,0 +1,4 @@
+Fix crash for ``consider-using-assignment-expr`` when a variable annotation without assignment
+is used as the ``if`` test expression.
+
+Closes #10707

--- a/pylint/extensions/code_style.py
+++ b/pylint/extensions/code_style.py
@@ -314,7 +314,7 @@ class CodeStyleChecker(BaseChecker):
             case nodes.Assign(
                 targets=[nodes.AssignName(name=target_name)]
             ) | nodes.AnnAssign(target=nodes.AssignName(name=target_name)):
-                return target_name == name  # type: ignore[no-any-return]
+                return target_name == name and prev_sibling.value is not None
         return False
 
     @staticmethod

--- a/tests/functional/ext/code_style/cs_consider_using_assignment_expr.py
+++ b/tests/functional/ext/code_style/cs_consider_using_assignment_expr.py
@@ -157,3 +157,8 @@ class A:
 A.var = 2
 if A.var:
     ...
+
+
+i: int
+if i:  # pylint: disable=used-before-assignment
+    pass


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

The `consider-using-assignment-expr` check should ignore cases where a variable annotation statement is represented as an `AnnAssign` node without an assigned value.

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #10707
