### PR TITLE
[primer] Add astropy to the primer for a repository that does science

### DIFF
--- a/doc/additional_tools/pyreverse/configuration.rst
+++ b/doc/additional_tools/pyreverse/configuration.rst
@@ -129,16 +129,16 @@ Display Options
 **Default:**  ``None``
 
 
---no-standalone
+--no-signatures
 ---------------
-*Only show nodes with connections.*
+*Show method names without parameter lists or return type annotations.*
 
 **Default:**  ``False``
 
 
---no-signatures
+--no-standalone
 ---------------
-*Show method names without parameter lists or return type annotations.*
+*Only show nodes with connections.*
 
 **Default:**  ``False``
 

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -904,6 +904,13 @@ Standard Checkers
 **Default:**  ``^\s*(# )?<?https?://\S+>?$``
 
 
+--ignore-pattern-in-long-lines
+""""""""""""""""""""""""""""""
+*Regexp for a part of a line that will not be counted when calculating the line length.*
+
+**Default:**  ``None``
+
+
 --indent-after-paren
 """"""""""""""""""""
 *Number of spaces of indent required inside a hanging or continued line.*
@@ -961,6 +968,8 @@ Standard Checkers
    expected-line-ending-format = ""
 
    ignore-long-lines = "^\\s*(# )?<?https?://\\S+>?$"
+
+   # ignore-pattern-in-long-lines =
 
    indent-after-paren = 4
 
@@ -1034,16 +1043,16 @@ Standard Checkers
 **Default:** ``""``
 
 
---known-standard-library
-""""""""""""""""""""""""
-*Force import order to recognize a module as part of the standard compatibility libraries.*
+--known-first-party
+"""""""""""""""""""
+*Force import order to recognize a module as part of a first party library.*
 
 **Default:**  ``()``
 
 
---known-first-party
-"""""""""""""""""""
-*Force import order to recognize a module as part of a first party library.*
+--known-standard-library
+""""""""""""""""""""""""
+*Force import order to recognize a module as part of the standard compatibility libraries.*
 
 **Default:**  ``()``
 
@@ -1087,9 +1096,9 @@ Standard Checkers
 
    int-import-graph = ""
 
-   known-standard-library = []
-
    known-first-party = []
+
+   known-standard-library = []
 
    known-third-party = ["enchant"]
 

--- a/tests/primer/packages_to_prime.json
+++ b/tests/primer/packages_to_prime.json
@@ -1,4 +1,9 @@
 {
+  "astropy": {
+    "branch": "main",
+    "directories": ["astropy"],
+    "url": "https://github.com/astropy/astropy"
+  },
   "ansible": {
     "branch": "devel",
     "directories": ["lib/ansible"],


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Feel like we lack a repository that does science. numpy and pandas are used for science but it's a lib. I'm missing that for #10425 

(The doc was also not re-generated for a long time)
