### PR TITLE
Fix dynamic color mapping for "fail-on" messages when using multiple reporter/output formats

### DIFF
--- a/doc/whatsnew/fragments/10825.bugfix
+++ b/doc/whatsnew/fragments/10825.bugfix
@@ -1,3 +1,3 @@
-Fixed dynamic color mapping for "fail-on" messages when using multiple reporter/output formats
+Fixed dynamic color mapping for "fail-on" messages when using multiple reporter/output formats.
 
 Closes #10825

--- a/doc/whatsnew/fragments/10825.bugfix
+++ b/doc/whatsnew/fragments/10825.bugfix
@@ -1,1 +1,3 @@
 Fixed dynamic color mapping for "fail-on" messages when using multiple reporter/output formats
+
+Closes #10825

--- a/doc/whatsnew/fragments/10825.bugfix.rst
+++ b/doc/whatsnew/fragments/10825.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed dynamic color mapping for "fail-on" messages when using multiple reporter/output formats

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -569,9 +569,9 @@ class PyLinter(
         if isinstance(self.reporter, ColorizedTextReporter):
             self.reporter.set_fail_on_symbols(self.fail_on_symbols)
         elif isinstance(self.reporter, reporters.MultiReporter):
-            for _reporter in self.reporter._sub_reporters:
-                if isinstance(self.reporter, ColorizedTextReporter):
-                    self.reporter.set_fail_on_symbols(self.fail_on_symbols)
+            for reporter in self.reporter._sub_reporters:
+                if isinstance(reporter, ColorizedTextReporter):
+                    reporter.set_fail_on_symbols(self.fail_on_symbols)
 
     def disable_reporters(self) -> None:
         """Disable all reporters."""


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #10825
