### PR TITLE
[refactor] Remove orphaned lowercase-l-suffix check (dead since 2018)

### DIFF
--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -451,9 +451,6 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
                         check_equal = False
                         self.check_indent_level(line, indents[-1], line_num)
 
-            if tok_type == tokenize.NUMBER and string.endswith("l"):
-                self.add_message("lowercase-l-suffix", line=line_num)
-
             if string in _KEYWORD_TOKENS:
                 self._check_keyword_parentheses(tokens, idx)
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The W0332 "lowercase-l-suffix" message was a Python 2-only check (maxversion: 3.0) that flagged `123l` vs `123L` for long integers. Its message definition was removed in May 2018 (commit 41d47dd024a3, "Remove a couple of Python 2 specific checks", closes #1896), but the check code (`if string.endswith("l")`) survived as dead code — the unregistered message would fail if it ever triggered, which it can't since Python 3's tokenizer never produces tokens ending in `l`.

Detected in #10425 
