### PR TITLE
Bump pylint to 4.0.3, update changelog

### DIFF
--- a/doc/whatsnew/4/4.0/index.rst
+++ b/doc/whatsnew/4/4.0/index.rst
@@ -74,6 +74,57 @@ to your liking.
 
 .. towncrier release notes start
 
+What's new in Pylint 4.0.3?
+---------------------------
+Release date: 2025-11-13
+
+
+False Positives Fixed
+---------------------
+
+- Add Enum dunder methods ``_generate_next_value_``, ``_missing_``, ``_numeric_repr_``, ``_add_alias_``, and ``_add_value_alias_`` to the list passed to ``--good-dunder-names``.
+
+  Closes #10435 (`#10435 <https://github.com/pylint-dev/pylint/issues/10435>`_)
+
+- Fixed false positive for ``invalid-name`` with ``typing.Annotated``.
+
+  Closes #10696 (`#10696 <https://github.com/pylint-dev/pylint/issues/10696>`_)
+
+- Fix false positive for ``f-string-without-interpolation`` with template strings
+  when using format spec.
+
+  Closes #10702 (`#10702 <https://github.com/pylint-dev/pylint/issues/10702>`_)
+
+- Fix a false positive when an UPPER_CASED class attribute was raising an
+  ``invalid-name`` when typed with ``Final``.
+
+  Closes #10711 (`#10711 <https://github.com/pylint-dev/pylint/issues/10711>`_)
+
+- Fix a false positive for ``unbalanced-tuple-unpacking`` when a tuple is assigned to a function call and the structure of the function's return value is ambiguous.
+
+  Closes #10721 (`#10721 <https://github.com/pylint-dev/pylint/issues/10721>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Make 'ignore' option work as expected again.
+
+  Closes #10669 (`#10669 <https://github.com/pylint-dev/pylint/issues/10669>`_)
+
+- Fix crash for ``consider-using-assignment-expr`` when a variable annotation without assignment
+  is used as the ``if`` test expression.
+
+  Closes #10707 (`#10707 <https://github.com/pylint-dev/pylint/issues/10707>`_)
+
+- Fix crash for ``prefer-typing-namedtuple`` and ``consider-math-not-float`` when
+  a ``slice`` object is called.
+
+  Closes #10708 (`#10708 <https://github.com/pylint-dev/pylint/issues/10708>`_)
+
+
+
 What's new in Pylint 4.0.2?
 --------------------------------
 Release date: 2025-10-20

--- a/doc/whatsnew/fragments/10435.false_positive
+++ b/doc/whatsnew/fragments/10435.false_positive
@@ -1,3 +1,0 @@
-Add Enum dunder methods ``_generate_next_value_``, ``_missing_``, ``_numeric_repr_``, ``_add_alias_``, and ``_add_value_alias_`` to the list passed to ``--good-dunder-names``.
-
-Closes #10435

--- a/doc/whatsnew/fragments/10669.bugfix
+++ b/doc/whatsnew/fragments/10669.bugfix
@@ -1,3 +1,0 @@
-Make 'ignore' option work as expected again.
-
-Closes #10669

--- a/doc/whatsnew/fragments/10696.false_positive
+++ b/doc/whatsnew/fragments/10696.false_positive
@@ -1,3 +1,0 @@
-Fixed false positive for ``invalid-name`` with ``typing.Annotated``.
-
-Closes #10696

--- a/doc/whatsnew/fragments/10702.false_positive
+++ b/doc/whatsnew/fragments/10702.false_positive
@@ -1,4 +1,0 @@
-Fix false positive for ``f-string-without-interpolation`` with template strings
-when using format spec.
-
-Closes #10702

--- a/doc/whatsnew/fragments/10707.bugfix
+++ b/doc/whatsnew/fragments/10707.bugfix
@@ -1,4 +1,0 @@
-Fix crash for ``consider-using-assignment-expr`` when a variable annotation without assignment
-is used as the ``if`` test expression.
-
-Closes #10707

--- a/doc/whatsnew/fragments/10708.bugfix
+++ b/doc/whatsnew/fragments/10708.bugfix
@@ -1,4 +1,0 @@
-Fix crash for ``prefer-typing-namedtuple`` and ``consider-math-not-float`` when
-a ``slice`` object is called.
-
-Closes #10708

--- a/doc/whatsnew/fragments/10711.false_positive
+++ b/doc/whatsnew/fragments/10711.false_positive
@@ -1,4 +1,0 @@
-Fix a false positive when an UPPER_CASED class attribute was raising an
-``invalid-name`` when typed with ``Final``.
-
-Closes #10711

--- a/doc/whatsnew/fragments/10721.false_positive
+++ b/doc/whatsnew/fragments/10721.false_positive
@@ -1,3 +1,0 @@
-Fix a false positive for ``unbalanced-tuple-unpacking`` when a tuple is assigned to a function call and the structure of the function's return value is ambiguous.
-
-Closes #10721

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "4.0.2"
+__version__ = "4.0.3"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "4.0.2"
+current = "4.0.3"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's new in Pylint 4.0.3?
---------------------------
Release date: 2025-11-13


False Positives Fixed
---------------------

- Add Enum dunder methods ``_generate_next_value_``, ``_missing_``, ``_numeric_repr_``, ``_add_alias_``, and ``_add_value_alias_`` to the list passed to ``--good-dunder-names``.

  Closes #10435 

- Fixed false positive for ``invalid-name`` with ``typing.Annotated``.

  Closes #10696 

- Fix false positive for ``f-string-without-interpolation`` with template strings
  when using format spec.

  Closes #10702

- Fix a false positive when an UPPER_CASED class attribute was raising an
  ``invalid-name`` when typed with ``Final``.

  Closes #10711 

- Fix a false positive for ``unbalanced-tuple-unpacking`` when a tuple is assigned to a function call and the structure of the function's return value is ambiguous.

  Closes #10721 



Other Bug Fixes
---------------

- Make 'ignore' option work as expected again.

  Closes #10669 

- Fix crash for ``consider-using-assignment-expr`` when a variable annotation without assignment
  is used as the ``if`` test expression.

  Closes #10707 

- Fix crash for ``prefer-typing-namedtuple`` and ``consider-math-not-float`` when
  a ``slice`` object is called.

  Closes #10708 


