### PR TITLE
Add CI check that generated documentation is up to date

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -158,3 +158,9 @@ jobs:
             echo "Make sure that 'tox -e docs' succeed without any modifications locally." ; \
             exit 1; \
           }
+      - name: Check that generated documentation is up to date
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::Generated documentation is out of date. Run 'tox -e docs' locally and commit the changes."
+            exit 1
+          fi

--- a/doc/user_guide/checkers/extensions.rst
+++ b/doc/user_guide/checkers/extensions.rst
@@ -270,7 +270,7 @@ Verbatim name of the checker is ``dict-init-mutate``.
 
 Dict-Init-Mutate checker Messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-:dict-init-mutate (C3401): *Declare all known key/values when initializing the dictionary.*
+:dict-init-mutate (C3401): *Declare all known key/values when initializing the dictionary: %s*
   Dictionaries can be initialized with a single statement using dictionary
   literal syntax.
 

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -8,7 +8,6 @@
 Standard Checkers
 ^^^^^^^^^^^^^^^^^
 
-Remember that only ``tool.pylint`` is required, the section title is not. There are specific notes under each example that cover this.
 
 .. _main-options:
 
@@ -89,6 +88,13 @@ Remember that only ``tool.pylint`` is required, the section title is not. There 
 *Specify a score threshold under which the program will exit with error.*
 
 **Default:**  ``10``
+
+
+--files
+"""""""
+*The files to lint. The flag can also be omitted as pylint will try to lint any file passed as argument. This can be used to set files to a directory in a configuration file and invoke pylint by only typing pylint on the command line. Any file passed as argument will overwrite any file set in the configuration file.*
+
+**Default:**  ``[]``
 
 
 --from-stdin
@@ -249,6 +255,8 @@ Remember that only ``tool.pylint`` is required, the section title is not. There 
    fail-on = []
 
    fail-under = 10
+
+   files = []
 
    from-stdin = false
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :scroll: Docs          |

## Description

The Sphinx extensions in doc/exts/ regenerate tracked .rst files on
every build, but a clean Sphinx build was not enough to flag drift in
the committed copies. Run 'git diff --exit-code' after 'tox -e docs' so
PRs that change checker messages or options must include the
regenerated docs.
