### PR TITLE
 Attribute duplicate-code messages to involved modules, not the last-checked one

### DIFF
--- a/doc/whatsnew/fragments/10880.internal
+++ b/doc/whatsnew/fragments/10880.internal
@@ -1,0 +1,3 @@
+``add_message`` now accepts optional ``module`` and ``filepath`` keyword arguments to override the reported message location.
+
+Refs #10880

--- a/doc/whatsnew/fragments/2368.bugfix
+++ b/doc/whatsnew/fragments/2368.bugfix
@@ -1,0 +1,3 @@
+``duplicate-code`` messages are now attributed to a module that actually contains the duplicated lines, instead of whichever module happened to be checked last.
+
+Closes #2368

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -139,6 +139,7 @@ class BaseChecker(_ArgumentsProvider):
         result += "\n"
         return result
 
+    # pylint: disable-next=too-many-arguments
     def add_message(
         self,
         msgid: str,
@@ -149,9 +150,20 @@ class BaseChecker(_ArgumentsProvider):
         col_offset: int | None = None,
         end_lineno: int | None = None,
         end_col_offset: int | None = None,
+        module: str | None = None,
+        filepath: str | None = None,
     ) -> None:
         self.linter.add_message(
-            msgid, line, node, args, confidence, col_offset, end_lineno, end_col_offset
+            msgid,
+            line=line,
+            node=node,
+            args=args,
+            confidence=confidence,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            module=module,
+            filepath=filepath,
         )
 
     def check_consistency(self) -> None:

--- a/pylint/checkers/symilar.py
+++ b/pylint/checkers/symilar.py
@@ -857,8 +857,8 @@ class SimilaritiesChecker(BaseRawFileChecker, Symilar):
                 for line in lineset.real_lines[start_line:end_line]:
                     msg.append(line.rstrip())
 
-            # Attribute the message to the first involved module rather than
-            # the last-checked module which may be unrelated (see #2368).
+            # Attribute the message to the first module in alphabetical order rather
+            # than the last-checked module which may be unrelated (see #2368).
             first_module = min(c[0].name for c in couples)
             self.add_message(
                 "R0801",

--- a/pylint/checkers/symilar.py
+++ b/pylint/checkers/symilar.py
@@ -846,8 +846,6 @@ class SimilaritiesChecker(BaseRawFileChecker, Symilar):
         total = sum(len(lineset) for lineset in self.linesets)
         duplicated = 0
         stats = self.linter.stats
-        original_name = self.linter.current_name
-        original_file = self.linter.current_file
         for num, couples in self._compute_sims():
             msg = []
             lineset = start_line = end_line = None
@@ -862,12 +860,13 @@ class SimilaritiesChecker(BaseRawFileChecker, Symilar):
             # Attribute the message to the first involved module rather than
             # the last-checked module which may be unrelated (see #2368).
             first_module = min(c[0].name for c in couples)
-            self.linter.current_name = first_module
-            self.linter.current_file = self._module_filepaths.get(first_module)
-            self.add_message("R0801", args=(len(couples), "\n".join(msg)))
+            self.add_message(
+                "R0801",
+                args=(len(couples), "\n".join(msg)),
+                module=first_module,
+                filepath=self._module_filepaths.get(first_module),
+            )
             duplicated += num * (len(couples) - 1)
-        self.linter.current_name = original_name
-        self.linter.current_file = original_file
         stats.nb_duplicated_lines += int(duplicated)
         stats.percent_duplicated_lines += float(total and duplicated * 100.0 / total)
 

--- a/pylint/checkers/symilar.py
+++ b/pylint/checkers/symilar.py
@@ -812,10 +812,12 @@ class SimilaritiesChecker(BaseRawFileChecker, Symilar):
             ignore_imports=self.linter.config.ignore_imports,
             ignore_signatures=self.linter.config.ignore_signatures,
         )
+        self._module_filepaths: dict[str, str | None] = {}
 
     def open(self) -> None:
         """Init the checkers: reset linesets and statistics information."""
         self.linesets = []
+        self._module_filepaths.clear()
         self.linter.stats.reset_duplicated_lines()
 
     def process_module(self, node: nodes.Module) -> None:
@@ -835,6 +837,7 @@ class SimilaritiesChecker(BaseRawFileChecker, Symilar):
                 DeprecationWarning,
                 stacklevel=2,
             )
+        self._module_filepaths[self.linter.current_name] = self.linter.current_file
         with node.stream() as stream:
             self.append_stream(self.linter.current_name, stream, node.file_encoding)
 
@@ -843,6 +846,8 @@ class SimilaritiesChecker(BaseRawFileChecker, Symilar):
         total = sum(len(lineset) for lineset in self.linesets)
         duplicated = 0
         stats = self.linter.stats
+        original_name = self.linter.current_name
+        original_file = self.linter.current_file
         for num, couples in self._compute_sims():
             msg = []
             lineset = start_line = end_line = None
@@ -854,8 +859,15 @@ class SimilaritiesChecker(BaseRawFileChecker, Symilar):
                 for line in lineset.real_lines[start_line:end_line]:
                     msg.append(line.rstrip())
 
+            # Attribute the message to the first involved module rather than
+            # the last-checked module which may be unrelated (see #2368).
+            first_module = min(c[0].name for c in couples)
+            self.linter.current_name = first_module
+            self.linter.current_file = self._module_filepaths.get(first_module)
             self.add_message("R0801", args=(len(couples), "\n".join(msg)))
             duplicated += num * (len(couples) - 1)
+        self.linter.current_name = original_name
+        self.linter.current_file = original_file
         stats.nb_duplicated_lines += int(duplicated)
         stats.percent_duplicated_lines += float(total and duplicated * 100.0 / total)
 

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1219,6 +1219,7 @@ class PyLinter(
             self.reporter.display_reports(sect)
         return note
 
+    # pylint: disable-next=too-many-arguments
     def _add_one_message(
         self,
         message_definition: MessageDefinition,
@@ -1229,6 +1230,8 @@ class PyLinter(
         col_offset: int | None,
         end_lineno: int | None,
         end_col_offset: int | None,
+        module: str | None = None,
+        filepath: str | None = None,
     ) -> None:
         """After various checks have passed a single Message is
         passed to the reporter and added to stats.
@@ -1282,11 +1285,15 @@ class PyLinter(
             msg %= args
         # get module and object
         if node is None:
-            module, obj = self.current_name, ""
+            _module, obj = self.current_name, ""
             abspath = self.current_file
         else:
-            module, obj = utils.get_module_and_frameid(node)
+            _module, obj = utils.get_module_and_frameid(node)
             abspath = node.root().file
+        if module is not None:
+            _module = module
+        if filepath is not None:
+            abspath = filepath
         if abspath is not None:
             path = abspath.replace(self.reporter.path_strip_prefix, "", 1)
         else:
@@ -1299,7 +1306,7 @@ class PyLinter(
                 MessageLocationTuple(
                     abspath or "",
                     path,
-                    module or "",
+                    _module or "",
                     obj,
                     line or 1,
                     col_offset or 0,
@@ -1311,6 +1318,7 @@ class PyLinter(
             )
         )
 
+    # pylint: disable-next=too-many-arguments
     def add_message(
         self,
         msgid: str,
@@ -1321,6 +1329,8 @@ class PyLinter(
         col_offset: int | None = None,
         end_lineno: int | None = None,
         end_col_offset: int | None = None,
+        module: str | None = None,
+        filepath: str | None = None,
     ) -> None:
         """Adds a message given by ID or name.
 
@@ -1329,6 +1339,9 @@ class PyLinter(
         AST checkers must provide the node argument (but may optionally
         provide line if the line number is different), raw and token checkers
         must provide the line argument.
+
+        The module and filepath parameters allow overriding the module name
+        and file path reported in the message location.
         """
         if confidence is None:
             confidence = interfaces.UNDEFINED
@@ -1343,6 +1356,8 @@ class PyLinter(
                 col_offset,
                 end_lineno,
                 end_col_offset,
+                module=module,
+                filepath=filepath,
             )
 
     def add_ignored_message(

--- a/pylint/testutils/unittest_linter.py
+++ b/pylint/testutils/unittest_linter.py
@@ -28,6 +28,7 @@ class UnittestLinter(PyLinter):
         finally:
             self._messages = []
 
+    # pylint: disable-next=too-many-arguments
     def add_message(
         self,
         msgid: str,
@@ -39,6 +40,8 @@ class UnittestLinter(PyLinter):
         col_offset: int | None = None,
         end_lineno: int | None = None,
         end_col_offset: int | None = None,
+        module: str | None = None,
+        filepath: str | None = None,
     ) -> None:
         """Add a MessageTest to the _messages attribute of the linter class."""
         # If confidence is None we set it to UNDEFINED as well in PyLinter

--- a/tests/regrtest_data/duplicate_code/2368/databaselib.py
+++ b/tests/regrtest_data/duplicate_code/2368/databaselib.py
@@ -1,0 +1,14 @@
+"""Database utilities."""
+
+
+def setup_connection(host, port, database):
+    """Set up a database connection with retries."""
+    retries = 3
+    timeout = 30
+    connection_string = f"{host}:{port}/{database}"
+    print(f"Connecting to {connection_string}")
+    for attempt in range(retries):
+        print(f"Attempt {attempt + 1} of {retries}")
+        if attempt > 0:
+            print(f"Waiting {timeout} seconds before retry")
+    return connection_string

--- a/tests/regrtest_data/duplicate_code/2368/projectlib.py
+++ b/tests/regrtest_data/duplicate_code/2368/projectlib.py
@@ -1,0 +1,14 @@
+"""Project utilities."""
+
+
+def setup_connection(host, port, database):
+    """Set up a database connection with retries."""
+    retries = 3
+    timeout = 30
+    connection_string = f"{host}:{port}/{database}"
+    print(f"Connecting to {connection_string}")
+    for attempt in range(retries):
+        print(f"Attempt {attempt + 1} of {retries}")
+        if attempt > 0:
+            print(f"Waiting {timeout} seconds before retry")
+    return connection_string

--- a/tests/regrtest_data/duplicate_code/2368/xmlgen.py
+++ b/tests/regrtest_data/duplicate_code/2368/xmlgen.py
@@ -1,0 +1,11 @@
+"""XML generation — no duplicate code here."""
+import xml.etree.ElementTree as ET
+
+
+def generate_xml(data):
+    """Generate an XML document from data."""
+    root = ET.Element("root")
+    for key, value in data.items():
+        child = ET.SubElement(root, key)
+        child.text = str(value)
+    return ET.tostring(root, encoding="unicode")

--- a/tests/test_similar.py
+++ b/tests/test_similar.py
@@ -15,6 +15,7 @@ import pytest
 
 from pylint.reporters.text import TextReporter
 from pylint.testutils._run import _Run as Run
+from pylint.testutils.reporter_for_tests import GenericTestReporter
 from pylint.testutils.utils import _patch_streams
 
 HERE = abspath(dirname(__file__))
@@ -265,6 +266,41 @@ class TestSymilarCodeChecker:
             exit=False,
         )
         assert not runner.linter.stats.by_msg
+
+    @staticmethod
+    def test_duplicate_code_module_attribution() -> None:
+        """R0801 should be attributed to a module with duplicates, not the last-checked one.
+
+        Regression test for https://github.com/pylint-dev/pylint/issues/2368
+        """
+        path = join(DATA, "2368")
+        reporter = GenericTestReporter()
+        # Pass files explicitly with the unrelated module last, so that current_name
+        # points to a file without duplication when close() fires.
+        Run(
+            [
+                join(path, "databaselib.py"),
+                join(path, "projectlib.py"),
+                join(path, "xmlgen.py"),
+                "--disable=all",
+                "--enable=duplicate-code",
+                "--min-similarity-lines=4",
+            ],
+            reporter=reporter,
+            exit=False,
+        )
+        messages = reporter.messages
+        assert messages, "Expected at least one R0801 message"
+        for msg in messages:
+            assert msg.symbol == "duplicate-code"
+            # The message text contains "=={module_name}:[start:end]" for each
+            # involved module. The message's own .module must be one of them,
+            # but not the unrelated module.
+            involved = re.findall(r"==(\S+?):\[", msg.msg)
+            assert msg.module in involved, (
+                f"R0801 attributed to {msg.module!r} which is not in "
+                f"the involved modules {involved}"
+            )
 
     def test_conditional_imports(self) -> None:
         """Tests enabling ignore-imports with conditional imports works correctly."""


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

R0801 messages emitted in SimilaritiesChecker.close() were attributed
to whichever module happened to be checked last, because add_message()
without a node falls back to linter.current_name. Now the checker
saves a module to filepath mapping during process_module() and sets the
correct module context before each add_message() call.

Closes https://github.com/pylint-dev/pylint/issues/2368

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
