### PR TITLE
Fix used-before-assignment false negative with bare type annotations

### DIFF
--- a/doc/whatsnew/fragments/10847.false_negative
+++ b/doc/whatsnew/fragments/10847.false_negative
@@ -1,0 +1,4 @@
+Fix ``used-before-assignment`` false negative when a variable has a bare type
+annotation (without a value) and is only assigned inside ``except`` blocks.
+
+Closes #10847

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -617,43 +617,36 @@ scope_type : {self.scope_type}
             uncertain_nodes_set = set(uncertain_nodes)
             found_nodes = [n for n in found_nodes if n not in uncertain_nodes_set]
 
-        # Filter out assignments in an Except clause that the node is not
-        # contained in, assuming they may fail
+        # Filter out assignments in except/try blocks, tracking whether any
+        # uncertainty came from these blocks (as opposed to if/elif tests).
         has_except_uncertainty = False
         if found_nodes:
             uncertain_nodes = self._uncertain_nodes_in_except_blocks(
                 found_nodes, node, node_statement
             )
-            if uncertain_nodes:
-                has_except_uncertainty = True
+            has_except_uncertainty = has_except_uncertainty or bool(uncertain_nodes)
             self.consumed_uncertain[node.name] += uncertain_nodes
             uncertain_nodes_set = set(uncertain_nodes)
             found_nodes = [n for n in found_nodes if n not in uncertain_nodes_set]
 
-        # If this node is in a Finally block of a Try/Finally,
-        # filter out assignments in the try portion, assuming they may fail
         if found_nodes:
             uncertain_nodes = (
                 self._uncertain_nodes_in_try_blocks_when_evaluating_finally_blocks(
                     found_nodes, node_statement, name
                 )
             )
-            if uncertain_nodes:
-                has_except_uncertainty = True
+            has_except_uncertainty = has_except_uncertainty or bool(uncertain_nodes)
             self.consumed_uncertain[node.name] += uncertain_nodes
             uncertain_nodes_set = set(uncertain_nodes)
             found_nodes = [n for n in found_nodes if n not in uncertain_nodes_set]
 
-        # If this node is in an ExceptHandler,
-        # filter out assignments in the try portion, assuming they may fail
         if found_nodes:
             uncertain_nodes = (
                 self._uncertain_nodes_in_try_blocks_when_evaluating_except_blocks(
                     found_nodes, node_statement
                 )
             )
-            if uncertain_nodes:
-                has_except_uncertainty = True
+            has_except_uncertainty = has_except_uncertainty or bool(uncertain_nodes)
             self.consumed_uncertain[node.name] += uncertain_nodes
             uncertain_nodes_set = set(uncertain_nodes)
             found_nodes = [n for n in found_nodes if n not in uncertain_nodes_set]

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -651,6 +651,19 @@ scope_type : {self.scope_type}
             uncertain_nodes_set = set(uncertain_nodes)
             found_nodes = [n for n in found_nodes if n not in uncertain_nodes_set]
 
+        # Filter out bare type annotations (AnnAssign without a value) when there
+        # are uncertain definitions. A bare annotation like `x: int` does not actually
+        # assign a value, so it should not suppress possibly-used-before-assignment
+        # when the real assignments are uncertain (e.g., in except blocks).
+        if found_nodes and self.consumed_uncertain.get(name):
+            found_nodes = [
+                n
+                for n in found_nodes
+                if not (
+                    isinstance(n.parent, nodes.AnnAssign) and n.parent.value is None
+                )
+            ]
+
         return found_nodes
 
     def _inferred_to_define_name_raise_or_return(

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -619,10 +619,13 @@ scope_type : {self.scope_type}
 
         # Filter out assignments in an Except clause that the node is not
         # contained in, assuming they may fail
+        has_except_uncertainty = False
         if found_nodes:
             uncertain_nodes = self._uncertain_nodes_in_except_blocks(
                 found_nodes, node, node_statement
             )
+            if uncertain_nodes:
+                has_except_uncertainty = True
             self.consumed_uncertain[node.name] += uncertain_nodes
             uncertain_nodes_set = set(uncertain_nodes)
             found_nodes = [n for n in found_nodes if n not in uncertain_nodes_set]
@@ -635,6 +638,8 @@ scope_type : {self.scope_type}
                     found_nodes, node_statement, name
                 )
             )
+            if uncertain_nodes:
+                has_except_uncertainty = True
             self.consumed_uncertain[node.name] += uncertain_nodes
             uncertain_nodes_set = set(uncertain_nodes)
             found_nodes = [n for n in found_nodes if n not in uncertain_nodes_set]
@@ -647,16 +652,21 @@ scope_type : {self.scope_type}
                     found_nodes, node_statement
                 )
             )
+            if uncertain_nodes:
+                has_except_uncertainty = True
             self.consumed_uncertain[node.name] += uncertain_nodes
             uncertain_nodes_set = set(uncertain_nodes)
             found_nodes = [n for n in found_nodes if n not in uncertain_nodes_set]
 
         # Treat bare type annotations (AnnAssign without a value) as uncertain
-        # when there are other uncertain definitions. A bare annotation like
-        # `x: int` does not actually assign a value, so it should not suppress
-        # possibly-used-before-assignment when the real assignments are uncertain
-        # (e.g., in except blocks).
-        if found_nodes and self.consumed_uncertain.get(name):
+        # when there are uncertain definitions from except/try blocks.
+        # A bare annotation like `x: int` does not actually assign a value,
+        # so it should not suppress possibly-used-before-assignment when the
+        # real assignments are in except blocks that may not execute.
+        # We only do this for except/try uncertainty, not for if/elif
+        # uncertainty, because if/elif branches are guaranteed to execute
+        # one path (the bare annotation masking is correct there).
+        if found_nodes and has_except_uncertainty:
             bare_annotations = [
                 n
                 for n in found_nodes

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -651,18 +651,21 @@ scope_type : {self.scope_type}
             uncertain_nodes_set = set(uncertain_nodes)
             found_nodes = [n for n in found_nodes if n not in uncertain_nodes_set]
 
-        # Filter out bare type annotations (AnnAssign without a value) when there
-        # are uncertain definitions. A bare annotation like `x: int` does not actually
-        # assign a value, so it should not suppress possibly-used-before-assignment
-        # when the real assignments are uncertain (e.g., in except blocks).
+        # Treat bare type annotations (AnnAssign without a value) as uncertain
+        # when there are other uncertain definitions. A bare annotation like
+        # `x: int` does not actually assign a value, so it should not suppress
+        # possibly-used-before-assignment when the real assignments are uncertain
+        # (e.g., in except blocks).
         if found_nodes and self.consumed_uncertain.get(name):
-            found_nodes = [
+            bare_annotations = [
                 n
                 for n in found_nodes
-                if not (
-                    isinstance(n.parent, nodes.AnnAssign) and n.parent.value is None
-                )
+                if isinstance(n.parent, nodes.AnnAssign) and n.parent.value is None
             ]
+            if bare_annotations:
+                self.consumed_uncertain[name] += bare_annotations
+                bare_set = set(bare_annotations)
+                found_nodes = [n for n in found_nodes if n not in bare_set]
 
         return found_nodes
 

--- a/tests/functional/u/used/used_before_assignment_type_annotations.py
+++ b/tests/functional/u/used/used_before_assignment_type_annotations.py
@@ -107,3 +107,31 @@ def loop_conditional_annotated_assignment():
             data={"cat": "harf"}
     token: str = data.get("cat")  # [possibly-used-before-assignment]
     print(token)
+
+
+def bare_annotation_with_except_assignment():
+    """A bare type annotation should not suppress used-before-assignment
+    when the only real assignments are in except blocks.
+
+    https://github.com/pylint-dev/pylint/issues/10847
+    """
+    result = None
+    err: int  # pylint: disable=unused-variable
+    try:
+        result = 1
+    except Exception:  # pylint: disable=broad-exception-caught
+        err = 1
+    if not result:
+        print(err)  # [used-before-assignment]
+
+
+def bare_annotation_with_value_and_except():
+    """A type annotation with a value should suppress the warning."""
+    result = None
+    err: int = 0
+    try:
+        result = 1
+    except Exception:  # pylint: disable=broad-exception-caught
+        err = 1
+    if not result:
+        print(err)

--- a/tests/functional/u/used/used_before_assignment_type_annotations.py
+++ b/tests/functional/u/used/used_before_assignment_type_annotations.py
@@ -118,7 +118,7 @@ def bare_annotation_with_except_assignment(text):
     err: int
     try:
         result = int(text)
-    except (TypeError, OverflowError):
+    except ValueError:
         err = 1
         result = -1
     if result < 0:
@@ -130,7 +130,7 @@ def bare_annotation_with_value_and_except(text):
     err: int = 0
     try:
         result = int(text)
-    except (TypeError, OverflowError):
+    except ValueError:
         err = 1
         result = -1
     if result < 0:

--- a/tests/functional/u/used/used_before_assignment_type_annotations.py
+++ b/tests/functional/u/used/used_before_assignment_type_annotations.py
@@ -116,10 +116,10 @@ def bare_annotation_with_except_assignment():
     https://github.com/pylint-dev/pylint/issues/10847
     """
     result = None
-    err: int  # pylint: disable=unused-variable
+    err: int
     try:
         result = 1
-    except Exception:  # pylint: disable=broad-exception-caught
+    except ValueError:
         err = 1
     if not result:
         print(err)  # [used-before-assignment]
@@ -131,7 +131,7 @@ def bare_annotation_with_value_and_except():
     err: int = 0
     try:
         result = 1
-    except Exception:  # pylint: disable=broad-exception-caught
+    except ValueError:
         err = 1
     if not result:
         print(err)

--- a/tests/functional/u/used/used_before_assignment_type_annotations.py
+++ b/tests/functional/u/used/used_before_assignment_type_annotations.py
@@ -135,3 +135,18 @@ def bare_annotation_with_value_and_except(text):
         result = -1
     if result < 0:
         print(err)
+
+
+def bare_annotation_with_if_elif(axis):
+    """A bare type annotation with if/elif should not be a false positive.
+
+    Regression test: the pandas pattern where a bare annotation precedes
+    an if/elif chain that covers all runtime values.
+    https://github.com/pylint-dev/pylint/pull/10852#pullrequestreview-3872486590
+    """
+    klass: type
+    if axis == 0:
+        klass = int
+    elif axis == 1:
+        klass = str
+    return klass

--- a/tests/functional/u/used/used_before_assignment_type_annotations.py
+++ b/tests/functional/u/used/used_before_assignment_type_annotations.py
@@ -109,29 +109,29 @@ def loop_conditional_annotated_assignment():
     print(token)
 
 
-def bare_annotation_with_except_assignment():
+def bare_annotation_with_except_assignment(text):
     """A bare type annotation should not suppress used-before-assignment
     when the only real assignments are in except blocks.
 
     https://github.com/pylint-dev/pylint/issues/10847
     """
-    result = None
     err: int
     try:
-        result = 1
-    except ValueError:
+        result = int(text)
+    except (TypeError, OverflowError):
         err = 1
-    if not result:
+        result = -1
+    if result < 0:
         print(err)  # [used-before-assignment]
 
 
-def bare_annotation_with_value_and_except():
+def bare_annotation_with_value_and_except(text):
     """A type annotation with a value should suppress the warning."""
-    result = None
     err: int = 0
     try:
-        result = 1
-    except ValueError:
+        result = int(text)
+    except (TypeError, OverflowError):
         err = 1
-    if not result:
+        result = -1
+    if result < 0:
         print(err)

--- a/tests/functional/u/used/used_before_assignment_type_annotations.txt
+++ b/tests/functional/u/used/used_before_assignment_type_annotations.txt
@@ -3,3 +3,4 @@ used-before-assignment:28:10:28:18:value_assignment_after_access:Using variable 
 undefined-variable:62:14:62:17:decorator_returning_incorrect_function.wrapper_with_type_and_no_value:Undefined variable 'var':HIGH
 possibly-used-before-assignment:97:17:97:21:conditional_annotated_assignment:Possibly using variable 'data' before assignment:CONTROL_FLOW
 possibly-used-before-assignment:108:17:108:21:loop_conditional_annotated_assignment:Possibly using variable 'data' before assignment:CONTROL_FLOW
+used-before-assignment:125:14:125:17:bare_annotation_with_except_assignment:Using variable 'err' before assignment:CONTROL_FLOW


### PR DESCRIPTION
## Description

Fixes #10847

When a variable has a bare type annotation (e.g. `err: int`) without a value and is only assigned inside `except` blocks, pylint failed to report `used-before-assignment`.

### Reproducer

```python
def case():
    result = None
    err: int  # bare annotation, no value
    try:
        result = 1
    except Exception:
        err = 1
    if not result:
        print(err)  # should warn, but didn't
```

Removing the type annotation correctly triggers the warning. Adding a value (`err: int = 0`) correctly suppresses it.

### Root cause

In `NamesConsumer.get_next_to_consume()`, the except-block assignments are correctly filtered into `consumed_uncertain`. However, the bare annotation's `AssignName` node remains in `found_nodes` — and since it appears before the usage in line order, `_is_variable_violation()` sets `maybe_before_assign = False` (usage line > definition line). The bare annotation is then treated as a valid definition, suppressing the check entirely.

### Fix

After all uncertain-node filtering in `get_next_to_consume()`, if the remaining `found_nodes` consists only of bare annotations (`AnnAssign` without a value) and there are uncertain definitions in `consumed_uncertain`, filter out the bare annotations. This causes `found_nodes` to be empty, allowing the code to correctly reach `_report_unfound_name_definition()` which emits the `used-before-assignment` warning.

### Test

Added two test cases to `used_before_assignment_type_annotations.py`:
- `bare_annotation_with_except_assignment()` — expects `used-before-assignment`
- `bare_annotation_with_value_and_except()` — no warning expected (annotation has a value)

All 872 functional tests pass (13 skipped). The one pre-existing failure (`use_yield_from`) is unrelated.

### Type of Changes

- Bug fix (false negative)