### PR TITLE
Enable flake8-return in ruff

### DIFF
--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -614,11 +614,10 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
     def remove_pylint_option_from_lines(options_pattern_obj: Match[str]) -> str:
         """Remove the `# pylint ...` pattern from lines."""
         lines = options_pattern_obj.string
-        purged_lines = (
+        return (
             lines[: options_pattern_obj.start(1)].rstrip()
             + lines[options_pattern_obj.end(1) :]
         )
-        return purged_lines
 
     @staticmethod
     def is_line_length_check_activated(pylint_pattern_match_object: Match[str]) -> bool:

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -1022,13 +1022,11 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
         )
         delimiter_first_party2 = ("and " if local else "") if first_party else ""
         delimiter_first_party = f"{delimiter_first_party1}{delimiter_first_party2}"
-        msg = (
+        return (
             f"{third_party}{delimiter_third_party}"
             f"{first_party}{delimiter_first_party}"
             f'{local if local else ""}'
         )
-
-        return msg
 
     def _get_full_import_name(self, importNode: ImportNode) -> str:
         # construct a more descriptive name of the import

--- a/pylint/pyreverse/diadefslib.py
+++ b/pylint/pyreverse/diadefslib.py
@@ -64,7 +64,7 @@ class DiaDefGenerator:
 
         A leaf node is one that is not a prefix (with an extra dot) of any other node.
         """
-        leaf_nodes = [
+        return [
             module
             for module in self.args
             if not any(
@@ -72,7 +72,6 @@ class DiaDefGenerator:
                 for other in self.args
             )
         ]
-        return leaf_nodes
 
     def _set_option(self, option: bool | None) -> bool:
         """Activate some options if not explicitly deactivated."""

--- a/pylint/pyreverse/dot_printer.py
+++ b/pylint/pyreverse/dot_printer.py
@@ -143,9 +143,7 @@ class DotPrinter(Printer):
     def _escape_annotation_label(self, annotation_label: str) -> str:
         # Escape vertical bar characters to make them appear as a literal characters
         # otherwise it gets treated as field separator of record-based nodes
-        annotation_label = annotation_label.replace("|", r"\|")
-
-        return annotation_label
+        return annotation_label.replace("|", r"\|")
 
     def emit_edge(
         self,

--- a/pylint/pyreverse/mermaidjs_printer.py
+++ b/pylint/pyreverse/mermaidjs_printer.py
@@ -35,8 +35,7 @@ class MermaidJSPrinter(Printer):
 
     def _escape_mermaid_text(self, text: str) -> str:
         """Escape characters that conflict with Markdown formatting."""
-        text = text.replace("__", r"\_\_")  # Double underscore → escaped
-        return text
+        return text.replace("__", r"\_\_")  # Double underscore → escaped
 
     def emit_node(
         self,

--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -185,14 +185,13 @@ class DiagramWriter:
 
     def get_class_properties(self, obj: ClassEntity) -> NodeProperties:
         """Get label and shape for classes."""
-        properties = NodeProperties(
+        return NodeProperties(
             label=obj.title,
             attrs=obj.attrs if not self.config.only_classnames else None,
             methods=obj.methods if not self.config.only_classnames else None,
             fontcolor="red" if is_exception(obj.node) else "black",
             color=self.get_shape_color(obj) if self.config.colorized else "black",
         )
-        return properties
 
     def get_shape_color(self, obj: DiagramEntity) -> str:
         """Get shape color."""

--- a/pylint/testutils/configuration_test.py
+++ b/pylint/testutils/configuration_test.py
@@ -151,5 +151,4 @@ def run_using_a_configuration_file(
     # in `_msg_states`, used by `is_message_enabled`.
     check = "pylint.lint.pylinter.check_parallel"
     with unittest.mock.patch(check):
-        runner = Run(args, exit=False)
-    return runner
+        return Run(args, exit=False)

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -84,8 +84,7 @@ def cmp(a: float, b: float) -> int:
 def diff_string(old: float, new: float) -> str:
     """Given an old and new value, return a string representing the difference."""
     diff = abs(old - new)
-    diff_str = f"{CMPS[cmp(old, new)]}{(diff and f'{diff:.2f}') or ''}"
-    return diff_str
+    return f"{CMPS[cmp(old, new)]}{(diff and f'{diff:.2f}') or ''}"
 
 
 def get_module_and_frameid(node: nodes.NodeNG) -> tuple[str, str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ lint.select = [
   "PIE", # flake8-pie
   "PTH", # flake8-pathlib
   "PYI", # flake8-pyi
+  "RET", # flake8-return
   "RUF", # ruff
   "UP",  # pyupgrade
   "W",   # pycodestyle

--- a/tests/pyreverse/conftest.py
+++ b/tests/pyreverse/conftest.py
@@ -92,7 +92,6 @@ def get_project() -> GetProjectCallable:
             return func(modname)
 
         with augmented_sys_path([discover_package_path(module, [])]):
-            project = project_from_files([module], _astroid_wrapper, project_name=name)
-        return project
+            return project_from_files([module], _astroid_wrapper, project_name=name)
 
     return _get_project

--- a/tests/reporters/unittest_json_reporter.py
+++ b/tests/reporters/unittest_json_reporter.py
@@ -102,8 +102,7 @@ def get_linter_result(score: bool, message: dict[str, Any]) -> list[dict[str, An
     if score:
         reporter.display_reports(EvaluationSection(expected_score_message))
     reporter.display_messages(None)
-    report_result = json.loads(output.getvalue())
-    return report_result  # type: ignore[no-any-return]
+    return json.loads(output.getvalue())  # type: ignore[no-any-return]
 
 
 @pytest.mark.parametrize(
@@ -200,8 +199,7 @@ def get_linter_result_for_v2(message: dict[str, Any]) -> list[dict[str, Any]]:
     )
     linter.stats.statement = 2
     reporter.display_messages(None)
-    report_result = json.loads(output.getvalue())
-    return report_result  # type: ignore[no-any-return]
+    return json.loads(output.getvalue())  # type: ignore[no-any-return]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -46,12 +46,11 @@ def _gen_file_data(idx: int = 0) -> FileItem:
     filepath = os.path.abspath(
         os.path.join(os.path.dirname(__file__), "input", "similar1")
     )
-    file_data = FileItem(
+    return FileItem(
         f"--test-file_data-name-{idx}--",
         filepath,
         f"--test-file_data-modname-{idx}--",
     )
-    return file_data
 
 
 def _gen_file_datas(count: int = 1) -> list[FileItem]:

--- a/tests/utils/unittest_utils.py
+++ b/tests/utils/unittest_utils.py
@@ -22,3 +22,9 @@ def test_decoding_stream_known_encoding() -> None:
     binary_io = io.BytesIO("€".encode("cp1252"))
     stream = utils.decoding_stream(binary_io, "cp1252")
     assert stream.read() == "€"
+
+
+def test_diff_string() -> None:
+    assert utils.diff_string(1.0, 1.0) == "="
+    assert utils.diff_string(1.0, 2.0) == "+1.00"
+    assert utils.diff_string(2.0, 1.0) == "-1.00"


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

flake8-return rule that flags a local variable assigned only to be returned on the next line. 