### PR TITLE
Fix RecursionError crash on circular MRO inference

### DIFF
--- a/doc/whatsnew/fragments/10821.bugfix
+++ b/doc/whatsnew/fragments/10821.bugfix
@@ -1,0 +1,5 @@
+Fix crash (``RecursionError``) when a class inherits from a re-imported module
+member that creates circular MRO inference (e.g., subclassing ``pdb.Pdb`` and
+patching it back onto the module).
+
+Closes #10821

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -577,16 +577,16 @@ class NameChecker(_BasicChecker):
     ) -> bool:
         if isinstance(inferred_assign_type, nodes.ClassDef):
             return True
-        if isinstance(inferred_assign_type, bases.Instance) and {
-            "EnumMeta",
-            "TypedDict",
-        }.intersection(
-            {
-                ancestor.name
-                for ancestor in cast(InferenceResult, inferred_assign_type).mro()
-            }
-        ):
-            return True
+        if isinstance(inferred_assign_type, bases.Instance):
+            try:
+                mro_names = {
+                    ancestor.name
+                    for ancestor in cast(InferenceResult, inferred_assign_type).mro()
+                }
+            except RecursionError:
+                return False
+            if {"EnumMeta", "TypedDict"}.intersection(mro_names):
+                return True
         if (
             isinstance(inferred_assign_type, nodes.FunctionDef)
             and inferred_assign_type.qname() == "typing.Annotated"

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -933,6 +933,9 @@ a metaclass class method.",
             self.add_message("inconsistent-mro", args=node.name, node=node)
         except astroid.DuplicateBasesError:
             self.add_message("duplicate-bases", args=node.name, node=node)
+        except RecursionError:
+            # Circular MRO inference (e.g., class patched onto its own module).
+            self.add_message("inconsistent-mro", args=node.name, node=node)
 
     def _check_enum_base(self, node: nodes.ClassDef, ancestor: nodes.ClassDef) -> None:
         match ancestor.getattr("__members__"):
@@ -1763,16 +1766,20 @@ a metaclass class method.",
             return
         # If `__setattr__` is defined on the class, then we can't reason about
         # what will happen when assigning to an attribute.
+        try:
+            mro = klass.mro()
+        except (astroid.MroError, RecursionError):
+            return
         if any(
             base.locals.get("__setattr__")
-            for base in klass.mro()
+            for base in mro
             if base.qname() != "builtins.object"
         ):
             return
 
         # If 'typing.Generic' is a base of bases of klass, the cached version
         # of 'slots()' might have been evaluated incorrectly, thus deleted cache entry.
-        if any(base.qname() == "typing.Generic" for base in klass.mro()):
+        if any(base.qname() == "typing.Generic" for base in mro):
             cache = getattr(klass, "__cache", None)
             if cache and cache.get(klass.slots) is not None:
                 del cache[klass.slots]

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1071,7 +1071,10 @@ class RefactoringChecker(checkers.BaseTokenChecker):
     ) -> bool:
         """Return True if the exception node in argument inherit from StopIteration."""
         stopiteration_qname = f"{utils.EXCEPTIONS_MODULE}.StopIteration"
-        return any(_class.qname() == stopiteration_qname for _class in exc.mro())
+        try:
+            return any(_class.qname() == stopiteration_qname for _class in exc.mro())
+        except RecursionError:
+            return False
 
     def _check_consider_using_comprehension_constructor(self, node: nodes.Call) -> None:
         match node:

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -145,7 +145,7 @@ def _(node: nodes.ClassDef | bases.Instance) -> Iterable[str]:
 
     try:
         mro = node.mro()[1:]
-    except (NotImplementedError, TypeError, astroid.MroError):
+    except (NotImplementedError, TypeError, astroid.MroError, RecursionError):
         mro = node.ancestors()
 
     other_values = [value for cls in mro for value in _node_names(cls)]
@@ -488,7 +488,10 @@ def _emit_no_member(
             owner.super_mro()
         except (astroid.MroError, astroid.SuperError):
             return False
-        if not all(has_known_bases(base) for base in owner.type.mro()):
+        try:
+            if not all(has_known_bases(base) for base in owner.type.mro()):
+                return False
+        except RecursionError:
             return False
     if isinstance(owner, nodes.Module):
         try:
@@ -749,7 +752,7 @@ def _no_context_variadic(
 def _is_invalid_metaclass(metaclass: nodes.ClassDef) -> bool:
     try:
         mro = metaclass.mro()
-    except (astroid.DuplicateBasesError, astroid.InconsistentMroError):
+    except (astroid.DuplicateBasesError, astroid.InconsistentMroError, RecursionError):
         return True
     return not any(is_builtin_object(cls) and cls.name == "type" for cls in mro)
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -958,7 +958,7 @@ def unimplemented_abstract_methods(
     visited: dict[str, nodes.FunctionDef] = {}
     try:
         mro = reversed(node.mro())
-    except astroid.ResolveError:
+    except (astroid.ResolveError, RecursionError):
         # Probably inconsistent hierarchy, don't try to figure this out here.
         return {}
     for ancestor in mro:

--- a/tests/functional/i/inconsistent/inconsistent_mro.py
+++ b/tests/functional/i/inconsistent/inconsistent_mro.py
@@ -1,5 +1,5 @@
 """Tests for inconsistent-mro."""
-# pylint: disable=missing-docstring,too-few-public-methods
+# pylint: disable=missing-docstring,too-few-public-methods,unused-import,wrong-import-position
 
 class Str(str):
     pass
@@ -7,3 +7,20 @@ class Str(str):
 
 class Inconsistent(str, Str): # [inconsistent-mro]
     pass
+
+
+# Regression test for https://github.com/pylint-dev/pylint/issues/10821
+# Circular MRO inference caused RecursionError crash when a class inherits
+# from a re-imported module member and patches it back conditionally.
+from pdb import Pdb as StdlibPdb
+
+class Pdb(StdlibPdb):  # [inconsistent-mro]
+    ...
+
+class PatchedPdb(Pdb):  # [inconsistent-mro]
+    ...
+
+if __name__ == '__main__':
+    import pdb
+    pdb.Pdb = PatchedPdb
+    pdb.main()

--- a/tests/functional/i/inconsistent/inconsistent_mro.txt
+++ b/tests/functional/i/inconsistent/inconsistent_mro.txt
@@ -1,1 +1,3 @@
 inconsistent-mro:8:0:8:18:Inconsistent:Inconsistent method resolution order for class 'Inconsistent':UNDEFINED
+inconsistent-mro:17:0:17:9:Pdb:Inconsistent method resolution order for class 'Pdb':UNDEFINED
+inconsistent-mro:20:0:20:16:PatchedPdb:Inconsistent method resolution order for class 'PatchedPdb':UNDEFINED


### PR DESCRIPTION
## Summary

- Catch `RecursionError` at all `mro()` call sites across pylint's checkers (`utils.py`, `class_checker.py`, `typecheck.py`, `name_checker/checker.py`, `refactoring_checker.py`)
- When astroid encounters circular MRO inference (e.g., a class that inherits from a re-imported module member and patches it back conditionally), pylint now gracefully reports `inconsistent-mro` instead of crashing with a `RecursionError`
- Added regression test to `inconsistent_mro.py` using the reproducer from the issue

## Reproducer

```python
from pdb import Pdb as StdlibPdb

class Pdb(StdlibPdb):
    ...

class PatchedPdb(Pdb):
    ...

if __name__ == '__main__':
    import pdb
    pdb.Pdb = PatchedPdb
    pdb.main()
```

**Before:** `RecursionError` crash (F0002 astroid-error)
**After:** `E0240: Inconsistent method resolution order for class 'Pdb'`

## Root cause

The circular inference happens in astroid's `_compute_mro` — when `Pdb` shadows `pdb.Pdb`, resolving `StdlibPdb` leads back to the local `Pdb`, creating an infinite loop. The fix is defensive: pylint already catches `astroid.ResolveError`, `InconsistentMroError`, and `DuplicateBasesError` at various `mro()` call sites, but `RecursionError` was unhandled. This PR adds `RecursionError` to each catch.

Closes #10821