### PR TITLE
Skip consider-using-min/max-builtin inside loops for performance

### DIFF
--- a/doc/whatsnew/fragments/9864.false_positive
+++ b/doc/whatsnew/fragments/9864.false_positive
@@ -1,1 +1,3 @@
 Skip ``consider-using-min-builtin`` and ``consider-using-max-builtin`` inside loops as using ``min()``/``max()`` is slower than if statements in this context.
+
+Closes #9864

--- a/doc/whatsnew/fragments/9864.false_positive
+++ b/doc/whatsnew/fragments/9864.false_positive
@@ -1,0 +1,1 @@
+Skip ``consider-using-min-builtin`` and ``consider-using-max-builtin`` inside loops as using ``min()``/``max()`` is slower than if statements in this context.

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -912,6 +912,17 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         self._check_consider_get(node)
         self._check_consider_using_min_max_builtin(node)
 
+    @staticmethod
+    def _is_inside_loop(node: nodes.If) -> bool:
+        """Check if the if statement is inside a for or while loop."""
+        frame = node.frame()
+        for parent in node.node_ancestors():
+            if parent is frame:
+                break
+            if isinstance(parent, (nodes.For, nodes.While)):
+                return True
+        return False
+
     def _check_consider_using_min_max_builtin(self, node: nodes.If) -> None:
         """Check if the given if node can be refactored as a min/max python builtin."""
         # This function is written expecting a test condition of form:
@@ -921,6 +932,11 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         #    a = b
         if self._is_actual_elif(node) or node.orelse:
             # Not interested in if statements with multiple branches.
+            return
+
+        # Do not suggest min/max inside loops as it's slower than if statements
+        # See https://github.com/pylint-dev/pylint/issues/9864
+        if self._is_inside_loop(node):
             return
 
         if len(node.body) != 1:

--- a/tests/functional/c/consider/consider_using_min_max_builtin.py
+++ b/tests/functional/c/consider/consider_using_min_max_builtin.py
@@ -130,3 +130,27 @@ if var == -1:
 var2 = 1
 if var2 in [1, 2]:
     var2 = None
+
+
+# https://github.com/pylint-dev/pylint/issues/9864
+# Do not suggest min/max inside loops as it's slower than if statements
+values = [1, 2, 3]
+min_a = float('inf')
+max_a = 0
+
+# These should NOT trigger consider-using-min-builtin or consider-using-max-builtin
+# because they are inside a for loop
+for i in values:
+    if i < min_a:
+        min_a = i
+    if i > max_a:
+        max_a = i
+
+# Also should NOT trigger inside a while loop
+i = 0
+while i < len(values):
+    if values[i] < min_a:
+        min_a = values[i]
+    if values[i] > max_a:
+        max_a = values[i]
+    i += 1


### PR DESCRIPTION
Fixes #9864

## Summary

Skip `consider-using-min-builtin` and `consider-using-max-builtin` suggestions when the if statement is inside a for or while loop. Using `min()`/`max()` inside loops is 3x slower than using if statements due to function call overhead.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The `consider-using-min-builtin` and `consider-using-max-builtin` checks suggest refactoring if statements like `if a < b: a = b` to use `a = max(a, b)`. However, when this pattern is used inside a loop (for tracking min/max values), using the builtin functions is significantly slower (about 3x) than using if statements due to the function call overhead.

This change adds a check to skip these suggestions when the if statement is inside a loop body.

## Changes

- Added `_is_inside_loop()` helper method to check if a node is inside a for/while loop
- Modified `_check_consider_using_min_max_builtin()` to skip the suggestion when inside a loop
- Added test cases for for-loops and while-loops to verify the fix
- Added changelog fragment

## Testing

Added test cases in `tests/functional/c/consider/consider_using_min_max_builtin.py` that verify:
- If statements inside for-loops do NOT trigger the suggestion
- If statements inside while-loops do NOT trigger the suggestion

```
 doc/whatsnew/fragments/9864.false_positive         |  1 +
 pylint/checkers/refactoring/refactoring_checker.py | 16 +++++++++++++++
 .../c/consider/consider_using_min_max_builtin.py   | 24 ++++++++++++++++++++++
 3 files changed, 41 insertions(+)
```