### PR TITLE
Moves note that section titles are irrelevant for parsing to top of doc

### DIFF
--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -8,6 +8,7 @@
 Standard Checkers
 ^^^^^^^^^^^^^^^^^
 
+Remember that only ``tool.pylint`` is required, the section title is not. There are specific notes under each example that cover this.
 
 .. _main-options:
 


### PR DESCRIPTION
Moves note that section titles are irrelevant for parsing to top of doc.

Closes #8004 

Documentation Change