### PR TITLE
Fix false positive for `f-string-without-interpolation` with template strings when using format spec

### DIFF
--- a/doc/whatsnew/fragments/10702.false_positive
+++ b/doc/whatsnew/fragments/10702.false_positive
@@ -1,0 +1,4 @@
+Fix false positive for ``f-string-without-interpolation`` with template strings
+when using format spec.
+
+Closes #10702

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -409,7 +409,7 @@ class StringFormatChecker(BaseChecker):
         self._check_interpolation(node)
 
     def _check_interpolation(self, node: nodes.JoinedStr) -> None:
-        if isinstance(node.parent, nodes.FormattedValue):
+        if isinstance(node.parent, (nodes.TemplateStr, nodes.FormattedValue)):
             return
         for value in node.values:
             if isinstance(value, nodes.FormattedValue):

--- a/tests/functional/f/f_string_without_interpolation_py314.py
+++ b/tests/functional/f/f_string_without_interpolation_py314.py
@@ -1,0 +1,4 @@
+# pylint: disable=missing-module-docstring
+
+PI = 3.14
+print(t"{PI:.1f}")

--- a/tests/functional/f/f_string_without_interpolation_py314.rc
+++ b/tests/functional/f/f_string_without_interpolation_py314.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.14


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

With the addition of the `TemplateStr` node, a `JoinedStr` may be a child node of `TemplateStr`. Before emitting f-string diagnostics, we should ensure that the `JoinedStr` is not part of a t-string.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #10702
