### PR TITLE
Fix undefined-variable false positive with metaclass in nested class

### DIFF
--- a/doc/whatsnew/fragments/10823.false_positive
+++ b/doc/whatsnew/fragments/10823.false_positive
@@ -1,0 +1,4 @@
+Fix ``undefined-variable`` false positive when a name used as a ``metaclass``
+argument in a nested class is referenced again later in the module.
+
+Closes #10823

--- a/tests/functional/u/undefined/undefined_variable_metaclass_nested.py
+++ b/tests/functional/u/undefined/undefined_variable_metaclass_nested.py
@@ -1,0 +1,20 @@
+"""Tests for undefined-variable false positive when a name is used as a metaclass
+in a nested class inside a method, and then used again at module level.
+
+https://github.com/pylint-dev/pylint/issues/10823
+"""
+# pylint: disable=too-few-public-methods,missing-class-docstring,missing-function-docstring
+# pylint: disable=unused-variable,pointless-statement
+
+import abc
+
+
+class Test:
+    def test1(self):
+        class A(metaclass=abc.ABCMeta):
+            pass
+
+
+# This should NOT trigger undefined-variable — abc was imported at module level
+# and consumed by the metaclass usage, but it should still be resolvable.
+abc.ABCMeta


### PR DESCRIPTION
## Description

Fixes #10823
Closes #10823

When an imported name is used as a `metaclass=` argument inside a nested class within a method, pylint incorrectly flags subsequent uses of that name at module level as `undefined-variable`.

### Reproducer

```python
import abc

class Test:
    def test1(self):
        class A(metaclass=abc.ABCMeta):
            pass

abc.ABCMeta  # E0602: Undefined variable 'abc' (undefined-variable)
```

### Root cause

`_check_classdef_metaclasses()` walks enclosing scopes to find the name used as a metaclass and collects `(scope_locals_dict, name)` tuples. Then `_check_metaclasses()` calls `scope_locals.pop(name, None)` — removing the name entirely from `to_consume` in the enclosing scope.

This was intended to prevent unused-import/unused-variable false positives: the metaclass usage should "count" as using the name. But `pop()` removes the name without moving it to the consumer's `consumed` dict. Later references to the same name can't find it in either `to_consume` or `consumed`, so pylint reports `undefined-variable`.

### Fix

Replace the raw `scope_locals.pop()` with `NamesConsumer.mark_as_consumed()`. This properly moves the name from `to_consume` to `consumed`, preserving both behaviors:

1. The import is not flagged as unused (moved out of `to_consume`)
2. Later references can find the name in `consumed` (no `undefined-variable`)

The function signatures change to pass the `NamesConsumer` and `found_nodes` needed by `mark_as_consumed()`.

### Test

Added `tests/functional/u/undefined/undefined_variable_metaclass_nested.py` — reproducer from the issue.