### PR TITLE
Fix inflated message stats in parallel mode

### DIFF
--- a/doc/whatsnew/fragments/10996.bugfix
+++ b/doc/whatsnew/fragments/10996.bugfix
@@ -1,0 +1,4 @@
+Fixed inflated message occurrence counts in the final ``Messages`` report when
+running pylint in parallel mode with ``--jobs`` greater than 1.
+
+Closes #10996

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -74,6 +74,15 @@ def _worker_check_single_file(
 
     if not _worker_linter:
         raise RuntimeError("Worker linter not yet initialised")
+
+    # A worker process can lint multiple files. The parent process expects the
+    # returned LinterStats instance to describe only the current file because it
+    # merges one stats object per _worker_check_single_file() result. If we keep
+    # the worker-level accumulated stats here, values such as stats.by_msg are
+    # counted repeatedly in the final report.
+    _worker_linter.stats = LinterStats()
+    _worker_linter.msg_status = 0
+
     _worker_linter.open()
     _worker_linter.check_single_file_item(file_item)
     mapreduce_data = defaultdict(list)

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -778,3 +778,39 @@ class TestCheckParallel:
             )
 
         assert "cyclic-import" not in linter.stats.by_msg
+
+    @pytest.mark.needs_two_cores
+    def test_parallel_message_stats_are_not_inflated(self) -> None:
+        """The final message report stats must match emitted diagnostics.
+
+        Each worker can process more than one file. The stats returned for a
+        worker invocation must therefore be per-file stats, not cumulative
+        worker-process stats, otherwise merge_stats() counts messages repeatedly.
+        """
+        num_files = 10
+        linter = PyLinter(reporter=Reporter())
+        linter.register_checker(MessageEmittingSequentialTestChecker(linter))
+
+        check_parallel(linter, jobs=2, files=_gen_file_datas(num_files))
+
+        assert len(linter.reporter.messages) == num_files
+        assert linter.stats.by_msg == {
+            "message-emitting-sequential-test-check": num_files
+        }
+
+
+class MessageEmittingSequentialTestChecker(BaseRawFileChecker):
+    """A sequential checker that emits one message per processed module."""
+
+    name = "message-emitting-sequential-checker"
+    msgs = {
+        "R9998": (
+            "Test",
+            "message-emitting-sequential-test-check",
+            "Some helpful text.",
+        )
+    }
+
+    def process_module(self, node: nodes.Module) -> None:
+        """Emit exactly one message per checked module."""
+        self.add_message("R9998")


### PR DESCRIPTION
Reset worker linter stats before checking each file so the parent process merges per-file statistics instead of cumulative worker-process snapshots.

This prevents the final `Messages` report from showing inflated occurrence counts when pylint runs with `--jobs` greater than 1.

Closes #10996.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Description

When pylint runs in parallel mode, a worker process can check multiple files. Before this change, the worker returned its accumulated `LinterStats` after each file. The parent process then merged every returned stats object, effectively summing cumulative worker snapshots instead of independent per-file statistics.

As a result, the emitted diagnostics were correct, but the final `Messages` report could show inflated occurrence counts when running with `--jobs > 1`.

This PR resets the worker linter stats before each file is checked, so each returned `LinterStats` object represents only the current file. The parent process can then merge the returned stats without double-counting previous files handled by the same worker.

A regression test was added to verify that the final message statistics match the number of emitted diagnostics in parallel mode.

Closes #10996