### PR TITLE
[primer] Update default branch for coverage

### DIFF
--- a/tests/primer/packages_to_prime.json
+++ b/tests/primer/packages_to_prime.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/psf/black"
   },
   "coverage": {
-    "branch": "master",
+    "branch": "main",
     "directories": ["coverage"],
     "url": "https://github.com/nedbat/coveragepy",
     "pylintrc_relpath": "pyproject.toml"


### PR DESCRIPTION
Fix primer, see https://github.com/pylint-dev/pylint/actions/runs/19213898067/job/54920283627
Refs https://github.com/coveragepy/coveragepy/commit/6dd976cd06d1fcfc912731a4865320653856509c