### PR TITLE
Fix crash in _called_in_methods when getattr returns non-NodeNG

### DIFF
--- a/doc/whatsnew/fragments/10892.bugfix
+++ b/doc/whatsnew/fragments/10892.bugfix
@@ -1,0 +1,3 @@
+Fix crash when checking ``attribute-defined-outside-init`` on classes that inherit from a base class pylint cannot fully analyze.
+
+Closes #10892

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -431,6 +431,8 @@ def _called_in_methods(
         except astroid.NotFoundError:
             continue
         for infer_method in inferred:
+            if not isinstance(infer_method, nodes.NodeNG):
+                continue
             for call in infer_method.nodes_of_class(nodes.Call):
                 try:
                     bound = next(call.func.infer())

--- a/tests/functional/r/regression_02/regression_10892.py
+++ b/tests/functional/r/regression_02/regression_10892.py
@@ -1,0 +1,23 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Regression test for https://github.com/pylint-dev/pylint/issues/10892
+
+Crash in ``_called_in_methods`` when ``klass.getattr()`` returns non-NodeNG
+objects (e.g. ``UninferableBase``) from the metaclass lookup path.
+"""
+
+# pylint: disable=missing-docstring,too-few-public-methods,undefined-variable
+
+
+class Meta(type):
+    __init__ = some_descriptor
+
+
+class MyClass(metaclass=Meta):
+    def setup(self):
+        self.attr = 1  # [attribute-defined-outside-init]
+
+    def method(self):
+        self.attr = 2  # [attribute-defined-outside-init]

--- a/tests/functional/r/regression_02/regression_10892.txt
+++ b/tests/functional/r/regression_02/regression_10892.txt
@@ -1,0 +1,2 @@
+attribute-defined-outside-init:20:8:20:17:MyClass.setup:Attribute 'attr' defined outside __init__:UNDEFINED
+attribute-defined-outside-init:23:8:23:17:MyClass.method:Attribute 'attr' defined outside __init__:UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`klass.getattr()` can return `UninferableBase` or `BoundMethod` objects which don't have `nodes_of_class`, causing a TypeError. Skip these items.

Discovered via primer crash on astropy.

Refs #10875 
