### PR TITLE
Fix wildcard import false positive

### DIFF
--- a/doc/whatsnew/fragments/10980.false_positive
+++ b/doc/whatsnew/fragments/10980.false_positive
@@ -1,0 +1,3 @@
+Fix ``used-before-assignment`` false positive for names bound by ``from X import *`` in every branch of an ``if``/``elif``/``else`` chain.
+
+Refs #10980

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -98,6 +98,16 @@ def _is_from_future_import(stmt: nodes.ImportFrom, name: str) -> bool | None:
     return None
 
 
+def _wildcard_import_binds(stmt: nodes.ImportFrom, name: str) -> bool:
+    """Check if the name is exported by a `from X import *` statement."""
+    if not any(node_name[0] == "*" for node_name in stmt.names):
+        return False
+    try:
+        return name in stmt.do_import_module(stmt.modname).wildcard_import_names()
+    except astroid.AstroidBuildingError:
+        return False
+
+
 def _get_unpacking_extra_info(node: nodes.Assign, inferred: InferenceResult) -> str:
     """Return extra information to add to the message for unpacking-non-sequence
     and unbalanced-tuple/dict-unpacking errors.
@@ -957,11 +967,17 @@ scope_type : {self.scope_type}
                 for child_named_expr in node.nodes_of_class(nodes.NamedExpr)
             ):
                 return True
-        if isinstance(node, (nodes.Import, nodes.ImportFrom)) and any(
-            (node_name[1] and node_name[1] == name)
-            or (node_name[0] == name)
-            or (node_name[0].startswith(name + "."))
-            for node_name in node.names
+        if isinstance(node, (nodes.Import, nodes.ImportFrom)) and (
+            any(
+                (node_name[1] and node_name[1] == name)
+                or (node_name[0] == name)
+                or (node_name[0].startswith(name + "."))
+                for node_name in node.names
+            )
+            or (
+                isinstance(node, nodes.ImportFrom)
+                and _wildcard_import_binds(node, name)
+            )
         ):
             return True
         if isinstance(node, nodes.With) and any(

--- a/tests/functional/u/used/used_before_assignment.py
+++ b/tests/functional/u/used/used_before_assignment.py
@@ -297,3 +297,19 @@ def conditional_import():
         os = None
     if os:
         pass
+
+
+def conditional_wildcard_import():  # pylint: disable=too-many-locals
+    if input():
+        from os.path import *  # pylint: disable=wildcard-import
+    else:
+        from os.path import *  # pylint: disable=wildcard-import
+    print(join("a", "b"))
+
+
+def conditional_wildcard_import_unresolvable():
+    if input():
+        x = 1
+    else:
+        from __nonexistent_module_xyz__ import *  # pylint: disable=wildcard-import, import-error
+    print(x)  # [possibly-used-before-assignment]

--- a/tests/functional/u/used/used_before_assignment.txt
+++ b/tests/functional/u/used/used_before_assignment.txt
@@ -17,3 +17,4 @@ used-before-assignment:239:10:239:11::Using variable 'x' before assignment:CONTR
 possibly-used-before-assignment:253:10:253:15:__:Possibly using variable 'fail1' before assignment:CONTROL_FLOW
 used-before-assignment:267:18:267:19:outer_.inner_try:Using variable 'a' before assignment:HIGH
 used-before-assignment:278:18:278:19:outer_.inner_while:Using variable 'a' before assignment:HIGH
+possibly-used-before-assignment:315:10:315:11:conditional_wildcard_import_unresolvable:Possibly using variable 'x' before assignment:CONTROL_FLOW


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This PR fixes a `used-before-assignment` false positive when a name is bound by `from X import *` in every branch of an `if`/`elif`/`else` chain. Pylint's binding detector was only comparing `node.names` entries against the target name, which never matches the literal `*`, so every branch looked like it didn't bind anything. Now the detector asks astroid what a wildcard import actually brings in (via the existing `Module.wildcard_import_names()`), which matches what Python does at runtime. 

Example: 
```python
import sys
if sys.platform == "linux":
    from os.path import *
else:
    from os.path import *
print(join("a", "b"))  # no more E0601
```