### PR TITLE
Don't run checkers just for their reports when all messages are disabled

### DIFF
--- a/doc/whatsnew/fragments/3443.performance
+++ b/doc/whatsnew/fragments/3443.performance
@@ -1,0 +1,3 @@
+The duplicate-code checker no longer runs when its message (R0801) is disabled, even if ``reports=yes`` is set. Previously, the checker's report (RP0801) would cause the expensive similarity computation to run regardless.
+
+Closes #3443

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -617,7 +617,10 @@ class PyLinter(
         needed_checkers: list[BaseChecker] = [self]
         for checker in self.get_checkers()[1:]:
             messages = {msg for msg in checker.msgs if self.is_message_enabled(msg)}
-            if messages or any(self.report_is_enabled(r[0]) for r in checker.reports):
+            if messages or (
+                not checker.msgs
+                and any(self.report_is_enabled(r[0]) for r in checker.reports)
+            ):
                 needed_checkers.append(checker)
         return needed_checkers
 

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -445,6 +445,20 @@ def test_disable_similar(initialized_linter: PyLinter) -> None:
     assert "similarities" not in [c.name for c in linter.prepare_checkers()]
 
 
+def test_disable_similar_with_reports(initialized_linter: PyLinter) -> None:
+    """Disabling R0801 should exclude the similarities checker even with reports enabled.
+
+    Regression test for https://github.com/pylint-dev/pylint/issues/3443
+    """
+    linter = initialized_linter
+    linter.set_option("reports", True)
+    linter.set_option("disable", "R0801")
+    checker_names = [c.name for c in linter.prepare_checkers()]
+    assert "similarities" not in checker_names
+    # Report-only checkers (no messages) should still be included
+    assert "metrics" in checker_names
+
+
 def test_disable_alot(linter: PyLinter) -> None:
     """Check that we disabled a lot of checkers."""
     linter.set_option("reports", False)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Previously, prepare_checkers() would include a checker if any of its reports were enabled, even when all its messages were disabled. This meant checkers like `similarities` would still run their expensive computations (e.g. O(n²) duplicate-code detection) just to populate a report the user didn't ask for.

Now, enabled reports only cause a checker to be included if it defines no messages at all (i.e. pure report-only checkers like RawMetrics).

Closes #3443
