### PR TITLE
Fix crash in deprecated checker for non-string ``__import__`` argument

### DIFF
--- a/doc/whatsnew/fragments/11059.bugfix
+++ b/doc/whatsnew/fragments/11059.bugfix
@@ -1,0 +1,4 @@
+Fix a crash in the deprecated checker when ``__import__`` is called with a
+non-string constant argument (for example ``__import__(1)``).
+
+Closes #11059

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -112,6 +112,7 @@ class DeprecatedMixin(BaseChecker):
                 and len(node.args) == 1
                 and (mod_path_node := utils.safe_infer(node.args[0]))
                 and isinstance(mod_path_node, nodes.Const)
+                and isinstance(mod_path_node.value, str)
             ):
                 self.check_deprecated_module(node, mod_path_node.value)
 

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -106,7 +106,7 @@ class DeprecatedMixin(BaseChecker):
             # Calling entry point for deprecation check logic.
             self.check_deprecated_method(node, inferred)
 
-            if (
+            if (  # pylint: disable=too-many-boolean-expressions
                 isinstance(inferred, nodes.FunctionDef)
                 and inferred.qname() == "builtins.__import__"
                 and len(node.args) == 1

--- a/tests/functional/d/deprecated/deprecated_module__import__.py
+++ b/tests/functional/d/deprecated/deprecated_module__import__.py
@@ -7,3 +7,8 @@ imp_meth = __import__("mypackage").meth()  # [deprecated-module]
 
 lib = "mypackage"
 infer_imp = __import__(lib)  # [deprecated-module]
+
+# Regression test for https://github.com/pylint-dev/pylint/issues/11059
+# A non-string argument to ``__import__`` (caught by ``no-value-for-parameter``
+# at runtime) should not crash the deprecated checker.
+non_str = __import__(1)


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Calling ``__import__`` with a non-string constant (e.g. ``__import__(1)``) crashed ``check_deprecated_module`` with ``AttributeError: 'int' object has no attribute 'startswith'``. Added an ``isinstance`` guard at the call site so only string constants flow through, and a regression entry alongside the existing ``__import__`` functional test.

Closes #11059
