### PR TITLE
Pin PyPy 3.11 to avoid astroid bootstrap failure

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,7 +47,7 @@ jobs:
           - os: ubuntu-latest
             python-version: "pypy-3.10"
           - os: ubuntu-latest
-            python-version: "pypy-3.11"
+            python-version: "pypy-3.11-v7.3.20"
     runs-on: ${{ matrix.os }}
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}

--- a/doc/whatsnew/fragments/10999.internal
+++ b/doc/whatsnew/fragments/10999.internal
@@ -1,5 +1,0 @@
-Pin the PyPy 3.11 version used by the test workflow to ``pypy-3.11-v7.3.20`` to avoid a collection-time failure in astroid bootstrap with the latest available PyPy 3.11.
-
-This is a temporary CI stabilization workaround until the upstream astroid compatibility issue is fixed.
-
-Refs #10999

--- a/doc/whatsnew/fragments/10999.internal
+++ b/doc/whatsnew/fragments/10999.internal
@@ -1,0 +1,5 @@
+Pin the PyPy 3.11 version used by the test workflow to ``pypy-3.11-v7.3.20`` to avoid a collection-time failure in astroid bootstrap with the latest available PyPy 3.11.
+
+This is a temporary CI stabilization workaround until the upstream astroid compatibility issue is fixed.
+
+Refs #10999


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

Pin the PyPy 3.11 version used in CI.

The current workflow uses the floating `pypy-3.11` version. With the latest available PyPy 3.11, the test job fails during pytest collection before pylint tests are executed:

```text
TypeError: expected str, got getset_descriptor object
```

The failure happens inside astroid bootstrap after astroid.extract_node() triggers AstroidManager.bootstrap().

This PR pins the CI job to a known PyPy 3.11 version to stabilize the test workflow. The underlying compatibility issue should be fixed upstream in astroid.

No issue.