### PR TITLE
Skip isort when ordering messages are disabled, cache isort.Config when enabled 

### DIFF
--- a/doc/whatsnew/fragments/10886.performance
+++ b/doc/whatsnew/fragments/10886.performance
@@ -1,10 +1,6 @@
-Skip expensive isort-based import classification in ``leave_module``
-when no import-ordering message is enabled (``wrong-import-order``,
-``ungrouped-imports``, ``wrong-import-position``).  Also cache the
-``isort.Config`` object so it is built once instead of once per import
-statement.  Both changes save ~6 s on ansible (564 files), a 17%
-reduction whether only ``cyclic-import`` is enabled (isort skipped
-entirely) or import-ordering checks are active (cached config avoids
-rebuilding it per import).
+Skip isort classification in the import checker when no import-ordering message is enabled,
+and cache the isort configuration so it is built once instead of once per import statement.
+Skipping the isort processing become a negligible improvement once the caching is applied.
+pylint became ~17% faster on ansible (~=4500 imports) even with isort enabled.
 
 Refs #10886, #2866, #10637

--- a/doc/whatsnew/fragments/10886.performance
+++ b/doc/whatsnew/fragments/10886.performance
@@ -1,0 +1,10 @@
+Skip expensive isort-based import classification in ``leave_module``
+when no import-ordering message is enabled (``wrong-import-order``,
+``ungrouped-imports``, ``wrong-import-position``).  Also cache the
+``isort.Config`` object so it is built once instead of once per import
+statement.  Both changes save ~6 s on ansible (564 files), a 17%
+reduction whether only ``cyclic-import`` is enabled (isort skipped
+entirely) or import-ordering checks are active (cached config avoids
+rebuilding it per import).
+
+Refs #10886, #2866, #10637

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -322,6 +322,11 @@ DEFAULT_KNOWN_FIRST_PARTY = ()
 DEFAULT_KNOWN_THIRD_PARTY = ("enchant",)
 DEFAULT_PREFERRED_MODULES = ()
 
+# Messages that require isort-based import classification.
+ISORT_MESSAGES = frozenset(
+    ("wrong-import-order", "ungrouped-imports", "wrong-import-position")
+)
+
 
 class ImportsChecker(DeprecatedMixin, BaseChecker):
     """BaseChecker for import statements.
@@ -590,6 +595,14 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
                 self._add_imported_module(node, imported_module.name)
 
     def leave_module(self, node: nodes.Module) -> None:
+        # Skip the expensive isort-based classification when no
+        # import-ordering message is enabled (e.g. only cyclic-import).
+        if any(self.linter.is_message_enabled(m) for m in ISORT_MESSAGES):
+            self.isort_leave_module(node)
+        self._imports_stack = []
+        self._non_import_nodes = []
+
+    def isort_leave_module(self, node: nodes.Module) -> None:
         # Check imports are grouped by category (standard, 3rd party, local)
         std_imports, ext_imports, loc_imports = self._check_imports_order(node)
 
@@ -617,9 +630,6 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             ):
                 continue
             met.add(package)
-
-        self._imports_stack = []
-        self._non_import_nodes = []
 
     def compute_first_non_import_node(
         self,
@@ -762,7 +772,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
         imports = [import_node for (import_node, _) in imports]
         return any(astroid.are_exclusive(import_node, node) for import_node in imports)
 
-    @property
+    @cached_property
     def _isort_config(self) -> isort.Config:
         """Get the config for use with isort.
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Description

On large codebases cyclic-import is often the only import message enabled.  The leave_module hook was unconditionally running isort to classify every import, even when no ordering message was active. isort.Config was also recreated per import, defeating isort's internal cache.

- Guard the isort path behind an ISORT_MESSAGES check
- Cache _isort_config with @cached_property

On ansible (564 files): ~6s saved when only cyclic-import is enabled, ~100x faster isort path when ordering checks are active.

Refs #2866, #10637
