### PR TITLE
Fix `unnecessary-comprehension` suggestion when iterating a dict

### DIFF
--- a/doc/whatsnew/fragments/8256.bugfix
+++ b/doc/whatsnew/fragments/8256.bugfix
@@ -1,0 +1,6 @@
+Fix the suggestion of ``unnecessary-comprehension`` for a dict comprehension
+that iterates a dict directly, e.g. ``{a: b for a, b in d}``. Iterating a dict
+yields its keys, so the suggestion is now ``dict(d.keys())`` instead of the
+incorrect ``dict(d)``, which would simply copy ``d``.
+
+Closes #8256

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1856,36 +1856,40 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             case _:
                 return
         if expr_list == target_list and expr_list:
-            args: tuple[str] | None = None
-            inferred = utils.safe_infer(node.iter)
-            match (node.parent, inferred):
-                case [nodes.DictComp(), objects.DictItems()]:
-                    args = (f"dict({node.iter.func.expr.as_string()})",)
-                case [nodes.ListComp(), nodes.List()]:
-                    args = (f"list({node.iter.as_string()})",)
-                case [nodes.SetComp(), nodes.Set()]:
-                    args = (f"set({node.iter.as_string()})",)
-            if args:
-                self.add_message(
-                    "unnecessary-comprehension", node=node.parent, args=args
-                )
-                return
-
-            match node.parent:
-                case nodes.DictComp():
-                    func = "dict"
-                case nodes.ListComp():
-                    func = "list"
-                case nodes.SetComp():
-                    func = "set"
-                case _:  # pragma: no cover
-                    raise AssertionError
-
             self.add_message(
                 "unnecessary-comprehension",
                 node=node.parent,
-                args=(f"{func}({node.iter.as_string()})",),
+                args=self._unnecessary_comprehension_suggestion(node),
             )
+
+    @staticmethod
+    def _unnecessary_comprehension_suggestion(
+        node: nodes.Comprehension,
+    ) -> tuple[str]:
+        """Build the replacement suggested by ``unnecessary-comprehension``."""
+        inferred = utils.safe_infer(node.iter)
+        match (node.parent, inferred):
+            case [nodes.DictComp(), objects.DictItems()]:
+                return (f"dict({node.iter.func.expr.as_string()})",)
+            case [nodes.DictComp(), nodes.Dict()]:
+                # Iterating a dict yields its keys, so the comprehension
+                # rebuilds a dict from them; ``dict(d)`` would just copy ``d``
+                # and is the wrong suggestion (see #8256).
+                return (f"dict({node.iter.as_string()}.keys())",)
+            case [nodes.ListComp(), nodes.List()]:
+                return (f"list({node.iter.as_string()})",)
+            case [nodes.SetComp(), nodes.Set()]:
+                return (f"set({node.iter.as_string()})",)
+        match node.parent:
+            case nodes.DictComp():
+                func = "dict"
+            case nodes.ListComp():
+                func = "list"
+            case nodes.SetComp():
+                func = "set"
+            case _:  # pragma: no cover
+                raise AssertionError
+        return (f"{func}({node.iter.as_string()})",)
 
     @staticmethod
     def _is_and_or_ternary(node: nodes.NodeNG | None) -> bool:

--- a/tests/functional/u/unnecessary/unnecessary_comprehension.py
+++ b/tests/functional/u/unnecessary/unnecessary_comprehension.py
@@ -49,3 +49,8 @@ my_set = set()
 ITEMS = {k: v for k, v in my_dict.items()} # [unnecessary-comprehension]
 {k: my_dict[k] for k in my_dict} # [consider-using-dict-items]
 {elem for elem in my_set}  # [unnecessary-comprehension]
+
+# Iterating a dict yields its keys, so suggest ``dict(d.keys())`` rather than
+# ``dict(d)``, which would just copy the dict (#8256).
+DICT_WITH_TUPLE_KEYS = {(1, 2): 3}
+{a: b for a, b in DICT_WITH_TUPLE_KEYS}  # [unnecessary-comprehension]

--- a/tests/functional/u/unnecessary/unnecessary_comprehension.txt
+++ b/tests/functional/u/unnecessary/unnecessary_comprehension.txt
@@ -13,3 +13,4 @@ unnecessary-comprehension:48:0:48:26::Unnecessary use of a comprehension, use li
 unnecessary-comprehension:49:8:49:42::Unnecessary use of a comprehension, use dict(my_dict) instead.:UNDEFINED
 consider-using-dict-items:50:0:None:None::Consider iterating with .items():UNDEFINED
 unnecessary-comprehension:51:0:51:25::Unnecessary use of a comprehension, use set(my_set) instead.:UNDEFINED
+unnecessary-comprehension:56:0:56:39::Unnecessary use of a comprehension, use dict(DICT_WITH_TUPLE_KEYS.keys()) instead.:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

For a dict comprehension that iterates a dict directly, e.g. `{a: b for a, b in d}`, `unnecessary-comprehension` suggested `dict(d)`. That is wrong: iterating a dict yields its keys, so the comprehension unpacks each key, whereas `dict(d)` would simply copy `d`. The suggestion is now `dict(d.keys())`, which is the equivalent expression (as agreed in the issue discussion).

```python
>>> d = {(1, 2): 3}
>>> {a: b for a, b in d}
{1: 2}
>>> dict(d)            # the old, wrong suggestion
{(1, 2): 3}
>>> dict(d.keys())     # the new suggestion
{1: 2}
```

The suggestion-building logic was extracted into a helper (`_unnecessary_comprehension_suggestion`) to keep `_check_unnecessary_comprehension` within the branch limit.

Closes #8256
