### PR TITLE
Fix augmented sys.path handling for parallel namespace-package checks

### DIFF
--- a/doc/whatsnew/fragments/10794.false_positive
+++ b/doc/whatsnew/fragments/10794.false_positive
@@ -1,0 +1,3 @@
+Fix a false positive ``relative-beyond-top-level`` error when linting specific files in namespace packages in parallel mode by augmenting ``sys.path`` before loading plugins and expanding files consistently for parallel workers.
+
+Closes #10794

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -32,6 +32,9 @@ def _worker_initialize(
     :param linter: A linter-class (PyLinter) instance pickled with dill
     :param extra_packages_paths: Extra entries to be added to `sys.path`
     """
+    if extra_packages_paths:
+        _augment_sys_path(extra_packages_paths)
+
     global _worker_linter  # pylint: disable=global-statement
     import dill  # pylint: disable=import-outside-toplevel
 
@@ -53,9 +56,6 @@ def _worker_initialize(
     )
     _worker_linter.load_plugin_modules(_worker_linter._dynamic_plugins, force=True)
     _worker_linter.load_plugin_configuration()
-
-    if extra_packages_paths:
-        _augment_sys_path(extra_packages_paths)
 
 
 def _worker_check_single_file(

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -925,19 +925,20 @@ class PyLinter(
         yield FileItem(modname, filepath, filepath)
 
     def _iterate_file_descrs(
-        self, files_or_modules: Sequence[str]
+        self, files_or_modules: Sequence[str], extra_packages_paths: Sequence[str] = ()
     ) -> Iterator[FileItem]:
         """Return generator yielding file descriptions (tuples of module name, file
         path, base name).
 
         The returned generator yield one item for each Python module that should be linted.
         """
-        for descr in self._expand_files(files_or_modules).values():
-            name, filepath, is_arg = descr["name"], descr["path"], descr["isarg"]
-            if descr["isignored"]:
-                self.stats.skipped += 1
-            elif self.should_analyze_file(name, filepath, is_argument=is_arg):
-                yield FileItem(name, filepath, descr["basename"])
+        with augmented_sys_path(extra_packages_paths):
+            for descr in self._expand_files(files_or_modules).values():
+                name, filepath, is_arg = descr["name"], descr["path"], descr["isarg"]
+                if descr["isignored"]:
+                    self.stats.skipped += 1
+                elif self.should_analyze_file(name, filepath, is_argument=is_arg):
+                    yield FileItem(name, filepath, descr["basename"])
 
     def _expand_files(
         self, files_or_modules: Sequence[str]

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -725,7 +725,7 @@ class PyLinter(
             check_parallel(
                 self,
                 self.config.jobs,
-                self._iterate_file_descrs(files_or_modules),
+                self._iterate_file_descrs(files_or_modules, extra_packages_paths),
                 extra_packages_paths,
             )
             sys.path = original_sys_path

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -719,30 +719,23 @@ class PyLinter(
             ).keys()
         )
 
-        # TODO: Move the parallel invocation into step 3 of the checking process
+        # 0) Get all FileItems
+        if self.config.from_stdin:
+            fileitems = self._get_file_descr_from_stdin(files_or_modules[0])
+            data: str | None = _read_stdin()
+        else:
+            fileitems = self._iterate_file_descrs(files_or_modules)
+            data = None
+
+        # 1) Decide if we lint in parallel or not
         if not self.config.from_stdin and self.config.jobs > 1:
             original_sys_path = sys.path[:]
             with augmented_sys_path(extra_packages_paths):
-                expanded_files = self._expand_files(files_or_modules)
-            check_parallel(
-                self,
-                self.config.jobs,
-                self._iterate_file_descrs_from_expanded_files(expanded_files),
-                extra_packages_paths,
-            )
+                check_parallel(self, self.config.jobs, fileitems, extra_packages_paths)
             sys.path = original_sys_path
             return
 
         progress_reporter = ProgressReporter(self.verbose)
-
-        # 1) Get all FileItems
-        with augmented_sys_path(extra_packages_paths):
-            if self.config.from_stdin:
-                fileitems = self._get_file_descr_from_stdin(files_or_modules[0])
-                data: str | None = _read_stdin()
-            else:
-                fileitems = self._iterate_file_descrs(files_or_modules)
-                data = None
 
         # The contextmanager also opens all checkers and sets up the PyLinter class
         with augmented_sys_path(extra_packages_paths):
@@ -927,21 +920,15 @@ class PyLinter(
         yield FileItem(modname, filepath, filepath)
 
     def _iterate_file_descrs(
-        self, files_or_modules: Sequence[str], extra_packages_paths: Sequence[str] = ()
+        self, files_or_modules: Sequence[str]
     ) -> Iterator[FileItem]:
         """Return generator yielding file descriptions (tuples of module name, file
         path, base name).
 
         The returned generator yield one item for each Python module that should be linted.
         """
-        with augmented_sys_path(extra_packages_paths):
-            expanded_files = self._expand_files(files_or_modules)
-        yield from self._iterate_file_descrs_from_expanded_files(expanded_files)
+        expanded_files = self._expand_files(files_or_modules)
 
-    def _iterate_file_descrs_from_expanded_files(
-        self, expanded_files: dict[str, ModuleDescriptionDict]
-    ) -> Iterator[FileItem]:
-        """Yield file descriptions from already-expanded module descriptions."""
         for descr in expanded_files.values():
             name, filepath, is_arg = descr["name"], descr["path"], descr["isarg"]
             if descr["isignored"]:

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -933,12 +933,19 @@ class PyLinter(
         The returned generator yield one item for each Python module that should be linted.
         """
         with augmented_sys_path(extra_packages_paths):
-            for descr in self._expand_files(files_or_modules).values():
-                name, filepath, is_arg = descr["name"], descr["path"], descr["isarg"]
-                if descr["isignored"]:
-                    self.stats.skipped += 1
-                elif self.should_analyze_file(name, filepath, is_argument=is_arg):
-                    yield FileItem(name, filepath, descr["basename"])
+            expanded_files = self._expand_files(files_or_modules)
+        yield from self._iterate_file_descrs_from_expanded_files(expanded_files)
+
+    def _iterate_file_descrs_from_expanded_files(
+        self, expanded_files: dict[str, ModuleDescriptionDict]
+    ) -> Iterator[FileItem]:
+        """Yield file descriptions from already-expanded module descriptions."""
+        for descr in expanded_files.values():
+            name, filepath, is_arg = descr["name"], descr["path"], descr["isarg"]
+            if descr["isignored"]:
+                self.stats.skipped += 1
+            elif self.should_analyze_file(name, filepath, is_argument=is_arg):
+                yield FileItem(name, filepath, descr["basename"])
 
     def _expand_files(
         self, files_or_modules: Sequence[str]

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -724,14 +724,16 @@ class PyLinter(
             fileitems = self._get_file_descr_from_stdin(files_or_modules[0])
             data: str | None = _read_stdin()
         else:
-            fileitems = self._iterate_file_descrs(files_or_modules)
+            fileitems = self._iterate_file_descrs(
+                files_or_modules,
+                extra_packages_paths=extra_packages_paths,
+            )
             data = None
 
         # 1) Decide if we lint in parallel or not
         if not self.config.from_stdin and self.config.jobs > 1:
             original_sys_path = sys.path[:]
-            with augmented_sys_path(extra_packages_paths):
-                check_parallel(self, self.config.jobs, fileitems, extra_packages_paths)
+            check_parallel(self, self.config.jobs, fileitems, extra_packages_paths)
             sys.path = original_sys_path
             return
 
@@ -920,14 +922,15 @@ class PyLinter(
         yield FileItem(modname, filepath, filepath)
 
     def _iterate_file_descrs(
-        self, files_or_modules: Sequence[str]
+        self, files_or_modules: Sequence[str], extra_packages_paths: Sequence[str] = ()
     ) -> Iterator[FileItem]:
         """Return generator yielding file descriptions (tuples of module name, file
         path, base name).
 
         The returned generator yield one item for each Python module that should be linted.
         """
-        expanded_files = self._expand_files(files_or_modules)
+        with augmented_sys_path(extra_packages_paths):
+            expanded_files = self._expand_files(files_or_modules)
 
         for descr in expanded_files.values():
             name, filepath, is_arg = descr["name"], descr["path"], descr["isarg"]

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -722,10 +722,12 @@ class PyLinter(
         # TODO: Move the parallel invocation into step 3 of the checking process
         if not self.config.from_stdin and self.config.jobs > 1:
             original_sys_path = sys.path[:]
+            with augmented_sys_path(extra_packages_paths):
+                expanded_files = self._expand_files(files_or_modules)
             check_parallel(
                 self,
                 self.config.jobs,
-                self._iterate_file_descrs(files_or_modules, extra_packages_paths),
+                self._iterate_file_descrs_from_expanded_files(expanded_files),
                 extra_packages_paths,
             )
             sys.path = original_sys_path

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -719,7 +719,7 @@ class PyLinter(
             ).keys()
         )
 
-        # 0) Get all FileItems
+        # 0) Gather all FileItems
         if self.config.from_stdin:
             fileitems = self._get_file_descr_from_stdin(files_or_modules[0])
             data: str | None = _read_stdin()
@@ -730,25 +730,24 @@ class PyLinter(
             )
             data = None
 
-        # 1) Decide if we lint in parallel or not
+        # 1) Lint in parallel if requested
         if not self.config.from_stdin and self.config.jobs > 1:
             original_sys_path = sys.path[:]
             check_parallel(self, self.config.jobs, fileitems, extra_packages_paths)
             sys.path = original_sys_path
             return
 
-        progress_reporter = ProgressReporter(self.verbose)
+        # 2) Sequential path: run the AST and linting pipeline.
+        reporter = ProgressReporter(self.verbose)
 
-        # The contextmanager also opens all checkers and sets up the PyLinter class
+        # The context manager also opens all checkers and sets up the PyLinter class.
         with augmented_sys_path(extra_packages_paths):
             with self._astroid_module_checker() as check_astroid_module:
-                # 2) Get the AST for each FileItem
-                ast_per_fileitem = self._get_asts(fileitems, data, progress_reporter)
+                # Get the AST for each FileItem.
+                ast_per_fileitem = self._get_asts(fileitems, data, reporter)
 
-                # 3) Lint each ast
-                self._lint_files(
-                    ast_per_fileitem, check_astroid_module, progress_reporter
-                )
+                # Lint each AST.
+                self._lint_files(ast_per_fileitem, check_astroid_module, reporter)
 
     def _get_asts(
         self,

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -719,7 +719,7 @@ class PyLinter(
             ).keys()
         )
 
-        # 0) Gather all FileItems
+        # 1) Gather all FileItems
         if self.config.from_stdin:
             fileitems = self._get_file_descr_from_stdin(files_or_modules[0])
             data: str | None = _read_stdin()
@@ -730,14 +730,15 @@ class PyLinter(
             )
             data = None
 
-        # 1) Lint in parallel if requested
+        # TODO: Move the parallel invocation into step 3 of the checking process
+        # 2) Lint in parallel if requested
         if not self.config.from_stdin and self.config.jobs > 1:
             original_sys_path = sys.path[:]
             check_parallel(self, self.config.jobs, fileitems, extra_packages_paths)
             sys.path = original_sys_path
             return
 
-        # 2) Sequential path: run the AST and linting pipeline.
+        # 3) Sequential path: run the AST and linting pipeline.
         reporter = ProgressReporter(self.verbose)
 
         # The context manager also opens all checkers and sets up the PyLinter class.

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1122,6 +1122,64 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
         with _test_cwd(path):
             self._runtest(args, code=0)
 
+    @pytest.mark.needs_two_cores
+    @pytest.mark.parametrize(
+        "args",
+        [
+            [
+                "--jobs",
+                "0",
+                "--disable=all",
+                "--enable=relative-beyond-top-level",
+                "--source-roots",
+                ".",
+                "a/",
+            ],
+            [
+                "--jobs",
+                "1",
+                "--disable=all",
+                "--enable=relative-beyond-top-level",
+                "--source-roots",
+                ".",
+                "a/c/d.py",
+            ],
+            [
+                "--jobs",
+                "0",
+                "--disable=all",
+                "--enable=relative-beyond-top-level",
+                "--source-roots",
+                ".",
+                "a/c/d.py",
+            ],
+        ],
+        ids=["jobs-0-dir", "jobs-1-file", "jobs-0-file"],
+    )
+    def test_issue_10794_relative_beyond_top_level_parallel_specific_file_subprocess(
+        self, args: list[str]
+    ) -> None:
+        """Regression test for https://github.com/pylint-dev/pylint/issues/10794 invoked in a subprocess."""
+        path = join(HERE, "regrtest_data", "pep420", "issue_10794")
+        pylint_call = [
+            sys.executable,
+            "-m",
+            "pylint",
+            *_add_rcfile_default_pylintrc([*args, "--persistent=no"]),
+        ]
+        with _test_cwd(path):
+            process = subprocess.run(
+                pylint_call,
+                cwd=path,
+                capture_output=True,
+                encoding="utf-8",
+                check=False,
+            )
+
+        output = f"{process.stdout}\n{process.stderr}"
+        assert process.returncode == 0, output
+        assert "relative-beyond-top-level" not in output
+
     def test_output_file_valid_path(self, tmp_path: Path) -> None:
         path = join(HERE, "regrtest_data", "unused_variable.py")
         output_file = tmp_path / "output.txt"

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1155,9 +1155,29 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
             ],
         ],
         ids=["jobs-0-dir", "jobs-1-file", "jobs-0-file"],
+        "jobs,to_lint",
+        [
+            [
+                "0",
+                "a/"
+            ],
+            [
+                "1",
+                "a/"
+            ],            
+            [
+                "1",
+                "a/c/d.py"
+            ],
+            [
+                "0",
+                "a/c/d.py"
+            ],
+        ],
+        ids=["jobs-0-dir", "jobs-1-dir", "jobs-1-file", "jobs-0-file"],
     )
     def test_issue_10794_relative_beyond_top_level_parallel_specific_file_subprocess(
-        self, args: list[str]
+        self, jobs: int, to_lint: str
     ) -> None:
         """Regression test for https://github.com/pylint-dev/pylint/issues/10794 invoked in a subprocess."""
         path = join(HERE, "regrtest_data", "pep420", "issue_10794")
@@ -1165,7 +1185,13 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
             sys.executable,
             "-m",
             "pylint",
-            *_add_rcfile_default_pylintrc([*args, "--persistent=no"]),
+            *_add_rcfile_default_pylintrc([           "--jobs",
+               jobs,
+                "--disable=all",
+                "--enable=relative-beyond-top-level",
+                "--source-roots",
+                ".",
+                to_lint, "--persistent=no"]),
         ]
         with _test_cwd(path):
             process = subprocess.run(

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1164,7 +1164,7 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
             [
                 "1",
                 "a/"
-            ],            
+            ],
             [
                 "1",
                 "a/c/d.py"

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1124,55 +1124,12 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
 
     @pytest.mark.needs_two_cores
     @pytest.mark.parametrize(
-        "args",
-        [
-            [
-                "--jobs",
-                "0",
-                "--disable=all",
-                "--enable=relative-beyond-top-level",
-                "--source-roots",
-                ".",
-                "a/",
-            ],
-            [
-                "--jobs",
-                "1",
-                "--disable=all",
-                "--enable=relative-beyond-top-level",
-                "--source-roots",
-                ".",
-                "a/c/d.py",
-            ],
-            [
-                "--jobs",
-                "0",
-                "--disable=all",
-                "--enable=relative-beyond-top-level",
-                "--source-roots",
-                ".",
-                "a/c/d.py",
-            ],
-        ],
-        ids=["jobs-0-dir", "jobs-1-file", "jobs-0-file"],
         "jobs,to_lint",
         [
-            [
-                "0",
-                "a/"
-            ],
-            [
-                "1",
-                "a/"
-            ],
-            [
-                "1",
-                "a/c/d.py"
-            ],
-            [
-                "0",
-                "a/c/d.py"
-            ],
+            ["0", "a/"],
+            ["1", "a/"],
+            ["1", "a/c/d.py"],
+            ["0", "a/c/d.py"],
         ],
         ids=["jobs-0-dir", "jobs-1-dir", "jobs-1-file", "jobs-0-file"],
     )
@@ -1185,13 +1142,18 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
             sys.executable,
             "-m",
             "pylint",
-            *_add_rcfile_default_pylintrc([           "--jobs",
-               jobs,
-                "--disable=all",
-                "--enable=relative-beyond-top-level",
-                "--source-roots",
-                ".",
-                to_lint, "--persistent=no"]),
+            *_add_rcfile_default_pylintrc(
+                [
+                    "--jobs",
+                    str(jobs),
+                    "--disable=all",
+                    "--enable=relative-beyond-top-level",
+                    "--source-roots",
+                    ".",
+                    to_lint,
+                    "--persistent=no",
+                ]
+            ),
         ]
         with _test_cwd(path):
             process = subprocess.run(


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|    | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Description

Finally closes #10794

- Augment `sys.path` before loading plugins in parallel workers so namespace-package imports resolve consistently.
- Expand files with the augmented `sys.path` before parallel iteration and split file-description iteration to reuse pre-expanded results.
- Add subprocess-based regression tests covering `--jobs 0` and `--jobs 1` for directory and specific-file invocation.

Follow-up to #10889 that fixes the parallel execution path behind #10794. It ensures namespace-package imports are resolved correctly when linting specific files in parallel mode. Additionally I also include another regression test that invokes pylint via a subprocess, because the previous one did pass even though the issue still remained in certain scenarios.