### PR TITLE
[primer] Add blank line after <details> tag for proper markdown rendering

### DIFF
--- a/pylint/testutils/_primer/primer_compare_command.py
+++ b/pylint/testutils/_primer/primer_compare_command.py
@@ -73,7 +73,7 @@ class CompareCommand(PrimerCommand):
             )
         if new_non_astroid_messages:
             comment += (
-                "The following messages are now emitted:\n\n<details>\n"
+                "The following messages are now emitted:\n\n<details>\n\n"
                 + new_non_astroid_messages
                 + "</details>\n\n"
             )
@@ -81,7 +81,7 @@ class CompareCommand(PrimerCommand):
         # Create comment for missing messages
         count = 1
         if missing_messages["messages"]:
-            comment += "The following messages are no longer emitted:\n\n<details>\n"
+            comment += "The following messages are no longer emitted:\n\n<details>\n\n"
             print("No longer emitted:")
         for message in missing_messages["messages"]:
             comment += f"{count}) {message['symbol']}:\n*{message['message']}*\n"
@@ -122,7 +122,12 @@ class CompareCommand(PrimerCommand):
                 - len(suffix)
                 - len(closing_tag)
             )
-            comment = comment[: max_len - 10] + "...\n"
+            # Cut at the last space before the limit to avoid mid-word truncation.
+            cut_point = comment.rfind(" ", 0, max_len - 10)
+            if cut_point > 0:
+                comment = comment[:cut_point] + "...\n"
+            else:
+                comment = comment[: max_len - 10] + "...\n"
             # Close any <details> tag left open by the truncation.
             if comment.count("<details>") > comment.count("</details>"):
                 comment += closing_tag

--- a/tests/testutils/_primer/batched_cases/expected.txt
+++ b/tests/testutils/_primer/batched_cases/expected.txt
@@ -6,6 +6,7 @@
 The following messages are no longer emitted:
 
 <details>
+
 1) locally-disabled:
 *Locally disabling redefined-builtin (W0622)*
 https://github.com/pylint-dev/astroid/blob/1234567890abcdef/astroid/__init__.py#L91

--- a/tests/testutils/_primer/cases/line_moved/expected.txt
+++ b/tests/testutils/_primer/cases/line_moved/expected.txt
@@ -6,6 +6,7 @@
 The following messages are now emitted:
 
 <details>
+
 1) too-complex:
 *'my_function' is too complex. The McCabe rating is 18*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L103
@@ -14,6 +15,7 @@ https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.
 The following messages are no longer emitted:
 
 <details>
+
 1) too-complex:
 *'my_function' is too complex. The McCabe rating is 18*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L100

--- a/tests/testutils/_primer/cases/message_changed/expected.txt
+++ b/tests/testutils/_primer/cases/message_changed/expected.txt
@@ -6,6 +6,7 @@
 The following messages are now emitted:
 
 <details>
+
 1) locally-disabled:
 *Locally disabling redefined-builtin [we added some text in the message] (W0622)*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
@@ -14,6 +15,7 @@ https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L
 The following messages are no longer emitted:
 
 <details>
+
 1) locally-disabled:
 *Locally disabling redefined-builtin (W0622)*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91

--- a/tests/testutils/_primer/cases/message_changed/expected_truncated.txt
+++ b/tests/testutils/_primer/cases/message_changed/expected_truncated.txt
@@ -6,11 +6,10 @@
 The following messages are now emitted:
 
 <details>
+
 1) locally-disabled:
-*Locally disabling redefined-builtin [we added some text in the message] (W0622)*
-https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
+*Locally disabling redefined-builtin [we added some text in the message]...
 </details>
-...
 
 *This comment was truncated because GitHub allows only 525 characters in a comment.*
 

--- a/tests/testutils/_primer/cases/message_changed/expected_truncated_in_details.txt
+++ b/tests/testutils/_primer/cases/message_changed/expected_truncated_in_details.txt
@@ -6,8 +6,9 @@
 The following messages are now emitted:
 
 <details>
+
 1) locally-disabled:
-*Locally disabling redefined-builtin [we added some text in the message...
+*Locally disabling redefined-builtin [we added some text in the...
 </details>
 
 *This comment was truncated because GitHub allows only 420 characters in a comment.*

--- a/tests/testutils/_primer/cases/message_changed_line/expected.txt
+++ b/tests/testutils/_primer/cases/message_changed_line/expected.txt
@@ -6,6 +6,7 @@
 The following messages are now emitted:
 
 <details>
+
 1) too-complex:
 *'my_function' is too complex. The McCabe rating is 17*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L103
@@ -14,6 +15,7 @@ https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.
 The following messages are no longer emitted:
 
 <details>
+
 1) too-complex:
 *'my_function' is too complex. The McCabe rating is 18*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L100

--- a/tests/testutils/_primer/cases/mixed_changes/expected.txt
+++ b/tests/testutils/_primer/cases/mixed_changes/expected.txt
@@ -6,6 +6,7 @@
 The following messages are now emitted:
 
 <details>
+
 1) locally-disabled:
 *Locally disabling redefined-builtin [we added some text in the message] (W0622)*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
@@ -17,6 +18,7 @@ https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.
 The following messages are no longer emitted:
 
 <details>
+
 1) locally-disabled:
 *Locally disabling redefined-builtin (W0622)*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91

--- a/tests/testutils/_primer/cases/new_message/expected.txt
+++ b/tests/testutils/_primer/cases/new_message/expected.txt
@@ -6,6 +6,7 @@
 The following messages are now emitted:
 
 <details>
+
 1) locally-disabled:
 *Locally disabling redefined-builtin [we added some text in the message] (W0622)*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91

--- a/tests/testutils/_primer/cases/removed_message/expected.txt
+++ b/tests/testutils/_primer/cases/removed_message/expected.txt
@@ -6,6 +6,7 @@
 The following messages are no longer emitted:
 
 <details>
+
 1) unknown-option-value:
 *Unknown option value for 'disable', expected a valid pylint message and got 'Ellipsis'*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91

--- a/tests/testutils/_primer/cases/type_changed/expected.txt
+++ b/tests/testutils/_primer/cases/type_changed/expected.txt
@@ -6,6 +6,7 @@
 The following messages are now emitted:
 
 <details>
+
 1) line-too-long:
 *Line too long (120/100)*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L50
@@ -14,6 +15,7 @@ https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.
 The following messages are no longer emitted:
 
 <details>
+
 1) line-too-long:
 *Line too long (120/100)*
 https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/node_classes.py#L50

--- a/tests/testutils/_primer/cases/useless_suppression/expected.txt
+++ b/tests/testutils/_primer/cases/useless_suppression/expected.txt
@@ -6,6 +6,7 @@
 The following messages are now emitted:
 
 <details>
+
 1) locally-disabled:
 *Locally disabling looping-through-iterator (W4801)*
 https://github.com/astropy/astropy/blob/1fb40bc1f22f176254ef583065aa155f53f3b414/astropy/coordinates/angles/angle_parsetab.py#L14


### PR DESCRIPTION

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description


GitHub markdown requires a blank line after ``<details>`` for the content inside to be rendered as markdown rather than plain text. (See https://github.com/pylint-dev/pylint/pull/10935#issuecomment-4160625632)

