### PR TITLE
docs(messages): document CWD-dependent wrong-import-order classification

### DIFF
--- a/doc/data/messages/w/wrong-import-order/details.rst
+++ b/doc/data/messages/w/wrong-import-order/details.rst
@@ -1,0 +1,25 @@
+Pylint uses ``isort`` to classify imports into standard library,
+third-party, first-party, and local import groups.
+
+``isort`` detects first-party imports by looking for packages relative to
+the current working directory. As a result, running pylint from different
+directories can change how the same import is classified.
+
+For example, with the following project layout::
+
+    project/
+        src/
+            my_package/
+                __init__.py
+                module.py
+
+An import of ``my_package`` in ``module.py`` may be treated as first-party
+when pylint is run from ``project/src``, but as third-party when pylint is
+run from ``project``.
+
+If this warning fires, or fails to fire, inconsistently between runs, set
+``known-first-party`` in your pylint configuration to make the
+classification deterministic::
+
+    [tool.pylint.imports]
+    known-first-party = ["my_package"]

--- a/doc/whatsnew/fragments/8801.other
+++ b/doc/whatsnew/fragments/8801.other
@@ -1,0 +1,5 @@
+Document that the ``wrong-import-order`` (C0411) classification of imports as
+third-party vs first-party depends on the current working directory and
+recommend ``known-first-party`` as the deterministic workaround.
+
+Closes #8801


### PR DESCRIPTION
## What changed

- New `doc/data/messages/w/wrong-import-order/details.rst` explaining that pylint classifies imports as first-party vs third-party using `isort.place_module()`, and that isort's first-party detection is rooted at the current working directory. The doc lists `known-first-party` as the deterministic workaround.
- New towncrier fragment `doc/whatsnew/fragments/8801.other`.

Closes #8801

## Why

Issue #8801 reports that running `pylint` against the same source tree from different working directories produces different `wrong-import-order` (C0411) output. The root cause is that `pylint/checkers/imports.py` calls `isort.place_module(package, config=self._isort_config)` (line 826 on `main`), and `isort.place_module()` walks the filesystem starting at CWD when classifying packages as first-party. Same source, different CWD, different classification.

This is an isort design decision rather than a pylint bug, but the issue carries the `Documentation` and `Needs PR` labels — the maintainer team has signalled that documenting the CWD dependency plus a deterministic workaround is the accepted ship vehicle. This PR adds a short details file (rendered into the auto-generated message page) and a news fragment that points users at `known-first-party`. Users who hit the inconsistency can pin classification per-repo without changing their invocation.

I did not change `imports.py` itself. Plumbing `src_paths` through `_isort_config()` is plausible but non-trivial (requires deriving stable roots from the linted file paths), and I'd rather ship the user-facing fix the maintainers asked for and let a code-side change happen separately if you decide to pursue it.

## Verification

The added files are RST + towncrier fragment, both inert at runtime. `pre-commit run --files doc/data/messages/w/wrong-import-order/details.rst doc/whatsnew/fragments/8801.other` is clean. CI's docs build will exercise the sphinx integration that generates the per-message page from `details.rst`.
