### PR TITLE
Fix crash in logging checker on a non-UTF-8 bytes format string

### DIFF
--- a/doc/whatsnew/fragments/10813.bugfix
+++ b/doc/whatsnew/fragments/10813.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in the logging checker when a logging call uses a ``bytes`` format string that is not valid UTF-8.
+
+Closes #10813

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -330,7 +330,10 @@ class LoggingChecker(checkers.BaseChecker):
         format_string = node.args[format_arg].value
         required_num_args = 0
         if isinstance(format_string, bytes):
-            format_string = format_string.decode()
+            # ``logging`` applies ``str()`` to the message before interpolation,
+            # so mirror that here. ``bytes.decode()`` would raise
+            # ``UnicodeDecodeError`` on non-UTF-8 bytes and crash the checker.
+            format_string = str(format_string)
         if isinstance(format_string, str):
             try:
                 if self._format_style == "old":

--- a/tests/functional/l/logging/logging_bytes_format_string.py
+++ b/tests/functional/l/logging/logging_bytes_format_string.py
@@ -1,0 +1,13 @@
+# pylint: disable=missing-module-docstring
+import logging
+
+# Regression test for https://github.com/pylint-dev/pylint/issues/10813
+# A bytes format string that is not valid UTF-8 used to crash the checker
+# with a ``UnicodeDecodeError``.
+logging.critical(b"\xc0\xc0")
+
+# Valid bytes format strings should still have their arguments checked, as
+# ``logging`` applies ``str()`` to the message before interpolation.
+logging.error(b"%s", "arg")
+logging.error(b"%s")  # [logging-too-few-args]
+logging.error(b"%s", 1, 2)  # [logging-too-many-args]

--- a/tests/functional/l/logging/logging_bytes_format_string.txt
+++ b/tests/functional/l/logging/logging_bytes_format_string.txt
@@ -1,0 +1,2 @@
+logging-too-few-args:12:0:12:20::Not enough arguments for logging format string:UNDEFINED
+logging-too-many-args:13:0:13:26::Too many arguments for logging format string:HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The logging checker crashed with a fatal `F0002` error on a logging call whose format string is `bytes` that isn't valid UTF-8, e.g.:

```python
import logging

logging.critical(b"\xc0\xc0")
```

`_check_format_string` ran `format_string.decode()`, which raises `UnicodeDecodeError` on non-UTF-8 bytes.

At runtime `logging` applies `str()` to the message before interpolation (`str(b"\xc0\xc0")` -> `"b'\\xc0\\xc0'"`), so I switched the bytes handling to `str(format_string)`. That never raises and matches the string `logging` actually formats, so argument-count checks on valid bytes format strings still work.

Testing: added a functional test (`logging_bytes_format_string`) covering the crashing case plus valid bytes format strings with too-few/too-many args. It crashes with `astroid-error` before the fix and passes after. All logging functional tests pass, and `ruff`/`black`/`isort` are clean.

Closes #10813