### PR TITLE
Fix pep695 use-before-assignment.  Fixes #11115

### DIFF
--- a/doc/whatsnew/fragments/11115.false_positive
+++ b/doc/whatsnew/fragments/11115.false_positive
@@ -1,0 +1,5 @@
+Fix a false positive for ``used-before-assignment`` (E0601) when a PEP 695
+type-parameter bound on a class or function forward-references a name defined
+later in the module. Such bounds are lazily evaluated, so the reference is valid.
+
+Closes #11115

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1983,6 +1983,7 @@ class VariablesChecker(BaseChecker):
                     or isinstance(stmt, nodes.AnnAssign)  # noqa: RUF021
                     and utils.get_node_first_ancestor_of_type(stmt, nodes.FunctionDef)
                     or isinstance(stmt, nodes.TypeAlias)
+                    or utils.is_node_in_pep695_type_context(node)
                 ):
                     self.add_message(
                         "used-before-assignment",

--- a/tests/functional/u/used/used_before_assignment_py312.py
+++ b/tests/functional/u/used/used_before_assignment_py312.py
@@ -21,3 +21,16 @@ type OtherAlias[T: Y] = T | None
 # https://github.com/pylint-dev/pylint/issues/9884
 def func[T: Y](x: T) -> None:  # [redefined-outer-name]  FALSE POSITIVE
     ...
+
+
+# https://github.com/pylint-dev/pylint/issues/11115
+class ForwardClass[T: ForwardBound]:
+    value: T
+
+def forward_func[U: ForwardBound](x: U) -> None:
+    ...
+
+type ForwardAlias[V: ForwardBound] = V | None
+
+class ForwardBound:
+    pass


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fixes a pep-695 forward declaration false positive

Closes #11115 
