### PR TITLE
Skip deployment for backport job

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: Backport
+      deployment: false
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >


### PR DESCRIPTION
Github just added the option to skip deployments for environments. The `Backport` one is just used to properly scope the secret, so I think adding `deployment: false` there makes sense.

_The other environment is the release job. We can keep it there as is._

https://github.blog/changelog/2026-03-19-github-actions-late-march-2026-updates/
https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments