### PR TITLE
Bump pylint to 4.0.4, update changelog

### DIFF
--- a/doc/whatsnew/4/4.0/index.rst
+++ b/doc/whatsnew/4/4.0/index.rst
@@ -74,6 +74,24 @@ to your liking.
 
 .. towncrier release notes start
 
+What's new in Pylint 4.0.4?
+--------------------------------
+Release date: 2025-11-30
+
+
+False Positives Fixed
+---------------------
+
+- Fixed false positive for ``invalid-name`` where module-level constants were incorrectly classified as variables when a class-level attribute with the same name exists.
+
+  Closes #10719 (`#10719 <https://github.com/pylint-dev/pylint/issues/10719>`_)
+
+- Fix a false positive for ``invalid-name`` on an UPPER_CASED name inside an ``if`` branch that assigns an object.
+
+  Closes #10745 (`#10745 <https://github.com/pylint-dev/pylint/issues/10745>`_)
+
+
+
 What's new in Pylint 4.0.3?
 ---------------------------
 Release date: 2025-11-13

--- a/doc/whatsnew/fragments/10719.false_positive
+++ b/doc/whatsnew/fragments/10719.false_positive
@@ -1,3 +1,0 @@
-Fixed false positive for ``invalid-name`` where module-level constants were incorrectly classified as variables when a class-level attribute with the same name exists.
-
-Closes #10719

--- a/doc/whatsnew/fragments/10745.false_positive
+++ b/doc/whatsnew/fragments/10745.false_positive
@@ -1,4 +1,0 @@
-Fix a false positive for ``invalid-name`` on an UPPER_CASED name inside an
-``if`` branch that assigns an object.
-
-Closes #10745

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "4.0.3"
+__version__ = "4.0.4"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "4.0.3"
+current = "4.0.4"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's new in Pylint 4.0.4?
--------------------------------
Release date: 2025-11-30


False Positives Fixed
---------------------

- Fixed false positive for ``invalid-name`` where module-level constants were incorrectly classified as variables when a class-level attribute with the same name exists.

  Closes #10719

- Fix a false positive for ``invalid-name`` on an UPPER_CASED name inside an ``if`` branch that assigns an object.

  Closes #10745