### PR TITLE
docs: properly escape backslashes

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -135,7 +135,7 @@ localized using the following rules:
 * "pylint" subdirectory of the user's XDG_CACHE_HOME if the environment variable is set, otherwise
     - Linux: "~/.cache/pylint"
     - macOS: "~/Library/Caches/pylint"
-    - Windows: "C:\Users\<username>\AppData\Local\pylint"
+    - Windows: "C:\\Users\\<username>\\AppData\\Local\\pylint"
 * ".pylint.d" directory in the current directory
 
 How does the website pylint dot org relate to this project?

--- a/doc/whatsnew/0/0.x.rst
+++ b/doc/whatsnew/0/0.x.rst
@@ -54,7 +54,7 @@ Release date: 2013-02-26
 * #113231: logging checker now looks at instances of Logger classes
   in addition to the base logging module. (patch by Mike Bryant)
 
-* #111799: don't warn about octal escape sequence, but warn about \o
+* #111799: don't warn about octal escape sequence, but warn about ``\o``
   which is not octal in Python (patch by Martin Pool)
 
 * #110839: bind <F5> to Run button in pylint-gui
@@ -940,7 +940,7 @@ Release date: 2005-02-16
 * fix false positive on W0706 ("identifier used to raise an exception
   assigned to...")
 
-* fix interpretation of "\t" as value for the indent-string
+* fix interpretation of ``\t`` as value for the indent-string
   configuration variable
 
 * fix --rcfile so that --rcfile=pylintrc (only --rcfile pylintrc was

--- a/doc/whatsnew/1/1.2.rst
+++ b/doc/whatsnew/1/1.2.rst
@@ -19,7 +19,7 @@ Release date: 2014-04-30
 
   Closes BitBucket #176
 
-* Do not warn about \u escapes in string literals when Unicode literals
+* Do not warn about ``\u`` escapes in string literals when Unicode literals
   are used for Python 2.*.
 
   Closes BitBucket #151

--- a/doc/whatsnew/2/2.12/full.rst
+++ b/doc/whatsnew/2/2.12/full.rst
@@ -13,7 +13,7 @@ Release date: 2021-11-25
 
   Closes #5342
 
-* Specified that the ``ignore-paths`` option considers "\" to represent a
+* Specified that the ``ignore-paths`` option considers ``\`` to represent a
   windows directory delimiter instead of a regular expression escape
   character.
 
@@ -23,7 +23,7 @@ Release date: 2021-11-25
   Closes #5437
 
 * Fixed handling of Sphinx-style parameter docstrings with asterisks. These
-  should be escaped with by prepending a "\".
+  should be escaped with by prepending a ``\``.
 
   Closes #5406
 


### PR DESCRIPTION
this should fix most cases except the autogenerated docs

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

