### PR TITLE
Lazy-import multiple libs to avoid startup cost

### DIFF
--- a/doc/whatsnew/fragments/2866.performance
+++ b/doc/whatsnew/fragments/2866.performance
@@ -1,0 +1,7 @@
+Lazy-import ``isort`` so it is only loaded when import-ordering
+messages are enabled (``wrong-import-order``, ``ungrouped-imports``,
+``wrong-import-position``).  ``import isort`` alone takes ~60 ms,
+and lazy loading isort saves ~10% of ``pylint`` startup time when
+loading checkers from 220 ms to 190 ms.
+
+Closes #2866

--- a/doc/whatsnew/fragments/2866.performance
+++ b/doc/whatsnew/fragments/2866.performance
@@ -1,6 +1,6 @@
-Lazily import ``dill`` in ``pylint.lint.parallel`` and ``isort`` in
-``pylint.checkers.imports`` so they are only loaded when actually needed.
-``dill`` (~13 ms) is now deferred until parallel checking runs, and
-``isort`` (~60 ms) until import-ordering messages are checked.
+Lazily import ``isort``, ``dill``, ``multiprocessing``/``concurrent.futures``,
+and ``tomlkit`` so they are only loaded when actually needed.
+This reduces startup time by ~25% (e.g. ``--version``: 91 => 67 ms,
+``--help``: 176 => 133 ms, single-file lint: 272 => 226 ms).
 
 Closes #2866

--- a/doc/whatsnew/fragments/2866.performance
+++ b/doc/whatsnew/fragments/2866.performance
@@ -1,7 +1,6 @@
-Lazy-import ``isort`` so it is only loaded when import-ordering
-messages are enabled (``wrong-import-order``, ``ungrouped-imports``,
-``wrong-import-position``).  ``import isort`` alone takes ~60 ms,
-and lazy loading isort saves ~10% of ``pylint`` startup time when
-loading checkers from 220 ms to 190 ms.
+Lazily import ``dill`` in ``pylint.lint.parallel`` and ``isort`` in
+``pylint.checkers.imports`` so they are only loaded when actually needed.
+``dill`` (~13 ms) is now deferred until parallel checking runs, and
+``isort`` (~60 ms) until import-ordering messages are checked.
 
 Closes #2866

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -15,9 +15,11 @@ from collections.abc import ItemsView, Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
+if TYPE_CHECKING:
+    import isort
+
 import astroid
 import astroid.modutils
-import isort
 from astroid import nodes
 from astroid.nodes._base_nodes import ImportNode
 
@@ -778,6 +780,8 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
 
         Only valid after CLI parsing finished, i.e. not in __init__
         """
+        import isort  # pylint: disable=import-outside-toplevel
+
         return isort.Config(
             # There is no typo here. EXTRA_standard_library is
             # what most users want. The option has been named
@@ -788,7 +792,9 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             known_third_party=self.linter.config.known_third_party,
         )
 
-    def _check_imports_order(self, _module_node: nodes.Module) -> tuple[
+    def _check_imports_order(  # pylint: disable=too-many-statements
+        self, _module_node: nodes.Module
+    ) -> tuple[
         list[tuple[ImportNode, str]],
         list[tuple[ImportNode, str]],
         list[tuple[ImportNode, str]],
@@ -797,6 +803,8 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
 
         Imports must follow this order: standard, 3rd party, 1st party, local
         """
+        import isort  # pylint: disable=import-outside-toplevel
+
         std_imports: list[tuple[ImportNode, str]] = []
         third_party_imports: list[tuple[ImportNode, str]] = []
         first_party_imports: list[tuple[ImportNode, str]] = []

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -14,8 +14,6 @@ import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, TextIO
 
-import tomlkit
-
 from pylint import utils
 from pylint.config.argument import (
     _Argument,
@@ -302,6 +300,8 @@ class _ArgumentsManager:
         """Write a configuration file according to the current configuration into
         stdout.
         """
+        import tomlkit  # pylint: disable=import-outside-toplevel
+
         toml_doc = tomlkit.document()
         tool_table = tomlkit.table(is_super_table=True)
         toml_doc.add(tomlkit.key("tool"), tool_table)

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -9,8 +9,6 @@ from collections import defaultdict
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any
 
-import dill
-
 from pylint import reporters
 from pylint.lint.utils import _augment_sys_path
 from pylint.message import Message
@@ -44,6 +42,8 @@ def _worker_initialize(
     :param extra_packages_paths: Extra entries to be added to `sys.path`
     """
     global _worker_linter  # pylint: disable=global-statement
+    import dill  # pylint: disable=import-outside-toplevel
+
     _worker_linter = dill.loads(linter)
     assert _worker_linter
 
@@ -144,6 +144,8 @@ def check_parallel(
     initializer = functools.partial(
         _worker_initialize, extra_packages_paths=extra_packages_paths
     )
+    import dill  # pylint: disable=import-outside-toplevel
+
     with ProcessPoolExecutor(
         max_workers=jobs, initializer=initializer, initargs=(dill.dumps(linter),)
     ) as executor:

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -15,17 +15,8 @@ from pylint.message import Message
 from pylint.typing import FileItem
 from pylint.utils import LinterStats, merge_stats
 
-try:
-    import multiprocessing
-except ImportError:
-    multiprocessing = None  # type: ignore[assignment]
-
-try:
-    from concurrent.futures import ProcessPoolExecutor
-except ImportError:
-    ProcessPoolExecutor = None  # type: ignore[assignment,misc]
-
 if TYPE_CHECKING:
+
     from pylint.lint import PyLinter
 
 # PyLinter object used by worker processes when checking files using parallel mode
@@ -79,6 +70,8 @@ def _worker_check_single_file(
     int,
     defaultdict[str, list[Any]],
 ]:
+    import multiprocessing  # pylint: disable=import-outside-toplevel
+
     if not _worker_linter:
         raise RuntimeError("Worker linter not yet initialised")
     _worker_linter.open()
@@ -144,6 +137,9 @@ def check_parallel(
     initializer = functools.partial(
         _worker_initialize, extra_packages_paths=extra_packages_paths
     )
+    # pylint: disable-next=import-outside-toplevel
+    from concurrent.futures import ProcessPoolExecutor
+
     import dill  # pylint: disable=import-outside-toplevel
 
     with ProcessPoolExecutor(

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -25,17 +25,6 @@ from pylint.lint.base_options import _make_run_options
 from pylint.lint.pylinter import MANAGER, PyLinter
 from pylint.reporters.base_reporter import BaseReporter
 
-try:
-    import multiprocessing
-    from multiprocessing import synchronize  # noqa pylint: disable=unused-import
-except ImportError:
-    multiprocessing = None  # type: ignore[assignment]
-
-try:
-    from concurrent.futures import ProcessPoolExecutor
-except ImportError:
-    ProcessPoolExecutor = None  # type: ignore[assignment,misc]
-
 
 def _query_cpu() -> int | None:
     """Try to determine number of CPUs allotted in a docker container.
@@ -110,10 +99,13 @@ def _cpu_count() -> int:
     # pylint: disable=not-callable,using-constant-test,useless-suppression
     if sched_getaffinity:
         cpu_count = len(sched_getaffinity(0))
-    elif multiprocessing:
-        cpu_count = multiprocessing.cpu_count()
     else:
-        cpu_count = 1
+        try:
+            import multiprocessing  # pylint: disable=import-outside-toplevel
+
+            cpu_count = multiprocessing.cpu_count()
+        except ImportError:
+            cpu_count = 1
     if sys.platform == "win32":
         # See also https://github.com/python/cpython/issues/94242
         cpu_count = min(cpu_count, 56)  # pragma: no cover
@@ -217,13 +209,16 @@ group are mutually exclusive.",
             )
             sys.exit(32)
         if linter.config.jobs > 1 or linter.config.jobs == 0:
-            if ProcessPoolExecutor is None:
+            try:
+                # pylint: disable-next=import-outside-toplevel,unused-import
+                from concurrent.futures import ProcessPoolExecutor  # noqa: F401
+            except ImportError:
                 print(
                     "concurrent.futures module is missing, fallback to single process",
                     file=sys.stderr,
                 )
                 linter.set_option("jobs", 1)
-            elif linter.config.jobs == 0:
+            if linter.config.jobs == 0:
                 linter.config.jobs = _cpu_count()
 
         if self._output:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

isort is only needed when import-ordering messages are enabled and dill when we run in parallel. Move the import from module level into the functions that use it so it is never loaded when only cyclic-import or other non-ordering checks are active.  This paves the way for making isort an optional dependency (refs #10637).

  Interleaved measurements (15 runs per branch, randomized order, median):

  ### Per-commit cumulative improvement vs main                                                                                                                                                                            
                                                            
  | Commit | `--version` | `--help` | `lint 1 file` |                                                                                                                                                                      
  |--------|------------|----------|---------------|        
  | `main` | 91.2ms | 176.0ms | 272.4ms |                                                                                                                                                                                  
  | + lazy `isort` | 85.2ms (-6.6%) | 148.4ms (-15.7%) | 239.2ms (-12.2%) |
  | + lazy `dill` | 81.3ms (-10.9%) | 143.6ms (-18.4%) | 234.0ms (-14.1%) |                                                                                                                                                
  | + lazy `multiprocessing`/`concurrent.futures` | 70.3ms (-22.9%) | 134.0ms (-23.9%) | 227.3ms (-16.6%) |
  | + lazy `tomlkit` | 66.8ms (-26.8%) | 133.1ms (-24.4%) | 226.2ms (-17.0%) |                                                                                                                                             
                                                                                                                                                                                                                           
  ### Summary (branch tip vs main)                                                                                                                                                                                         
                                                                                                                                                                                                                           
  | Command | main | branch | delta | % |                   
  |---------|------|--------|-------|---|
  | `--version` | 91.2ms | 66.8ms | -24.4ms | -26.8% |                                                                                                                                                                     
  | `--help` | 176.0ms | 133.1ms | -42.9ms | -24.4% |
  | `lint 1 file` | 272.4ms | 226.2ms | -46.2ms | -17.0% |    

  `--version` only benefits from the `dill` deferral (isort is loaded later in the pipeline). `--help` and single-file lint benefit from both. The lint benchmark used `--disable=all --enable=C0301` so isort was never
  needed.
  
  Benchmark:
  ```python
  import subprocess, statistics, random

  def bench_interleaved(branches, cmd, n=15):                                                                                                                                                                              
      """Interleave runs across branches to cancel out system load variance."""
      times = {b: [] for b in branches}                                                                                                                                                                                    
      order = branches * n                                  
      random.shuffle(order)
      for branch in order:
          subprocess.run(['git', 'checkout', branch], capture_output=True)
          r = subprocess.run(['python', '-c', cmd], capture_output=True, text=True)
          for line in (r.stdout + r.stderr).splitlines():
              if 'time:' in line:
                  times[branch].append(float(line.split(':')[1].strip().rstrip('s')))
      return {b: statistics.median(times[b]) for b in branches}

  cmd_version = '''
  import time; t=time.perf_counter()
  try:
      from pylint import run_pylint; run_pylint(["--version"])
  except SystemExit: pass
  print(f"time: {time.perf_counter()-t:.4f}s")
  '''

  cmd_help = '''
  import time; t=time.perf_counter()
  try:
      from pylint import run_pylint; run_pylint(["--help"])
  except SystemExit: pass
  print(f"time: {time.perf_counter()-t:.4f}s")
  '''

  cmd_lint = '''
  import time; t=time.perf_counter()
  try:
      from pylint import run_pylint; run_pylint(["--disable=all", "--enable=C0301", "-rn", "pylint/__init__.py"])
  except SystemExit: pass
  print(f"time: {time.perf_counter()-t:.4f}s")
  '''

  branches = ['main', 'lazy-load-isort']
  results = {}
  for label, cmd in [('--version', cmd_version), ('--help', cmd_help), ('lint 1 file', cmd_lint)]:
      results[label] = bench_interleaved(branches, cmd, n=15)

  subprocess.run(['git', 'checkout', 'lazy-load-isort'], capture_output=True)

  print(f"{'Command':<15} {'main':>10} {'branch':>10} {'delta':>10} {'%':>8}")
  print('-' * 55)
  for label in ['--version', '--help', 'lint 1 file']:
      m = results[label]['main']
      b = results[label]['lazy-load-isort']
      d = b - m
      pct = d / m * 100
      print(f'{label:<15} {m*1000:>8.1f}ms {b*1000:>8.1f}ms {d*1000:>+8.1f}ms {pct:>+7.1f}%')
```      

Closes #2866
