### PR TITLE
Add ``ignore-pattern-in-long-lines`` configuration option

### DIFF
--- a/doc/whatsnew/fragments/3352.feature
+++ b/doc/whatsnew/fragments/3352.feature
@@ -1,0 +1,3 @@
+Add support for ``ignore-pattern-in-long-lines`` to allow ignoring specific parts of a line when checking line length.
+
+Refs #3352

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -185,6 +185,18 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
             },
         ),
         (
+            "ignore-pattern-in-long-lines",
+            {
+                "type": "regexp",
+                "metavar": "<regexp>",
+                "default": None,
+                "help": (
+                    "Regexp for a part of a line that will not be counted when "
+                    "calculating the line length."
+                ),
+            },
+        ),
+        (
             "single-line-if-stmt",
             {
                 "default": False,
@@ -699,6 +711,10 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
                 checker_off = True
             # The 'pylint: disable whatever' should not be taken into account for line length count
             lines = self.remove_pylint_option_from_lines(mobj)
+
+        ignore_pattern_in_long_lines = self.linter.config.ignore_pattern_in_long_lines
+        if ignore_pattern_in_long_lines:
+            lines = ignore_pattern_in_long_lines.sub("", lines)
 
         # here we re-run specific_splitlines since we have filtered out pylint options above
         for offset, line in enumerate(self.specific_splitlines(lines)):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in `[script/.contributors_aliases.json](cci:7://file:///home/jasss/github/pylint/script/.contributors_aliases.json:0:0-0:0)`
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|     | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Description

This PR adds a new configuration option `ignore-patterns-in-long-lines` to validation.

It allows users to specify a regular expression for parts of a line (e.g., specific comments like `# type: ignore` or `# noqa`) that should not be counted before calculating the line length. This addresses the limitation where `ignore-long-lines` only allows exempting the entire line.

Example usage in `pylintrc` , `pyproject.toml` and `command line`:

```ini
[FORMAT]
# Ignore type comments when checking line length
ignore-patterns-in-long-lines=\s*# type: ignore
```

```toml
[tool.pylint.format]
ignore-patterns-in-long-lines = "\\s*# type: ignore"
```

```bash
.venv/bin/pylint command_verify.py --max-line-length=50 --ignore-patterns-in-long-lines='\s*# type: ignore.*'
```

Refs #3352

Closes #3352