### PR TITLE
Skip PEP 695 type parameters in attribute member checks

### DIFF
--- a/doc/whatsnew/fragments/11053.bugfix
+++ b/doc/whatsnew/fragments/11053.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in the typecheck checker when accessing an attribute on a PEP 695 type parameter (e.g. ``T.a`` inside ``def f[T](): ...``).
+
+Closes #11053

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1154,6 +1154,12 @@ accessed. Python regular expressions are accepted.",
             ):
                 continue
 
+            if isinstance(owner, (nodes.TypeVar, nodes.TypeVarTuple, nodes.ParamSpec)):
+                # PEP 695 type parameters have no concrete type at
+                # static-analysis time, so we can't reason about their
+                # attributes.
+                continue
+
             # If any of the inferred owners defines a dynamic ``__getattr__``
             # the attribute may exist at runtime. Since the access is
             # considered correct as soon as a single inferred owner could have

--- a/tests/functional/r/regression_03/regression_11053.py
+++ b/tests/functional/r/regression_03/regression_11053.py
@@ -1,0 +1,15 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Regression test for https://github.com/pylint-dev/pylint/issues/11053
+
+Attribute access on a PEP 695 type parameter crashed ``visit_attribute``
+because the ``TypeVar`` astroid node has no ``pytype()`` method.
+"""
+
+# pylint: disable=missing-docstring,pointless-statement
+
+
+def f[T]():
+    T.a

--- a/tests/functional/r/regression_03/regression_11053.rc
+++ b/tests/functional/r/regression_03/regression_11053.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.12


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Require astroid 4.2.0.

Closes #11053
