### PR TITLE
Avoid recursing into child nodes on same line when parsing disable comments

### DIFF
--- a/custom_dict.txt
+++ b/custom_dict.txt
@@ -286,6 +286,7 @@ readlines
 recognise
 recurse
 recurses
+recursing
 redef
 reportid
 rgx

--- a/pylint/utils/file_state.py
+++ b/pylint/utils/file_state.py
@@ -63,8 +63,10 @@ class FileState:
         """Recursively walk (depth first) AST to collect block level options
         line numbers and set the state correctly.
         """
-        for child in node.get_children():
-            self._set_state_on_block_lines(msgs_store, child, msg, msg_state)
+        # Avoid recursing into child nodes on the same line.
+        if node.lineno != node.end_lineno:
+            for child in node.get_children():
+                self._set_state_on_block_lines(msgs_store, child, msg, msg_state)
         # first child line number used to distinguish between disable
         # which are the first child of scoped node with those defined later.
         # For instance in the code below:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
I found pylint is about 3-5% faster if it can avoid recursing into nested nodes on the same line when parsing disable comments, e.g. for argument and annotation nodes in a function signature.

A function definition usually spans multiple lines, but the arguments node in many cases does not, and we can short-circuit at that level before descending into all child nodes for no reason.

```py
def only_the_args_node_matters(not: these=individual, other=nodes):  # pylint: disable=...
```

Thus, this performance optimization depends on astroid 4.1: pylint-dev/astroid#2865

### Profile

Linting astroid:
**main**
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)

336207/96    0.481    0.000    0.995    0.010 file_state.py:56(_set_state_on_block_lines)

**pr**
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)

124968/96    0.150    0.000    0.330    0.003 file_state.py:56(_set_state_on_block_lines)
