### PR TITLE
Show visual indication when score is below --fail-under threshold

### DIFF
--- a/doc/whatsnew/fragments/8503.feature
+++ b/doc/whatsnew/fragments/8503.feature
@@ -1,0 +1,3 @@
+When the score is below the ``--fail-under`` threshold, the evaluation output now includes a message indicating that the score is below the threshold.
+
+Closes #8503

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1211,6 +1211,12 @@ class PyLinter(
                     f" skipped {unchecked_files_count} files/modules"
                 )
 
+            if note is not None and note < self.config.fail_under:
+                msg += (
+                    f"\nYour score {note:.2f} is below the"
+                    f" fail-under threshold of {self.config.fail_under}"
+                )
+
         if self.config.score:
             sect = report_nodes.EvaluationSection(msg)
             self.reporter.display_reports(sect)

--- a/tests/reporters/unittest_reporting.py
+++ b/tests/reporters/unittest_reporting.py
@@ -189,6 +189,7 @@ def test_multi_format_output(tmp_path: Path) -> None:
         linter.set_option("score", True)
         linter.set_option("score", True)
         linter.set_option("output-format", formats)
+        linter.set_option("fail-under", -10)
 
         assert linter.reporter.linter is linter
         with pytest.raises(NotImplementedError):

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -788,6 +788,36 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
             code=22,
         )
 
+    def test_fail_under_visual_indication(self) -> None:
+        """Test that --fail-under shows a visual message when score is below threshold."""
+        # When score is below fail-under, output should contain visual indication
+        out = StringIO()
+        self._run_pylint(
+            [
+                "--fail-under",
+                "7.6",
+                "--enable=all",
+                join(HERE, "regrtest_data", "fail_under_plus7_5.py"),
+            ],
+            out=out,
+        )
+        output = out.getvalue()
+        assert "below the fail-under threshold" in output
+
+        # When score meets fail-under, output should NOT contain the warning
+        out = StringIO()
+        self._run_pylint(
+            [
+                "--fail-under",
+                "7.5",
+                "--enable=all",
+                join(HERE, "regrtest_data", "fail_under_plus7_5.py"),
+            ],
+            out=out,
+        )
+        output = out.getvalue()
+        assert "below the fail-under threshold" not in output
+
     @pytest.mark.parametrize(
         "fu_score,fo_msgs,fname,out",
         [


### PR DESCRIPTION
## Summary

- When the score is below the `--fail-under` threshold, the evaluation output now includes a visual message: `Your score X.XX is below the fail-under threshold of Y.Y`
- Previously, pylint would exit with code 16 but give no visual indication in the terminal, making it unclear why the command failed
- Added a test verifying the message appears when below threshold and does not appear when at or above threshold

**Before:**
```
------------------------------------
Your code has been rated at 7.19/10
```

**After:**
```
--------------------------------------------------------------------------------------------
Your code has been rated at 7.19/10
Your score 7.19 is below the fail-under threshold of 10.0
```

Closes #8503

## Test plan

- [x] Existing `test_fail_under` tests pass (exit codes unchanged)
- [x] Existing `test_fail_on` parametrized tests pass (20 cases)
- [x] New `test_fail_under_visual_indication` test verifies the message is shown when score < threshold
- [x] New test verifies the message is NOT shown when score >= threshold
- [x] Manual testing confirms the visual output

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*