### PR TITLE
Fix typo in multiple-statements message text

### DIFF
--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -553,7 +553,7 @@ Format checker Messages
 :trailing-newlines (C0305): *Trailing newlines*
   Used when there are trailing blank lines in a file.
 :multiple-statements (C0321): *More than one statement on a single line*
-  Used when more than on statement are found on the same line.
+  Used when more than one statement is found on the same line.
 :superfluous-parens (C0325): *Unnecessary parens after %r keyword*
   Used when a single item in parentheses follows an if, for, or other keyword.
 :mixed-line-endings (C0327): *Mixed line endings LF and CRLF*

--- a/doc/whatsnew/fragments/10870.other
+++ b/doc/whatsnew/fragments/10870.other
@@ -1,3 +1,0 @@
-Fixed a typo in the ``multiple-statements`` message text in ``pylint/checkers/format.py``.
-
-Closes #10870

--- a/doc/whatsnew/fragments/10870.other
+++ b/doc/whatsnew/fragments/10870.other
@@ -1,0 +1,3 @@
+Fixed a typo in the ``multiple-statements`` message text in ``pylint/checkers/format.py``.
+
+Closes #10870

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -92,7 +92,7 @@ MSGS: dict[str, MessageDefinitionTuple] = {
     "C0321": (
         "More than one statement on a single line",
         "multiple-statements",
-        "Used when more than on statement are found on the same line.",
+        "Used when more than one statement is found on the same line.",
         {"scope": WarningScope.NODE},
     ),
     "C0325": (


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description

This fixes the typo in the `multiple-statements` message in `pylint/checkers/format.py`:

- from: `Used when more than on statement are found on the same line.`
- to: `Used when more than one statement is found on the same line.`

Closes #10870