### PR TITLE
Fix `nested-min-max` dropping arguments after the splatted call

### DIFF
--- a/doc/whatsnew/fragments/11134.bugfix
+++ b/doc/whatsnew/fragments/11134.bugfix
@@ -1,0 +1,3 @@
+Fix a false suggestion from ``nested-min-max`` (``W3301``): when rewriting a nested ``min``/``max`` into a splat call, arguments positioned after the splatted call were silently dropped, so the suggested code changed the result.
+
+Closes #11134

--- a/pylint/checkers/nested_min_max.py
+++ b/pylint/checkers/nested_min_max.py
@@ -129,7 +129,7 @@ class NestedMinMaxChecker(BaseChecker):
                     fixed_node.args = [
                         *fixed_node.args[:idx],
                         splat_node,
-                        *fixed_node.args[idx + 1 : idx],
+                        *fixed_node.args[idx + 1 :],
                     ]
         func_name = (
             node.func.attrname

--- a/tests/functional/n/nested_min_max.py
+++ b/tests/functional/n/nested_min_max.py
@@ -70,3 +70,8 @@ max(1, max(5, 3, key=abs))
 max(1, max([5, 3], key=len))
 # Regression guard: a keyword on the *outer* call (inner has none) is still flagged.
 max(1, max(5, 3), key=abs)  # [nested-min-max]
+
+# Regression guard: arguments after the splatted inner call must be preserved.
+LIST3 = [1, 2, 3]
+max(max(LIST3), 5, 7)  # [nested-min-max]
+max(4, max(LIST3), 7)  # [nested-min-max]

--- a/tests/functional/n/nested_min_max.txt
+++ b/tests/functional/n/nested_min_max.txt
@@ -19,3 +19,5 @@ nested-min-max:55:0:55:27::Do not use nested call of 'max'; it's possible to do 
 nested-min-max:63:0:63:24::Do not use nested call of 'max'; it's possible to do 'max(3, max(MATRIX))' instead:INFERENCE
 nested-min-max:64:4:64:23::Do not use nested call of 'max'; it's possible to do 'max(3, *MATRIX)' instead:INFERENCE
 nested-min-max:72:0:72:26::Do not use nested call of 'max'; it's possible to do 'max(1, 5, 3, key=abs)' instead:INFERENCE
+nested-min-max:76:0:76:21::Do not use nested call of 'max'; it's possible to do 'max(*LIST3, 5, 7)' instead:INFERENCE
+nested-min-max:77:0:77:21::Do not use nested call of 'max'; it's possible to do 'max(4, *LIST3, 7)' instead:INFERENCE


### PR DESCRIPTION
## Type of Changes

| Type | |
|------|-|
| ✓ | 🐛 Bug fix |

## Description

`nested-min-max` (W3301), when suggesting a splat rewrite, silently dropped every argument positioned **after** the splatted call:

```python
LIST = [1, 2, 3]
max(max(LIST), 5, 7)   # suggested `max(*LIST)`  — drops 5, 7 (evaluates to 3, not 7)
max(4, max(LIST), 7)   # suggested `max(4, *LIST)` — drops 7
```

The splat was built with `fixed_node.args[idx + 1 : idx]` — a slice with `start > stop`, which is always empty. Changed to `fixed_node.args[idx + 1 :]`.

Same class of defect as #11130 / #11131 (the `key=`/`default=` drop), via a different code path — existing fixtures only splat the **last** argument, the one position where the empty slice happened to coincide with the correct one, so the bug was untested.

Functional test cases added in `tests/functional/n/nested_min_max.py`.

Closes #11134
