### PR TITLE
Bump pylint to 4.0.5, update changelog

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -313,6 +313,7 @@ contributors:
 - Grizzly Nyo <grizzly.nyo@gmail.com>
 - Gabriel R. Sezefredo <g@briel.dev>: Fixed "exception-escape" false positive with generators
 - Filipe Brandenburger <filbranden@google.com>
+- Felix Preuschoff <37065638+felixp98@users.noreply.github.com>
 - Fantix King <fantix@uchicago.edu> (UChicago)
 - Eric McDonald <221418+emcd@users.noreply.github.com>
 - Elias Dorneles <eliasdorneles@gmail.com>: minor adjust to config defaults and docs
@@ -494,6 +495,7 @@ contributors:
 - Michael Giuffrida <mgiuffrida@users.noreply.github.com>
 - Melvin Hazeleger <31448155+melvio@users.noreply.github.com>
 - Meltem Kenis <meltem.kenis@plentific.com>
+- Mehraz Hossain Rumman <59512321+MehrazRumman@users.noreply.github.com>
 - Mehdi Drissi <mdrissi@hmc.edu>
 - Matěj Grabovský <mgrabovs@redhat.com>
 - Matthijs Blom <19817960+MatthijsBlom@users.noreply.github.com>
@@ -524,6 +526,7 @@ contributors:
 - Kayran Schmidt <59456929+yumasheta@users.noreply.github.com>
 - Karthik Nadig <kanadig@microsoft.com>
 - Jürgen Hermann <jh@web.de>
+- Julfried <julian.grimm8@gmail.com>
 - Josselin Feist <josselin@trailofbits.com>
 - Jonathan Kotta <KottaJonathan@JohnDeere.com>
 - John Paraskevopoulos <io.paraskev@gmail.com>: add 'differing-param-doc' and 'differing-type-doc'
@@ -565,7 +568,6 @@ contributors:
 - Giuseppe Valente <gvalente@arista.com>
 - Gary Tyler McLeod <mail@garytyler.com>
 - Felix von Drigalski <FvDrigalski@gmail.com>
-- Felix Preuschoff <37065638+felixp98@users.noreply.github.com>
 - Fabrice Douchant <Fabrice.Douchant@logilab.fr>
 - Fabio Natali <me@fabionatali.com>
 - Fabian Damken <fdamken+github@frisp.org>

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -1085,7 +1085,8 @@ Stdlib checker Messages
 :unspecified-encoding (W1514): *Using open without explicitly specifying an encoding*
   It is better to specify an encoding when opening documents. Using the system
   default implicitly can create problems on other operating systems. See
-  https://peps.python.org/pep-0597/
+  https://peps.python.org/pep-0597/ This message can't be emitted when using
+  Python >= 3.15.
 :forgotten-debug-statement (W1515): *Leaving functions creating breakpoints in production code is not recommended*
   Calls to breakpoint(), sys.breakpointhook() and pdb.set_trace() should be
   removed from code that is not actively being debugged.

--- a/doc/whatsnew/4/4.0/index.rst
+++ b/doc/whatsnew/4/4.0/index.rst
@@ -74,6 +74,52 @@ to your liking.
 
 .. towncrier release notes start
 
+What's new in Pylint 4.0.5?
+---------------------------
+Release date: 2026-02-20
+
+
+False Positives Fixed
+---------------------
+
+- Fix possibly-used-before-assignment false positive when using self.fail() in tests.
+
+  Closes #10743 (`#10743 <https://github.com/pylint-dev/pylint/issues/10743>`_)
+
+- Fixed false positive for ``logging-unsupported-format`` when no arguments are provided to logging functions.
+
+  According to Python's logging documentation, no formatting is performed when no arguments are supplied, so strings like ``logging.error("%test")`` are valid.
+
+  Closes #10752 (`#10752 <https://github.com/pylint-dev/pylint/issues/10752>`_)
+
+- Fix a false positive for ``invalid-name`` where a dataclass field typed with ``Final``
+  was evaluated against the ``class_const`` regex instead of the ``class_attribute`` regex.
+
+  Closes #10790 (`#10790 <https://github.com/pylint-dev/pylint/issues/10790>`_)
+
+- Avoid emitting `unspecified-encoding` (W1514) when `py-version` is 3.15+.
+
+  Refs #10791 (`#10791 <https://github.com/pylint-dev/pylint/issues/10791>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Fix `--known_third_party` config being ignored.
+
+  Closes #10801 (`#10801 <https://github.com/pylint-dev/pylint/issues/10801>`_)
+
+- Fixed dynamic color mapping for "fail-on" messages when using multiple reporter/output formats.
+
+  Closes #10825 (`#10825 <https://github.com/pylint-dev/pylint/issues/10825>`_)
+
+- dependency on isort is now set to <9, permitting to use isort 8.
+
+  Closes #10857 (`#10857 <https://github.com/pylint-dev/pylint/issues/10857>`_)
+
+
+
 What's new in Pylint 4.0.4?
 --------------------------------
 Release date: 2025-11-30

--- a/doc/whatsnew/fragments/10743.false_positive
+++ b/doc/whatsnew/fragments/10743.false_positive
@@ -1,3 +1,0 @@
-Fix possibly-used-before-assignment false positive when using self.fail() in tests.
-
-Closes #10743

--- a/doc/whatsnew/fragments/10752.false_positive
+++ b/doc/whatsnew/fragments/10752.false_positive
@@ -1,5 +1,0 @@
-Fixed false positive for ``logging-unsupported-format`` when no arguments are provided to logging functions.
-
-According to Python's logging documentation, no formatting is performed when no arguments are supplied, so strings like ``logging.error("%test")`` are valid.
-
-Closes #10752

--- a/doc/whatsnew/fragments/10790.false_positive
+++ b/doc/whatsnew/fragments/10790.false_positive
@@ -1,4 +1,0 @@
-Fix a false positive for ``invalid-name`` where a dataclass field typed with ``Final``
-was evaluated against the ``class_const`` regex instead of the ``class_attribute`` regex.
-
-Closes #10790

--- a/doc/whatsnew/fragments/10791.false_positive
+++ b/doc/whatsnew/fragments/10791.false_positive
@@ -1,3 +1,0 @@
-Avoid emitting `unspecified-encoding` (W1514) when `py-version` is 3.15+.
-
-Refs #10791

--- a/doc/whatsnew/fragments/10801.bugfix
+++ b/doc/whatsnew/fragments/10801.bugfix
@@ -1,3 +1,0 @@
-Fix `--known_third_party` config being ignored.
-
-Closes #10801

--- a/doc/whatsnew/fragments/10825.bugfix
+++ b/doc/whatsnew/fragments/10825.bugfix
@@ -1,3 +1,0 @@
-Fixed dynamic color mapping for "fail-on" messages when using multiple reporter/output formats.
-
-Closes #10825

--- a/doc/whatsnew/fragments/10857.bugfix
+++ b/doc/whatsnew/fragments/10857.bugfix
@@ -1,3 +1,0 @@
-dependency on isort is now set to <9, permitting to use isort 8.
-
-Closes #10857

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "4.0.4"
+__version__ = "4.0.5"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "4.0.4"
+current = "4.0.5"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's new in Pylint 4.0.5?
---------------------------
Release date: 2026-02-20


False Positives Fixed
---------------------

- Fix possibly-used-before-assignment false positive when using self.fail() in tests.

  Closes #10743

- Fixed false positive for ``logging-unsupported-format`` when no arguments are provided to logging functions.

  According to Python's logging documentation, no formatting is performed when no arguments are supplied, so strings like ``logging.error("%test")`` are valid.

  Closes #10752 

- Fix a false positive for ``invalid-name`` where a dataclass field typed with ``Final``
  was evaluated against the ``class_const`` regex instead of the ``class_attribute`` regex.

  Closes #10790 

- Avoid emitting `unspecified-encoding` (W1514) when `py-version` is 3.15+.

  Refs #10791 



Other Bug Fixes
---------------

- Fix `--known_third_party` config being ignored.

  Closes #10801 

- Fixed dynamic color mapping for "fail-on" messages when using multiple reporter/output formats.

  Closes #10825

- dependency on isort is now set to <9, permitting to use isort 8.

  Closes #10857 


