### PR TITLE
[doc] Upgrade Read the Docs build image to Ubuntu 24.04/Python 3.13

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ python:
     - requirements: doc/readthedoc_requirements.txt
 
 build:
-  os: ubuntu-24.04
+  os: ubuntu-26.04
   tools:
     python: "3.13"
   jobs:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,9 +11,9 @@ python:
     - requirements: doc/readthedoc_requirements.txt
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.13"
   jobs:
     pre_build:
       - towncrier build --yes --date TBA

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ python:
 build:
   os: ubuntu-26.04
   tools:
-    python: "3.13"
+    python: "3.14"
   jobs:
     pre_build:
       - towncrier build --yes --date TBA


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Ubuntu 20.04 is being deprecated by Read the Docs (June 2026), might as well upgrade this one to a more modern Ubuntu and a faster python while it's on my mind.
