### PR TITLE
Fix crash with TypeVarTuple base aliases

### DIFF
--- a/doc/whatsnew/fragments/11057.bugfix
+++ b/doc/whatsnew/fragments/11057.bugfix
@@ -1,0 +1,3 @@
+Fixed a crash when linting a class that inherits from a PEP 695 ``TypeVarTuple`` from a type alias.
+
+Closes #11057

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -35,6 +35,7 @@ from pylint.checkers.utils import (
     is_property_setter_or_deleter,
     node_frame_class,
     only_required_for_messages,
+    safe_class_type,
     safe_infer,
     unimplemented_abstract_methods,
     uninferable_final_decorators,
@@ -1203,7 +1204,7 @@ a metaclass class method.",
             return
 
         accessed = self._accessed.accessed(cnode)
-        if cnode.type != "metaclass":
+        if safe_class_type(cnode) != "metaclass":
             self._check_accessed_members(cnode, accessed)
         # checks attributes are defined in an allowed method such as __init__
         if not self.linter.is_message_enabled("attribute-defined-outside-init"):
@@ -1276,7 +1277,7 @@ a metaclass class method.",
         # 'is_method()' is called and makes sure that this is a 'nodes.ClassDef'
         klass: nodes.ClassDef = node.parent.frame()
         # check first argument is self if this is actually a method
-        self._check_first_arg_for_type(node, klass.type == "metaclass")
+        self._check_first_arg_for_type(node, safe_class_type(klass) == "metaclass")
         if node.name == "__init__":
             self._check_init(node, klass)
             return

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 from astroid import nodes
 
 from pylint.checkers import BaseChecker
-from pylint.checkers.utils import is_enum, only_required_for_messages
+from pylint.checkers.utils import is_enum, only_required_for_messages, safe_class_type
 from pylint.interfaces import HIGH
 from pylint.typing import MessageDefinitionTuple
 
@@ -502,7 +502,8 @@ class MisdesignChecker(BaseChecker):
             )
 
         # Stop here if the class is excluded via configuration.
-        if node.type == "class" and self._exclude_too_few_public_methods:
+        node_type = safe_class_type(node)
+        if node_type == "class" and self._exclude_too_few_public_methods:
             for ancestor in node.ancestors():
                 if any(
                     pattern.match(ancestor.qname())
@@ -512,7 +513,7 @@ class MisdesignChecker(BaseChecker):
 
         # Stop here for exception, metaclass, interface classes and other
         # classes for which we don't need to count the methods.
-        if node.type != "class" or _is_exempt_from_public_methods(node):
+        if node_type != "class" or _is_exempt_from_public_methods(node):
             return
 
         # Does the class contain more than n public methods ?

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -16,7 +16,7 @@ import string
 from collections.abc import Callable, Iterable, Iterator
 from functools import lru_cache, partial
 from re import Match
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Literal, TypeVar
 
 import astroid
 import astroid.exceptions
@@ -1689,11 +1689,87 @@ def is_protocol_class(cls: nodes.NodeNG) -> bool:
     for base in cls.bases:
         try:
             for inf_base in base.infer():
-                if inf_base.qname() in TYPING_PROTOCOLS:
+                if (
+                    isinstance(inf_base, nodes.ClassDef)
+                    and inf_base.qname() in TYPING_PROTOCOLS
+                ):
                     return True
         except astroid.InferenceError:
             continue
     return False
+
+
+def _is_metaclass(cls: nodes.ClassDef, seen: set[str] | None = None) -> bool:
+    """Return whether a class node can be used as a metaclass."""
+    if cls.name == "type":
+        return True
+    if seen is None:
+        seen = set()
+
+    for base in cls.bases:
+        try:
+            inferred_bases = tuple(base.infer())
+        except astroid.InferenceError:
+            continue
+        for base_obj in inferred_bases:
+            if isinstance(base_obj, bases.Instance):
+                return False
+            if base_obj is cls or not isinstance(base_obj, nodes.ClassDef):
+                continue
+
+            base_obj_name = base_obj.qname()
+            if base_obj_name in seen:
+                continue
+            seen.add(base_obj_name)
+
+            if base_obj._type == "metaclass" or _is_metaclass(base_obj, seen):
+                return True
+    return False
+
+
+_ClassType = Literal["class", "exception", "metaclass"]
+
+
+def _class_type_literal(value: object) -> _ClassType:
+    if value == "exception":
+        return "exception"
+    if value == "metaclass":
+        return "metaclass"
+    return "class"
+
+
+def safe_class_type(
+    cls: nodes.ClassDef, ancestors: set[str] | None = None
+) -> _ClassType:
+    """Return a class node type while ignoring non-class inferred bases."""
+    if cls._type is not None:
+        return _class_type_literal(cls._type)
+    if _is_metaclass(cls):
+        cls._type = "metaclass"
+    elif cls.name.endswith("Exception"):
+        cls._type = "exception"
+    else:
+        if ancestors is None:
+            ancestors = set()
+        cls_name = cls.qname()
+        if cls_name in ancestors:
+            cls._type = "class"
+            return "class"
+        ancestors.add(cls_name)
+        for ancestor in cls.ancestors(recurs=False):
+            if not isinstance(ancestor, nodes.ClassDef):
+                continue
+            ancestor_type = safe_class_type(ancestor, ancestors)
+            if ancestor_type == "class":
+                continue
+            if ancestor_type == "metaclass" and cls._type != "metaclass":
+                continue
+            cls._type = ancestor_type
+            break
+
+    if cls._type is None:
+        cls._type = "class"
+    return _class_type_literal(cls._type)
 
 
 def is_call_of_name(node: nodes.NodeNG, name: str) -> bool:

--- a/tests/checkers/unittest_utils.py
+++ b/tests/checkers/unittest_utils.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import sys
+
 import astroid
 import pytest
 from astroid import nodes
@@ -132,6 +134,146 @@ def test_is_subclass_of_not_classdefs() -> None:
     assert not utils.is_subclass_of(None, node)
     assert not utils.is_subclass_of(node, None)
     assert not utils.is_subclass_of(None, None)
+
+
+def test_safe_class_type_preserves_common_class_kinds() -> None:
+    (
+        plain,
+        custom_exception,
+        custom_error,
+        meta,
+        sub_meta,
+        derived_error,
+    ) = astroid.extract_node(
+        """
+    class Plain: #@
+        pass
+
+    class CustomException: #@
+        pass
+
+    class CustomError(Exception): #@
+        pass
+
+    class Meta(type): #@
+        pass
+
+    class SubMeta(Meta): #@
+        pass
+
+    class DerivedError(Plain, CustomError): #@
+        pass
+    """
+    )
+
+    assert utils.safe_class_type(plain) == "class"
+    assert utils.safe_class_type(custom_exception) == "exception"
+    assert utils.safe_class_type(custom_error) == "exception"
+    assert utils.safe_class_type(meta) == "metaclass"
+    assert utils.safe_class_type(sub_meta) == "metaclass"
+    assert utils.safe_class_type(derived_error) == "exception"
+
+    assert utils.safe_class_type(plain) == "class"
+    assert utils.safe_class_type(custom_exception) == "exception"
+    assert utils.safe_class_type(meta) == "metaclass"
+
+
+def test_safe_class_type_ignores_instance_and_function_bases() -> None:
+    instance_base, function_base = astroid.extract_node("""
+    class Base:
+        pass
+
+    base = Base()
+
+    class Child(base): #@
+        pass
+
+    def factory():
+        pass
+
+    class FunctionBase(factory): #@
+        pass
+    """)
+
+    assert utils.safe_class_type(instance_base) == "class"
+    assert utils.safe_class_type(function_base) == "class"
+
+
+def test_safe_class_type_handles_ancestor_cycles() -> None:
+    first, second, third = astroid.extract_node("""
+    class First(Second): #@
+        pass
+
+    class Second(First): #@
+        pass
+
+    class Third(First): #@
+        pass
+    """)
+
+    assert utils.safe_class_type(first) == "class"
+    assert utils.safe_class_type(second) == "class"
+    assert utils.safe_class_type(third) == "class"
+
+    guarded = astroid.extract_node("""
+    class Guarded: #@
+        pass
+    """)
+    assert utils.safe_class_type(guarded, {guarded.qname()}) == "class"
+
+
+def test_safe_class_type_handles_shared_non_metaclass_base() -> None:
+    child = astroid.extract_node("""
+    class Root:
+        pass
+
+    class Left(Root):
+        pass
+
+    class Right(Root):
+        pass
+
+    class Child(Left, Right): #@
+        pass
+    """)
+
+    assert utils.safe_class_type(child) == "class"
+
+
+def test_safe_class_type_ignores_non_class_and_metaclass_ancestors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    klass, meta = astroid.extract_node("""
+    class Klass: #@
+        pass
+
+    class Meta(type): #@
+        pass
+    """)
+    non_class = astroid.extract_node("value = 1")
+
+    assert utils.safe_class_type(meta) == "metaclass"
+
+    def ancestors(recurs: bool = True) -> list[nodes.NodeNG]:
+        assert recurs is False
+        return [non_class, meta]
+
+    monkeypatch.setattr(klass, "ancestors", ancestors)
+
+    assert utils.safe_class_type(klass) == "class"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="PEP 695 requires Python 3.12")
+def test_safe_class_type_ignores_typevartuple_base() -> None:
+    klass = astroid.extract_node("""
+    type T[*P] = None
+
+    class TypeVarTupleBase(P): #@
+        pass
+    """)
+
+    assert utils.safe_class_type(klass) == "class"
+    assert not utils.is_protocol_class(klass)
 
 
 def test_parse_format_method_string() -> None:

--- a/tests/functional/i/inherit_non_class_py312.py
+++ b/tests/functional/i/inherit_non_class_py312.py
@@ -1,0 +1,8 @@
+"""Tests for non-class inheritance with Python 3.12 generic type syntax."""
+# pylint: disable=invalid-name,too-few-public-methods
+
+type T[*P] = None
+
+
+class TypeVarTupleBase(P):  # [inherit-non-class]
+    """A TypeVarTuple cannot be inherited from."""

--- a/tests/functional/i/inherit_non_class_py312.rc
+++ b/tests/functional/i/inherit_non_class_py312.rc
@@ -1,0 +1,5 @@
+[main]
+py-version=3.12
+
+[testoptions]
+min_pyver=3.12

--- a/tests/functional/i/inherit_non_class_py312.txt
+++ b/tests/functional/i/inherit_non_class_py312.txt
@@ -1,0 +1,1 @@
+inherit-non-class:7:0:7:22:TypeVarTupleBase:Inheriting 'P', which is not a class.:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| x   | :bug: Bug fix          |

## Description

Closes #11057

This fixes a crash when Pylint analyzes a class that inherits from a PEP 695 `TypeVarTuple` introduced by a type alias, for example:

```python
type T[*P] = None
class C(P): pass
```

The crash came from two class-processing paths assuming inferred bases and class type inference always expose `qname()`. Pylint now ignores non-qualified inferred bases while checking `typing.Protocol`, and uses a safe class-type helper for default class checks when the class type calculation hits the missing-`qname` TypeVarTuple shape.

Validation performed locally on Python 3.13:

- Reproduced the original `AttributeError: 'TypeVarTuple' object has no attribute 'qname'` before the fix.
- `python -m pylint /tmp/pylint-11057.py --reports=n --score=n --py-version=3.12` now reports `inherit-non-class` without `astroid-error`.
- `python -m pytest tests/test_functional.py -k 'inherit_non_class or protocol_classes or too_few_public_methods' -q`
- `python -m pytest tests/checkers/unittest_utils.py tests/checkers/unittest_design.py -q`
- `python -m pytest tests/test_functional.py -q`
- `SKIP=pylint python -m pre_commit run --files ...` passed; the pre-commit `pylint` hook could not locate its hook executable locally, so I also ran local Pylint on the touched source files.