### PR TITLE
Fix bad truncation html formatting around </details> in primer comments

### DIFF
--- a/pylint/testutils/_primer/primer_compare_command.py
+++ b/pylint/testutils/_primer/primer_compare_command.py
@@ -41,7 +41,7 @@ class CompareCommand(PrimerCommand):
     def _create_comment_for_package(
         self, package: str, new_messages: PackageData, missing_messages: PackageData
     ) -> str:
-        comment = f"\n\n**Effect on [{package}]({self.packages[package].url}):**\n"
+        comment = f"\n**Effect on [{package}]({self.packages[package].url}):**\n\n"
         # Create comment for new messages
         count = 1
         astroid_errors = 0
@@ -73,15 +73,15 @@ class CompareCommand(PrimerCommand):
             )
         if new_non_astroid_messages:
             comment += (
-                "The following messages are now emitted:\n\n<details>\n\n"
+                "The following messages are now emitted:\n\n<details>\n"
                 + new_non_astroid_messages
-                + "\n</details>\n\n"
+                + "</details>\n\n"
             )
 
         # Create comment for missing messages
         count = 1
         if missing_messages["messages"]:
-            comment += "The following messages are no longer emitted:\n\n<details>\n\n"
+            comment += "The following messages are no longer emitted:\n\n<details>\n"
             print("No longer emitted:")
         for message in missing_messages["messages"]:
             comment += f"{count}) {message['symbol']}:\n*{message['message']}*\n"
@@ -99,8 +99,8 @@ class CompareCommand(PrimerCommand):
             )
             count += 1
             print(message)
-        if missing_messages:
-            comment += "\n</details>\n\n"
+        if missing_messages["messages"]:
+            comment += "</details>\n\n"
         return comment
 
     def _truncate_comment(self, comment: str) -> str:

--- a/pylint/testutils/_primer/primer_compare_command.py
+++ b/pylint/testutils/_primer/primer_compare_command.py
@@ -113,11 +113,19 @@ class CompareCommand(PrimerCommand):
                 f"*This comment was truncated because GitHub allows only"
                 f" {MAX_GITHUB_COMMENT_LENGTH} characters in a comment.*"
             )
+            # Reserve space for the suffix and a potential </details> closing tag.
+            suffix = f"\n{truncation_information}\n\n"
+            closing_tag = "</details>\n"
             max_len = (
                 MAX_GITHUB_COMMENT_LENGTH
                 - len(hash_information)
-                - len(truncation_information)
+                - len(suffix)
+                - len(closing_tag)
             )
-            comment = f"{comment[:max_len - 10]}...\n\n{truncation_information}\n\n"
+            comment = comment[: max_len - 10] + "...\n"
+            # Close any <details> tag left open by the truncation.
+            if comment.count("<details>") > comment.count("</details>"):
+                comment += closing_tag
+            comment += suffix
         comment += hash_information
         return comment

--- a/tests/testutils/_primer/batched_cases/expected.txt
+++ b/tests/testutils/_primer/batched_cases/expected.txt
@@ -1,19 +1,17 @@
 🤖 **Effect of this PR on checked open source code:** 🤖
 
 
-
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
+
 The following messages are no longer emitted:
 
 <details>
-
 1) locally-disabled:
 *Locally disabling redefined-builtin (W0622)*
 https://github.com/pylint-dev/astroid/blob/1234567890abcdef/astroid/__init__.py#L91
 2) unknown-option-value:
 *Unknown option value for 'disable', expected a valid pylint message and got 'Ellipsis'*
 https://github.com/pylint-dev/astroid/blob/1234567890abcdef/astroid/__init__.py#L91
-
 </details>
 
 *This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/message_changed/expected.txt
+++ b/tests/testutils/_primer/cases/message_changed/expected.txt
@@ -1,26 +1,22 @@
 🤖 **Effect of this PR on checked open source code:** 🤖
 
 
-
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
+
 The following messages are now emitted:
 
 <details>
-
 1) locally-disabled:
 *Locally disabling redefined-builtin [we added some text in the message] (W0622)*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
-
 </details>
 
 The following messages are no longer emitted:
 
 <details>
-
 1) locally-disabled:
 *Locally disabling redefined-builtin (W0622)*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
-
 </details>
 
 *This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/message_changed/expected_truncated_in_details.txt
+++ b/tests/testutils/_primer/cases/message_changed/expected_truncated_in_details.txt
@@ -7,11 +7,9 @@ The following messages are now emitted:
 
 <details>
 1) locally-disabled:
-*Locally disabling redefined-builtin [we added some text in the message] (W0622)*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
+*Locally disabling redefined-builtin [we added some text in the message...
 </details>
-...
 
-*This comment was truncated because GitHub allows only 525 characters in a comment.*
+*This comment was truncated because GitHub allows only 420 characters in a comment.*
 
 *This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/new_message/expected.txt
+++ b/tests/testutils/_primer/cases/new_message/expected.txt
@@ -1,19 +1,14 @@
 🤖 **Effect of this PR on checked open source code:** 🤖
 
 
-
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
+
 The following messages are now emitted:
 
 <details>
-
 1) locally-disabled:
 *Locally disabling redefined-builtin [we added some text in the message] (W0622)*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
-
-</details>
-
-
 </details>
 
 *This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/removed_message/expected.txt
+++ b/tests/testutils/_primer/cases/removed_message/expected.txt
@@ -1,16 +1,14 @@
 🤖 **Effect of this PR on checked open source code:** 🤖
 
 
-
 **Effect on [astroid](https://github.com/pylint-dev/astroid):**
+
 The following messages are no longer emitted:
 
 <details>
-
 1) unknown-option-value:
 *Unknown option value for 'disable', expected a valid pylint message and got 'Ellipsis'*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
-
 </details>
 
 *This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/test_primer.py
+++ b/tests/testutils/_primer/test_primer.py
@@ -86,6 +86,19 @@ class TestPrimer:
             )
         assert len(content) < max_comment_length
 
+    def test_truncated_compare_in_details(self) -> None:
+        """Test for the truncation of comments that are too long inside details."""
+        max_comment_length = 420
+        directory = CASES_PATH / "message_changed"
+        with patch(
+            "pylint.testutils._primer.primer_compare_command.MAX_GITHUB_COMMENT_LENGTH",
+            max_comment_length,
+        ):
+            content = self.__assert_expected(
+                directory, expected_file=directory / "expected_truncated_in_details.txt"
+            )
+        assert len(content) < max_comment_length
+
     @staticmethod
     def __assert_expected(
         directory: Path,


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

  - Remove extra blank lines inside <details> blocks and between sections
  - Fix duplicate </details> tag emitted when missing_messages was truthy but had no actual messages (wrong truthiness check on dict vs dict["messages"])                                                                  
  - Close any <details> tag left open when a comment is truncated mid-block, preventing the rest of the PR page from collapsing into the hidden section

This is a small fix before tackling #10914