### PR TITLE
[test] Add primer test cases for suboptimal diff scenarios

### DIFF
--- a/tests/testutils/_primer/cases/line_moved/expected.txt
+++ b/tests/testutils/_primer/cases/line_moved/expected.txt
@@ -1,0 +1,22 @@
+🤖 **Effect of this PR on checked open source code:** 🤖
+
+
+**Effect on [astroid](https://github.com/pylint-dev/astroid):**
+
+The following messages are now emitted:
+
+<details>
+1) too-complex:
+*'my_function' is too complex. The McCabe rating is 18*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L103
+</details>
+
+The following messages are no longer emitted:
+
+<details>
+1) too-complex:
+*'my_function' is too complex. The McCabe rating is 18*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L100
+</details>
+
+*This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/line_moved/expected_comparator.json
+++ b/tests/testutils/_primer/cases/line_moved/expected_comparator.json
@@ -1,0 +1,1 @@
+[{ "package": "astroid", "missing": 1, "new": 1 }]

--- a/tests/testutils/_primer/cases/line_moved/main.json
+++ b/tests/testutils/_primer/cases/line_moved/main.json
@@ -1,0 +1,20 @@
+{
+  "astroid": {
+    "commit": "1234567890abcdef",
+    "messages": [
+      {
+        "type": "convention",
+        "module": "astroid.node_classes",
+        "obj": "my_function",
+        "line": 100,
+        "column": 0,
+        "endLine": 100,
+        "endColumn": 15,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/node_classes.py",
+        "symbol": "too-complex",
+        "message": "'my_function' is too complex. The McCabe rating is 18",
+        "message-id": "R1260"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/line_moved/pr.json
+++ b/tests/testutils/_primer/cases/line_moved/pr.json
@@ -1,0 +1,20 @@
+{
+  "astroid": {
+    "commit": "123456789abcdef",
+    "messages": [
+      {
+        "type": "convention",
+        "module": "astroid.node_classes",
+        "obj": "my_function",
+        "line": 103,
+        "column": 0,
+        "endLine": 103,
+        "endColumn": 15,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/node_classes.py",
+        "symbol": "too-complex",
+        "message": "'my_function' is too complex. The McCabe rating is 18",
+        "message-id": "R1260"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/message_changed_line/expected.txt
+++ b/tests/testutils/_primer/cases/message_changed_line/expected.txt
@@ -1,0 +1,22 @@
+🤖 **Effect of this PR on checked open source code:** 🤖
+
+
+**Effect on [astroid](https://github.com/pylint-dev/astroid):**
+
+The following messages are now emitted:
+
+<details>
+1) too-complex:
+*'my_function' is too complex. The McCabe rating is 17*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L103
+</details>
+
+The following messages are no longer emitted:
+
+<details>
+1) too-complex:
+*'my_function' is too complex. The McCabe rating is 18*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L100
+</details>
+
+*This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/message_changed_line/expected_comparator.json
+++ b/tests/testutils/_primer/cases/message_changed_line/expected_comparator.json
@@ -1,0 +1,1 @@
+[{ "package": "astroid", "missing": 1, "new": 1 }]

--- a/tests/testutils/_primer/cases/message_changed_line/main.json
+++ b/tests/testutils/_primer/cases/message_changed_line/main.json
@@ -1,0 +1,33 @@
+{
+  "astroid": {
+    "commit": "1234567890abcdef",
+    "messages": [
+      {
+        "type": "convention",
+        "module": "astroid.node_classes",
+        "obj": "my_function",
+        "line": 100,
+        "column": 0,
+        "endLine": 100,
+        "endColumn": 15,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/node_classes.py",
+        "symbol": "too-complex",
+        "message": "'my_function' is too complex. The McCabe rating is 18",
+        "message-id": "R1260"
+      },
+      {
+        "type": "warning",
+        "module": "astroid",
+        "obj": "",
+        "line": 91,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/__init__.py",
+        "symbol": "unknown-option-value",
+        "message": "Unknown option value for 'disable', expected a valid pylint message and got 'Ellipsis'",
+        "message-id": "W0012"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/message_changed_line/pr.json
+++ b/tests/testutils/_primer/cases/message_changed_line/pr.json
@@ -1,0 +1,33 @@
+{
+  "astroid": {
+    "commit": "123456789abcdef",
+    "messages": [
+      {
+        "type": "convention",
+        "module": "astroid.node_classes",
+        "obj": "my_function",
+        "line": 103,
+        "column": 0,
+        "endLine": 103,
+        "endColumn": 15,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/node_classes.py",
+        "symbol": "too-complex",
+        "message": "'my_function' is too complex. The McCabe rating is 17",
+        "message-id": "R1260"
+      },
+      {
+        "type": "warning",
+        "module": "astroid",
+        "obj": "",
+        "line": 91,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/__init__.py",
+        "symbol": "unknown-option-value",
+        "message": "Unknown option value for 'disable', expected a valid pylint message and got 'Ellipsis'",
+        "message-id": "W0012"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/mixed_changes/expected.txt
+++ b/tests/testutils/_primer/cases/mixed_changes/expected.txt
@@ -1,0 +1,28 @@
+🤖 **Effect of this PR on checked open source code:** 🤖
+
+
+**Effect on [astroid](https://github.com/pylint-dev/astroid):**
+
+The following messages are now emitted:
+
+<details>
+1) locally-disabled:
+*Locally disabling redefined-builtin [we added some text in the message] (W0622)*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
+2) too-complex:
+*'my_function' is too complex. The McCabe rating is 17*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L105
+</details>
+
+The following messages are no longer emitted:
+
+<details>
+1) locally-disabled:
+*Locally disabling redefined-builtin (W0622)*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
+2) too-complex:
+*'my_function' is too complex. The McCabe rating is 18*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L100
+</details>
+
+*This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/mixed_changes/expected_comparator.json
+++ b/tests/testutils/_primer/cases/mixed_changes/expected_comparator.json
@@ -1,0 +1,1 @@
+[{ "package": "astroid", "missing": 2, "new": 2 }]

--- a/tests/testutils/_primer/cases/mixed_changes/main.json
+++ b/tests/testutils/_primer/cases/mixed_changes/main.json
@@ -1,0 +1,46 @@
+{
+  "astroid": {
+    "commit": "1234567890abcdef",
+    "messages": [
+      {
+        "type": "info",
+        "module": "astroid",
+        "obj": "",
+        "line": 91,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/__init__.py",
+        "symbol": "locally-disabled",
+        "message": "Locally disabling redefined-builtin (W0622)",
+        "message-id": "I0011"
+      },
+      {
+        "type": "convention",
+        "module": "astroid.node_classes",
+        "obj": "my_function",
+        "line": 100,
+        "column": 0,
+        "endLine": 100,
+        "endColumn": 15,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/node_classes.py",
+        "symbol": "too-complex",
+        "message": "'my_function' is too complex. The McCabe rating is 18",
+        "message-id": "R1260"
+      },
+      {
+        "type": "warning",
+        "module": "astroid",
+        "obj": "",
+        "line": 91,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/__init__.py",
+        "symbol": "unknown-option-value",
+        "message": "Unknown option value for 'disable', expected a valid pylint message and got 'Ellipsis'",
+        "message-id": "W0012"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/mixed_changes/pr.json
+++ b/tests/testutils/_primer/cases/mixed_changes/pr.json
@@ -1,0 +1,46 @@
+{
+  "astroid": {
+    "commit": "123456789abcdef",
+    "messages": [
+      {
+        "type": "info",
+        "module": "astroid",
+        "obj": "",
+        "line": 91,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/__init__.py",
+        "symbol": "locally-disabled",
+        "message": "Locally disabling redefined-builtin [we added some text in the message] (W0622)",
+        "message-id": "I0011"
+      },
+      {
+        "type": "convention",
+        "module": "astroid.node_classes",
+        "obj": "my_function",
+        "line": 105,
+        "column": 0,
+        "endLine": 105,
+        "endColumn": 15,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/node_classes.py",
+        "symbol": "too-complex",
+        "message": "'my_function' is too complex. The McCabe rating is 17",
+        "message-id": "R1260"
+      },
+      {
+        "type": "warning",
+        "module": "astroid",
+        "obj": "",
+        "line": 91,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/__init__.py",
+        "symbol": "unknown-option-value",
+        "message": "Unknown option value for 'disable', expected a valid pylint message and got 'Ellipsis'",
+        "message-id": "W0012"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/type_changed/expected.txt
+++ b/tests/testutils/_primer/cases/type_changed/expected.txt
@@ -1,0 +1,22 @@
+🤖 **Effect of this PR on checked open source code:** 🤖
+
+
+**Effect on [astroid](https://github.com/pylint-dev/astroid):**
+
+The following messages are now emitted:
+
+<details>
+1) line-too-long:
+*Line too long (120/100)*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L50
+</details>
+
+The following messages are no longer emitted:
+
+<details>
+1) line-too-long:
+*Line too long (120/100)*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L50
+</details>
+
+*This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/type_changed/expected_comparator.json
+++ b/tests/testutils/_primer/cases/type_changed/expected_comparator.json
@@ -1,0 +1,1 @@
+[{ "package": "astroid", "missing": 1, "new": 1 }]

--- a/tests/testutils/_primer/cases/type_changed/main.json
+++ b/tests/testutils/_primer/cases/type_changed/main.json
@@ -1,0 +1,33 @@
+{
+  "astroid": {
+    "commit": "123456789abcdef",
+    "messages": [
+      {
+        "type": "convention",
+        "module": "astroid.node_classes",
+        "obj": "my_function",
+        "line": 50,
+        "column": 0,
+        "endLine": 50,
+        "endColumn": 20,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/node_classes.py",
+        "symbol": "line-too-long",
+        "message": "Line too long (120/100)",
+        "message-id": "C0301"
+      },
+      {
+        "type": "warning",
+        "module": "astroid",
+        "obj": "",
+        "line": 91,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/__init__.py",
+        "symbol": "unknown-option-value",
+        "message": "Unknown option value for 'disable', expected a valid pylint message and got 'Ellipsis'",
+        "message-id": "W0012"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/type_changed/pr.json
+++ b/tests/testutils/_primer/cases/type_changed/pr.json
@@ -1,0 +1,33 @@
+{
+  "astroid": {
+    "commit": "123456789abcdef",
+    "messages": [
+      {
+        "type": "warning",
+        "module": "astroid.node_classes",
+        "obj": "my_function",
+        "line": 50,
+        "column": 0,
+        "endLine": 50,
+        "endColumn": 20,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/node_classes.py",
+        "symbol": "line-too-long",
+        "message": "Line too long (120/100)",
+        "message-id": "C0301"
+      },
+      {
+        "type": "warning",
+        "module": "astroid",
+        "obj": "",
+        "line": 91,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/__init__.py",
+        "symbol": "unknown-option-value",
+        "message": "Unknown option value for 'disable', expected a valid pylint message and got 'Ellipsis'",
+        "message-id": "W0012"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/useless_suppression/expected.txt
+++ b/tests/testutils/_primer/cases/useless_suppression/expected.txt
@@ -1,0 +1,17 @@
+🤖 **Effect of this PR on checked open source code:** 🤖
+
+
+**Effect on [astropy](https://github.com/astropy/astropy):**
+
+The following messages are now emitted:
+
+<details>
+1) locally-disabled:
+*Locally disabling looping-through-iterator (W4801)*
+https://github.com/astropy/astropy/blob/1fb40bc1f22f176254ef583065aa155f53f3b414/astropy/coordinates/angles/angle_parsetab.py#L14
+2) useless-suppression:
+*Useless suppression of 'looping-through-iterator'*
+https://github.com/astropy/astropy/blob/1fb40bc1f22f176254ef583065aa155f53f3b414/astropy/coordinates/angles/angle_parsetab.py#L14
+</details>
+
+*This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/useless_suppression/expected_comparator.json
+++ b/tests/testutils/_primer/cases/useless_suppression/expected_comparator.json
@@ -1,0 +1,1 @@
+[{ "package": "astropy", "missing": 0, "new": 2 }]

--- a/tests/testutils/_primer/cases/useless_suppression/main.json
+++ b/tests/testutils/_primer/cases/useless_suppression/main.json
@@ -1,0 +1,6 @@
+{
+  "astropy": {
+    "commit": "1fb40bc1f22f176254ef583065aa155f53f3b414",
+    "messages": []
+  }
+}

--- a/tests/testutils/_primer/cases/useless_suppression/pr.json
+++ b/tests/testutils/_primer/cases/useless_suppression/pr.json
@@ -1,0 +1,33 @@
+{
+  "astropy": {
+    "commit": "1fb40bc1f22f176254ef583065aa155f53f3b414",
+    "messages": [
+      {
+        "type": "info",
+        "module": "astropy.coordinates.angles.angle_parsetab",
+        "obj": "",
+        "line": 14,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/astropy/astropy/astropy/coordinates/angles/angle_parsetab.py",
+        "symbol": "locally-disabled",
+        "message": "Locally disabling looping-through-iterator (W4801)",
+        "message-id": "I0011"
+      },
+      {
+        "type": "warning",
+        "module": "astropy.coordinates.angles.angle_parsetab",
+        "obj": "",
+        "line": 14,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/astropy/astropy/astropy/coordinates/angles/angle_parsetab.py",
+        "symbol": "useless-suppression",
+        "message": "Useless suppression of 'looping-through-iterator'",
+        "message-id": "I0021"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Document current behavior where line-only moves, message text changes, type changes, and useless-suppression pairs all show as full remove+add in the primer comment. These cases will help validate future smarter diff logic in #10914 
