### PR TITLE
fix: avoid false positive when module-level names match class-level names

### DIFF
--- a/doc/whatsnew/fragments/10719.false_positive
+++ b/doc/whatsnew/fragments/10719.false_positive
@@ -1,0 +1,3 @@
+Fixed false positive for ``invalid-name`` where module-level constants were incorrectly classified as variables when a class-level attribute with the same name exists.
+
+Closes #10719

--- a/tests/functional/i/invalid/invalid_name/invalid_name_module_level.py
+++ b/tests/functional/i/invalid/invalid_name/invalid_name_module_level.py
@@ -55,3 +55,15 @@ except PackageNotFoundError:
 
 from typing import Annotated
 IntWithAnnotation = Annotated[int, "anything"]
+
+
+# Regression test for #10719: module-level constants should not be incorrectly
+# classified as variables when a class-level attribute with the same name exists.
+class Theme:
+    INPUT = ">>> "
+
+
+INPUT = Theme()
+input = Theme()  # pylint: disable=redefined-builtin
+OUTPUT = Theme()
+output = Theme()

--- a/tests/functional/n/no/no_dummy_redefined.py
+++ b/tests/functional/n/no/no_dummy_redefined.py
@@ -1,4 +1,5 @@
 """Make sure warnings about redefinitions do not trigger for dummy variables."""
+# pylint: disable=invalid-name
 
 
 _, INTERESTING = 'a=b'.split('=')

--- a/tests/functional/n/no/no_dummy_redefined.txt
+++ b/tests/functional/n/no/no_dummy_redefined.txt
@@ -1,1 +1,1 @@
-redefined-outer-name:11:4:11:9:clobbering:Redefining name 'value' from outer scope (line 6):UNDEFINED
+redefined-outer-name:12:4:12:9:clobbering:Redefining name 'value' from outer scope (line 7):UNDEFINED


### PR DESCRIPTION
## Description
Fixes a false positive  where module-level constants were incorrectly classified as variables when a class-level attribute with the same name exists. I added a scope check so now when we check for reassignments, we make sure we only look at nodes within the same scope

Closes #10719
