### PR TITLE
Fix `nested-min-max` false positive when the inner call has keyword arguments

### DIFF
--- a/doc/whatsnew/fragments/11130.bugfix
+++ b/doc/whatsnew/fragments/11130.bugfix
@@ -1,0 +1,3 @@
+Fix a false positive for ``nested-min-max`` (``W3301``) when the inner ``min``/``max`` call carries a keyword argument such as ``key=``. Flattening the call dropped the keyword and changed the result, so nested calls whose inner call has keyword arguments are no longer flagged.
+
+Closes #11130

--- a/pylint/checkers/nested_min_max.py
+++ b/pylint/checkers/nested_min_max.py
@@ -72,6 +72,11 @@ class NestedMinMaxChecker(BaseChecker):
                 # Allow: max(max([[1, 2, 3], [4, 5, 6]]))
                 # Meaning, redundant call only if parent max call has more than 1 arg.
                 and len(arg.parent.args) > 1
+                # An inner call carrying keyword arguments (e.g. ``key=`` or
+                # ``default=``) must not be flattened: the keyword would be
+                # silently dropped and the suggested call would change the
+                # result, e.g. ``max(a, max(b, c, key=k))``.
+                and not arg.keywords
             )
         ]
 

--- a/tests/functional/n/nested_min_max.py
+++ b/tests/functional/n/nested_min_max.py
@@ -62,3 +62,11 @@ max(max(MATRIX))
 max(max(max(MATRIX)))
 max(3, max(max(MATRIX)))  # [nested-min-max]
 max(max(3, max(MATRIX)))  # [nested-min-max]
+
+# An inner call carrying a keyword argument (e.g. ``key=``) must not be
+# flattened: the keyword would be silently dropped and the flattened call
+# would change the result, e.g. ``max(1, max(5, 3, key=abs))`` != ``max(1, 5, 3)``.
+max(1, max(5, 3, key=abs))
+max(1, max([5, 3], key=len))
+# Regression guard: a keyword on the *outer* call (inner has none) is still flagged.
+max(1, max(5, 3), key=abs)  # [nested-min-max]

--- a/tests/functional/n/nested_min_max.txt
+++ b/tests/functional/n/nested_min_max.txt
@@ -18,3 +18,4 @@ nested-min-max:52:0:52:33::Do not use nested call of 'max'; it's possible to do 
 nested-min-max:55:0:55:27::Do not use nested call of 'max'; it's possible to do 'max(3, *list(range(4)))' instead:INFERENCE
 nested-min-max:63:0:63:24::Do not use nested call of 'max'; it's possible to do 'max(3, max(MATRIX))' instead:INFERENCE
 nested-min-max:64:4:64:23::Do not use nested call of 'max'; it's possible to do 'max(3, *MATRIX)' instead:INFERENCE
+nested-min-max:72:0:72:26::Do not use nested call of 'max'; it's possible to do 'max(1, 5, 3, key=abs)' instead:INFERENCE


### PR DESCRIPTION
## Type of Changes

| Type | |
|------|-|
| ✓ | 🐛 Bug fix |

## Description

`nested-min-max` (W3301) flagged nested `min`/`max` calls even when the **inner** call carried a keyword argument (`key=`, `default=`), and the suggested replacement silently dropped the keyword — changing the result:

```pycon
>>> k = lambda z: -z
>>> max(1, max(5, 3, key=k))   # original
3
>>> max(1, 5, 3)               # pylint's suggested replacement
5
```

`get_redundant_calls` now excludes inner calls that carry keyword arguments, so those cases are no longer flagged. The outer-keyword case `max(a, max(b, c), key=k)` is still flagged (there the key applies to all arguments).

Functional test cases added in `tests/functional/n/nested_min_max.py`.

Closes #11130
