### PR TITLE
testutils: don't clobber older-Python expected-output files on update (#10844)

### DIFF
--- a/doc/whatsnew/fragments/10844.bugfix
+++ b/doc/whatsnew/fragments/10844.bugfix
@@ -1,0 +1,7 @@
+Stop ``test_functional.py --update-functional-output`` from deleting or
+overwriting expected-output files that belong to an older Python version.
+When the resolved expected-output file is e.g. ``foo.313.txt`` while the
+running interpreter is Python 3.14, the inherited file is now left
+untouched and a new ``foo.<current>.txt`` is written instead.
+
+Closes #10844

--- a/pylint/testutils/functional/lint_module_output_update.py
+++ b/pylint/testutils/functional/lint_module_output_update.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import csv
 import os
+import sys
+from pathlib import Path
 
 from pylint.testutils.lint_module_test import LintModuleTest, MessageCounter
 from pylint.testutils.output_line import OutputLine
@@ -30,14 +32,74 @@ class LintModuleOutputUpdate(LintModuleTest):
         expected_output: list[OutputLine],
         actual_output: list[OutputLine],
     ) -> None:
-        """Overwrite or remove the expected output file based on actual output."""
-        # Remove the expected file if no output is actually emitted and a file exists
+        """Overwrite or remove the expected output file based on actual output.
+
+        When the resolved expected-output file is owned by an *older* Python
+        version (e.g. ``foo.313.txt`` while running on Python 3.14), do not
+        delete or overwrite it. Instead, write a new version-specific file
+        for the current interpreter (``foo.314.txt``). This preserves the
+        recorded expectations for older versions while letting the user
+        record the new behaviour on the running version. See #10844.
+        """
+        expected_path = Path(self._test_file.expected_output)
+        current_suffix = f"{sys.version_info[0]}{sys.version_info[1]}"
+        target_path = self._target_path_for_current_version(
+            expected_path, current_suffix
+        )
+
+        # Empty actual output: the running interpreter emits no diagnostics.
         if not actual_output:
-            if os.path.exists(self._test_file.expected_output):
-                os.remove(self._test_file.expected_output)
+            if target_path == expected_path:
+                # The resolved file belongs to this Python version (or is
+                # the version-less base file); preserve the historical
+                # behaviour of removing it.
+                if os.path.exists(expected_path):
+                    os.remove(expected_path)
+                return
+            # The resolved file belongs to an older Python version. Don't
+            # delete it — write an empty current-version file to shadow it
+            # instead, so we record "no diagnostics on this version"
+            # without erasing what older versions still expect.
+            target_path.write_text("", encoding="utf-8")
             return
-        # Write file with expected output
-        with open(self._test_file.expected_output, "w", encoding="utf-8") as f:
+
+        # Non-empty actual output: write to the current version's file
+        # (which may or may not be the resolved file).
+        with open(target_path, "w", encoding="utf-8") as f:
             writer = csv.writer(f, dialect="test")
             for line in actual_output:
                 self.safe_write_output_line(writer, line)
+
+    def _target_path_for_current_version(
+        self, expected_path: Path, current_suffix: str
+    ) -> Path:
+        """Return the file path we should write to for the current Python.
+
+        If ``expected_path`` is the bare ``<base>.txt`` (no version suffix)
+        or already matches the current version (``<base>.<current>.txt``),
+        write to it directly. Otherwise the resolved file belongs to an
+        older Python — return a sibling ``<base>.<current>.txt`` so we
+        don't clobber the older version's expectations.
+        """
+        # ``self._test_file.base`` may be an absolute path (the legacy code
+        # constructs ``FunctionalTestFile`` with the full filename as the
+        # ``filename`` argument and strips ``.py`` from it). The actual
+        # filename stem we need to compare against is just the trailing
+        # path component.
+        base_short = os.path.basename(self._test_file.base)
+        # Examples:
+        #   "foo.txt"         -> stem "foo"          -> file_suffix=""
+        #   "foo.313.txt"     -> stem "foo.313"      -> file_suffix="313"
+        # The base may itself contain dots (e.g. "sub.foo"), so we strip
+        # the base prefix off the stem rather than splitting on "." blindly.
+        stem = expected_path.stem  # filename without ".txt"
+        if stem == base_short:
+            file_suffix = ""
+        else:
+            prefix = f"{base_short}."
+            # Defensively guard against unexpected layouts and fall through
+            # to "no rewrite needed" if the stem doesn't start with the base.
+            file_suffix = stem[len(prefix) :] if stem.startswith(prefix) else ""
+        if file_suffix in ("", current_suffix):
+            return expected_path
+        return expected_path.with_name(f"{base_short}.{current_suffix}.txt")

--- a/tests/testutils/test_lint_module_output_update.py
+++ b/tests/testutils/test_lint_module_output_update.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import shutil
+import sys
 from collections.abc import Callable
 from pathlib import Path
 
@@ -69,6 +70,70 @@ def test_lint_module_output_update_remove_useless_txt(
     filename.write_text("", encoding="utf8")
     lmou.runTest()
     assert not expected_output_file.exists()
+
+
+def test_lint_module_output_update_preserves_older_version_txt(
+    lint_module_fixture: Callable[[str], tuple[Path, Path, LintModuleOutputUpdate]],
+) -> None:
+    """Don't delete an older Python version's expected-output file. See #10844.
+
+    When running on Python ``X.Y`` and the only existing expected-output is
+    ``foo.<earlier>.txt`` (i.e. inherited from an older Python version),
+    ``--update-functional-output`` previously deleted that file when
+    ``actual_output`` was empty, silently wiping the older version's
+    expectations. The fix writes an empty current-version file
+    (``foo.<X><Y>.txt``) instead, leaving the inherited file intact.
+    """
+    filename, _expected_output_file, lmou = lint_module_fixture("fine_name")
+    # Pick a version strictly older than the running interpreter so the
+    # resolver picks it as the inherited file.
+    older = (sys.version_info[0], max(sys.version_info[1] - 1, 0))
+    older_suffix = f"{older[0]}{older[1]}"
+    older_path = filename.parent / f"fine_name.{older_suffix}.txt"
+    older_path.write_text("", encoding="utf8")
+    filename.write_text("", encoding="utf8")
+
+    lmou.runTest()
+
+    # Older version's file is untouched.
+    assert older_path.exists(), (
+        f"Expected {older_path.name} to be preserved on Python "
+        f"{sys.version_info[0]}.{sys.version_info[1]} (it belongs to an "
+        f"older Python version)."
+    )
+    # A current-version shadow is written as the empty record.
+    current_suffix = f"{sys.version_info[0]}{sys.version_info[1]}"
+    current_path = filename.parent / f"fine_name.{current_suffix}.txt"
+    assert current_path.exists()
+    assert current_path.read_text(encoding="utf8") == ""
+
+
+def test_lint_module_output_update_writes_current_version_when_inherited(
+    lint_module_fixture: Callable[[str], tuple[Path, Path, LintModuleOutputUpdate]],
+) -> None:
+    """When updating with non-empty output and the resolved file belongs to
+    an older Python version, write a new ``<base>.<current>.txt`` instead
+    of overwriting the inherited file.
+    """
+    filename, _expected_output_file, lmou = lint_module_fixture("foo")
+    older = (sys.version_info[0], max(sys.version_info[1] - 1, 0))
+    older_suffix = f"{older[0]}{older[1]}"
+    older_path = filename.parent / f"foo.{older_suffix}.txt"
+    older_path.write_text("preserved-marker\n", encoding="utf8")
+    filename.write_text("# [disallowed-name]\n", encoding="utf8")
+
+    lmou.runTest()
+
+    # Older version's file is untouched.
+    assert older_path.read_text(encoding="utf8") == "preserved-marker\n"
+    # New current-version file holds the actual output.
+    current_suffix = f"{sys.version_info[0]}{sys.version_info[1]}"
+    current_path = filename.parent / f"foo.{current_suffix}.txt"
+    assert current_path.exists()
+    assert (
+        current_path.read_text(encoding="utf8")
+        == 'disallowed-name:1:0:None:None::"Disallowed name ""foo""":HIGH\n'
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #10844

`test_functional.py --update-functional-output` could silently delete or
overwrite expected-output files belonging to **older** Python versions.

Concretely: `FunctionalTestFile.expected_output` resolves the highest
`<base>.<MMNN>.txt` whose version is `≤` the running interpreter, falling
back to `<base>.txt`. So on Python 3.14 with only `foo.313.txt` on disk,
that path is reused as the "current expected output". The update flow
previously wrote (or `os.remove`'d) that resolved path directly, which
clobbered the file that *3.13* still depends on.

## Changes

- `pylint/testutils/functional/lint_module_output_update.py` —
  `_check_output_text` now routes the rewrite through a small
  `_target_path_for_current_version` helper. When the resolved file
  belongs to an older Python (its suffix isn't empty and isn't the
  current `<major><minor>`), the helper redirects writes to a sibling
  `<base>.<current>.txt`. The empty-output branch behaves the same
  way: the older file is left alone and an empty current-version
  shadow is created instead. The inline comment in the diff documents
  the invariant for readers approaching the file cold.
- `tests/testutils/test_lint_module_output_update.py` — two regression
  tests, one for the empty-`actual_output` deletion path and one for the
  non-empty overwrite path.
- `doc/whatsnew/fragments/10844.bugfix` — towncrier fragment.

## Reproduce BEFORE/AFTER yourself (copy-paste)

A reviewer can verify the fix end-to-end by pasting the block below.
The reproducer uses `pytest` to drive `LintModuleOutputUpdate` directly,
so it works on any Python 3.10+ where pylint installs (no need to
actually run on Python 3.14 — the test simulates the inherited-older-file
scenario by creating a `<base>.<current-1>.txt` and recording it gets
preserved).

```bash
# --- one-time setup ---
git clone https://github.com/pylint-dev/pylint.git /tmp/repro-10844 && cd /tmp/repro-10844
python -m venv .venv && source .venv/bin/activate
pip install -e . pytest pytest-timeout pytest-benchmark pytest-xdist requests

# --- BEFORE (origin/main) ---
git fetch origin main && git checkout origin/main
git fetch https://github.com/jbbqqf/pylint.git feat/10844-update-functional-output-version-aware
# import the new tests from the fix branch so we can exercise the bug on main:
git checkout FETCH_HEAD -- tests/testutils/test_lint_module_output_update.py
pytest tests/testutils/test_lint_module_output_update.py -k "preserves_older_version_txt or writes_current_version_when_inherited" -v
# Expected: 2 FAILED — the older-version file is overwritten / deleted.
git checkout origin/main -- tests/testutils/test_lint_module_output_update.py

# --- AFTER (this PR) ---
git checkout FETCH_HEAD
pytest tests/testutils/test_lint_module_output_update.py -v
# Expected: 13 PASSED — including both new regression tests, plus the
# original 11 tests still green (no regressions to the old update flow).
```

## What I ran locally

- `pytest tests/testutils/test_lint_module_output_update.py -v` → **13/13 passed**
- `pytest tests/testutils/ -q` → **85/85 passed** (whole testutils suite)
- `pytest tests/test_functional.py -q --timeout=60` → 537 passed, 6 skipped,
  1 pre-existing failure (`recursion_error_3152` due to `import-error`
  on the test runner's installed packages — reproduces on `origin/main`
  with the patch reverted, unrelated)
- `ruff check pylint/testutils/functional/lint_module_output_update.py
  tests/testutils/test_lint_module_output_update.py` → clean

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | No version-suffixed file (legacy) | `foo.txt` exists | Unchanged behavior — overwrite or remove the bare file | `test_lint_module_output_update_effective`, `test_lint_module_output_update_remove_useless_txt` |
| 2 | Older-version file inherited, empty current output | only `foo.<curr-1>.txt` exists, `actual_output=[]` | Older file preserved; empty `foo.<curr>.txt` created | `test_lint_module_output_update_preserves_older_version_txt` (new) |
| 3 | Older-version file inherited, non-empty current output | only `foo.<curr-1>.txt` exists, real diagnostics emitted | Older file preserved; new `foo.<curr>.txt` holds the actual output | `test_lint_module_output_update_writes_current_version_when_inherited` (new) |
| 4 | No expected file at all | nothing exists | Unchanged: empty output → no file created; non-empty output → write `foo.txt` | `test_lint_module_output_update_fail_before` |

## Risk / blast radius

Scope is `pylint/testutils/functional/lint_module_output_update.py` —
only used by the `--update-functional-output` development helper, never
on a normal user lint. The default-path behavior (no version suffix,
or suffix matching current Python) is byte-for-byte identical to the
old code — verified by the three pre-existing tests still passing
unchanged. The new code path only kicks in when the resolved
expected-output file belongs to an older Python, which previously
crashed users' workflow by deleting recorded expectations.

## Release note

```release-note
Fix `test_functional.py --update-functional-output` deleting expected-output
files for other Python versions. Closes #10844.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed
manually against `pylint`'s testutils source and `FunctionalTestFile.expected_output`
resolution semantics. The reproducer block above was used during
development and is the same one a reviewer can paste verbatim.*
