### PR TITLE
Fix inconsistent `used-before-assignment` for partial bindings

### DIFF
--- a/doc/whatsnew/fragments/9879.false_positive
+++ b/doc/whatsnew/fragments/9879.false_positive
@@ -1,0 +1,3 @@
+Fix ``used-before-assignment`` false positive for names bound in only some arms of an ``if/elif/else`` chain.
+
+Closes #9879

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -730,10 +730,10 @@ scope_type : {self.scope_type}
         # Search both if and else branches
         if_branch_handles = self._branch_handles_name(name, node.body)
         else_branch_handles = self._branch_handles_name(name, node.orelse)
-        if if_branch_handles ^ else_branch_handles:
+        if if_branch_handles and else_branch_handles:
+            self.names_defined_under_one_branch_only.discard(name)
+        elif if_branch_handles ^ else_branch_handles:
             self.names_defined_under_one_branch_only.add(name)
-        elif name in self.names_defined_under_one_branch_only:
-            self.names_defined_under_one_branch_only.remove(name)
         return if_branch_handles and else_branch_handles
 
     def _branch_handles_name(self, name: str, body: Iterable[nodes.NodeNG]) -> bool:

--- a/tests/functional/r/regression_02/regression_9879.py
+++ b/tests/functional/r/regression_02/regression_9879.py
@@ -1,0 +1,14 @@
+"""Regression test for https://github.com/pylint-dev/pylint/issues/9879"""
+# pylint: disable=missing-function-docstring
+
+
+def func(mode):
+    if mode == "a":
+        pass
+    elif mode == "b":
+        x = 1
+    elif mode == "c":
+        pass
+    else:
+        assert False
+    print(x)  # [possibly-used-before-assignment]

--- a/tests/functional/r/regression_02/regression_9879.txt
+++ b/tests/functional/r/regression_02/regression_9879.txt
@@ -1,0 +1,1 @@
+possibly-used-before-assignment:14:10:14:11:func:Possibly using variable 'x' before assignment:CONTROL_FLOW

--- a/tests/functional/u/used/used_before_assignment_typing.314.txt
+++ b/tests/functional/u/used/used_before_assignment_typing.314.txt
@@ -1,15 +1,15 @@
 undefined-variable:79:20:79:27:MyClass.incorrect_default_method:Undefined variable 'MyClass':UNDEFINED
 possibly-used-before-assignment:171:14:171:20:TypeCheckingMultiBranch.defined_in_elif_branch:Possibly using variable 'bisect' before assignment:INFERENCE
 possibly-used-before-assignment:172:15:172:23:TypeCheckingMultiBranch.defined_in_elif_branch:Possibly using variable 'calendar' before assignment:INFERENCE
-used-before-assignment:175:14:175:22:TypeCheckingMultiBranch.defined_in_else_branch:Using variable 'zoneinfo' before assignment:INFERENCE
-used-before-assignment:176:14:176:20:TypeCheckingMultiBranch.defined_in_else_branch:Using variable 'pprint' before assignment:INFERENCE
-used-before-assignment:177:14:177:25:TypeCheckingMultiBranch.defined_in_else_branch:Using variable 'collections' before assignment:INFERENCE
+possibly-used-before-assignment:175:14:175:22:TypeCheckingMultiBranch.defined_in_else_branch:Possibly using variable 'zoneinfo' before assignment:INFERENCE
+possibly-used-before-assignment:176:14:176:20:TypeCheckingMultiBranch.defined_in_else_branch:Possibly using variable 'pprint' before assignment:INFERENCE
+possibly-used-before-assignment:177:14:177:25:TypeCheckingMultiBranch.defined_in_else_branch:Possibly using variable 'collections' before assignment:INFERENCE
 possibly-used-before-assignment:181:14:181:19:TypeCheckingMultiBranch.defined_in_nested_if_else:Possibly using variable 'heapq' before assignment:INFERENCE
-used-before-assignment:185:14:185:19:TypeCheckingMultiBranch.defined_in_try_except:Using variable 'types' before assignment:INFERENCE
-used-before-assignment:186:14:186:18:TypeCheckingMultiBranch.defined_in_try_except:Using variable 'copy' before assignment:INFERENCE
-used-before-assignment:187:14:187:21:TypeCheckingMultiBranch.defined_in_try_except:Using variable 'numbers' before assignment:INFERENCE
-used-before-assignment:188:15:188:20:TypeCheckingMultiBranch.defined_in_try_except:Using variable 'array' before assignment:INFERENCE
-used-before-assignment:191:14:191:19:TypeCheckingMultiBranch.defined_in_loops:Using variable 'email' before assignment:INFERENCE
-used-before-assignment:192:14:192:21:TypeCheckingMultiBranch.defined_in_loops:Using variable 'mailbox' before assignment:INFERENCE
-used-before-assignment:193:14:193:23:TypeCheckingMultiBranch.defined_in_loops:Using variable 'mimetypes' before assignment:INFERENCE
-used-before-assignment:197:14:197:22:TypeCheckingMultiBranch.defined_in_with:Using variable 'binascii' before assignment:INFERENCE
+possibly-used-before-assignment:185:14:185:19:TypeCheckingMultiBranch.defined_in_try_except:Possibly using variable 'types' before assignment:INFERENCE
+possibly-used-before-assignment:186:14:186:18:TypeCheckingMultiBranch.defined_in_try_except:Possibly using variable 'copy' before assignment:INFERENCE
+possibly-used-before-assignment:187:14:187:21:TypeCheckingMultiBranch.defined_in_try_except:Possibly using variable 'numbers' before assignment:INFERENCE
+possibly-used-before-assignment:188:15:188:20:TypeCheckingMultiBranch.defined_in_try_except:Possibly using variable 'array' before assignment:INFERENCE
+possibly-used-before-assignment:191:14:191:19:TypeCheckingMultiBranch.defined_in_loops:Possibly using variable 'email' before assignment:INFERENCE
+possibly-used-before-assignment:192:14:192:21:TypeCheckingMultiBranch.defined_in_loops:Possibly using variable 'mailbox' before assignment:INFERENCE
+possibly-used-before-assignment:193:14:193:23:TypeCheckingMultiBranch.defined_in_loops:Possibly using variable 'mimetypes' before assignment:INFERENCE
+possibly-used-before-assignment:197:14:197:22:TypeCheckingMultiBranch.defined_in_with:Possibly using variable 'binascii' before assignment:INFERENCE

--- a/tests/functional/u/used/used_before_assignment_typing.py
+++ b/tests/functional/u/used/used_before_assignment_typing.py
@@ -172,29 +172,29 @@ class TypeCheckingMultiBranch:  # pylint: disable=too-few-public-methods,unused-
         return calendar.Calendar()  # >=3.14:[possibly-used-before-assignment]
 
     def defined_in_else_branch(self) -> urlopen:
-        print(zoneinfo)  # [used-before-assignment]
-        print(pprint())  # [used-before-assignment]
-        print(collections())  # [used-before-assignment]
+        print(zoneinfo)  # [possibly-used-before-assignment]
+        print(pprint())  # [possibly-used-before-assignment]
+        print(collections())  # [possibly-used-before-assignment]
         return urlopen
 
     def defined_in_nested_if_else(self) -> heapq:  # <3.14:[possibly-used-before-assignment]
         print(heapq)  # >=3.14:[possibly-used-before-assignment]
         return heapq
 
-    def defined_in_try_except(self) -> array:  # <3.14:[used-before-assignment]
-        print(types)  # [used-before-assignment]
-        print(copy)  # [used-before-assignment]
-        print(numbers)  # [used-before-assignment]
-        return array  # >=3.14:[used-before-assignment]
+    def defined_in_try_except(self) -> array:  # <3.14:[possibly-used-before-assignment]
+        print(types)  # [possibly-used-before-assignment]
+        print(copy)  # [possibly-used-before-assignment]
+        print(numbers)  # [possibly-used-before-assignment]
+        return array  # >=3.14:[possibly-used-before-assignment]
 
-    def defined_in_loops(self) -> json:  # <3.14:[used-before-assignment]
-        print(email)  # [used-before-assignment]
-        print(mailbox)  # [used-before-assignment]
-        print(mimetypes)  # [used-before-assignment]
+    def defined_in_loops(self) -> json:  # <3.14:[possibly-used-before-assignment]
+        print(email)  # [possibly-used-before-assignment]
+        print(mailbox)  # [possibly-used-before-assignment]
+        print(mimetypes)  # [possibly-used-before-assignment]
         return json
 
-    def defined_in_with(self) -> base64:  # <3.14:[used-before-assignment]
-        print(binascii)  # [used-before-assignment]
+    def defined_in_with(self) -> base64:  # <3.14:[possibly-used-before-assignment]
+        print(binascii)  # [possibly-used-before-assignment]
         return base64
 
 

--- a/tests/functional/u/used/used_before_assignment_typing.txt
+++ b/tests/functional/u/used/used_before_assignment_typing.txt
@@ -5,17 +5,17 @@ used-before-assignment:140:35:140:39:MyFourthClass.is_close:Using variable 'math
 used-before-assignment:153:20:153:28:VariableAnnotationsGuardedByTypeChecking:Using variable 'datetime' before assignment:INFERENCE
 possibly-used-before-assignment:170:40:170:48:TypeCheckingMultiBranch.defined_in_elif_branch:Possibly using variable 'calendar' before assignment:INFERENCE
 possibly-used-before-assignment:171:14:171:20:TypeCheckingMultiBranch.defined_in_elif_branch:Possibly using variable 'bisect' before assignment:INFERENCE
-used-before-assignment:175:14:175:22:TypeCheckingMultiBranch.defined_in_else_branch:Using variable 'zoneinfo' before assignment:INFERENCE
-used-before-assignment:176:14:176:20:TypeCheckingMultiBranch.defined_in_else_branch:Using variable 'pprint' before assignment:INFERENCE
-used-before-assignment:177:14:177:25:TypeCheckingMultiBranch.defined_in_else_branch:Using variable 'collections' before assignment:INFERENCE
+possibly-used-before-assignment:175:14:175:22:TypeCheckingMultiBranch.defined_in_else_branch:Possibly using variable 'zoneinfo' before assignment:INFERENCE
+possibly-used-before-assignment:176:14:176:20:TypeCheckingMultiBranch.defined_in_else_branch:Possibly using variable 'pprint' before assignment:INFERENCE
+possibly-used-before-assignment:177:14:177:25:TypeCheckingMultiBranch.defined_in_else_branch:Possibly using variable 'collections' before assignment:INFERENCE
 possibly-used-before-assignment:180:43:180:48:TypeCheckingMultiBranch.defined_in_nested_if_else:Possibly using variable 'heapq' before assignment:INFERENCE
-used-before-assignment:184:39:184:44:TypeCheckingMultiBranch.defined_in_try_except:Using variable 'array' before assignment:INFERENCE
-used-before-assignment:185:14:185:19:TypeCheckingMultiBranch.defined_in_try_except:Using variable 'types' before assignment:INFERENCE
-used-before-assignment:186:14:186:18:TypeCheckingMultiBranch.defined_in_try_except:Using variable 'copy' before assignment:INFERENCE
-used-before-assignment:187:14:187:21:TypeCheckingMultiBranch.defined_in_try_except:Using variable 'numbers' before assignment:INFERENCE
-used-before-assignment:190:34:190:38:TypeCheckingMultiBranch.defined_in_loops:Using variable 'json' before assignment:INFERENCE
-used-before-assignment:191:14:191:19:TypeCheckingMultiBranch.defined_in_loops:Using variable 'email' before assignment:INFERENCE
-used-before-assignment:192:14:192:21:TypeCheckingMultiBranch.defined_in_loops:Using variable 'mailbox' before assignment:INFERENCE
-used-before-assignment:193:14:193:23:TypeCheckingMultiBranch.defined_in_loops:Using variable 'mimetypes' before assignment:INFERENCE
-used-before-assignment:196:33:196:39:TypeCheckingMultiBranch.defined_in_with:Using variable 'base64' before assignment:INFERENCE
-used-before-assignment:197:14:197:22:TypeCheckingMultiBranch.defined_in_with:Using variable 'binascii' before assignment:INFERENCE
+possibly-used-before-assignment:184:39:184:44:TypeCheckingMultiBranch.defined_in_try_except:Possibly using variable 'array' before assignment:INFERENCE
+possibly-used-before-assignment:185:14:185:19:TypeCheckingMultiBranch.defined_in_try_except:Possibly using variable 'types' before assignment:INFERENCE
+possibly-used-before-assignment:186:14:186:18:TypeCheckingMultiBranch.defined_in_try_except:Possibly using variable 'copy' before assignment:INFERENCE
+possibly-used-before-assignment:187:14:187:21:TypeCheckingMultiBranch.defined_in_try_except:Possibly using variable 'numbers' before assignment:INFERENCE
+possibly-used-before-assignment:190:34:190:38:TypeCheckingMultiBranch.defined_in_loops:Possibly using variable 'json' before assignment:INFERENCE
+possibly-used-before-assignment:191:14:191:19:TypeCheckingMultiBranch.defined_in_loops:Possibly using variable 'email' before assignment:INFERENCE
+possibly-used-before-assignment:192:14:192:21:TypeCheckingMultiBranch.defined_in_loops:Possibly using variable 'mailbox' before assignment:INFERENCE
+possibly-used-before-assignment:193:14:193:23:TypeCheckingMultiBranch.defined_in_loops:Possibly using variable 'mimetypes' before assignment:INFERENCE
+possibly-used-before-assignment:196:33:196:39:TypeCheckingMultiBranch.defined_in_with:Possibly using variable 'base64' before assignment:INFERENCE
+possibly-used-before-assignment:197:14:197:22:TypeCheckingMultiBranch.defined_in_with:Possibly using variable 'binascii' before assignment:INFERENCE


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This PR fixes an inconsistency where pylint emitted `used-before-assignment` instead of `possibly-used-before-assignment` for the same partial-binding patterns in if/elif/else chains, depending on how many arms happened to bind the name. Such cases now consistently emit `possibly-used-before-assignment`.

Example: 
```python
def func(mode):
    if mode == "a":
        pass
    elif mode == "b":
        x = 1
    elif mode == "c":
        pass
    else:
        assert False
    print(x)
# before: used-before-assignment (E0601)
# after:  possibly-used-before-assignment (E0606)
```

Closes #9879.