### PR TITLE
[primer] Show changed messages as diffs instead of removed+added

### DIFF
--- a/custom_dict.txt
+++ b/custom_dict.txt
@@ -353,6 +353,7 @@ tomlkit
 toplevel
 towncrier
 tp
+traceback
 truthey
 truthness
 truthy

--- a/doc/whatsnew/fragments/10914.internal
+++ b/doc/whatsnew/fragments/10914.internal
@@ -1,0 +1,13 @@
+The primer now pairs residual messages — first by ``(symbol, path, obj)`` and then by
+exact source location — and reports altered messages as a single *changed* entry with
+a compact diff, rather than as a separate removal + addition. The location-based pass
+also catches symbol renames at the same code position (e.g. ``used-before-assignment``
+→ ``possibly-used-before-assignment``). When several messages are eligible, the one
+closest to the original line wins, so pairs never cross. New messages are classified
+into fixed false positives (``useless-suppression``), ``astroid-error`` fatal errors,
+and the rest. ``astroid-error`` messages are excluded from pairing (their text embeds
+a unique crash-report path) so persistent crashes keep raising the prominent warning.
+Truncated comments are now cut at a line break and keep their code fences and
+``<details>`` blocks closed.
+
+Refs #10914

--- a/pylint/testutils/_primer/comparator.py
+++ b/pylint/testutils/_primer/comparator.py
@@ -5,15 +5,25 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator
+from collections import defaultdict
+from collections.abc import Callable, Hashable, Iterator
+from difflib import SequenceMatcher
+from operator import itemgetter
 from pathlib import Path
 from typing import NamedTuple
 
 from pylint.reporters.json_reporter import JSONMessage
-from pylint.testutils._primer.primer_command import (
-    PackageData,
-    PackageMessages,
-)
+from pylint.testutils._primer.primer_command import PackageData, PackageMessages
+
+
+class ChangedMessage(NamedTuple):
+    """A message that was present on both runs but with altered details."""
+
+    old: JSONMessage
+    new: JSONMessage
+
+
+_LOCATION_KEYS = {"line", "column", "endLine", "endColumn"}
 
 
 class PackageDiff(NamedTuple):
@@ -22,6 +32,196 @@ class PackageDiff(NamedTuple):
     package: str
     missing: PackageData  # emitted on main but not on the PR
     new: PackageData  # emitted on the PR but not on main
+    changed: list[ChangedMessage]  # same message, altered line / text
+
+
+SYMBOL_RENAME_SIMILARITY_THRESHOLD = 0.6
+
+
+def _pair_by_key(
+    old_residuals: list[JSONMessage],
+    new_residuals: list[JSONMessage],
+    key: Callable[[JSONMessage], tuple[Hashable, ...]],
+    accept: Callable[[JSONMessage, JSONMessage], bool] = lambda _o, _n: True,
+) -> tuple[list[ChangedMessage], list[JSONMessage], list[JSONMessage]]:
+    """Pair messages whose ``key`` matches, preferring the closest line.
+
+    Two messages sharing the key are the "same warning" — if they differ only
+    in line numbers or message text, they should be reported as *changed*
+    rather than as a separate removal + addition.  Leftovers on each side are
+    passed through to the next pass (or reported as missing/new).
+
+    ``accept`` is an optional predicate that can veto a candidate pair (used to
+    avoid pairing two unrelated messages that happen to share the key).  Among
+    the accepted candidates, the one nearest to the old message's line wins, so
+    two warnings that both moved pair with their own counterpart instead of
+    crossing (10→21 and 20→11 when 10→11 and 20→21 was meant).
+    """
+    new_by_key: dict[tuple[Hashable, ...], list[JSONMessage]] = defaultdict(list)
+    for m in new_residuals:
+        new_by_key[key(m)].append(m)
+
+    paired: list[ChangedMessage] = []
+    final_missing: list[JSONMessage] = []
+    matched_new: set[int] = set()
+    for old in old_residuals:
+        bucket = new_by_key.get(key(old), [])
+        candidates = [
+            (abs(m["line"] - old["line"]), i, m)
+            for i, m in enumerate(bucket)
+            if accept(old, m)
+        ]
+        if candidates:
+            _distance, index, new = min(candidates, key=itemgetter(0, 1))
+            bucket.pop(index)
+            paired.append(ChangedMessage(old=old, new=new))
+            matched_new.add(id(new))
+        else:
+            final_missing.append(old)
+    final_new = [m for m in new_residuals if id(m) not in matched_new]
+    return paired, final_missing, final_new
+
+
+def _is_symbol_rename(old: JSONMessage, new: JSONMessage) -> bool:
+    """True when the two symbols are textually similar enough to be a rename.
+
+    Used to avoid pairing unrelated messages that happen to share a source
+    position (e.g. ``useless-suppression`` removed and ``locally-disabled``
+    added on the same line — those are conceptually opposite, not a rename).
+    """
+    ratio = SequenceMatcher(None, old["symbol"], new["symbol"]).ratio()
+    return ratio >= SYMBOL_RENAME_SIMILARITY_THRESHOLD
+
+
+def _pair_residuals(
+    old_residuals: list[JSONMessage], new_residuals: list[JSONMessage]
+) -> tuple[list[ChangedMessage], list[JSONMessage], list[JSONMessage]]:
+    """Pair residual messages with two passes of decreasing strictness.
+
+    First by ``(symbol, path, obj)`` — catches line-only or message-only changes
+    for the same warning. Then by exact source location, gated on symbol
+    similarity — catches symbol renames such as ``used-before-assignment`` →
+    ``possibly-used-before-assignment``, where the same code position now
+    emits a renamed message.
+
+    ``astroid-error`` messages embed a unique crash-report path, so a file
+    crashing on both runs would pair as a meaningless traceback "diff".  They
+    are kept out of pairing so they stay counted in the prominent astroid
+    error warning instead.
+    """
+    old_errors = [m for m in old_residuals if m["symbol"] == "astroid-error"]
+    new_errors = [m for m in new_residuals if m["symbol"] == "astroid-error"]
+    old_residuals = [m for m in old_residuals if m["symbol"] != "astroid-error"]
+    new_residuals = [m for m in new_residuals if m["symbol"] != "astroid-error"]
+
+    paired_by_symbol, missing, new = _pair_by_key(
+        old_residuals,
+        new_residuals,
+        key=lambda m: (m["symbol"], m["path"], m["obj"]),
+    )
+    paired_by_location, missing, new = _pair_by_key(
+        missing,
+        new,
+        key=lambda m: (
+            m["path"],
+            m["line"],
+            m["column"],
+            m.get("endLine"),
+            m.get("endColumn"),
+        ),
+        accept=_is_symbol_rename,
+    )
+    return paired_by_symbol + paired_by_location, missing + old_errors, new + new_errors
+
+
+def format_span(msg: JSONMessage) -> str:
+    """Format a message's location as ``line:col to endLine:endCol``."""
+    start = f"{msg['line']}:{msg['column']}"
+    end_line = msg.get("endLine")
+    end_col = msg.get("endColumn")
+    if end_line is not None and end_col is not None:
+        return f"`{start}`-`{end_line}:{end_col}`"
+    return f"`{start}`"
+
+
+def message_diff(change: ChangedMessage) -> str:
+    """Return a compact summary of changed fields between two messages.
+
+    Location changes are merged into a single human-readable span.
+    String fields (like ``message``) get a ``diff`` code block so GitHub
+    renders them with red/green highlighting.
+    """
+    old, new = change.old, change.new
+    changed_keys: set[str] = set()
+    for key in old.keys() | new.keys():
+        if old.get(key) != new.get(key):
+            changed_keys.add(key)
+
+    parts: list[str] = []
+    # Location: combine line/column/endLine/endColumn into one sentence.
+    if changed_keys & _LOCATION_KEYS:
+        parts.append(f"Moved from {format_span(old)} to {format_span(new)}.")
+
+    # Other fields (typically ``message`` or ``type``). ``get`` guards against
+    # a field existing on only one side (e.g. the PR changed the JSON schema).
+    for key in sorted(changed_keys - _LOCATION_KEYS):
+        old_val = old.get(key)
+        new_val = new.get(key)
+        if (
+            isinstance(old_val, str)
+            and isinstance(new_val, str)
+            and (any(len(v) > 40 or "\n" in v for v in (old_val, new_val)))
+        ):
+            parts.append(_diff_block(old_val, new_val))
+        else:
+            parts.append(f"{key}: `{old_val}` → `{new_val}`")
+    return "\n\n".join(parts)
+
+
+def _diff_block(old: str, new: str) -> str:
+    """Render a ``diff`` code block comparing two values line by line.
+
+    Unchanged lines of multi-line values (e.g. ``duplicate-code``) are kept
+    as context, so only the lines that actually changed stand out.  When a
+    changed block keeps its line count, each new line gets a ``^`` caret
+    hint under the characters that differ from its old counterpart.
+    """
+    old_lines, new_lines = old.splitlines(), new.splitlines()
+    matcher = SequenceMatcher(None, old_lines, new_lines)
+    lines: list[str] = []
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            lines.extend(f"  {line}" for line in old_lines[i1:i2])
+            continue
+        lines.extend(f"- {line}" for line in old_lines[i1:i2])
+        for offset, line in enumerate(new_lines[j1:j2]):
+            lines.append(f"+ {line}")
+            if tag == "replace" and i2 - i1 == j2 - j1:
+                caret_line = _caret_hint(old_lines[i1 + offset], line)
+                if caret_line:
+                    lines.append(f"  {caret_line}")
+    return "```diff\n" + "\n".join(lines) + "\n```"
+
+
+def _caret_hint(old: str, new: str) -> str:
+    """Build a ``^`` marker line highlighting changed spans in *new*.
+
+    Uses SequenceMatcher to find which parts of *new* differ from *old*
+    and places ``^`` characters under them (aligned with the ``+ `` prefix).
+    Returns an empty string when the whole line changed (carets wouldn't help).
+    """
+    matcher = SequenceMatcher(None, old, new)
+    carets = [" "] * len(new)
+    changed_count = 0
+    for tag, _i1, _i2, j1, j2 in matcher.get_opcodes():
+        if tag != "equal":
+            for j in range(j1, j2):
+                carets[j] = "^"
+            changed_count += j2 - j1
+    # If most of the string changed, carets are just noise.
+    if changed_count > len(new) * 0.6:
+        return ""
+    return "".join(carets).rstrip()
 
 
 class Comparator:
@@ -58,24 +258,32 @@ class Comparator:
         main_data = self._main_data
         pr_data = self._pr_data
 
-        missing_messages: PackageMessages = {}
         for package, data in main_data.items():
-            package_missing_messages: list[JSONMessage] = []
+            # First pass: exact-match removal.
+            pr_messages = list(pr_data[package]["messages"])
+            residual_old: list[JSONMessage] = []
             for message in data["messages"]:
                 try:
-                    pr_data[package]["messages"].remove(message)
+                    pr_messages.remove(message)
                 except ValueError:
-                    package_missing_messages.append(message)
-            missing_messages[package] = PackageData(
-                commit=pr_data[package]["commit"],
-                messages=package_missing_messages,
+                    residual_old.append(message)
+
+            # Second pass: pair residuals by symbol then by location to
+            # detect *changed* messages (same warning, different line/text,
+            # or a symbol rename at the same source position).
+            paired, final_missing, final_new = _pair_residuals(
+                residual_old, pr_messages
             )
 
-        for package, pkg_missing in missing_messages.items():
-            new_messages = pr_data[package]
-            if not pkg_missing["messages"] and not new_messages["messages"]:
+            if not final_missing and not final_new and not paired:
                 continue
-            yield PackageDiff(package, pkg_missing, new_messages)
+            commit = pr_data[package]["commit"]
+            yield PackageDiff(
+                package,
+                missing=PackageData(commit=commit, messages=final_missing),
+                new=PackageData(commit=commit, messages=final_new),
+                changed=paired,
+            )
 
     @staticmethod
     def _load_json(file_path: Path | str) -> PackageMessages:

--- a/pylint/testutils/_primer/primer_compare_command.py
+++ b/pylint/testutils/_primer/primer_compare_command.py
@@ -3,12 +3,36 @@
 # Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import PurePosixPath
 
-from pylint.testutils._primer.comparator import Comparator
-from pylint.testutils._primer.primer_command import PackageData, PrimerCommand
+from pylint.reporters.json_reporter import JSONMessage
+from pylint.testutils._primer.comparator import (
+    ChangedMessage,
+    Comparator,
+    message_diff,
+)
+from pylint.testutils._primer.primer_command import PrimerCommand
 
 MAX_GITHUB_COMMENT_LENGTH = 65536
+
+
+def _format_messages(
+    messages: list[JSONMessage],
+    source_link: Callable[[JSONMessage], str],
+) -> str:
+    """Format a list of messages as a numbered body for a ``<details>`` block."""
+    body = ""
+    for count, msg in enumerate(messages, 1):
+        body += (
+            f"{count}) {msg['symbol']}:\n*{msg['message']}*\n" f"{source_link(msg)}\n"
+        )
+    return body
+
+
+def _details_section(title: str, body: str) -> str:
+    # Blank line after <details> required for GitHub markdown rendering.
+    return f"{title}\n\n<details>\n\n{body}</details>\n\n"
 
 
 class CompareCommand(PrimerCommand):
@@ -26,9 +50,17 @@ class CompareCommand(PrimerCommand):
             if len(comment) >= MAX_GITHUB_COMMENT_LENGTH:
                 break
             package = diff.package
-            comment += f"\n**Effect on [{package}]({self.packages[package].url}):**\n\n"
-            comment += self._format_new_messages(package, diff.new)
-            comment += self._format_missing_messages(package, diff.missing)
+            url = self.packages[package].url
+            assert not url.endswith(
+                ".git"
+            ), "You don't need the .git at the end of the github url."
+            source_link = self._source_link_for(package, diff.new["commit"])
+            comment += f"\n**Effect on [{package}]({url}):**\n\n"
+            comment += self._format_changed_messages(diff.changed, source_link)
+            comment += self._format_new_messages(diff.new["messages"], source_link)
+            comment += self._format_missing_messages(
+                diff.missing["messages"], source_link
+            )
         comment = (
             f"🤖 **Effect of this PR on checked open source code:** 🤖\n\n{comment}"
             if comment
@@ -39,71 +71,84 @@ class CompareCommand(PrimerCommand):
         )
         return self._truncate_comment(comment)
 
-    def _format_new_messages(self, package: str, new_messages: PackageData) -> str:
-        comment = ""
-        count = 1
-        astroid_errors = 0
-        new_non_astroid_messages = ""
-        if new_messages["messages"]:
-            print("Now emitted:")
-        for message in new_messages["messages"]:
-            filepath = str(
-                PurePosixPath(message["path"]).relative_to(
-                    self.packages[package].clone_directory
-                )
+    def _source_link_for(
+        self, package: str, commit: str
+    ) -> Callable[[JSONMessage], str]:
+        clone_dir = self.packages[package].clone_directory
+        url = self.packages[package].url
+
+        def _link(msg: JSONMessage) -> str:
+            filepath = str(PurePosixPath(msg["path"]).relative_to(clone_dir))
+            return f"{url}/blob/{commit}/{filepath}#L{msg['line']}"
+
+        return _link
+
+    def _format_changed_messages(
+        self,
+        changed: list[ChangedMessage],
+        source_link: Callable[[JSONMessage], str],
+    ) -> str:
+        if not changed:
+            return ""
+        print("Changed:")
+        body = ""
+        for count, change in enumerate(changed, 1):
+            print(change.new)
+            body += (
+                f"{count}) [{change.new['symbol']}]({source_link(change.new)}):\n"
+                f"{message_diff(change)}\n"
             )
-            # Existing astroid errors may still show up as "new" because the timestamp
-            # in the message is slightly different.
+        return _details_section("Changed messages:", body)
+
+    def _format_new_messages(
+        self,
+        messages: list[JSONMessage],
+        source_link: Callable[[JSONMessage], str],
+    ) -> str:
+        if not messages:
+            return ""
+        print("Now emitted:")
+        astroid_errors = 0
+        fixed_fp: list[JSONMessage] = []
+        other_new: list[JSONMessage] = []
+        for message in messages:
+            print(message)
             if message["symbol"] == "astroid-error":
                 astroid_errors += 1
+            elif message["symbol"] == "useless-suppression":
+                fixed_fp.append(message)
             else:
-                new_non_astroid_messages += (
-                    f"{count}) {message['symbol']}:\n*{message['message']}*\n"
-                    f"{self.packages[package].url}/blob/{new_messages['commit']}/{filepath}#L{message['line']}\n"
-                )
-                print(message)
-                count += 1
+                other_new.append(message)
 
+        out = ""
         if astroid_errors:
-            comment += (
+            out += (
                 f'{astroid_errors} "astroid error(s)" were found. '
                 "Please open the GitHub Actions log to see what failed or crashed.\n\n"
             )
-        if new_non_astroid_messages:
-            comment += (
-                "The following messages are now emitted:\n\n<details>\n\n"
-                + new_non_astroid_messages
-                + "</details>\n\n"
+        if fixed_fp:
+            out += _details_section(
+                "🎉 Fixed false positives:", _format_messages(fixed_fp, source_link)
             )
-        return comment
+        if other_new:
+            out += _details_section(
+                "New messages:", _format_messages(other_new, source_link)
+            )
+        return out
 
     def _format_missing_messages(
-        self, package: str, missing_messages: PackageData
+        self,
+        messages: list[JSONMessage],
+        source_link: Callable[[JSONMessage], str],
     ) -> str:
-        comment = ""
-        count = 1
-        if missing_messages["messages"]:
-            comment += "The following messages are no longer emitted:\n\n<details>\n\n"
-            print("No longer emitted:")
-        for message in missing_messages["messages"]:
-            comment += f"{count}) {message['symbol']}:\n*{message['message']}*\n"
-            filepath = str(
-                PurePosixPath(message["path"]).relative_to(
-                    self.packages[package].clone_directory
-                )
-            )
-            assert not self.packages[package].url.endswith(
-                ".git"
-            ), "You don't need the .git at the end of the github url."
-            comment += (
-                f"{self.packages[package].url}"
-                f"/blob/{missing_messages['commit']}/{filepath}#L{message['line']}\n"
-            )
-            count += 1
+        if not messages:
+            return ""
+        print("No longer emitted:")
+        for message in messages:
             print(message)
-        if missing_messages["messages"]:
-            comment += "</details>\n\n"
-        return comment
+        return _details_section(
+            "Removed messages:", _format_messages(messages, source_link)
+        )
 
     def _truncate_comment(self, comment: str) -> str:
         """GitHub allows only a set number of characters in a comment."""
@@ -115,22 +160,30 @@ class CompareCommand(PrimerCommand):
                 f"*This comment was truncated because GitHub allows only"
                 f" {MAX_GITHUB_COMMENT_LENGTH} characters in a comment.*"
             )
-            # Reserve space for the suffix and a potential </details> closing tag.
+            # Reserve space for the ellipsis, the suffix and the potential
+            # closing tags for a code fence and a <details> block.
             suffix = f"\n{truncation_information}\n\n"
+            ellipsis = "\n...\n"
+            code_fence = "```\n"
             closing_tag = "</details>\n"
             max_len = (
                 MAX_GITHUB_COMMENT_LENGTH
                 - len(hash_information)
                 - len(suffix)
+                - len(ellipsis)
+                - len(code_fence)
                 - len(closing_tag)
             )
-            # Cut at the last space before the limit to avoid mid-word truncation.
-            cut_point = comment.rfind(" ", 0, max_len - 10)
-            if cut_point > 0:
-                comment = comment[:cut_point] + "...\n"
-            else:
-                comment = comment[: max_len - 10] + "...\n"
-            # Close any <details> tag left open by the truncation.
+            # Cut at the last line break before the limit so the comment ends
+            # with complete lines (links and diff lines contain no space to
+            # cut at); fall back to a hard cut inside a very long line.
+            cut_point = comment.rfind("\n", 0, max_len)
+            if cut_point <= 0:
+                cut_point = max_len
+            comment = comment[:cut_point] + ellipsis
+            # Close any code fence or <details> tag left open by the cut.
+            if comment.count("```") % 2:
+                comment += code_fence
             if comment.count("<details>") > comment.count("</details>"):
                 comment += closing_tag
             comment += suffix

--- a/tests/testutils/_primer/batched_cases/expected.txt
+++ b/tests/testutils/_primer/batched_cases/expected.txt
@@ -3,7 +3,7 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are no longer emitted:
+Removed messages:
 
 <details>
 

--- a/tests/testutils/_primer/batched_cases/expected_comparator.json
+++ b/tests/testutils/_primer/batched_cases/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 2, "new": 0 }]
+[{ "package": "astroid", "missing": 2, "new": 0, "changed": 0 }]

--- a/tests/testutils/_primer/cases/confidence_changed/expected.txt
+++ b/tests/testutils/_primer/cases/confidence_changed/expected.txt
@@ -3,22 +3,12 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+Changed messages:
 
 <details>
 
-1) dangerous-default-value:
-*Dangerous default value [] as argument*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/inference.py#L42
-</details>
-
-The following messages are no longer emitted:
-
-<details>
-
-1) dangerous-default-value:
-*Dangerous default value [] as argument*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/inference.py#L42
+1) [dangerous-default-value](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/inference.py#L42):
+confidence: `UNDEFINED` → `HIGH`
 </details>
 
 *This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/confidence_changed/expected_comparator.json
+++ b/tests/testutils/_primer/cases/confidence_changed/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 1, "new": 1 }]
+[{ "package": "astroid", "missing": 0, "new": 0, "changed": 1 }]

--- a/tests/testutils/_primer/cases/fp_hidden_by_existing_disable/expected.txt
+++ b/tests/testutils/_primer/cases/fp_hidden_by_existing_disable/expected.txt
@@ -3,7 +3,7 @@
 
 **Effect on [astropy](https://github.com/astropy/astropy):**
 
-The following messages are now emitted:
+New messages:
 
 <details>
 
@@ -12,7 +12,7 @@ The following messages are now emitted:
 https://github.com/astropy/astropy/blob/1fb40bc1f22f176254ef583065aa155f53f3b414/astropy/io/fits/file.py#L623
 </details>
 
-The following messages are no longer emitted:
+Removed messages:
 
 <details>
 

--- a/tests/testutils/_primer/cases/fp_hidden_by_existing_disable/expected_comparator.json
+++ b/tests/testutils/_primer/cases/fp_hidden_by_existing_disable/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astropy", "missing": 1, "new": 1 }]
+[{ "package": "astropy", "missing": 1, "new": 1, "changed": 0 }]

--- a/tests/testutils/_primer/cases/line_moved/expected.txt
+++ b/tests/testutils/_primer/cases/line_moved/expected.txt
@@ -3,22 +3,12 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+Changed messages:
 
 <details>
 
-1) too-complex:
-*'my_function' is too complex. The McCabe rating is 18*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L103
-</details>
-
-The following messages are no longer emitted:
-
-<details>
-
-1) too-complex:
-*'my_function' is too complex. The McCabe rating is 18*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L100
+1) [too-complex](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L103):
+Moved from `100:0`-`100:15` to `103:0`-`103:15`.
 </details>
 
 *This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/line_moved/expected_comparator.json
+++ b/tests/testutils/_primer/cases/line_moved/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 1, "new": 1 }]
+[{ "package": "astroid", "missing": 0, "new": 0, "changed": 1 }]

--- a/tests/testutils/_primer/cases/lines_crossed/expected.txt
+++ b/tests/testutils/_primer/cases/lines_crossed/expected.txt
@@ -3,28 +3,14 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+Changed messages:
 
 <details>
 
-1) unused-variable:
-*Unused variable 'node'*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/rebuilder.py#L21
-2) unused-variable:
-*Unused variable 'node'*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/rebuilder.py#L11
-</details>
-
-The following messages are no longer emitted:
-
-<details>
-
-1) unused-variable:
-*Unused variable 'node'*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/rebuilder.py#L10
-2) unused-variable:
-*Unused variable 'node'*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/rebuilder.py#L20
+1) [unused-variable](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/rebuilder.py#L11):
+Moved from `10:4`-`10:16` to `11:4`-`11:16`.
+2) [unused-variable](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/rebuilder.py#L21):
+Moved from `20:4`-`20:16` to `21:4`-`21:16`.
 </details>
 
 *This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/lines_crossed/expected_comparator.json
+++ b/tests/testutils/_primer/cases/lines_crossed/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 2, "new": 2 }]
+[{ "package": "astroid", "missing": 0, "new": 0, "changed": 2 }]

--- a/tests/testutils/_primer/cases/message_changed/expected.txt
+++ b/tests/testutils/_primer/cases/message_changed/expected.txt
@@ -3,22 +3,16 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+Changed messages:
 
 <details>
 
-1) locally-disabled:
-*Locally disabling redefined-builtin [we added some text in the message] (W0622)*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
-</details>
-
-The following messages are no longer emitted:
-
-<details>
-
-1) locally-disabled:
-*Locally disabling redefined-builtin (W0622)*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
+1) [locally-disabled](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91):
+```diff
+- Locally disabling redefined-builtin (W0622)
++ Locally disabling redefined-builtin [we added some text in the message] (W0622)
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
 </details>
 
 *This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/message_changed/expected_comparator.json
+++ b/tests/testutils/_primer/cases/message_changed/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 1, "new": 1 }]
+[{ "package": "astroid", "missing": 0, "new": 0, "changed": 1 }]

--- a/tests/testutils/_primer/cases/message_changed/expected_truncated.txt
+++ b/tests/testutils/_primer/cases/message_changed/expected_truncated.txt
@@ -3,12 +3,15 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+Changed messages:
 
 <details>
 
-1) locally-disabled:
-*Locally disabling redefined-builtin [we added some text in the message]...
+1) [locally-disabled](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91):
+```diff
+- Locally disabling redefined-builtin (W0622)
+...
+```
 </details>
 
 *This comment was truncated because GitHub allows only 525 characters in a comment.*

--- a/tests/testutils/_primer/cases/message_changed/expected_truncated_in_details.txt
+++ b/tests/testutils/_primer/cases/message_changed/expected_truncated_in_details.txt
@@ -3,12 +3,12 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+Changed messages:
 
 <details>
 
-1) locally-disabled:
-*Locally disabling redefined-builtin [we added some text in the...
+1) [locally-disabled](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91):
+...
 </details>
 
 *This comment was truncated because GitHub allows only 420 characters in a comment.*

--- a/tests/testutils/_primer/cases/message_changed_line/expected.txt
+++ b/tests/testutils/_primer/cases/message_changed_line/expected.txt
@@ -3,22 +3,18 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+Changed messages:
 
 <details>
 
-1) too-complex:
-*'my_function' is too complex. The McCabe rating is 17*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L103
-</details>
+1) [too-complex](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L103):
+Moved from `100:0`-`100:15` to `103:0`-`103:15`.
 
-The following messages are no longer emitted:
-
-<details>
-
-1) too-complex:
-*'my_function' is too complex. The McCabe rating is 18*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L100
+```diff
+- 'my_function' is too complex. The McCabe rating is 18
++ 'my_function' is too complex. The McCabe rating is 17
+                                                      ^
+```
 </details>
 
 *This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/message_changed_line/expected_comparator.json
+++ b/tests/testutils/_primer/cases/message_changed_line/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 1, "new": 1 }]
+[{ "package": "astroid", "missing": 0, "new": 0, "changed": 1 }]

--- a/tests/testutils/_primer/cases/mixed_changes/expected.txt
+++ b/tests/testutils/_primer/cases/mixed_changes/expected.txt
@@ -3,28 +3,24 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+Changed messages:
 
 <details>
 
-1) locally-disabled:
-*Locally disabling redefined-builtin [we added some text in the message] (W0622)*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
-2) too-complex:
-*'my_function' is too complex. The McCabe rating is 17*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L105
-</details>
+1) [locally-disabled](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91):
+```diff
+- Locally disabling redefined-builtin (W0622)
++ Locally disabling redefined-builtin [we added some text in the message] (W0622)
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+2) [too-complex](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L105):
+Moved from `100:0`-`100:15` to `105:0`-`105:15`.
 
-The following messages are no longer emitted:
-
-<details>
-
-1) locally-disabled:
-*Locally disabling redefined-builtin (W0622)*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
-2) too-complex:
-*'my_function' is too complex. The McCabe rating is 18*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L100
+```diff
+- 'my_function' is too complex. The McCabe rating is 18
++ 'my_function' is too complex. The McCabe rating is 17
+                                                      ^
+```
 </details>
 
 *This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/mixed_changes/expected_comparator.json
+++ b/tests/testutils/_primer/cases/mixed_changes/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 2, "new": 2 }]
+[{ "package": "astroid", "missing": 0, "new": 0, "changed": 2 }]

--- a/tests/testutils/_primer/cases/multi_package/expected.txt
+++ b/tests/testutils/_primer/cases/multi_package/expected.txt
@@ -3,28 +3,24 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+Changed messages:
 
 <details>
 
-1) too-complex:
-*'my_function' is too complex. The McCabe rating is 17*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L105
-</details>
+1) [too-complex](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L105):
+Moved from `100:0`-`100:15` to `105:0`-`105:15`.
 
-The following messages are no longer emitted:
-
-<details>
-
-1) too-complex:
-*'my_function' is too complex. The McCabe rating is 18*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L100
+```diff
+- 'my_function' is too complex. The McCabe rating is 18
++ 'my_function' is too complex. The McCabe rating is 17
+                                                      ^
+```
 </details>
 
 
 **Effect on [astropy](https://github.com/astropy/astropy):**
 
-The following messages are now emitted:
+New messages:
 
 <details>
 
@@ -33,7 +29,7 @@ The following messages are now emitted:
 https://github.com/astropy/astropy/blob/1fb40bc1f22f176254ef583065aa155f53f3b414/astropy/coordinates/angles/angle_parsetab.py#L14
 </details>
 
-The following messages are no longer emitted:
+Removed messages:
 
 <details>
 

--- a/tests/testutils/_primer/cases/multi_package/expected_comparator.json
+++ b/tests/testutils/_primer/cases/multi_package/expected_comparator.json
@@ -1,4 +1,4 @@
 [
-  { "package": "astroid", "missing": 1, "new": 1 },
-  { "package": "astropy", "missing": 1, "new": 1 }
+  { "package": "astroid", "missing": 0, "new": 0, "changed": 1 },
+  { "package": "astropy", "missing": 1, "new": 1, "changed": 0 }
 ]

--- a/tests/testutils/_primer/cases/multi_package/expected_truncated_break.txt
+++ b/tests/testutils/_primer/cases/multi_package/expected_truncated_break.txt
@@ -3,12 +3,16 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+Changed messages:
 
 <details>
 
-1) too-complex:
-*'my_function' is too complex. The McCabe rating is...
+1) [too-complex](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L105):
+Moved from `100:0`-`100:15` to `105:0`-`105:15`.
+
+```diff
+...
+```
 </details>
 
 *This comment was truncated because GitHub allows only 500 characters in a comment.*

--- a/tests/testutils/_primer/cases/multiline_message_changed/expected.txt
+++ b/tests/testutils/_primer/cases/multiline_message_changed/expected.txt
@@ -3,32 +3,23 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+Changed messages:
 
 <details>
 
-1) duplicate-code:
-*Similar lines in 2 files
-==astroid.arguments:[10:15]
-==astroid.bases:[20:25]
-    result = []
-    for arg in args:
-        result.append(arg)*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/arguments.py#L1
-</details>
-
-The following messages are no longer emitted:
-
-<details>
-
-1) duplicate-code:
-*Similar lines in 2 files
-==astroid.arguments:[10:14]
-==astroid.bases:[20:24]
-    result = []
-    for arg in args:
-        result.append(arg)*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/arguments.py#L1
+1) [duplicate-code](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/arguments.py#L1):
+```diff
+  Similar lines in 2 files
+- ==astroid.arguments:[10:14]
+- ==astroid.bases:[20:24]
++ ==astroid.arguments:[10:15]
+                           ^
++ ==astroid.bases:[20:25]
+                       ^
+      result = []
+      for arg in args:
+          result.append(arg)
+```
 </details>
 
 *This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/multiline_message_changed/expected_comparator.json
+++ b/tests/testutils/_primer/cases/multiline_message_changed/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 1, "new": 1 }]
+[{ "package": "astroid", "missing": 0, "new": 0, "changed": 1 }]

--- a/tests/testutils/_primer/cases/new_message/expected.txt
+++ b/tests/testutils/_primer/cases/new_message/expected.txt
@@ -3,7 +3,7 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+New messages:
 
 <details>
 

--- a/tests/testutils/_primer/cases/new_message/expected_comparator.json
+++ b/tests/testutils/_primer/cases/new_message/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 0, "new": 1 }]
+[{ "package": "astroid", "missing": 0, "new": 1, "changed": 0 }]

--- a/tests/testutils/_primer/cases/new_messages_classified/expected.txt
+++ b/tests/testutils/_primer/cases/new_messages_classified/expected.txt
@@ -5,17 +5,23 @@
 
 1 "astroid error(s)" were found. Please open the GitHub Actions log to see what failed or crashed.
 
-The following messages are now emitted:
+🎉 Fixed false positives:
+
+<details>
+
+1) useless-suppression:
+*Useless suppression of 'looping-through-iterator'*
+https://github.com/astropy/astropy/blob/1fb40bc1f22f176254ef583065aa155f53f3b414/astropy/coordinates/angles/angle_parsetab.py#L14
+</details>
+
+New messages:
 
 <details>
 
 1) locally-disabled:
 *Locally disabling looping-through-iterator (W4801)*
 https://github.com/astropy/astropy/blob/1fb40bc1f22f176254ef583065aa155f53f3b414/astropy/coordinates/angles/angle_parsetab.py#L14
-2) useless-suppression:
-*Useless suppression of 'looping-through-iterator'*
-https://github.com/astropy/astropy/blob/1fb40bc1f22f176254ef583065aa155f53f3b414/astropy/coordinates/angles/angle_parsetab.py#L14
-3) unused-variable:
+2) unused-variable:
 *Unused variable 'foo'*
 https://github.com/astropy/astropy/blob/1fb40bc1f22f176254ef583065aa155f53f3b414/astropy/coordinates/angles/angle_parsetab.py#L42
 </details>

--- a/tests/testutils/_primer/cases/new_messages_classified/expected_comparator.json
+++ b/tests/testutils/_primer/cases/new_messages_classified/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astropy", "missing": 0, "new": 4 }]
+[{ "package": "astropy", "missing": 0, "new": 4, "changed": 0 }]

--- a/tests/testutils/_primer/cases/persistent_astroid_error/expected.txt
+++ b/tests/testutils/_primer/cases/persistent_astroid_error/expected.txt
@@ -5,7 +5,7 @@
 
 1 "astroid error(s)" were found. Please open the GitHub Actions log to see what failed or crashed.
 
-The following messages are no longer emitted:
+Removed messages:
 
 <details>
 

--- a/tests/testutils/_primer/cases/persistent_astroid_error/expected_comparator.json
+++ b/tests/testutils/_primer/cases/persistent_astroid_error/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astropy", "missing": 1, "new": 1 }]
+[{ "package": "astropy", "missing": 1, "new": 1, "changed": 0 }]

--- a/tests/testutils/_primer/cases/removed_message/expected.txt
+++ b/tests/testutils/_primer/cases/removed_message/expected.txt
@@ -3,7 +3,7 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are no longer emitted:
+Removed messages:
 
 <details>
 

--- a/tests/testutils/_primer/cases/removed_message/expected_comparator.json
+++ b/tests/testutils/_primer/cases/removed_message/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 1, "new": 0 }]
+[{ "package": "astroid", "missing": 1, "new": 0, "changed": 0 }]

--- a/tests/testutils/_primer/cases/rename_shadowed_by_unrelated/expected.txt
+++ b/tests/testutils/_primer/cases/rename_shadowed_by_unrelated/expected.txt
@@ -3,24 +3,32 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+Changed messages:
+
+<details>
+
+1) [possibly-used-before-assignment](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/wcs.py#L3072):
+confidence: `HIGH` → `INFERENCE`
+
+```diff
+- Using variable 'orig_key' before assignment
++ Possibly using variable 'orig_key' before assignment
+  ^^^^^^^^^^
+```
+
+messageId: `E0601` → `E0606`
+
+symbol: `used-before-assignment` → `possibly-used-before-assignment`
+
+type: `error` → `warning`
+</details>
+
+New messages:
 
 <details>
 
 1) too-many-locals:
 *Too many local variables (20/15)*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/wcs.py#L3072
-2) possibly-used-before-assignment:
-*Possibly using variable 'orig_key' before assignment*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/wcs.py#L3072
-</details>
-
-The following messages are no longer emitted:
-
-<details>
-
-1) used-before-assignment:
-*Using variable 'orig_key' before assignment*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/wcs.py#L3072
 </details>
 

--- a/tests/testutils/_primer/cases/rename_shadowed_by_unrelated/expected_comparator.json
+++ b/tests/testutils/_primer/cases/rename_shadowed_by_unrelated/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 1, "new": 2 }]
+[{ "package": "astroid", "missing": 0, "new": 1, "changed": 1 }]

--- a/tests/testutils/_primer/cases/similar_symbols_not_paired/expected.txt
+++ b/tests/testutils/_primer/cases/similar_symbols_not_paired/expected.txt
@@ -3,7 +3,7 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+New messages:
 
 <details>
 
@@ -12,7 +12,7 @@ The following messages are now emitted:
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/helpers.py#L12
 </details>
 
-The following messages are no longer emitted:
+Removed messages:
 
 <details>
 

--- a/tests/testutils/_primer/cases/similar_symbols_not_paired/expected_comparator.json
+++ b/tests/testutils/_primer/cases/similar_symbols_not_paired/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 1, "new": 1 }]
+[{ "package": "astroid", "missing": 1, "new": 1, "changed": 0 }]

--- a/tests/testutils/_primer/cases/symbol_renamed/expected.txt
+++ b/tests/testutils/_primer/cases/symbol_renamed/expected.txt
@@ -3,22 +3,24 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+Changed messages:
 
 <details>
 
-1) possibly-used-before-assignment:
-*Possibly using variable 'orig_key' before assignment*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/wcs.py#L3072
-</details>
+1) [possibly-used-before-assignment](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/wcs.py#L3072):
+confidence: `HIGH` → `INFERENCE`
 
-The following messages are no longer emitted:
+```diff
+- Using variable 'orig_key' before assignment
++ Possibly using variable 'orig_key' before assignment
+  ^^^^^^^^^^
+```
 
-<details>
+messageId: `E0601` → `E0606`
 
-1) used-before-assignment:
-*Using variable 'orig_key' before assignment*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/wcs.py#L3072
+symbol: `used-before-assignment` → `possibly-used-before-assignment`
+
+type: `error` → `warning`
 </details>
 
 *This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/symbol_renamed/expected_comparator.json
+++ b/tests/testutils/_primer/cases/symbol_renamed/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 1, "new": 1 }]
+[{ "package": "astroid", "missing": 0, "new": 0, "changed": 1 }]

--- a/tests/testutils/_primer/cases/symbol_renamed_and_moved/expected.txt
+++ b/tests/testutils/_primer/cases/symbol_renamed_and_moved/expected.txt
@@ -3,7 +3,7 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+New messages:
 
 <details>
 
@@ -12,7 +12,7 @@ The following messages are now emitted:
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/wcs.py#L3074
 </details>
 
-The following messages are no longer emitted:
+Removed messages:
 
 <details>
 

--- a/tests/testutils/_primer/cases/symbol_renamed_and_moved/expected_comparator.json
+++ b/tests/testutils/_primer/cases/symbol_renamed_and_moved/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 1, "new": 1 }]
+[{ "package": "astroid", "missing": 1, "new": 1, "changed": 0 }]

--- a/tests/testutils/_primer/cases/type_changed/expected.txt
+++ b/tests/testutils/_primer/cases/type_changed/expected.txt
@@ -3,22 +3,12 @@
 
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
 
-The following messages are now emitted:
+Changed messages:
 
 <details>
 
-1) line-too-long:
-*Line too long (120/100)*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L50
-</details>
-
-The following messages are no longer emitted:
-
-<details>
-
-1) line-too-long:
-*Line too long (120/100)*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L50
+1) [line-too-long](https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L50):
+type: `convention` → `warning`
 </details>
 
 *This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/type_changed/expected_comparator.json
+++ b/tests/testutils/_primer/cases/type_changed/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astroid", "missing": 1, "new": 1 }]
+[{ "package": "astroid", "missing": 0, "new": 0, "changed": 1 }]

--- a/tests/testutils/_primer/cases/useless_suppression/expected.txt
+++ b/tests/testutils/_primer/cases/useless_suppression/expected.txt
@@ -3,7 +3,7 @@
 
 **Effect on [astropy](https://github.com/astropy/astropy):**
 
-The following messages are now emitted:
+🎉 Fixed false positives:
 
 <details>
 
@@ -12,7 +12,7 @@ The following messages are now emitted:
 https://github.com/astropy/astropy/blob/1fb40bc1f22f176254ef583065aa155f53f3b414/astropy/coordinates/angles/angle_parsetab.py#L14
 </details>
 
-The following messages are no longer emitted:
+Removed messages:
 
 <details>
 

--- a/tests/testutils/_primer/cases/useless_suppression/expected_comparator.json
+++ b/tests/testutils/_primer/cases/useless_suppression/expected_comparator.json
@@ -1,1 +1,1 @@
-[{ "package": "astropy", "missing": 1, "new": 1 }]
+[{ "package": "astropy", "missing": 1, "new": 1, "changed": 0 }]

--- a/tests/testutils/_primer/test_comparator.py
+++ b/tests/testutils/_primer/test_comparator.py
@@ -4,12 +4,41 @@
 
 import json
 from pathlib import Path
+from typing import cast
 
 import pytest
 
-from pylint.testutils._primer.comparator import Comparator
+from pylint.reporters.json_reporter import JSONMessage
+from pylint.testutils._primer.comparator import (
+    ChangedMessage,
+    Comparator,
+    _caret_hint,
+    _is_symbol_rename,
+    format_span,
+    message_diff,
+)
 
 CASES_PATH = Path(__file__).parent / "cases"
+
+
+def _msg(**overrides: object) -> JSONMessage:
+    base: dict[str, object] = {
+        "type": "warning",
+        "module": "m",
+        "obj": "",
+        "line": 1,
+        "column": 0,
+        "endLine": 1,
+        "endColumn": 5,
+        "path": "m.py",
+        "symbol": "s",
+        "message": "msg",
+        "messageId": "W0000",
+        "confidence": "UNDEFINED",
+        "absolutePath": "m.py",
+    }
+    base.update(overrides)
+    return cast(JSONMessage, base)
 
 
 @pytest.mark.parametrize(
@@ -22,10 +51,79 @@ def test_comparator(directory: Path) -> None:
     expected = json.loads((directory / "expected_comparator.json").read_text("utf-8"))
     results = list(comparator)
     assert len(results) == len(expected)
-    for (package, missing, new), exp in zip(results, expected):
+    for (package, missing, new, changed), exp in zip(results, expected):
         assert package == exp["package"]
         assert len(missing["messages"]) == exp["missing"]
         assert len(new["messages"]) == exp["new"]
+        assert len(changed) == exp["changed"]
+
+
+def test_format_span_without_end_position() -> None:
+    """Messages missing endLine/endColumn fall back to a start-only span."""
+    assert (
+        format_span(_msg(line=42, column=7, endLine=None, endColumn=None)) == "`42:7`"
+    )
+
+
+def test_format_span_with_end_position() -> None:
+    assert (
+        format_span(_msg(line=42, column=7, endLine=43, endColumn=2)) == "`42:7`-`43:2`"
+    )
+
+
+def test_message_diff_merges_location_changes() -> None:
+    """All location fields collapse into a single 'Moved from' sentence."""
+    old = _msg()
+    new = _msg(line=2, column=1, endLine=2, endColumn=6)
+    assert message_diff(ChangedMessage(old=old, new=new)) == (
+        "Moved from `1:0`-`1:5` to `2:1`-`2:6`."
+    )
+
+
+def test_caret_hint_returns_empty_when_mostly_changed() -> None:
+    """When more than 60% of the text differs, carets are noise and are skipped."""
+    assert _caret_hint("hello world", "goodbye universe") == ""
+
+
+@pytest.mark.parametrize(
+    ("old_symbol", "new_symbol", "expected"),
+    [
+        ("used-before-assignment", "possibly-used-before-assignment", True),
+        ("abstract-method", "no-abstract-method", True),
+        ("useless-suppression", "locally-disabled", False),
+        ("too-complex", "too-many-locals", False),
+        # Similar-looking but unrelated symbols must stay below the threshold.
+        ("unused-variable", "unused-import", False),
+        ("no-member", "no-name-in-module", False),
+    ],
+)
+def test_is_symbol_rename(old_symbol: str, new_symbol: str, expected: bool) -> None:
+    old = _msg(symbol=old_symbol)
+    new = _msg(symbol=new_symbol)
+    assert _is_symbol_rename(old, new) is expected
+
+
+def test_message_diff_field_on_one_side_only() -> None:
+    """A field present on only one side must not crash the diff rendering."""
+    old = _msg()
+    new = _msg(suggestion="use x instead")
+    diff = message_diff(ChangedMessage(old=old, new=new))
+    assert "suggestion: `None` → `use x instead`" in diff
+
+
+def test_message_diff_multiline_value_diffs_line_by_line() -> None:
+    """Multi-line messages (e.g. duplicate-code) diff per line, keeping context."""
+    old = _msg(message="Similar lines in 2 files\n==a:[10:14]\nresult = []")
+    new = _msg(message="Similar lines in 2 files\n==a:[10:15]\nresult = []")
+    assert message_diff(ChangedMessage(old=old, new=new)) == (
+        "```diff\n"
+        "  Similar lines in 2 files\n"
+        "- ==a:[10:14]\n"
+        "+ ==a:[10:15]\n"
+        "           ^\n"
+        "  result = []\n"
+        "```"
+    )
 
 
 def test_comparator_batched() -> None:
@@ -38,7 +136,8 @@ def test_comparator_batched() -> None:
     expected = json.loads((fixture / "expected_comparator.json").read_text("utf-8"))
     results = list(comparator)
     assert len(results) == len(expected)
-    for (package, missing, new), exp in zip(results, expected):
+    for (package, missing, new, changed), exp in zip(results, expected):
         assert package == exp["package"]
         assert len(missing["messages"]) == exp["missing"]
         assert len(new["messages"]) == exp["new"]
+        assert len(changed) == exp["changed"]

--- a/tests/testutils/_primer/test_primer.py
+++ b/tests/testutils/_primer/test_primer.py
@@ -118,8 +118,8 @@ class TestPrimer:
             )
         assert len(content) < max_comment_length
 
-    def test_truncate_falls_back_when_no_space(self) -> None:
-        """When the pre-limit prefix has no space, cut at ``max_len - 10`` directly."""
+    def test_truncate_falls_back_when_no_line_break(self) -> None:
+        """When the pre-limit prefix has no line break, cut inside the line."""
         max_comment_length = 200
         config = argparse.Namespace(commit="v2.14.2")
         command = CompareCommand(PRIMER_DIRECTORY, {}, config)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Description

Instead of reporting moved or reworded diagnostics as separate removal + addition, the primer comparator now pairs residual messages by (symbol, path, obj) and shows a compact diff of what changed.                    
                                                            
  Rendering improvements:                                                                                                                                                                                                  
  - Symbol name is a clickable link to the source location  
  - Location changes shown with backtick-formatted spans (100:0 to 100:15)
  - ^^ caret hints highlight exactly which characters changed in the message text
  - Blank line before ```diff blocks so GitHub renders them correctly                                                                                                                                                      
  - Extract _details_section helper to deduplicate <details> wrapping                                                                                                                                                      
                                                                                                                                                                                                                           
  Test infrastructure:                                                                                                                                                                                                     
  - Move test data from cases/ and batched_cases/ to fixtures/                                                                                                                                                             
  - Add fixtures: line_moved, message_changed_line, mixed_changes, type_changed                                                                                                                                            
  - Add test_truncated_compare_in_details for truncation inside a <details> block
