### PR TITLE
Fix no-value-for-parameter false negative when kwargs is inferable

### DIFF
--- a/doc/whatsnew/fragments/8785.false_negative
+++ b/doc/whatsnew/fragments/8785.false_negative
@@ -1,0 +1,4 @@
+``no-value-for-parameter`` is now emitted when ``**kwargs`` is used in a call
+with an inferable dictionary that does not provide the required parameter.
+
+Closes #8785

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1686,15 +1686,16 @@ accessed. Python regular expressions are accepted.",
                 )
 
         # 3. Match the **kwargs, if any.
-        if node.kwargs:
+        # When **kwargs is used, only mark parameters as assigned if the
+        # enclosing scope passes through variadic keywords without context
+        # (e.g. def wrapper(**kwargs): f(**kwargs)).  Otherwise, the kwargs
+        # dict was already unpacked by CallSite and its keys were matched
+        # in step 2 above; blindly marking all parameters as assigned would
+        # mask no-value-for-parameter false negatives.  (See #8785.)
+        if node.kwargs and has_no_context_keywords_variadic:
             for i, [(name, _defval), _assigned] in enumerate(parameters):
-                # Assume that *kwargs provides values for all remaining
-                # unassigned named parameters.
                 if name is not None:
                     parameters[i] = (parameters[i][0], True)
-                else:
-                    # **kwargs can't assign to tuples.
-                    pass
 
         # Check that any parameters without a default have been assigned
         # values.

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1686,13 +1686,21 @@ accessed. Python regular expressions are accepted.",
                 )
 
         # 3. Match the **kwargs, if any.
-        # When **kwargs is used, only mark parameters as assigned if the
-        # enclosing scope passes through variadic keywords without context
-        # (e.g. def wrapper(**kwargs): f(**kwargs)).  Otherwise, the kwargs
-        # dict was already unpacked by CallSite and its keys were matched
-        # in step 2 above; blindly marking all parameters as assigned would
-        # mask no-value-for-parameter false negatives.  (See #8785.)
-        if node.kwargs and has_no_context_keywords_variadic:
+        # CallSite already unpacked literal ``**{...}`` dicts in step 2, so
+        # we only assume the **kwargs covers remaining parameters when its
+        # full key set is NOT statically provable: either the enclosing
+        # scope forwards a variadic kwargs without context
+        # (``def wrapper(**kw): f(**kw)``) or any ``**operand`` is not a
+        # literal Dict node (Name, Call, subscript, comprehension, etc.).
+        # Otherwise the gate stays closed and ``no-value-for-parameter``
+        # is allowed to fire when keys don't match parameter names.
+        # See #8785 and primer follow-up on #11002.
+        kwargs_might_supply_more = any(
+            not isinstance(kw.value, nodes.Dict) for kw in node.kwargs
+        )
+        if node.kwargs and (
+            has_no_context_keywords_variadic or kwargs_might_supply_more
+        ):
             for i, [(name, _defval), _assigned] in enumerate(parameters):
                 if name is not None:
                     parameters[i] = (parameters[i][0], True)

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1686,15 +1686,14 @@ accessed. Python regular expressions are accepted.",
                 )
 
         # 3. Match the **kwargs, if any.
-        # CallSite already unpacked literal ``**{...}`` dicts in step 2, so
-        # we only assume the **kwargs covers remaining parameters when its
-        # full key set is NOT statically provable: either the enclosing
-        # scope forwards a variadic kwargs without context
-        # (``def wrapper(**kw): f(**kw)``) or any ``**operand`` is not a
-        # literal Dict node (Name, Call, subscript, comprehension, etc.).
-        # Otherwise the gate stays closed and ``no-value-for-parameter``
-        # is allowed to fire when keys don't match parameter names.
-        # See #8785 and primer follow-up on #11002.
+        # CallSite unpacks literal ``**{...}`` operands into keyword_arguments
+        # in step 2. We therefore only assume **kwargs covers the remaining
+        # named parameters when its full key set is not statically provable:
+        # the enclosing scope forwards a variadic kwarg without context
+        # (``def wrap(**kw): f(**kw)``), or at least one ``**operand`` is not
+        # a literal Dict (Name, Call, subscript, ...). A literal
+        # ``f(**{"y": ...})`` keeps the gate closed and lets
+        # ``no-value-for-parameter`` fire (see #8785).
         kwargs_might_supply_more = any(
             not isinstance(kw.value, nodes.Dict) for kw in node.kwargs
         )

--- a/tests/functional/a/arguments.py
+++ b/tests/functional/a/arguments.py
@@ -354,3 +354,12 @@ class MyClass(metaclass=Meta): # pylint: disable=too-few-public-methods
 MyClass(1, 2, 3, 4) # [too-many-function-args]
 MyClass(1, 2) # [no-value-for-parameter]
 MyClass(1, 2, 3)
+
+
+# https://github.com/pylint-dev/pylint/issues/8785
+# **kwargs unpacking should not suppress no-value-for-parameter
+import copy
+import os
+
+copy.copy(**{"y": os.environ})  # [unexpected-keyword-arg, no-value-for-parameter]
+copy.copy(y=os.environ)  # [no-value-for-parameter, unexpected-keyword-arg]

--- a/tests/functional/a/arguments.txt
+++ b/tests/functional/a/arguments.txt
@@ -42,3 +42,7 @@ no-value-for-parameter:318:0:318:16::No value for argument 'param1' in function 
 no-value-for-parameter:335:0:335:13::No value for argument '__class_or_tuple' in function call:HIGH
 too-many-function-args:354:0:354:19::Too many positional arguments for class call:UNDEFINED
 no-value-for-parameter:355:0:355:13::No value for argument 'c' in class call:UNDEFINED
+no-value-for-parameter:364:0:364:30::No value for argument 'x' in function call:UNDEFINED
+unexpected-keyword-arg:364:0:364:30::Unexpected keyword argument 'y' in function call:UNDEFINED
+no-value-for-parameter:365:0:365:23::No value for argument 'x' in function call:UNDEFINED
+unexpected-keyword-arg:365:0:365:23::Unexpected keyword argument 'y' in function call:UNDEFINED

--- a/tests/functional/k/kwargs_unpacking_no_false_positive.py
+++ b/tests/functional/k/kwargs_unpacking_no_false_positive.py
@@ -14,13 +14,13 @@ class P:
         self.y = y
 
 
-# dict.update — astroid can't see post-update keys
+# dict.update
 data_update = {"x": 1}
 data_update.update({"y": 2})
 P(**data_update)
 
 
-# dict.setdefault — same story
+# dict.setdefault
 data_setdefault = {}
 data_setdefault.setdefault("x", 0)
 data_setdefault.setdefault("y", 0)

--- a/tests/functional/k/kwargs_unpacking_no_false_positive.py
+++ b/tests/functional/k/kwargs_unpacking_no_false_positive.py
@@ -10,6 +10,11 @@ with ``**something``, and ``something`` is populated dynamically (forwarded
 ``**kwargs``, ``dict.update``, ``setdefault``, a loop, constant-keyed
 assignment, or an opaque external source). None of the calls below should
 emit ``no-value-for-parameter``.
+
+Each FP block is paired with a sibling call that exposes a genuinely
+missing required argument (direct kwarg or literal ``**{...}`` covering
+only a subset of the parameters). Those siblings must still emit
+``no-value-for-parameter`` so the gate is not over-suppressing.
 """
 # pylint: disable=missing-docstring,too-few-public-methods,unused-argument
 
@@ -42,6 +47,10 @@ class Forwarder:
         return needs_two(**kwargs)
 
 
+# Paired violation: a direct call missing ``y`` is still caught.
+Point(x=1)  # [no-value-for-parameter]
+
+
 # 2. Dict populated via ``dict.update`` before being unpacked
 #    (``data_kwargs.update({...})`` then ``Klass(**data_kwargs)`` --
 #    sentry slack entrypoint).
@@ -49,6 +58,10 @@ def via_update() -> Point:
     data = {"x": 1}
     data.update({"y": 2})
     return Point(**data)
+
+
+# Paired violation: a literal ``**{"x": ...}`` missing ``y`` is still caught.
+Point(**{"x": 1})  # [no-value-for-parameter]
 
 
 # 3. Dict populated via ``setdefault`` before being unpacked
@@ -61,6 +74,10 @@ def via_setdefault() -> Point:
     return Point(**data)
 
 
+# Paired violation: a literal ``**{"y": ...}`` missing ``x`` is still caught.
+Point(**{"y": 0})  # [no-value-for-parameter]
+
+
 # 4. Dict populated in a loop before being unpacked
 #    (``NextDnsData(**coordinators)`` -- home-assistant nextdns).
 PAIRS = [("x", 1), ("y", 2)]
@@ -71,6 +88,11 @@ def via_loop() -> Point:
     for name, value in PAIRS:
         data[name] = value
     return Point(**data)
+
+
+# Paired violation: a literal ``**{"x": ...}`` whose loop counterpart would
+# also stop short is still caught.
+Point(**{"x": 2})  # [no-value-for-parameter]
 
 
 # 5. Dict populated by constant-keyed assignment whose key string equals the
@@ -87,6 +109,11 @@ def via_constant_keys(value_x: int, value_y: int) -> Point:
     return Point(**data)
 
 
+# Paired violation: a literal ``**{ATTR_X: ...}`` missing ``y`` is still
+# caught (the key resolves to ``"x"`` via inference).
+Point(**{ATTR_X: 1})  # [no-value-for-parameter]
+
+
 # 6. Dict obtained from an opaque external source then unpacked, optionally
 #    after popping unrelated keys (``GalaxyAPI(self.galaxy, name,
 #    **server_options)`` where ``server_options`` comes from
@@ -100,3 +127,8 @@ def via_opaque_dict() -> Point:
     options = opaque_options()
     options.pop("ignored")
     return Point(**options)  # [unexpected-keyword-arg]
+
+
+# Paired violation: a direct call to ``needs_two`` missing ``b`` is still
+# caught.
+needs_two(a=1)  # [no-value-for-parameter]

--- a/tests/functional/k/kwargs_unpacking_no_false_positive.py
+++ b/tests/functional/k/kwargs_unpacking_no_false_positive.py
@@ -1,60 +1,102 @@
-"""Regression test for #8785 follow-up: ``no-value-for-parameter`` must not
-fire when a required argument is supplied via ``**`` unpacking of a dict
-whose full contents pylint cannot statically prove.
+"""Regression test: ``no-value-for-parameter`` must not fire when a required
+argument is supplied via ``**`` unpacking of a dict whose contents pylint
+cannot statically prove.
 
-The patterns below were all observed as fresh false positives by the
-primer run on the original #8785 fix.
+The patterns below were all observed as fresh false positives in ansible,
+sentry and home-assistant when running the proposed implementation from
+https://github.com/pylint-dev/pylint/pull/11002 against open-source code.
+They share a single shape: a callable with required parameters is invoked
+with ``**something``, and ``something`` is populated dynamically (forwarded
+``**kwargs``, ``dict.update``, ``setdefault``, a loop, constant-keyed
+assignment, or an opaque external source). None of the calls below should
+emit ``no-value-for-parameter``.
 """
 # pylint: disable=missing-docstring,too-few-public-methods,unused-argument
 
-
-class P:
-    def __init__(self, x, y):
-        self.x = x
-        self.y = y
+from dataclasses import dataclass
+from typing import Any
 
 
-# dict.update
-data_update = {"x": 1}
-data_update.update({"y": 2})
-P(**data_update)
+@dataclass
+class Point:
+    x: int
+    y: int
 
 
-# dict.setdefault
-data_setdefault = {}
-data_setdefault.setdefault("x", 0)
-data_setdefault.setdefault("y", 0)
-P(**data_setdefault)
+def needs_two(a: int, b: int) -> int:
+    return a + b
 
 
-# Loop-built dict
-data_loop = {}
-for key, value in [("x", 1), ("y", 2)]:
-    data_loop[key] = value
-P(**data_loop)
+# 1. Outer ``**kwargs`` parameter forwarded to a callee with required params.
+#    This is the dominant pattern -- any thin wrapper / facade does this.
+def forward_to_ctor(**kwargs: Any) -> Point:
+    return Point(**kwargs)
 
 
-# Subscript-built dict
+def forward_to_func(**kwargs: Any) -> int:
+    return needs_two(**kwargs)
+
+
+class Forwarder:
+    def relay(self, **kwargs: Any) -> int:
+        return needs_two(**kwargs)
+
+
+# 2. Dict populated via ``dict.update`` before being unpacked
+#    (``data_kwargs.update({...})`` then ``Klass(**data_kwargs)`` --
+#    sentry slack entrypoint).
+def via_update() -> Point:
+    data = {"x": 1}
+    data.update({"y": 2})
+    return Point(**data)
+
+
+# 3. Dict populated via ``setdefault`` before being unpacked
+#    (``update_snuba_query(..., **updated_query_fields)`` -- sentry
+#    incidents/logic.py).
+def via_setdefault() -> Point:
+    data: dict[str, int] = {}
+    data.setdefault("x", 0)
+    data.setdefault("y", 0)
+    return Point(**data)
+
+
+# 4. Dict populated in a loop before being unpacked
+#    (``NextDnsData(**coordinators)`` -- home-assistant nextdns).
+PAIRS = [("x", 1), ("y", 2)]
+
+
+def via_loop() -> Point:
+    data: dict[str, int] = {}
+    for name, value in PAIRS:
+        data[name] = value
+    return Point(**data)
+
+
+# 5. Dict populated by constant-keyed assignment whose key string equals the
+#    target parameter name (``kwargs[ATTR_MESSAGE] = message`` then
+#    ``self.async_send_message(**kwargs)`` -- home-assistant notify/legacy).
 ATTR_X = "x"
 ATTR_Y = "y"
-data_subscript = {}
-data_subscript[ATTR_X] = 1
-data_subscript[ATTR_Y] = 2
-P(**data_subscript)
 
 
-# Opaque source (function return)
-def get_opts():
-    return {"x": 1, "y": 2}
+def via_constant_keys(value_x: int, value_y: int) -> Point:
+    data: dict[str, int] = {}
+    data[ATTR_X] = value_x
+    data[ATTR_Y] = value_y
+    return Point(**data)
 
 
-opts = get_opts()
-P(**opts)
+# 6. Dict obtained from an opaque external source then unpacked, optionally
+#    after popping unrelated keys (``GalaxyAPI(self.galaxy, name,
+#    **server_options)`` where ``server_options`` comes from
+#    ``config.get_plugin_options(...)`` -- ansible galaxy CLI; same shape as
+#    ``BigtableKVStorage(**options)`` in sentry).
+def opaque_options() -> dict[str, Any]:
+    return {"x": 1, "y": 2, "ignored": "ignored"}
 
 
-# Forwarded **kwargs
-def wrap(**kw):
-    P(**kw)
-
-
-wrap(x=1, y=2)
+def via_opaque_dict() -> Point:
+    options = opaque_options()
+    options.pop("ignored")
+    return Point(**options)  # [unexpected-keyword-arg]

--- a/tests/functional/k/kwargs_unpacking_no_false_positive.py
+++ b/tests/functional/k/kwargs_unpacking_no_false_positive.py
@@ -1,0 +1,60 @@
+"""Regression test for #8785 follow-up: ``no-value-for-parameter`` must not
+fire when a required argument is supplied via ``**`` unpacking of a dict
+whose full contents pylint cannot statically prove.
+
+The patterns below were all observed as fresh false positives by the
+primer run on the original #8785 fix.
+"""
+# pylint: disable=missing-docstring,too-few-public-methods,unused-argument
+
+
+class P:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+
+# dict.update — astroid can't see post-update keys
+data_update = {"x": 1}
+data_update.update({"y": 2})
+P(**data_update)
+
+
+# dict.setdefault — same story
+data_setdefault = {}
+data_setdefault.setdefault("x", 0)
+data_setdefault.setdefault("y", 0)
+P(**data_setdefault)
+
+
+# Loop-built dict
+data_loop = {}
+for key, value in [("x", 1), ("y", 2)]:
+    data_loop[key] = value
+P(**data_loop)
+
+
+# Subscript-built dict
+ATTR_X = "x"
+ATTR_Y = "y"
+data_subscript = {}
+data_subscript[ATTR_X] = 1
+data_subscript[ATTR_Y] = 2
+P(**data_subscript)
+
+
+# Opaque source (function return)
+def get_opts():
+    return {"x": 1, "y": 2}
+
+
+opts = get_opts()
+P(**opts)
+
+
+# Forwarded **kwargs
+def wrap(**kw):
+    P(**kw)
+
+
+wrap(x=1, y=2)

--- a/tests/functional/k/kwargs_unpacking_no_false_positive.txt
+++ b/tests/functional/k/kwargs_unpacking_no_false_positive.txt
@@ -1,1 +1,7 @@
-unexpected-keyword-arg:102:11:102:27:via_opaque_dict:Unexpected keyword argument 'ignored' in constructor call:UNDEFINED
+no-value-for-parameter:51:0:51:10::No value for argument 'y' in constructor call:UNDEFINED
+no-value-for-parameter:64:0:64:17::No value for argument 'y' in constructor call:UNDEFINED
+no-value-for-parameter:78:0:78:17::No value for argument 'x' in constructor call:UNDEFINED
+no-value-for-parameter:95:0:95:17::No value for argument 'y' in constructor call:UNDEFINED
+no-value-for-parameter:114:0:114:20::No value for argument 'y' in constructor call:UNDEFINED
+unexpected-keyword-arg:129:11:129:27:via_opaque_dict:Unexpected keyword argument 'ignored' in constructor call:UNDEFINED
+no-value-for-parameter:134:0:134:14::No value for argument 'b' in function call:UNDEFINED

--- a/tests/functional/k/kwargs_unpacking_no_false_positive.txt
+++ b/tests/functional/k/kwargs_unpacking_no_false_positive.txt
@@ -1,0 +1,1 @@
+unexpected-keyword-arg:102:11:102:27:via_opaque_dict:Unexpected keyword argument 'ignored' in constructor call:UNDEFINED

--- a/tests/functional/s/shallow_copy_environ.py
+++ b/tests/functional/s/shallow_copy_environ.py
@@ -33,5 +33,5 @@ copy.copy()  # [no-value-for-parameter]
 copy.copy(x=TEST_DICT)
 copy.copy(x=os.environ)  # [shallow-copy-environ]
 copy.copy(**{"x": os.environ})  # [shallow-copy-environ]
-copy.copy(**{"y": os.environ})  # [unexpected-keyword-arg]
+copy.copy(**{"y": os.environ})  # [no-value-for-parameter, unexpected-keyword-arg]
 copy.copy(y=os.environ)  # [no-value-for-parameter, unexpected-keyword-arg]

--- a/tests/functional/s/shallow_copy_environ.txt
+++ b/tests/functional/s/shallow_copy_environ.txt
@@ -3,6 +3,7 @@ shallow-copy-environ:17:0:17:18::Using copy.copy(os.environ). Use os.environ.cop
 no-value-for-parameter:32:0:32:11::No value for argument 'x' in function call:UNDEFINED
 shallow-copy-environ:34:0:34:23::Using copy.copy(os.environ). Use os.environ.copy() instead.:HIGH
 shallow-copy-environ:35:0:35:30::Using copy.copy(os.environ). Use os.environ.copy() instead.:INFERENCE
+no-value-for-parameter:36:0:36:30::No value for argument 'x' in function call:UNDEFINED
 unexpected-keyword-arg:36:0:36:30::Unexpected keyword argument 'y' in function call:UNDEFINED
 no-value-for-parameter:37:0:37:23::No value for argument 'x' in function call:UNDEFINED
 unexpected-keyword-arg:37:0:37:23::Unexpected keyword argument 'y' in function call:UNDEFINED


### PR DESCRIPTION
Fixes #8785.

`_check_argument_order` step 3 unconditionally marked all remaining
parameters as assigned whenever the call had any `**kwargs` operand,
masking `no-value-for-parameter` even when the operand was an inferable
literal dict whose keys were already matched in step 2.

Gate step 3 so it only runs when the full key set is not statically
provable: either the enclosing scope forwards a variadic kwarg without
context (`def wrap(**kw): f(**kw)`), or at least one `**operand` is
not a literal `Dict` node (`Name`, `Call`, subscript, ...). Literal
`f(**{"y": ...})` now lets `no-value-for-parameter` fire, while the
opaque shapes observed across ansible / sentry / home-assistant stay
silent.

Regression coverage in `tests/functional/k/kwargs_unpacking_no_false_positive`
exercises the six primer-found shapes:

- `dict.update`
- `dict.setdefault`
- loop-built dict
- subscript-built dict
- opaque function return
- forwarded `**kwargs`
