### PR TITLE
Add benchmark comparison workflow with PR comments

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,0 +1,176 @@
+name: Benchmark
+
+on:
+  pull_request:
+    paths:
+      - "pylint/**"
+      - "tests/benchmark/**"
+      - "requirements*"
+    branches:
+      - main
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CACHE_VERSION: 5
+  KEY_PREFIX: venv
+  DEFAULT_PYTHON: "3.13"
+
+permissions:
+  contents: read
+
+jobs:
+  # Run on PRs: compare main vs PR, upload comment artifact
+  benchmark-compare:
+    if: github.event_name == 'pull_request'
+    name: Compare benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out PR code
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          check-latest: true
+
+      - name: Restore Python virtual environment
+        id: cache-venv
+        uses: actions/cache@v5.0.3
+        with:
+          path: venv
+          key: >-
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ hashFiles('pyproject.toml',
+            'requirements_test.txt', 'requirements_test_min.txt',
+            'requirements_test_pre_commit.txt') }}
+
+      - name: Create Python virtual environment
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          python -m venv venv
+          . venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install --upgrade --requirement requirements_test.txt
+
+      # Run benchmarks on main
+      - name: Check out main
+        run: git checkout ${{ github.event.pull_request.base.sha }}
+
+      - name: Run benchmarks on main
+        run: |
+          . venv/bin/activate
+          pip install . --no-deps --force-reinstall
+          pytest --exitfirst \
+            --benchmark-only \
+            --benchmark-save=main \
+            --benchmark-group-by="group" \
+            --benchmark-sort=name \
+            tests/benchmark/
+
+      # Run benchmarks on PR
+      - name: Check out PR
+        run: git checkout ${{ github.event.pull_request.head.sha }}
+
+      - name: Run benchmarks on PR
+        run: |
+          . venv/bin/activate
+          pip install . --no-deps --force-reinstall
+          pytest --exitfirst \
+            --benchmark-only \
+            --benchmark-save=pr \
+            --benchmark-group-by="group" \
+            --benchmark-sort=name \
+            tests/benchmark/
+
+      # Compare
+      - name: Find benchmark JSON files
+        id: find-json
+        run: |
+          echo "base=$(find .benchmarks -name '*_main.json' | head -1)" >> "$GITHUB_OUTPUT"
+          echo "pr=$(find .benchmarks -name '*_pr.json' | head -1)" >> "$GITHUB_OUTPUT"
+
+      - name: Compare benchmarks
+        run: |
+          . venv/bin/activate
+          python tests/benchmark/compare.py \
+            --base "${{ steps.find-json.outputs.base }}" \
+            --pr "${{ steps.find-json.outputs.pr }}" \
+            --output benchmark_comment.md
+
+      - name: Save PR number
+        run: echo ${{ github.event.pull_request.number }} > pr_number.txt
+
+      - name: Upload benchmark comment
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: benchmark_result
+          path: |
+            benchmark_comment.md
+            pr_number.txt
+
+  # Run on tags: save benchmark data permanently
+  benchmark-release:
+    if: github.event_name == 'push'
+    name: Benchmark release ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          check-latest: true
+
+      - name: Restore Python virtual environment
+        id: cache-venv
+        uses: actions/cache@v5.0.3
+        with:
+          path: venv
+          key: >-
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ hashFiles('pyproject.toml',
+            'requirements_test.txt', 'requirements_test_min.txt',
+            'requirements_test_pre_commit.txt') }}
+
+      - name: Create Python virtual environment
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          python -m venv venv
+          . venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install --upgrade --requirement requirements_test.txt
+
+      - name: Run benchmarks
+        run: |
+          . venv/bin/activate
+          pip install . --no-deps
+          pytest --exitfirst \
+            --benchmark-only \
+            --benchmark-autosave \
+            --benchmark-save-data \
+            --benchmark-group-by="group" \
+            --benchmark-sort=name \
+            tests/benchmark/
+
+      - name: Upload benchmark artifact
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: benchmark-${{ github.ref_name }}
+          include-hidden-files: true
+          path: .benchmarks/
+          retention-days: 0

--- a/.github/workflows/benchmark_comment.yaml
+++ b/.github/workflows/benchmark_comment.yaml
@@ -1,0 +1,70 @@
+name: Benchmark / Comment
+
+on:
+  workflow_run:
+    workflows: [Benchmark]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    name: Post results
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download benchmark result
+        uses: actions/github-script@v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+            const [result] = artifacts.data.artifacts.filter(
+              a => a.name === 'benchmark_result'
+            );
+            if (!result) {
+              console.log('No benchmark artifact found');
+              return;
+            }
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: result.id,
+              archive_format: 'zip',
+            });
+            fs.writeFileSync('benchmark_result.zip', Buffer.from(download.data));
+
+      - name: Unzip result
+        run: unzip benchmark_result.zip
+
+      - name: Post comment
+        id: post-comment
+        uses: actions/github-script@v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const comment = fs.readFileSync('benchmark_comment.md', { encoding: 'utf8' });
+            console.log("Comment to post:");
+            console.log(comment);
+            const prNumber = parseInt(fs.readFileSync('pr_number.txt', { encoding: 'utf8' }));
+            await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment,
+            });
+            return prNumber;
+
+      - name: Hide old benchmark comments
+        uses: kanga333/comment-hider@c12bb20b48aeb8fc098e35967de8d4f8018fffdf # v0.4.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          leave_visible: 1
+          issue_number: ${{ steps.post-comment.outputs.result }}

--- a/tests/benchmark/compare.py
+++ b/tests/benchmark/compare.py
@@ -1,0 +1,119 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Compare two pytest-benchmark JSON results and output a markdown summary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_benchmarks(path: Path) -> dict[str, dict[str, Any]]:
+    """Load benchmark results from a pytest-benchmark JSON file."""
+    data = json.loads(path.read_text())
+    return {b["name"]: b["stats"] for b in data["benchmarks"]}
+
+
+def format_time(seconds: float) -> str:
+    """Format seconds into a human-readable string."""
+    if seconds >= 1:
+        return f"{seconds:.3f}s"
+    if seconds >= 0.001:
+        return f"{seconds * 1000:.1f}ms"
+    return f"{seconds * 1_000_000:.0f}µs"
+
+
+def compare(base_path: Path, pr_path: Path, threshold: float = 5.0) -> str:
+    """Compare two benchmark results and return a markdown table.
+
+    Args:
+        base_path: Path to the base (main) benchmark JSON.
+        pr_path: Path to the PR benchmark JSON.
+        threshold: Percentage change above which to flag a result.
+
+    Returns:
+        Markdown-formatted comparison string.
+    """
+    base = load_benchmarks(base_path)
+    pr = load_benchmarks(pr_path)
+
+    all_names = sorted(set(base) | set(pr))
+    if not all_names:
+        return "No benchmarks found."
+
+    rows: list[tuple[str, str, str, str, str]] = []
+    has_significant = False
+
+    for name in all_names:
+        if name not in base or name not in pr:
+            continue
+        base_median = base[name]["median"]
+        pr_median = pr[name]["median"]
+        delta_pct = (pr_median - base_median) / base_median * 100
+
+        if abs(delta_pct) >= threshold:
+            has_significant = True
+            if delta_pct > 0:
+                flag = "🔴"
+            else:
+                flag = "🟢"
+        else:
+            flag = ""
+
+        # Shorten test name for readability
+        short_name = name.split("::")[-1]
+
+        rows.append(
+            (
+                short_name,
+                format_time(base_median),
+                format_time(pr_median),
+                f"{delta_pct:+.1f}%",
+                flag,
+            )
+        )
+
+    lines = []
+    lines.append("## Benchmark comparison")
+    lines.append("")
+    lines.append(f"Threshold: ±{threshold:.0f}%")
+    lines.append("")
+    lines.append("| Benchmark | main | PR | Change | |")
+    lines.append("|:----------|-----:|---:|-------:|-|")
+    for name, base_t, pr_t, delta, flag in rows:
+        lines.append(f"| `{name}` | {base_t} | {pr_t} | {delta} | {flag} |")
+
+    if not has_significant:
+        lines.append("")
+        lines.append("No significant performance changes detected.")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base", required=True, type=Path, help="Base (main) benchmark JSON"
+    )
+    parser.add_argument("--pr", required=True, type=Path, help="PR benchmark JSON")
+    parser.add_argument(
+        "--threshold", type=float, default=5.0, help="Significance threshold (%%)"
+    )
+    parser.add_argument("--output", type=Path, help="Output file (default: stdout)")
+    args = parser.parse_args()
+
+    result = compare(args.base, args.pr, args.threshold)
+
+    if args.output:
+        args.output.write_text(result)
+    else:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

- benchmark.yaml: on PRs, runs pytest-benchmark on both main and PR, compares results via tests/benchmark/compare.py. On tags, saves benchmark data permanently as artifacts (retention-days: 0).
- benchmark_comment.yaml: posts the comparison as a PR comment (hides old comments, same pattern as primer_comment.yaml)
- tests/benchmark/compare.py: reads two pytest-benchmark JSON files, computes median deltas, outputs markdown with ±5% threshold flags
