### PR TITLE
Fix crash on chained TypeAlias assignment with a non-name target

### DIFF
--- a/doc/whatsnew/fragments/11056.bugfix
+++ b/doc/whatsnew/fragments/11056.bugfix
@@ -1,0 +1,5 @@
+Fix a crash in the name checker when a chained assignment of a ``TypeAlias``
+value has a non-name target such as a ``Subscript`` (for example
+``a[0] = b = TypeAlias``).
+
+Closes #11056

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -450,7 +450,9 @@ class NameChecker(_BasicChecker):
                 )
 
                 # Check TypeVar's and TypeAliases assigned alone or in tuple assignment
-                if isinstance(node.parent, nodes.Assign):
+                if isinstance(node.parent, nodes.Assign) and isinstance(
+                    assign_type.targets[0], nodes.AssignName
+                ):
                     if typevar_node_type := self._assigns_typevar(assign_type.value):
                         self._check_name(
                             typevar_node_type, assign_type.targets[0].name, node

--- a/tests/functional/t/type/typealias_assign_subscript_target.py
+++ b/tests/functional/t/type/typealias_assign_subscript_target.py
@@ -1,0 +1,14 @@
+"""Regression test for a crash in the name checker when a chained assignment
+of a ``TypeAlias`` value has a non-name target such as a ``Subscript``.
+
+For ``a[0] = b = TypeAlias`` the first target of the ``Assign`` is a
+``Subscript`` rather than an ``AssignName``; accessing ``.name`` on it
+crashed with an ``AttributeError``.
+
+https://github.com/pylint-dev/pylint/issues/11056
+"""
+# pylint: disable=invalid-name,undefined-variable
+
+from typing import TypeAlias
+
+a[0] = b = TypeAlias


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

When an ``Assign`` chains a non-name target with a name target whose value is a ``TypeAlias`` (e.g. ``a[0] = b = TypeAlias``), the name checker walked ``assign_type.targets[0]`` assuming it was always an ``AssignName`` and crashed with ``AttributeError: 'Subscript' object has no attribute 'name'``. Guard the lookup with an ``isinstance`` check so non-name first targets are skipped instead of crashing.

Closes #11056
