### PR TITLE
Expand use-implicit-booleaness-not-len to catch len(x) == 0 and > 0

### DIFF
--- a/pylint/checkers/refactoring/implicit_booleaness_checker.py
+++ b/pylint/checkers/refactoring/implicit_booleaness_checker.py
@@ -176,8 +176,11 @@ class ImplicitBooleanessChecker(checkers.BaseChecker):
         "use-implicit-booleaness-not-comparison",
         "use-implicit-booleaness-not-comparison-to-string",
         "use-implicit-booleaness-not-comparison-to-zero",
+        "use-implicit-booleaness-not-len",
     )
     def visit_compare(self, node: nodes.Compare) -> None:
+        if self.linter.is_message_enabled("use-implicit-booleaness-not-len"):
+            self._check_len_comparison_to_zero(node)
         if self.linter.is_message_enabled("use-implicit-booleaness-not-comparison"):
             self._check_use_implicit_booleaness_not_comparison(node)
         if self.linter.is_message_enabled(
@@ -186,6 +189,36 @@ class ImplicitBooleanessChecker(checkers.BaseChecker):
             "use-implicit-booleaness-not-comparison-to-str"
         ):
             self._check_compare_to_str_or_zero(node)
+
+    def _check_len_comparison_to_zero(self, node: nodes.Compare) -> None:
+        """Flag comparisons like len(x) == 0, len(x) > 0, 0 < len(x)."""
+        if len(node.ops) != 1:
+            return
+
+        operator, right_operand = node.ops[0]
+        left_operand = node.left
+
+        # Check both orientations: len(x) op 0 and 0 op len(x).
+        if utils.is_call_of_name(left_operand, "len") and _is_constant_zero(
+            right_operand
+        ):
+            # len(x) == 0, len(x) != 0, len(x) > 0, len(x) <= 0
+            if operator in ("==", "!=", ">", "<="):
+                self.add_message(
+                    "use-implicit-booleaness-not-len",
+                    node=node,
+                    confidence=HIGH,
+                )
+        elif utils.is_call_of_name(right_operand, "len") and _is_constant_zero(
+            left_operand
+        ):
+            # 0 == len(x), 0 != len(x), 0 < len(x), 0 >= len(x)
+            if operator in ("==", "!=", "<", ">="):
+                self.add_message(
+                    "use-implicit-booleaness-not-len",
+                    node=node,
+                    confidence=HIGH,
+                )
 
     def _check_compare_to_str_or_zero(self, node: nodes.Compare) -> None:
         # Skip check for chained comparisons

--- a/tests/functional/u/use/use_implicit_booleaness_not_len.py
+++ b/tests/functional/u/use/use_implicit_booleaness_not_len.py
@@ -14,22 +14,22 @@ if z and len(['T', 'E', 'S', 'T']):  # [use-implicit-booleaness-not-len]
 if True or len('TEST'):  # [use-implicit-booleaness-not-len]
     pass
 
-if len('TEST') == 0:  # Should be fine
+if len('TEST') == 0:  # [use-implicit-booleaness-not-len]
     pass
 
 if len('TEST') < 1:  # Should be fine
     pass
 
-if len('TEST') <= 0:  # Should be fine
+if len('TEST') <= 0:  # [use-implicit-booleaness-not-len]
     pass
 
 if 1 > len('TEST'):  # Should be fine
     pass
 
-if 0 >= len('TEST'):  # Should be fine
+if 0 >= len('TEST'):  # [use-implicit-booleaness-not-len]
     pass
 
-if z and len('TEST') == 0:  # Should be fine
+if z and len('TEST') == 0:  # [use-implicit-booleaness-not-len]
     pass
 
 if 0 == len('TEST') < 10:  # Should be fine

--- a/tests/functional/u/use/use_implicit_booleaness_not_len.txt
+++ b/tests/functional/u/use/use_implicit_booleaness_not_len.txt
@@ -2,6 +2,10 @@ use-implicit-booleaness-not-len:4:3:4:14::Do not use `len(SEQUENCE)` without com
 use-implicit-booleaness-not-len:7:3:7:18::Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty:HIGH
 use-implicit-booleaness-not-len:11:9:11:34::Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty:INFERENCE
 use-implicit-booleaness-not-len:14:11:14:22::Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty:INFERENCE
+use-implicit-booleaness-not-len:17:3:17:19::Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty:HIGH
+use-implicit-booleaness-not-len:23:3:23:19::Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty:HIGH
+use-implicit-booleaness-not-len:29:3:29:19::Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty:HIGH
+use-implicit-booleaness-not-len:32:9:32:25::Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty:HIGH
 comparison-of-constants:39:3:39:28::"Comparison between constants: ""0 < 1"" has a constant value":HIGH
 use-implicit-booleaness-not-len:56:5:56:16::Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty:INFERENCE
 use-implicit-booleaness-not-len:61:5:61:20::Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty:HIGH


### PR DESCRIPTION
Expands C1802 to flag len() compared to 0.

## Why this matters

`if len(x) > 0:` is the same as `if x:`. The rule caught `if len(x):` but missed the comparison form. People write it after "fixing" the bare len() warning.

## Changes

- **implicit_booleaness_checker.py**: Added `_check_len_comparison_to_zero` method. Flags `len(x) == 0`, `len(x) != 0`, `len(x) > 0`, `len(x) <= 0` and reversed forms. Skips chained comparisons and non-zero values.
- **use_implicit_booleaness_not_len.py**: Updated test expectations
- **use_implicit_booleaness_not_len.txt**: Added 4 new expected warnings

## Testing

Functional test updated with new expected output.

Closes #10281

This contribution was developed with AI assistance (Claude Code).