### PR TITLE
Enable running pylint test suite with custom astroid SHA

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,10 +15,10 @@ on:
   workflow_call:
     inputs:
       repository:
-        required: false
+        required: true
         type: string
       astroid_sha:
-        required: false
+        required: true
         type: string
 
 env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,14 @@ on:
       - main
       - "maintenance/**"
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      repository:
+        required: false
+        type: string
+      astroid_sha:
+        required: false
+        type: string
 
 env:
   CACHE_VERSION: 5
@@ -47,6 +55,8 @@ jobs:
       - &checkout
         name: Check out code from GitHub
         uses: actions/checkout@v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
       - &setup-python
         name: Set up Python ${{ matrix.python-version }}
         id: python
@@ -59,6 +69,7 @@ jobs:
         id: generate-python-key
         run: >-
           echo "key=${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{
+            inputs.astroid_sha }}-${{
             hashFiles('pyproject.toml', 'requirements_test.txt',
           'requirements_test_min.txt', 'requirements_test_pre_commit.txt') }}" >>
           $GITHUB_OUTPUT
@@ -78,6 +89,11 @@ jobs:
           . venv/bin/activate
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements_test.txt
+      - name: Install requested astroid SHA
+        if: inputs.astroid_sha != ''
+        run: |
+          . venv/bin/activate
+          pip install --force-reinstall --no-deps git+https://github.com/${{ github.repository }}@${{ inputs.astroid_sha }}
       - name: Run pytest
         run: |
           . venv/bin/activate
@@ -190,6 +206,7 @@ jobs:
         id: generate-python-key
         run: >-
           echo "key=venv-${{ env.CACHE_VERSION }}-${{
+            inputs.astroid_sha }}-${{
             hashFiles('pyproject.toml', 'requirements_test_min.txt')
           }}" >> $env:GITHUB_OUTPUT
       - *cache-python
@@ -200,6 +217,11 @@ jobs:
           . venv\\Scripts\\activate
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements_test_min.txt
+      - name: Install requested astroid SHA
+        if: inputs.astroid_sha != ''
+        run: |
+          . venv\\Scripts\\activate
+          pip install --force-reinstall --no-deps git+https://github.com/${{ github.repository }}@${{ inputs.astroid_sha }}
       - name: Run pytest
         run: |
           . venv\\Scripts\\activate

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,9 +14,6 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
-      repository:
-        required: true
-        type: string
       astroid_sha:
         required: true
         type: string
@@ -56,7 +53,7 @@ jobs:
         name: Check out code from GitHub
         uses: actions/checkout@v6.0.2
         with:
-          repository: ${{ inputs.repository || github.repository }}
+          repository: ${{ github.repository }}
       - &setup-python
         name: Set up Python ${{ matrix.python-version }}
         id: python
@@ -93,7 +90,7 @@ jobs:
         if: inputs.astroid_sha != ''
         run: |
           . venv/bin/activate
-          pip install --force-reinstall --no-deps git+https://github.com/${{ github.repository }}@${{ inputs.astroid_sha }}
+          pip install --force-reinstall --no-deps git+https://github.com/${{ github.repository_owner }}/astroid@${{ inputs.astroid_sha }}
       - name: Run pytest
         run: |
           . venv/bin/activate
@@ -221,7 +218,7 @@ jobs:
         if: inputs.astroid_sha != ''
         run: |
           . venv\\Scripts\\activate
-          pip install --force-reinstall --no-deps git+https://github.com/${{ github.repository }}@${{ inputs.astroid_sha }}
+          pip install --force-reinstall --no-deps git+https://github.com/${{ github.repository_owner }}/astroid@${{ inputs.astroid_sha }}
       - name: Run pytest
         run: |
           . venv\\Scripts\\activate


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This tweak to the tests workflow allows invoking the pylint test suite on astroid PRs to shorten the feedback loop for astroid changes. This avoids the need for checking out astroid PRs locally, running pylint tests locally, and applying the "pylint-tested" label.

Companion astroid PR: https://github.com/pylint-dev/astroid/pull/2956
[Example workflow run](https://github.com/jacobtylerwalls/astroid/actions/runs/21800375771/job/62894806554), see test failures with "Hello from PR." output demonstrating the astroid PR's SHA was used.

Later, we could extend this to also run the pylint primer on astroid PRs, see https://github.com/pylint-dev/astroid/pull/2927#pullrequestreview-3704581066.

This does raise a question about how frequently to update pylint main to cope with astroid main, but tighter feedback loops are probably better.