### PR TITLE
[test] Update test_enable_message_block for astroid block_range change

### DIFF
--- a/doc/whatsnew/fragments/10933.false_positive
+++ b/doc/whatsnew/fragments/10933.false_positive
@@ -1,0 +1,18 @@
+Fix ``# pylint: enable`` inside a ``try`` block leaking into the ``except``
+handler. For example in the following code, ``no-member`` is no longer
+incorrectly re-enabled in the ``except`` block:
+
+.. code-block:: python
+
+    class Basket:
+        # pylint: disable=no-member
+        def pick(self):
+            try:
+                # pylint: enable=no-member
+                print(self.apple)  # no-member emitted here
+            except KeyError:
+                print(self.banana)  # no-member NOT emitted here (correct)
+
+Requires astroid 4.2.
+
+Refs #10933

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   # Also upgrade test-min dependency group and requirements_test_min.txt.
   # Pinned to dev of second minor update to allow editable installs and fix primer issues,
   # see https://github.com/pylint-dev/astroid/issues/1341
-  "astroid>=4.1.1,<=4.2.dev0",
+  "astroid>=4.2.0b1,<=4.2.dev0",
   "colorama>=0.4.5; sys_platform=='win32'",
   "dill>=0.2; python_version<'3.11'",
   "dill>=0.3.6; python_version>='3.11'",
@@ -88,7 +88,7 @@ docs = [
 # Configuration for the build system
 test-min = [
   # Base test dependencies
-  "astroid==4.1.2",                     # Pinned to a specific version for tests
+  "astroid==4.2.0b1",                   # Pinned to a specific version for tests
   "py~=1.11.0",
   "pytest>=8.4,<10",
   "pytest-benchmark~=5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   # Also upgrade test-min dependency group and requirements_test_min.txt.
   # Pinned to dev of second minor update to allow editable installs and fix primer issues,
   # see https://github.com/pylint-dev/astroid/issues/1341
-  "astroid>=4.2.0b1,<=4.3.0",
+  "astroid>=4.2.0b1,<=4.3",
   "colorama>=0.4.5; sys_platform=='win32'",
   "dill>=0.2; python_version<'3.11'",
   "dill>=0.3.6; python_version>='3.11'",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==4.1.2   # Pinned to a specific version for tests
+astroid==4.2.0b1   # Pinned to a specific version for tests
 typing-extensions~=4.15
 py~=1.11.0
 pytest>=8.4,<10.0

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -317,7 +317,7 @@ def test_enable_message_block(initialized_linter: PyLinter) -> None:
     # meth6
     assert not linter.is_message_enabled("E1101", 57)
     assert linter.is_message_enabled("E1101", 61)
-    assert linter.is_message_enabled("E1101", 64)
+    assert not linter.is_message_enabled("E1101", 64)
     assert not linter.is_message_enabled("E1101", 66)
 
     assert linter.is_message_enabled("E0602", 57)


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |

## Description

Astroid's `block_range` now scopes `try` body pragmas to the `try` block only, so `# pylint: enable=E1101` inside `try` no longer leaks into the `except` handler. Update the expected assertion accordingly.

Will be mergeable once we release astroid, and the last minor version of pylint 4.x, it's a breaking change for pylint.
