### PR TITLE
Pin primer packages to explicit commits, auto-update on release

### DIFF
--- a/pylint/testutils/_primer/package_to_lint.py
+++ b/pylint/testutils/_primer/package_to_lint.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Literal
 
 from git import GitCommandError
-from git.cmd import Git
 from git.repo import Repo
 
 PRIMER_DIRECTORY_PATH = Path("tests") / ".pylint_primer_tests"
@@ -43,7 +42,7 @@ class PackageToLint:
     directories: list[str]
     """Directories within the repository to run pylint over."""
 
-    commit: str | None = None
+    commit: str
     """Commit hash to pin the repository on."""
 
     pylint_additional_args: list[str] = field(default_factory=list)
@@ -99,63 +98,39 @@ class PackageToLint:
         return self._pull_repository()
 
     def _clone_repository(self) -> str:
-        options: dict[str, str | int] = {
-            "url": self.url,
-            "to_path": str(self.clone_directory),
-            "branch": self.branch,
-            "depth": 1,
-        }
-        logging.info("Directory does not exists, cloning: %s", options)
+        logging.info(
+            "Directory does not exist, cloning %s (branch %s, commit %s)",
+            self.url,
+            self.branch,
+            self.commit,
+        )
         repo = Repo.clone_from(
             url=self.url, to_path=self.clone_directory, branch=self.branch, depth=1
         )
-        if self.commit:
-            repo.git.fetch("origin", self.commit, depth=1)
-            repo.git.checkout(self.commit)
+        repo.git.fetch("origin", self.commit, depth=1)
+        repo.git.checkout(self.commit)
         return str(repo.head.object.hexsha)
 
     def _pull_repository(self) -> str:
         repo = Repo(self.clone_directory)
-        local_sha1_commit = str(repo.head.object.hexsha)
+        local_sha1_commit: str = repo.head.object.hexsha
 
-        target_commit = self.commit
-        if target_commit and local_sha1_commit.startswith(target_commit):
-            logging.info("Repository already at pinned commit %s.", target_commit)
+        if local_sha1_commit.startswith(self.commit):
+            logging.info("Repository already at pinned commit %s.", self.commit)
             return local_sha1_commit
 
-        if target_commit:
-            logging.info(
-                "Pinned commit is '%s' while local is '%s': fetching",
-                target_commit,
-                local_sha1_commit,
-            )
-            try:
-                if repo.is_dirty():
-                    raise DirtyPrimerDirectoryException(self.clone_directory)
-                repo.git.fetch("origin", target_commit, depth=1)
-                repo.git.checkout(target_commit)
-            except GitCommandError as e:
-                raise SystemError(
-                    f"Failed to fetch pinned commit for {self.clone_directory}"
-                ) from e
-            return str(repo.head.object.hexsha)
-
-        remote_sha1_commit = Git().ls_remote(self.url, self.branch).split("\t")[0]
-        if remote_sha1_commit != local_sha1_commit:
-            logging.info(
-                "Remote sha is '%s' while local sha is '%s': pulling new commits",
-                remote_sha1_commit,
-                local_sha1_commit,
-            )
-            try:
-                if repo.is_dirty():
-                    raise DirtyPrimerDirectoryException(self.clone_directory)
-                origin = repo.remotes.origin
-                origin.pull()
-            except GitCommandError as e:
-                raise SystemError(
-                    f"Failed to clone repository for {self.clone_directory}"
-                ) from e
-        else:
-            logging.info("Repository already up to date.")
-        return str(remote_sha1_commit)
+        logging.info(
+            "Pinned commit is '%s' while local is '%s': fetching",
+            self.commit,
+            local_sha1_commit,
+        )
+        try:
+            if repo.is_dirty():
+                raise DirtyPrimerDirectoryException(self.clone_directory)
+            repo.git.fetch("origin", self.commit, depth=1)
+            repo.git.checkout(self.commit)
+        except GitCommandError as e:
+            raise SystemError(
+                f"Failed to fetch pinned commit for {self.clone_directory}"
+            ) from e
+        return str(repo.head.object.hexsha)

--- a/pylint/testutils/_primer/package_to_lint.py
+++ b/pylint/testutils/_primer/package_to_lint.py
@@ -99,14 +99,12 @@ class PackageToLint:
 
     def _clone_repository(self) -> str:
         logging.info(
-            "Directory does not exist, cloning %s (branch %s, commit %s)",
+            "Directory does not exist, cloning %s at commit %s",
             self.url,
-            self.branch,
             self.commit,
         )
-        repo = Repo.clone_from(
-            url=self.url, to_path=self.clone_directory, branch=self.branch, depth=1
-        )
+        repo = Repo.init(self.clone_directory)
+        repo.create_remote("origin", self.url)
         repo.git.fetch("origin", self.commit, depth=1)
         repo.git.checkout(self.commit)
         return str(repo.head.object.hexsha)

--- a/pylint/testutils/_primer/package_to_lint.py
+++ b/pylint/testutils/_primer/package_to_lint.py
@@ -109,11 +109,38 @@ class PackageToLint:
         repo = Repo.clone_from(
             url=self.url, to_path=self.clone_directory, branch=self.branch, depth=1
         )
+        if self.commit:
+            repo.git.fetch("origin", self.commit, depth=1)
+            repo.git.checkout(self.commit)
         return str(repo.head.object.hexsha)
 
     def _pull_repository(self) -> str:
+        repo = Repo(self.clone_directory)
+        local_sha1_commit = str(repo.head.object.hexsha)
+
+        target_commit = self.commit
+        if target_commit and local_sha1_commit.startswith(target_commit):
+            logging.info("Repository already at pinned commit %s.", target_commit)
+            return local_sha1_commit
+
+        if target_commit:
+            logging.info(
+                "Pinned commit is '%s' while local is '%s': fetching",
+                target_commit,
+                local_sha1_commit,
+            )
+            try:
+                if repo.is_dirty():
+                    raise DirtyPrimerDirectoryException(self.clone_directory)
+                repo.git.fetch("origin", target_commit, depth=1)
+                repo.git.checkout(target_commit)
+            except GitCommandError as e:
+                raise SystemError(
+                    f"Failed to fetch pinned commit for {self.clone_directory}"
+                ) from e
+            return str(repo.head.object.hexsha)
+
         remote_sha1_commit = Git().ls_remote(self.url, self.branch).split("\t")[0]
-        local_sha1_commit = Repo(self.clone_directory).head.object.hexsha
         if remote_sha1_commit != local_sha1_commit:
             logging.info(
                 "Remote sha is '%s' while local sha is '%s': pulling new commits",
@@ -121,7 +148,6 @@ class PackageToLint:
                 local_sha1_commit,
             )
             try:
-                repo = Repo(self.clone_directory)
                 if repo.is_dirty():
                     raise DirtyPrimerDirectoryException(self.clone_directory)
                 origin = repo.remotes.origin

--- a/script/update_primer_commits.py
+++ b/script/update_primer_commits.py
@@ -14,7 +14,10 @@ from pathlib import Path
 from git.cmd import Git
 
 PACKAGES_FILE = (
-    Path(__file__).resolve().parent.parent / "tests" / "primer" / "packages_to_prime.json"
+    Path(__file__).resolve().parent.parent
+    / "tests"
+    / "primer"
+    / "packages_to_prime.json"
 )
 
 

--- a/script/update_primer_commits.py
+++ b/script/update_primer_commits.py
@@ -1,0 +1,40 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Update the pinned commit hashes in packages_to_prime.json to the latest
+remote HEAD of each package's branch.
+
+Called automatically by tbump before a release commit.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from git.cmd import Git
+
+PACKAGES_FILE = (
+    Path(__file__).resolve().parent.parent / "tests/primer/packages_to_prime.json"
+)
+
+
+def main() -> None:
+    text = PACKAGES_FILE.read_text(encoding="utf-8")
+    packages = json.loads(text)
+
+    for name, data in packages.items():
+        old = data["commit"]
+        sha = Git().ls_remote(data["url"], data["branch"]).split("\t")[0]
+        if sha != old:
+            print(f"  {name}: {old[:12]} -> {sha[:12]}")
+            text = text.replace(old, sha)
+        else:
+            print(f"  {name}: up to date ({sha[:12]})")
+
+    PACKAGES_FILE.write_text(text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/update_primer_commits.py
+++ b/script/update_primer_commits.py
@@ -8,15 +8,13 @@ remote HEAD of each package's branch.
 Called automatically by tbump before a release commit.
 """
 
-from __future__ import annotations
-
 import json
 from pathlib import Path
 
 from git.cmd import Git
 
 PACKAGES_FILE = (
-    Path(__file__).resolve().parent.parent / "tests/primer/packages_to_prime.json"
+    Path(__file__).resolve().parent.parent / "tests" / "primer" / "packages_to_prime.json"
 )
 
 

--- a/tbump.toml
+++ b/tbump.toml
@@ -58,6 +58,10 @@ name = "Upgrade the contributors list"
 cmd = "python3 script/create_contributor_list.py"
 
 [[before_commit]]
+name = "Update primer commit pins to latest"
+cmd = "python3 script/update_primer_commits.py"
+
+[[before_commit]]
 name = "Apply pre-commit"
 cmd = "pre-commit run --all-files||echo 'Hack so this command does not fail'"
 

--- a/tests/primer/packages_to_prime.json
+++ b/tests/primer/packages_to_prime.json
@@ -1,83 +1,98 @@
 {
   "astropy": {
     "branch": "main",
+    "commit": "ed8dd553853d9be8800aaea50d306e74e1025bd6",
     "directories": ["astropy"],
     "url": "https://github.com/astropy/astropy"
   },
   "ansible": {
     "branch": "devel",
+    "commit": "a8003fe7323cc10b9b74a4ef3bc4f0f02a51aa5e",
     "directories": ["lib/ansible"],
     "url": "https://github.com/ansible/ansible",
     "pylintrc_relpath": "test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg"
   },
   "astroid": {
     "branch": "main",
+    "commit": "a0488ceab0436dd7fac738098b3ee0f05a485a15",
     "directories": ["astroid"],
     "url": "https://github.com/pylint-dev/astroid",
     "pylintrc_relpath": "pylintrc"
   },
   "black": {
     "branch": "main",
+    "commit": "0dae20b2d009f2f03de8696d06b0c947d3abafc9",
     "directories": ["src/black/", "src/blackd/", "src/blib2to3/"],
     "url": "https://github.com/psf/black"
   },
   "coverage": {
     "branch": "main",
+    "commit": "0829a651e11beb59a9f4db469f1f0447e1608f99",
     "directories": ["coverage"],
     "url": "https://github.com/nedbat/coveragepy",
     "pylintrc_relpath": "pyproject.toml"
   },
   "django": {
     "branch": "main",
+    "commit": "3483bfc0920b0ef0b28563aabe8ff546699b6ece",
     "directories": ["django"],
     "minimum_python": "3.12",
     "url": "https://github.com/django/django"
   },
   "flask": {
     "branch": "main",
+    "commit": "4cae5d8e411b1e69949d8fae669afeacbd3e5908",
     "directories": ["src/flask"],
     "url": "https://github.com/pallets/flask"
   },
   "home-assistant": {
     "branch": "dev",
+    "commit": "60dc88fa1530c8d549871d44efdaa2ec8844522c",
     "directories": ["homeassistant"],
     "url": "https://github.com/home-assistant/core"
   },
   "music21": {
     "branch": "master",
+    "commit": "65fe74f6584bdeed8421dc57b0452b4d364e4159",
     "directories": ["music21"],
     "pylintrc_relpath": ".pylintrc",
     "url": "https://github.com/cuthbertLab/music21"
   },
   "pandas": {
     "branch": "main",
+    "commit": "32bef071aa4cbd4565c4601f918cd231ad0bdbc1",
     "directories": ["pandas/core"],
     "pylint_additional_args": ["--ignore-patterns=\"test_"],
     "url": "https://github.com/pandas-dev/pandas"
   },
   "poetry-core": {
     "branch": "main",
+    "commit": "d4315275a74d327e617de4174fea85ee475d71e7",
     "directories": ["src"],
     "url": "https://github.com/python-poetry/poetry-core",
     "pylint_additional_args": ["--recursive=y", "--source-roots=src"]
   },
   "psycopg": {
     "branch": "master",
+    "commit": "e61b15ab1015d012d6f124ce2f2955bbf15a187f",
     "directories": ["psycopg/psycopg"],
     "url": "https://github.com/psycopg/psycopg"
   },
   "pygame": {
     "branch": "main",
+    "commit": "85fda3f719d437cf27106afae8c890e6b88ba5f5",
     "directories": ["src_py"],
     "url": "https://github.com/pygame/pygame"
   },
   "pytest": {
     "branch": "main",
+    "commit": "f7338e05685c952f21f838f0beab95cd29e05452",
     "directories": ["src/_pytest"],
     "url": "https://github.com/pytest-dev/pytest"
   },
   "sentry": {
     "branch": "master",
+    "commit": "0807ef56c72c4b7706ad12c45560dace6543f203",
     "directories": ["src/sentry"],
     "url": "https://github.com/getsentry/sentry"
   }

--- a/tests/primer/packages_to_prime.json
+++ b/tests/primer/packages_to_prime.json
@@ -1,13 +1,13 @@
 {
   "astropy": {
     "branch": "main",
-    "commit": "ed8dd553853d9be8800aaea50d306e74e1025bd6",
+    "commit": "1fb40bc1f22f176254ef583065aa155f53f3b414",
     "directories": ["astropy"],
     "url": "https://github.com/astropy/astropy"
   },
   "ansible": {
     "branch": "devel",
-    "commit": "a8003fe7323cc10b9b74a4ef3bc4f0f02a51aa5e",
+    "commit": "3f10c2c0a910b15675534891ca567dcde355ad8e",
     "directories": ["lib/ansible"],
     "url": "https://github.com/ansible/ansible",
     "pylintrc_relpath": "test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg"
@@ -21,20 +21,20 @@
   },
   "black": {
     "branch": "main",
-    "commit": "0dae20b2d009f2f03de8696d06b0c947d3abafc9",
+    "commit": "acc73dc4ff97d2c1d5999914a9a182b6e2728b8a",
     "directories": ["src/black/", "src/blackd/", "src/blib2to3/"],
     "url": "https://github.com/psf/black"
   },
   "coverage": {
     "branch": "main",
-    "commit": "0829a651e11beb59a9f4db469f1f0447e1608f99",
+    "commit": "2a53705f5fe588158b8a8d37ff3beee86388b9e4",
     "directories": ["coverage"],
     "url": "https://github.com/nedbat/coveragepy",
     "pylintrc_relpath": "pyproject.toml"
   },
   "django": {
     "branch": "main",
-    "commit": "3483bfc0920b0ef0b28563aabe8ff546699b6ece",
+    "commit": "ad5ea292748246b2f07f3e379a250985c1ebcba5",
     "directories": ["django"],
     "minimum_python": "3.12",
     "url": "https://github.com/django/django"
@@ -47,7 +47,7 @@
   },
   "home-assistant": {
     "branch": "dev",
-    "commit": "60dc88fa1530c8d549871d44efdaa2ec8844522c",
+    "commit": "9ad1356e4b3ee8c837c28dfde850fab8b6927aea",
     "directories": ["homeassistant"],
     "url": "https://github.com/home-assistant/core"
   },
@@ -60,7 +60,7 @@
   },
   "pandas": {
     "branch": "main",
-    "commit": "32bef071aa4cbd4565c4601f918cd231ad0bdbc1",
+    "commit": "b77f5fc2227d91b09f90bebd905cc6ff3ae3c1f4",
     "directories": ["pandas/core"],
     "pylint_additional_args": ["--ignore-patterns=\"test_"],
     "url": "https://github.com/pandas-dev/pandas"
@@ -86,13 +86,13 @@
   },
   "pytest": {
     "branch": "main",
-    "commit": "f7338e05685c952f21f838f0beab95cd29e05452",
+    "commit": "77dceaa1fd1598293a7a39a837f859620a07002f",
     "directories": ["src/_pytest"],
     "url": "https://github.com/pytest-dev/pytest"
   },
   "sentry": {
     "branch": "master",
-    "commit": "0807ef56c72c4b7706ad12c45560dace6543f203",
+    "commit": "7a701584e61d8a093132eb37c45fd0359c1652ee",
     "directories": ["src/sentry"],
     "url": "https://github.com/getsentry/sentry"
   }

--- a/tests/testutils/_primer/test_package_to_lint.py
+++ b/tests/testutils/_primer/test_package_to_lint.py
@@ -119,6 +119,7 @@ def test_pull_repository_dirty_raises(mock_repo_cls: MagicMock) -> None:
     with pytest.raises(DirtyPrimerDirectoryException):
         FAKE_PACKAGE._pull_repository()
 
+
 @patch("pylint.testutils._primer.package_to_lint.Repo")
 def test_pull_repository_git_error_raises_system_error(
     mock_repo_cls: MagicMock,

--- a/tests/testutils/_primer/test_package_to_lint.py
+++ b/tests/testutils/_primer/test_package_to_lint.py
@@ -69,19 +69,15 @@ FAKE_PACKAGE = PackageToLint(
 
 @patch("pylint.testutils._primer.package_to_lint.Repo")
 def test_clone_repository(mock_repo_cls: MagicMock) -> None:
-    """Test _clone_repository clones then checks out the pinned commit."""
+    """Test _clone_repository inits, adds remote, and checks out the pinned commit."""
     mock_repo = MagicMock()
     mock_repo.head.object.hexsha = FAKE_COMMIT
-    mock_repo_cls.clone_from.return_value = mock_repo
+    mock_repo_cls.init.return_value = mock_repo
 
     result = FAKE_PACKAGE._clone_repository()  # pylint: disable=protected-access
 
-    mock_repo_cls.clone_from.assert_called_once_with(
-        url=FAKE_PACKAGE.url,
-        to_path=FAKE_PACKAGE.clone_directory,
-        branch="main",
-        depth=1,
-    )
+    mock_repo_cls.init.assert_called_once_with(FAKE_PACKAGE.clone_directory)
+    mock_repo.create_remote.assert_called_once_with("origin", FAKE_PACKAGE.url)
     mock_repo.git.fetch.assert_called_once_with("origin", FAKE_COMMIT, depth=1)
     mock_repo.git.checkout.assert_called_once_with(FAKE_COMMIT)
     assert result == FAKE_COMMIT

--- a/tests/testutils/_primer/test_package_to_lint.py
+++ b/tests/testutils/_primer/test_package_to_lint.py
@@ -69,13 +69,12 @@ FAKE_PACKAGE = PackageToLint(
 
 @patch("pylint.testutils._primer.package_to_lint.Repo")
 def test_clone_repository(mock_repo_cls: MagicMock) -> None:
-    """Test _clone_repository inits, adds remote, and checks out the pinned commit."""
+    """Test _clone_repository initialization, adds remote, and checks out the pinned commit."""
     mock_repo = MagicMock()
     mock_repo.head.object.hexsha = FAKE_COMMIT
     mock_repo_cls.init.return_value = mock_repo
 
-    result = FAKE_PACKAGE._clone_repository()  # pylint: disable=protected-access
-
+    result = FAKE_PACKAGE._clone_repository()
     mock_repo_cls.init.assert_called_once_with(FAKE_PACKAGE.clone_directory)
     mock_repo.create_remote.assert_called_once_with("origin", FAKE_PACKAGE.url)
     mock_repo.git.fetch.assert_called_once_with("origin", FAKE_COMMIT, depth=1)
@@ -90,8 +89,7 @@ def test_pull_repository_already_at_commit(mock_repo_cls: MagicMock) -> None:
     mock_repo.head.object.hexsha = FAKE_COMMIT
     mock_repo_cls.return_value = mock_repo
 
-    result = FAKE_PACKAGE._pull_repository()  # pylint: disable=protected-access
-
+    result = FAKE_PACKAGE._pull_repository()
     assert result == FAKE_COMMIT
     mock_repo.git.fetch.assert_not_called()
 
@@ -104,8 +102,7 @@ def test_pull_repository_fetches_new_commit(mock_repo_cls: MagicMock) -> None:
     mock_repo.is_dirty.return_value = False
     mock_repo_cls.return_value = mock_repo
 
-    FAKE_PACKAGE._pull_repository()  # pylint: disable=protected-access
-
+    FAKE_PACKAGE._pull_repository()
     mock_repo.is_dirty.assert_called_once()
     mock_repo.git.fetch.assert_called_once_with("origin", FAKE_COMMIT, depth=1)
     mock_repo.git.checkout.assert_called_once_with(FAKE_COMMIT)
@@ -120,8 +117,7 @@ def test_pull_repository_dirty_raises(mock_repo_cls: MagicMock) -> None:
     mock_repo_cls.return_value = mock_repo
 
     with pytest.raises(DirtyPrimerDirectoryException):
-        FAKE_PACKAGE._pull_repository()  # pylint: disable=protected-access
-
+        FAKE_PACKAGE._pull_repository()
 
 @patch("pylint.testutils._primer.package_to_lint.Repo")
 def test_pull_repository_git_error_raises_system_error(
@@ -135,4 +131,4 @@ def test_pull_repository_git_error_raises_system_error(
     mock_repo_cls.return_value = mock_repo
 
     with pytest.raises(SystemError, match="Failed to fetch pinned commit"):
-        FAKE_PACKAGE._pull_repository()  # pylint: disable=protected-access
+        FAKE_PACKAGE._pull_repository()

--- a/tests/testutils/_primer/test_package_to_lint.py
+++ b/tests/testutils/_primer/test_package_to_lint.py
@@ -16,6 +16,7 @@ def test_package_to_lint() -> None:
         url="https://github.com/vimeo/graph-explorer.git",
         branch="main",
         directories=["graph_explorer"],
+        commit="abc123",
         pylintrc_relpath=".pylintrcui",
         pylint_additional_args=args,
     )
@@ -42,6 +43,7 @@ def test_package_to_lint_default_value() -> None:
         url="https://github.com/pallets/flask.git",
         branch="main",
         directories=["src/flask"],  # Must work on Windows (src\\flask)
+        commit="abc123",
     )
     assert package_to_lint.pylintrc == ""
     expected_path_to_lint = (

--- a/tests/testutils/_primer/test_package_to_lint.py
+++ b/tests/testutils/_primer/test_package_to_lint.py
@@ -2,7 +2,13 @@
 # For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
 
+from unittest.mock import MagicMock, patch
+
+import pytest
+from git import GitCommandError
+
 from pylint.testutils._primer import PRIMER_DIRECTORY_PATH, PackageToLint
+from pylint.testutils._primer.package_to_lint import DirtyPrimerDirectoryException
 
 
 def test_package_to_lint() -> None:
@@ -50,3 +56,87 @@ def test_package_to_lint_default_value() -> None:
         PRIMER_DIRECTORY_PATH / "pallets" / "flask" / "src" / "flask"
     )
     assert package_to_lint.pylint_args == [str(expected_path_to_lint), "--rcfile="]
+
+
+FAKE_COMMIT = "abc123def456789"
+FAKE_PACKAGE = PackageToLint(
+    url="https://github.com/fake/repo",
+    branch="main",
+    directories=["src"],
+    commit=FAKE_COMMIT,
+)
+
+
+@patch("pylint.testutils._primer.package_to_lint.Repo")
+def test_clone_repository(mock_repo_cls: MagicMock) -> None:
+    """Test _clone_repository clones then checks out the pinned commit."""
+    mock_repo = MagicMock()
+    mock_repo.head.object.hexsha = FAKE_COMMIT
+    mock_repo_cls.clone_from.return_value = mock_repo
+
+    result = FAKE_PACKAGE._clone_repository()  # pylint: disable=protected-access
+
+    mock_repo_cls.clone_from.assert_called_once_with(
+        url=FAKE_PACKAGE.url,
+        to_path=FAKE_PACKAGE.clone_directory,
+        branch="main",
+        depth=1,
+    )
+    mock_repo.git.fetch.assert_called_once_with("origin", FAKE_COMMIT, depth=1)
+    mock_repo.git.checkout.assert_called_once_with(FAKE_COMMIT)
+    assert result == FAKE_COMMIT
+
+
+@patch("pylint.testutils._primer.package_to_lint.Repo")
+def test_pull_repository_already_at_commit(mock_repo_cls: MagicMock) -> None:
+    """Test _pull_repository short-circuits when already at the pinned commit."""
+    mock_repo = MagicMock()
+    mock_repo.head.object.hexsha = FAKE_COMMIT
+    mock_repo_cls.return_value = mock_repo
+
+    result = FAKE_PACKAGE._pull_repository()  # pylint: disable=protected-access
+
+    assert result == FAKE_COMMIT
+    mock_repo.git.fetch.assert_not_called()
+
+
+@patch("pylint.testutils._primer.package_to_lint.Repo")
+def test_pull_repository_fetches_new_commit(mock_repo_cls: MagicMock) -> None:
+    """Test _pull_repository fetches and checks out when commit differs."""
+    mock_repo = MagicMock()
+    mock_repo.head.object.hexsha = "old_commit_hash"
+    mock_repo.is_dirty.return_value = False
+    mock_repo_cls.return_value = mock_repo
+
+    FAKE_PACKAGE._pull_repository()  # pylint: disable=protected-access
+
+    mock_repo.is_dirty.assert_called_once()
+    mock_repo.git.fetch.assert_called_once_with("origin", FAKE_COMMIT, depth=1)
+    mock_repo.git.checkout.assert_called_once_with(FAKE_COMMIT)
+
+
+@patch("pylint.testutils._primer.package_to_lint.Repo")
+def test_pull_repository_dirty_raises(mock_repo_cls: MagicMock) -> None:
+    """Test _pull_repository raises when the local clone is dirty."""
+    mock_repo = MagicMock()
+    mock_repo.head.object.hexsha = "old_commit_hash"
+    mock_repo.is_dirty.return_value = True
+    mock_repo_cls.return_value = mock_repo
+
+    with pytest.raises(DirtyPrimerDirectoryException):
+        FAKE_PACKAGE._pull_repository()  # pylint: disable=protected-access
+
+
+@patch("pylint.testutils._primer.package_to_lint.Repo")
+def test_pull_repository_git_error_raises_system_error(
+    mock_repo_cls: MagicMock,
+) -> None:
+    """Test _pull_repository wraps GitCommandError in SystemError."""
+    mock_repo = MagicMock()
+    mock_repo.head.object.hexsha = "old_commit_hash"
+    mock_repo.is_dirty.return_value = False
+    mock_repo.git.fetch.side_effect = GitCommandError("git fetch", 128)
+    mock_repo_cls.return_value = mock_repo
+
+    with pytest.raises(SystemError, match="Failed to fetch pinned commit"):
+        FAKE_PACKAGE._pull_repository()  # pylint: disable=protected-access


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |

## Issue
Closes #8998

## Description

Primer results could change between runs when upstream repos push new code. Pin each package to a specific commit hash and checkout that commit during clone/pull. A new tbump hook runs
script/update_primer_commits.py to refresh pins to latest on release.
