### PR TITLE
Fix crash in variables checker when `NotImplemented` is used as an `if` test

### DIFF
--- a/doc/whatsnew/fragments/11025.bugfix
+++ b/doc/whatsnew/fragments/11025.bugfix
@@ -1,0 +1,7 @@
+Fix crash in the variables checker when ``NotImplemented`` is used as an
+``if`` test (e.g. ``if NotImplemented: ...``). ``bool(NotImplemented)``
+raises ``TypeError`` on Python 3.12+, which surfaced as
+``TypeError: NotImplemented should not be used in a boolean context``
+during used-before-assignment analysis.
+
+Closes #11025

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -734,7 +734,15 @@ scope_type : {self.scope_type}
                 only_search_else = False
                 continue
             val = inferred.value
-            only_search_if = only_search_if or (val != NotImplemented and val)
+            # Guard against `NotImplemented`: `bool(NotImplemented)` raises
+            # `TypeError` in Python 3.12+, which would crash the variables
+            # checker on input such as ``if NotImplemented: ...``. Treat it
+            # the same way the ``only_search_if`` branch already does — as
+            # neither truthy nor falsy for control-flow analysis. See #11025.
+            if val is NotImplemented:
+                only_search_else = False
+                continue
+            only_search_if = only_search_if or val
             only_search_else = only_search_else and not val
 
         # Only search else branch when test condition is inferred to be false

--- a/tests/functional/r/regression_02/regression_11025.py
+++ b/tests/functional/r/regression_02/regression_11025.py
@@ -1,0 +1,14 @@
+"""Regression test for https://github.com/pylint-dev/pylint/issues/11025
+
+Pylint crashed in the variables checker with::
+
+    TypeError: NotImplemented should not be used in a boolean context
+
+when ``NotImplemented`` appeared as an ``if`` test, because
+``bool(NotImplemented)`` raises ``TypeError`` on Python 3.12+.
+"""
+
+
+if NotImplemented:
+    x = 1  # pylint: disable=invalid-name
+x  # [pointless-statement, possibly-used-before-assignment]

--- a/tests/functional/r/regression_02/regression_11025.txt
+++ b/tests/functional/r/regression_02/regression_11025.txt
@@ -1,0 +1,2 @@
+pointless-statement:14:0:14:1::"Statement seems to have no effect":UNDEFINED
+possibly-used-before-assignment:14:0:14:1::"Possibly using variable 'x' before assignment":CONTROL_FLOW


### PR DESCRIPTION
## Type of Changes

| | Type |
|---|---|
| ✓ | Bug fix |
|   | Refactor |
|   | New feature |

## Description

Fixes #11025.

`bool(NotImplemented)` raises `TypeError` on Python 3.12+. Pylint already knew this — the loop in `NamesConsumer._inferred_to_define_name_raise_or_return_for_if_node` guarded `only_search_if` against it with `val != NotImplemented and val`. But the very next statement still evaluated `not val` to update `only_search_else`, which re-triggered the same TypeError and crashed the variables checker for any code that put `NotImplemented` in an `if` test.

Stack trace from the report:

```
File "pylint/checkers/variables.py", line 734, in
    _inferred_to_define_name_raise_or_return_for_if_node
    only_search_else = only_search_else and not val
                                            ^^^^^^^
TypeError: NotImplemented should not be used in a boolean context
```

### Fix

Treat `NotImplemented` as inferable-but-not-a-truth-value: when it appears as an inferred test constant, set `only_search_else = False` and `continue`, mirroring the existing skip pattern at the top of the loop. Both branches are then inspected normally for assignments and nothing tries to coerce `NotImplemented` to bool.

### Reproducer

Before this PR — fatal crash:

```python
# crash.py
if NotImplemented:
    x = 1
x
```

```
$ pylint crash.py
TypeError: NotImplemented should not be used in a boolean context
crash.py:1:0: F0002: ... Fatal error while checking 'crash.py'. (astroid-error)
```

After this PR:

```
$ pylint crash.py
crash.py:3:0: W0104: Statement seems to have no effect (pointless-statement)
crash.py:3:0: E0606: Possibly using variable 'x' before assignment (possibly-used-before-assignment)
```

### Tests

Added `tests/functional/r/regression_02/regression_11025.py` covering the original reproducer. The functional test passes locally (`pytest -k regression_11025`); without the fix it fails with the same TypeError. Verified on Python 3.14.4 against `main` at `0ede7d9` — before fix: crash; after fix: clean diagnostics.

### Changelog

`doc/whatsnew/fragments/11025.bugfix` added — towncrier bugfix entry referencing the issue.

---

Closes #11025