### PR TITLE
Fix false positive `unused-variable` for globals matching `dummy-variables-rgx`

### DIFF
--- a/doc/whatsnew/fragments/10890.false_positive
+++ b/doc/whatsnew/fragments/10890.false_positive
@@ -1,0 +1,5 @@
+Fix a false positive for ``unused-variable`` where global variables matching
+``dummy-variables-rgx`` were still reported as unused when
+``allow-global-unused-variables`` was disabled.
+
+Closes #10890

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -3286,6 +3286,8 @@ class VariablesChecker(BaseChecker):
                     and node.modname == "__future__"
                 ):
                     continue
+                if self._is_name_ignored(node, name):
+                    continue
                 self.add_message("unused-variable", args=(name,), node=node)
 
     # pylint: disable = too-many-branches

--- a/tests/functional/u/unused/unused_global_variable5.py
+++ b/tests/functional/u/unused/unused_global_variable5.py
@@ -1,0 +1,9 @@
+# pylint: disable=missing-docstring,invalid-name
+
+# Test that global variables matching dummy-variables-rgx are not
+# reported as unused (issue #10890).
+
+_ = []  # This should NOT trigger unused-variable
+__ = {}  # This should NOT trigger unused-variable
+
+var = "pylint"  # [unused-variable]

--- a/tests/functional/u/unused/unused_global_variable5.rc
+++ b/tests/functional/u/unused/unused_global_variable5.rc
@@ -1,0 +1,3 @@
+[variables]
+allow-global-unused-variables=no
+dummy-variables-rgx=_+$

--- a/tests/functional/u/unused/unused_global_variable5.txt
+++ b/tests/functional/u/unused/unused_global_variable5.txt
@@ -1,0 +1,1 @@
+unused-variable:9:0:9:3::Unused variable 'var':UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

When `allow-global-unused-variables` is disabled, global variables whose names match `dummy-variables-rgx` were still reported as unused (`W0612`). For example:

```python
# With dummy-variables-rgx matching "_"
_ = []  # False positive: W0612 unused-variable
```

The same variable inside a function body would correctly be ignored.

The fix adds a `_is_name_ignored` check in `_check_globals`, consistent with how local variables are already handled elsewhere in the variables checker.

### Test

Added `unused_global_variable5` functional test that verifies:
- `_` and `__` (matching `dummy-variables-rgx=_+$`) are **not** reported at global scope
- `var` (not matching the regex) **is** still reported

### Changelog

Added `doc/whatsnew/fragments/10890.false_positive`.

Closes #10890