### PR TITLE
Fix false positive for bad-dunder-name on __suppress_context__

### DIFF
--- a/doc/whatsnew/fragments/10960.false_positive
+++ b/doc/whatsnew/fragments/10960.false_positive
@@ -1,0 +1,3 @@
+Fix a false positive for ``bad-dunder-name`` when there is a user-defined ``__suppress_context__`` attribute on exception subclasses.
+
+Closes #10960

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -253,6 +253,7 @@ DUNDER_PROPERTIES = [
     "__module__",
     "__sizeof__",
     "__subclasshook__",
+    "__suppress_context__",
     "__weakref__",
 ]
 

--- a/tests/functional/ext/bad_dunder/bad_dunder_name.py
+++ b/tests/functional/ext/bad_dunder/bad_dunder_name.py
@@ -53,5 +53,11 @@ class Apples:
         return 1
 
 
+class MyError(Exception):
+    @property
+    def __suppress_context__(self):
+        return True
+
+
 def __increase_me__(val):
     return val + 1


### PR DESCRIPTION
Closes #10960

### Type of Changes

| | Type |
| ------------- | ------------- |
| ✓ | :bug: Bug fix |

### Description

Adds `__suppress_context__` to `DUNDER_PROPERTIES` so that the `bad-dunder-name` extension checker (`W3201`) stays silent when an exception subclass overrides this `BaseException` attribute as a `property`, as suggested in #10960.

This matches the prior-art pattern used to silence the warning for other overridable dunders (e.g. `__index__` in #8613 / #8619 and `__doc__`).

### Changes

- `pylint/constants.py`: append `"__suppress_context__"` to `DUNDER_PROPERTIES` (alphabetical position).
- `tests/functional/ext/bad_dunder/bad_dunder_name.py`: add a regression test case: an `Exception` subclass with a `@property def __suppress_context__(self)`. This line is not annotated with `[bad-dunder-name]`, so the test harness will fail the run if the warning ever fires for it again.
- `doc/whatsnew/fragments/10960.false_positive`: changelog fragment.