### PR TITLE
Fix crash in typecheck checker when metaclass argument is a non-class

### DIFF
--- a/doc/whatsnew/fragments/11071.bugfix
+++ b/doc/whatsnew/fragments/11071.bugfix
@@ -1,0 +1,4 @@
+Fix a crash in the typecheck checker when a class uses a non-class object
+(for example a function) as its ``metaclass=`` argument.
+
+Closes #11071

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -670,7 +670,7 @@ def _determine_callable(
 
             # Try to use the metaclass' __call__ if any.
             meta = callable_obj.metaclass()
-            if meta and isinstance(meta, nodes.NodeNG):
+            if isinstance(meta, nodes.ClassDef):
                 meta_call, _, from_builtins = _get_local_callable(meta, "__call__")
                 if meta_call and not from_builtins:
                     _check_is_function_def(meta_call)

--- a/tests/functional/r/regression_03/regression_11071.py
+++ b/tests/functional/r/regression_03/regression_11071.py
@@ -1,0 +1,19 @@
+"""Regression test for https://github.com/pylint-dev/pylint/issues/11071.
+
+A class whose ``metaclass=`` argument resolves to a plain ``FunctionDef``
+(rather than a ``ClassDef``) crashed the typecheck checker when looking up
+``__call__`` on the metaclass via ``local_attr``.
+"""
+
+# pylint: disable=missing-docstring,too-few-public-methods,invalid-metaclass
+
+
+def fn():
+    pass
+
+
+class C(metaclass=fn):
+    pass
+
+
+C()


### PR DESCRIPTION
Closes #11071

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

When a class uses a non-class object (such as a function) as its `metaclass=` argument, `_determine_callable` would call `_get_local_callable` on it and crash with `AttributeError: 'FunctionDef' object has no attribute 'local_attr'`. The metaclass check now narrows to `ClassDef` before the lookup. Regression covered by `regression_11071`.