### PR TITLE
Emit duplicate constructor doc warning for skipped init

### DIFF
--- a/doc/user_guide/checkers/extensions.rst
+++ b/doc/user_guide/checkers/extensions.rst
@@ -598,7 +598,7 @@ See also :ref:`parameter_documentation checker's options' documentation <paramet
 
 Parameter Documentation checker Messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-:multiple-constructor-doc (W9005): *"%s" has constructor parameters documented in class and __init__*
+:multiple-constructor-doc (W9005): *"%s" has constructor parameters documented in class and %s*
   Please remove parameter declarations in the class or constructor.
 :missing-raises-doc (W9006): *"%s" not documented as being raised*
   Please document exceptions for all raised exception types.

--- a/doc/whatsnew/fragments/6692.bugfix
+++ b/doc/whatsnew/fragments/6692.bugfix
@@ -1,0 +1,3 @@
+The ``docparams`` extension now emits ``multiple-constructor-doc`` when
+constructor parameters are documented in both the class docstring and the
+``__init__`` docstring, even when ``__init__`` is skipped by ``no-docstring-rgx``.

--- a/doc/whatsnew/fragments/6692.bugfix
+++ b/doc/whatsnew/fragments/6692.bugfix
@@ -1,3 +1,5 @@
 The ``docparams`` extension now emits ``multiple-constructor-doc`` when
 constructor parameters are documented in both the class docstring and the
 ``__init__`` docstring, even when ``__init__`` is skipped by ``no-docstring-rgx``.
+
+Closes #6692

--- a/doc/whatsnew/fragments/6692.false_negative
+++ b/doc/whatsnew/fragments/6692.false_negative
@@ -1,5 +1,6 @@
 The ``docparams`` extension now emits ``multiple-constructor-doc`` when
 constructor parameters are documented in both the class docstring and the
-``__init__`` docstring, even when ``__init__`` is skipped by ``no-docstring-rgx``.
+constructor docstring, even when the constructor method is skipped by
+``no-docstring-rgx``.
 
 Closes #6692

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -201,6 +201,7 @@ class DocstringParameterChecker(BaseChecker):
         node_doc = utils.docstringify(
             node.doc_node, self.linter.config.default_docstring_type
         )
+        self.check_constructor_params_are_not_documented_twice(node, node_doc)
 
         # skip functions that match the 'no-docstring-rgx' config option
         no_docstring_rgx = self.linter.config.no_docstring_rgx
@@ -227,7 +228,6 @@ class DocstringParameterChecker(BaseChecker):
                 class_doc = utils.docstringify(
                     class_node.doc_node, self.linter.config.default_docstring_type
                 )
-                self.check_single_constructor_params(class_doc, node_doc, class_node)
 
                 # __init__ or class docstrings can have no parameters documented
                 # as long as the other documents them.
@@ -249,6 +249,21 @@ class DocstringParameterChecker(BaseChecker):
         self.check_arguments_in_docstring(
             node_doc, node.args, node, node_allow_no_param
         )
+
+    def check_constructor_params_are_not_documented_twice(
+        self, node: nodes.FunctionDef, node_doc: Docstring
+    ) -> None:
+        if node.name not in self.constructor_names:
+            return
+
+        class_node = checker_utils.node_frame_class(node)
+        if class_node is None:
+            return
+
+        class_doc = utils.docstringify(
+            class_node.doc_node, self.linter.config.default_docstring_type
+        )
+        self.check_single_constructor_params(class_doc, node_doc, class_node)
 
     def check_functiondef_returns(
         self, node: nodes.FunctionDef, node_doc: Docstring

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -45,7 +45,7 @@ class DocstringParameterChecker(BaseChecker):
     name = "parameter_documentation"
     msgs = {
         "W9005": (
-            '"%s" has constructor parameters documented in class and __init__',
+            '"%s" has constructor parameters documented in class and %s',
             "multiple-constructor-doc",
             "Please remove parameter declarations in the class or constructor.",
         ),
@@ -263,7 +263,7 @@ class DocstringParameterChecker(BaseChecker):
         class_doc = utils.docstringify(
             class_node.doc_node, self.linter.config.default_docstring_type
         )
-        self.check_single_constructor_params(class_doc, node_doc, class_node)
+        self.check_single_constructor_params(class_doc, node_doc, class_node, node.name)
 
     def check_functiondef_returns(
         self, node: nodes.FunctionDef, node_doc: Docstring
@@ -660,12 +660,16 @@ class DocstringParameterChecker(BaseChecker):
         )
 
     def check_single_constructor_params(
-        self, class_doc: Docstring, init_doc: Docstring, class_node: nodes.ClassDef
+        self,
+        class_doc: Docstring,
+        init_doc: Docstring,
+        class_node: nodes.ClassDef,
+        constructor_name: str,
     ) -> None:
         if class_doc.has_params() and init_doc.has_params():
             self.add_message(
                 "multiple-constructor-doc",
-                args=(class_node.name,),
+                args=(class_node.name, constructor_name),
                 node=class_node,
                 confidence=HIGH,
             )

--- a/tests/functional/ext/docparams/parameter/multiple_constructor_doc_default.py
+++ b/tests/functional/ext/docparams/parameter/multiple_constructor_doc_default.py
@@ -1,0 +1,17 @@
+# pylint: disable=missing-module-docstring, too-few-public-methods
+
+
+class ConstructorDocsInClassAndInit:  # [multiple-constructor-doc]
+    """Class summary.
+
+    Args:
+        value: documented in class.
+    """
+
+    def __init__(self, value: int) -> None:
+        """Initialize.
+
+        Args:
+            value: documented in __init__.
+        """
+        self.value = value

--- a/tests/functional/ext/docparams/parameter/multiple_constructor_doc_default.py
+++ b/tests/functional/ext/docparams/parameter/multiple_constructor_doc_default.py
@@ -1,6 +1,15 @@
 # pylint: disable=missing-module-docstring, too-few-public-methods
 
 
+def __init__(value: int) -> int:
+    """Module-level function named like a constructor.
+
+    Args:
+        value: not a class constructor parameter.
+    """
+    return value
+
+
 class ConstructorDocsInClassAndInit:  # [multiple-constructor-doc]
     """Class summary.
 
@@ -15,3 +24,21 @@ class ConstructorDocsInClassAndInit:  # [multiple-constructor-doc]
             value: documented in __init__.
         """
         self.value = value
+
+
+class ConstructorDocsInClassAndNew:  # [multiple-constructor-doc]
+    """Class summary.
+
+    Args:
+        value: documented in class.
+    """
+
+    def __new__(cls, value: int):
+        """Create instance.
+
+        Args:
+            value: documented in __new__.
+        """
+        instance = super().__new__(cls)
+        instance.value = value
+        return instance

--- a/tests/functional/ext/docparams/parameter/multiple_constructor_doc_default.rc
+++ b/tests/functional/ext/docparams/parameter/multiple_constructor_doc_default.rc
@@ -1,0 +1,2 @@
+[MAIN]
+load-plugins=pylint.extensions.docparams

--- a/tests/functional/ext/docparams/parameter/multiple_constructor_doc_default.txt
+++ b/tests/functional/ext/docparams/parameter/multiple_constructor_doc_default.txt
@@ -1,1 +1,2 @@
-multiple-constructor-doc:4:0:4:35:ConstructorDocsInClassAndInit:"""ConstructorDocsInClassAndInit"" has constructor parameters documented in class and __init__":HIGH
+multiple-constructor-doc:13:0:13:35:ConstructorDocsInClassAndInit:"""ConstructorDocsInClassAndInit"" has constructor parameters documented in class and __init__":HIGH
+multiple-constructor-doc:29:0:29:34:ConstructorDocsInClassAndNew:"""ConstructorDocsInClassAndNew"" has constructor parameters documented in class and __new__":HIGH

--- a/tests/functional/ext/docparams/parameter/multiple_constructor_doc_default.txt
+++ b/tests/functional/ext/docparams/parameter/multiple_constructor_doc_default.txt
@@ -1,0 +1,1 @@
+multiple-constructor-doc:4:0:4:35:ConstructorDocsInClassAndInit:"""ConstructorDocsInClassAndInit"" has constructor parameters documented in class and __init__":HIGH


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->
The `docparams` extension now checks for constructor parameters documented in both the class docstring and the `__init__` docstring before `__init__` is skipped by the default `no-docstring-rgx`.

This keeps normal parameter documentation checks respecting `no-docstring-rgx`, while still emitting `multiple-constructor-doc` for duplicated constructor documentation.

Added a regression functional test for the default configuration where `__init__` is skipped but both docstrings document the same constructor parameter.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #6692

- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
