### PR TITLE
Refactor pyreverse to use dataclass wrappers instead of modifying nodes directly

### DIFF
--- a/pylint/pyreverse/diadefslib.py
+++ b/pylint/pyreverse/diadefslib.py
@@ -159,8 +159,9 @@ class DiaDefGenerator:
         """Return associated nodes of a class node."""
         if level == 0:
             return
-        for association_nodes in list(klass_node.instance_attrs_type.values()) + list(
-            klass_node.locals_type.values()
+        info = self.linker.class_info[klass_node]
+        for association_nodes in list(info.instance_attrs_type.values()) + list(
+            info.locals_type.values()
         ):
             for node in association_nodes:
                 if isinstance(node, astroid.Instance):
@@ -203,11 +204,11 @@ class DefaultDiadefGenerator(LocalsVisitor, DiaDefGenerator):
         mode = self.config.mode
         if len(node.modules) > 1:
             self.pkgdiagram: PackageDiagram | None = PackageDiagram(
-                f"packages {node.name}", mode
+                f"packages {node.name}", mode, self.linker
             )
         else:
             self.pkgdiagram = None
-        self.classdiagram = ClassDiagram(f"classes {node.name}", mode)
+        self.classdiagram = ClassDiagram(f"classes {node.name}", mode, self.linker)
 
     def leave_project(self, _: Project) -> Any:
         """Leave the pyreverse.utils.Project node.
@@ -248,7 +249,7 @@ class ClassDiadefGenerator(DiaDefGenerator):
 
     def class_diagram(self, project: Project, klass: nodes.ClassDef) -> ClassDiagram:
         """Return a class diagram definition for the class and related classes."""
-        self.classdiagram = ClassDiagram(klass, self.config.mode)
+        self.classdiagram = ClassDiagram(klass, self.config.mode, self.linker)
         if len(project.modules) > 1:
             module, klass = klass.rsplit(".", 1)
             module = project.get_module(module)

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -95,7 +95,7 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
     """Walk on the project tree and resolve relationships.
 
     Analysis data is stored in info dictionaries (class_info, module_info,
-    function_info) rather than on AST nodes. See node_info module for details
+    function_info). See node_info module for details
     on the stored attributes.
 
     If tag=True, unique identifiers are generated for visited nodes.

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -143,8 +143,6 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
         * optionally tag the node with a unique id
         """
         info = self.module_info[node]
-        if info.uid is not None or info.depends:
-            return
         if self.tag:
             info.uid = self.generate_id()
 
@@ -155,8 +153,6 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
         * optionally tag the node with a unique id
         """
         info = self.class_info[node]
-        if info.uid is not None or info.instance_attrs_type:
-            return
         if self.tag:
             info.uid = self.generate_id()
         # resolve ancestors
@@ -185,8 +181,6 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
         * optionally tag the node with a unique id
         """
         info = self.function_info[node]
-        if info.uid is not None or info.locals_type:
-            return
         if self.tag:
             info.uid = self.generate_id()
 
@@ -198,8 +192,6 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
         # avoid double parsing done by different Linkers.visit
         # running over the same project:
         node_id = id(node)
-        if node_id in self._handled_assigns:
-            return
         self._handled_assigns.add(node_id)
         if node.name in node.frame():
             frame = node.frame()

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -126,32 +126,20 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
         aggregation_handler.set_next(association_handler)
 
     def visit_project(self, node: Project) -> None:
-        """Visit a pyreverse.utils.Project node.
-
-        * optionally tag the node with a unique id
-        """
+        """Visit a pyreverse.utils.Project node and optionally assign a unique id."""
         if self.tag:
             node.uid = self.generate_id()
         for module in node.modules:
             self.visit(module)
 
     def visit_module(self, node: nodes.Module) -> None:
-        """Visit an nodes.Module node.
-
-        * set the locals_type mapping
-        * set the depends mapping
-        * optionally tag the node with a unique id
-        """
+        """Visit an nodes.Module node and optionally assign a unique id."""
         info = self.module_info[node]
         if self.tag:
             info.uid = self.generate_id()
 
     def visit_classdef(self, node: nodes.ClassDef) -> None:
-        """Visit an nodes.Class node.
-
-        * set the locals_type and instance_attrs_type mappings
-        * optionally tag the node with a unique id
-        """
+        """Visit an nodes.Class node and optionally assign a unique id."""
         info = self.class_info[node]
         if self.tag:
             info.uid = self.generate_id()
@@ -175,11 +163,7 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
                     self.compositions_handler.handle(local_node, node, info)
 
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
-        """Visit an nodes.Function node.
-
-        * set the locals_type mapping
-        * optionally tag the node with a unique id
-        """
+        """Visit an nodes.Function node and optionally assign a unique id."""
         info = self.function_info[node]
         if self.tag:
             info.uid = self.generate_id()

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -94,30 +94,11 @@ class Project:
 class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
     """Walk on the project tree and resolve relationships.
 
-    According to options the following attributes may be
-    added to visited nodes:
+    Analysis data is stored in info dictionaries (class_info, module_info,
+    function_info) rather than on AST nodes. See node_info module for details
+    on the stored attributes.
 
-    * uid,
-      a unique identifier for the node (on astroid.Project, nodes.Module,
-      nodes.Class and astroid.locals_type). Only if the linker
-      has been instantiated with tag=True parameter (False by default).
-
-    * Function
-      a mapping from locals names to their bounded value, which may be a
-      constant like a string or an integer, or an astroid node
-      (on nodes.Module, nodes.Class and nodes.Function).
-
-    * instance_attrs_type
-      as locals_type but for klass member attributes (only on nodes.Class)
-
-    * associations_type
-      as instance_attrs_type but for association relationships
-
-    * aggregations_type
-      as instance_attrs_type but for aggregations relationships
-
-    * compositions_type
-      as instance_attrs_type but for compositions relationships
+    If tag=True, unique identifiers are generated for visited nodes.
     """
 
     def __init__(self, project: Project, tag: bool = False) -> None:

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -169,14 +169,12 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
             info.uid = self.generate_id()
 
     def visit_assignname(self, node: nodes.AssignName) -> None:
-        """Visit an nodes.AssignName node.
+        """Visit an AssignName node and update locals_type for its frame."""
+        # avoid double parsing done by different Linkers.visit running over the same project:
+        if node in self._handled_assigns:
+            return
+        self._handled_assigns.add(node)
 
-        handle locals_type
-        """
-        # avoid double parsing done by different Linkers.visit
-        # running over the same project:
-        node_id = id(node)
-        self._handled_assigns.add(node_id)
         if node.name in node.frame():
             frame = node.frame()
         else:

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -291,7 +291,7 @@ class RelationshipHandlerInterface(ABC):
     def set_next(
         self, handler: RelationshipHandlerInterface
     ) -> RelationshipHandlerInterface:
-        pass
+        raise NotImplementedError()
 
     @abstractmethod
     def handle(
@@ -300,7 +300,7 @@ class RelationshipHandlerInterface(ABC):
         parent: nodes.ClassDef,
         info: ClassInfo,
     ) -> None:
-        pass
+        raise NotImplementedError()
 
 
 class AbstractRelationshipHandler(RelationshipHandlerInterface):

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -115,7 +115,7 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
         self.function_info: InfoDict[nodes.FunctionDef, FunctionInfo] = InfoDict(
             FunctionInfo
         )
-        self._handled_assigns: set[int] = set()
+        self._handled_assigns: set[nodes.AssignName] = set()
 
         # Chain: Composition → Aggregation → Association
         self.compositions_handler = CompositionsHandler()

--- a/pylint/pyreverse/node_info.py
+++ b/pylint/pyreverse/node_info.py
@@ -37,7 +37,14 @@ class InfoDict(dict[K, V], Generic[K, V]):
 
 @dataclass
 class ModuleInfo:
-    """Analysis info for Module nodes."""
+    """Analysis info for Module nodes.
+
+    Attributes:
+        locals_type: Mapping from local names to inferred types.
+        depends: List of module dependencies.
+        type_depends: List of type-checking-only dependencies.
+        uid: Unique identifier (only set if Linker tag=True).
+    """
 
     locals_type: defaultdict[str, list[nodes.NodeNG]] = field(
         default_factory=lambda: defaultdict(list)
@@ -49,7 +56,17 @@ class ModuleInfo:
 
 @dataclass
 class ClassInfo:
-    """Analysis info for ClassDef nodes."""
+    """Analysis info for ClassDef nodes.
+
+    Attributes:
+        locals_type: Mapping from local names to inferred types.
+        instance_attrs_type: Mapping from instance attribute names to types.
+        compositions_type: Attributes representing composition relationships.
+        aggregations_type: Attributes representing aggregation relationships.
+        associations_type: Attributes representing association relationships.
+        specializations: List of subclasses.
+        uid: Unique identifier (only set if Linker tag=True).
+    """
 
     locals_type: defaultdict[str, list[nodes.NodeNG]] = field(
         default_factory=lambda: defaultdict(list)
@@ -72,7 +89,12 @@ class ClassInfo:
 
 @dataclass
 class FunctionInfo:
-    """Analysis info for FunctionDef nodes."""
+    """Analysis info for FunctionDef nodes.
+
+    Attributes:
+        locals_type: Mapping from local names to inferred types.
+        uid: Unique identifier (only set if Linker tag=True).
+    """
 
     locals_type: defaultdict[str, list[nodes.NodeNG]] = field(
         default_factory=lambda: defaultdict(list)

--- a/pylint/pyreverse/node_info.py
+++ b/pylint/pyreverse/node_info.py
@@ -1,0 +1,80 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Dataclass wrappers for storing analysis info about astroid nodes.
+
+This module provides typed dataclasses to hold the analysis metadata that was
+previously stored directly on astroid nodes. This enables proper type hints
+and avoids modifying external objects.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from astroid import nodes
+
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class InfoDict(dict[K, V], Generic[K, V]):
+    """Dict that auto-creates values using a factory when accessing missing keys."""
+
+    def __init__(self, factory: type[V]) -> None:
+        super().__init__()
+        self._factory = factory
+
+    def __missing__(self, key: K) -> V:
+        self[key] = self._factory()
+        return self[key]
+
+
+@dataclass
+class ModuleInfo:
+    """Analysis info for Module nodes."""
+
+    locals_type: defaultdict[str, list[nodes.NodeNG]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    depends: list[str] = field(default_factory=list)
+    type_depends: list[str] = field(default_factory=list)
+    uid: int | None = None
+
+
+@dataclass
+class ClassInfo:
+    """Analysis info for ClassDef nodes."""
+
+    locals_type: defaultdict[str, list[nodes.NodeNG]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    instance_attrs_type: defaultdict[str, list[nodes.NodeNG]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    compositions_type: defaultdict[str, list[nodes.ClassDef]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    aggregations_type: defaultdict[str, list[nodes.ClassDef]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    associations_type: defaultdict[str, list[nodes.ClassDef]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    specializations: list[nodes.ClassDef] = field(default_factory=list)
+    uid: int | None = None
+
+
+@dataclass
+class FunctionInfo:
+    """Analysis info for FunctionDef nodes."""
+
+    locals_type: defaultdict[str, list[nodes.NodeNG]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    uid: int | None = None

--- a/tests/pyreverse/test_inspector.py
+++ b/tests/pyreverse/test_inspector.py
@@ -24,11 +24,13 @@ HERE = Path(__file__)
 TESTS = HERE.parent.parent
 
 
-@pytest.fixture
-def test_context(get_project: GetProjectCallable) -> Generator[tuple[Project, Linker]]:
+@pytest.fixture(params=[True, False], ids=["tag=True", "tag=False"])
+def test_context(
+    request: pytest.FixtureRequest, get_project: GetProjectCallable
+) -> Generator[tuple[Project, Linker]]:
     with _test_cwd(TESTS):
         project = get_project("data", "data")
-        linker = Linker(project)
+        linker = Linker(project, tag=request.param)
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             linker.visit(project)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
|    | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

Refactor pyreverse Linker class to avoid monkey patching of astroid nodes. Instead the analysis data is now stored in properly typed dataclasses, defined in the node_info module.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #7850
