### PR TITLE
[primer] Add comparator test cases for tricky message pairings

### DIFF
--- a/tests/testutils/_primer/cases/lines_crossed/expected.txt
+++ b/tests/testutils/_primer/cases/lines_crossed/expected.txt
@@ -1,0 +1,30 @@
+🤖 **Effect of this PR on checked open source code:** 🤖
+
+
+**Effect on [astroid](https://github.com/pylint-dev/astroid):**
+
+The following messages are now emitted:
+
+<details>
+
+1) unused-variable:
+*Unused variable 'node'*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/rebuilder.py#L21
+2) unused-variable:
+*Unused variable 'node'*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/rebuilder.py#L11
+</details>
+
+The following messages are no longer emitted:
+
+<details>
+
+1) unused-variable:
+*Unused variable 'node'*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/rebuilder.py#L10
+2) unused-variable:
+*Unused variable 'node'*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/rebuilder.py#L20
+</details>
+
+*This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/lines_crossed/expected_comparator.json
+++ b/tests/testutils/_primer/cases/lines_crossed/expected_comparator.json
@@ -1,0 +1,1 @@
+[{ "package": "astroid", "missing": 2, "new": 2 }]

--- a/tests/testutils/_primer/cases/lines_crossed/main.json
+++ b/tests/testutils/_primer/cases/lines_crossed/main.json
@@ -1,0 +1,37 @@
+{
+  "astroid": {
+    "commit": "1234567890abcdef",
+    "messages": [
+      {
+        "type": "warning",
+        "module": "astroid.rebuilder",
+        "obj": "",
+        "line": 10,
+        "column": 4,
+        "endLine": 10,
+        "endColumn": 16,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/rebuilder.py",
+        "symbol": "unused-variable",
+        "message": "Unused variable 'node'",
+        "messageId": "W0612",
+        "confidence": "UNDEFINED",
+        "absolutePath": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/rebuilder.py"
+      },
+      {
+        "type": "warning",
+        "module": "astroid.rebuilder",
+        "obj": "",
+        "line": 20,
+        "column": 4,
+        "endLine": 20,
+        "endColumn": 16,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/rebuilder.py",
+        "symbol": "unused-variable",
+        "message": "Unused variable 'node'",
+        "messageId": "W0612",
+        "confidence": "UNDEFINED",
+        "absolutePath": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/rebuilder.py"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/lines_crossed/pr.json
+++ b/tests/testutils/_primer/cases/lines_crossed/pr.json
@@ -1,0 +1,37 @@
+{
+  "astroid": {
+    "commit": "123456789abcdef",
+    "messages": [
+      {
+        "type": "warning",
+        "module": "astroid.rebuilder",
+        "obj": "",
+        "line": 21,
+        "column": 4,
+        "endLine": 21,
+        "endColumn": 16,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/rebuilder.py",
+        "symbol": "unused-variable",
+        "message": "Unused variable 'node'",
+        "messageId": "W0612",
+        "confidence": "UNDEFINED",
+        "absolutePath": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/rebuilder.py"
+      },
+      {
+        "type": "warning",
+        "module": "astroid.rebuilder",
+        "obj": "",
+        "line": 11,
+        "column": 4,
+        "endLine": 11,
+        "endColumn": 16,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/rebuilder.py",
+        "symbol": "unused-variable",
+        "message": "Unused variable 'node'",
+        "messageId": "W0612",
+        "confidence": "UNDEFINED",
+        "absolutePath": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/rebuilder.py"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/multiline_message_changed/expected.txt
+++ b/tests/testutils/_primer/cases/multiline_message_changed/expected.txt
@@ -1,0 +1,34 @@
+🤖 **Effect of this PR on checked open source code:** 🤖
+
+
+**Effect on [astroid](https://github.com/pylint-dev/astroid):**
+
+The following messages are now emitted:
+
+<details>
+
+1) duplicate-code:
+*Similar lines in 2 files
+==astroid.arguments:[10:15]
+==astroid.bases:[20:25]
+    result = []
+    for arg in args:
+        result.append(arg)*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/arguments.py#L1
+</details>
+
+The following messages are no longer emitted:
+
+<details>
+
+1) duplicate-code:
+*Similar lines in 2 files
+==astroid.arguments:[10:14]
+==astroid.bases:[20:24]
+    result = []
+    for arg in args:
+        result.append(arg)*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/arguments.py#L1
+</details>
+
+*This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/multiline_message_changed/expected_comparator.json
+++ b/tests/testutils/_primer/cases/multiline_message_changed/expected_comparator.json
@@ -1,0 +1,1 @@
+[{ "package": "astroid", "missing": 1, "new": 1 }]

--- a/tests/testutils/_primer/cases/multiline_message_changed/main.json
+++ b/tests/testutils/_primer/cases/multiline_message_changed/main.json
@@ -1,0 +1,22 @@
+{
+  "astroid": {
+    "commit": "1234567890abcdef",
+    "messages": [
+      {
+        "type": "refactor",
+        "module": "astroid.arguments",
+        "obj": "",
+        "line": 1,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/arguments.py",
+        "symbol": "duplicate-code",
+        "message": "Similar lines in 2 files\n==astroid.arguments:[10:14]\n==astroid.bases:[20:24]\n    result = []\n    for arg in args:\n        result.append(arg)",
+        "messageId": "R0801",
+        "confidence": "UNDEFINED",
+        "absolutePath": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/arguments.py"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/multiline_message_changed/pr.json
+++ b/tests/testutils/_primer/cases/multiline_message_changed/pr.json
@@ -1,0 +1,22 @@
+{
+  "astroid": {
+    "commit": "123456789abcdef",
+    "messages": [
+      {
+        "type": "refactor",
+        "module": "astroid.arguments",
+        "obj": "",
+        "line": 1,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/arguments.py",
+        "symbol": "duplicate-code",
+        "message": "Similar lines in 2 files\n==astroid.arguments:[10:15]\n==astroid.bases:[20:25]\n    result = []\n    for arg in args:\n        result.append(arg)",
+        "messageId": "R0801",
+        "confidence": "UNDEFINED",
+        "absolutePath": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/arguments.py"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/rename_shadowed_by_unrelated/expected.txt
+++ b/tests/testutils/_primer/cases/rename_shadowed_by_unrelated/expected.txt
@@ -1,0 +1,27 @@
+🤖 **Effect of this PR on checked open source code:** 🤖
+
+
+**Effect on [astroid](https://github.com/pylint-dev/astroid):**
+
+The following messages are now emitted:
+
+<details>
+
+1) too-many-locals:
+*Too many local variables (20/15)*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/wcs.py#L3072
+2) possibly-used-before-assignment:
+*Possibly using variable 'orig_key' before assignment*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/wcs.py#L3072
+</details>
+
+The following messages are no longer emitted:
+
+<details>
+
+1) used-before-assignment:
+*Using variable 'orig_key' before assignment*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/wcs.py#L3072
+</details>
+
+*This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/rename_shadowed_by_unrelated/expected_comparator.json
+++ b/tests/testutils/_primer/cases/rename_shadowed_by_unrelated/expected_comparator.json
@@ -1,0 +1,1 @@
+[{ "package": "astroid", "missing": 1, "new": 2 }]

--- a/tests/testutils/_primer/cases/rename_shadowed_by_unrelated/main.json
+++ b/tests/testutils/_primer/cases/rename_shadowed_by_unrelated/main.json
@@ -1,0 +1,22 @@
+{
+  "astroid": {
+    "commit": "1234567890abcdef",
+    "messages": [
+      {
+        "type": "error",
+        "module": "astroid.wcs",
+        "obj": "WCS.fix",
+        "line": 3072,
+        "column": 12,
+        "endLine": 3072,
+        "endColumn": 20,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/wcs.py",
+        "symbol": "used-before-assignment",
+        "message": "Using variable 'orig_key' before assignment",
+        "messageId": "E0601",
+        "confidence": "HIGH",
+        "absolutePath": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/wcs.py"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/rename_shadowed_by_unrelated/pr.json
+++ b/tests/testutils/_primer/cases/rename_shadowed_by_unrelated/pr.json
@@ -1,0 +1,37 @@
+{
+  "astroid": {
+    "commit": "123456789abcdef",
+    "messages": [
+      {
+        "type": "refactor",
+        "module": "astroid.wcs",
+        "obj": "WCS.fix",
+        "line": 3072,
+        "column": 12,
+        "endLine": 3072,
+        "endColumn": 20,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/wcs.py",
+        "symbol": "too-many-locals",
+        "message": "Too many local variables (20/15)",
+        "messageId": "R0914",
+        "confidence": "UNDEFINED",
+        "absolutePath": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/wcs.py"
+      },
+      {
+        "type": "warning",
+        "module": "astroid.wcs",
+        "obj": "WCS.fix",
+        "line": 3072,
+        "column": 12,
+        "endLine": 3072,
+        "endColumn": 20,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/wcs.py",
+        "symbol": "possibly-used-before-assignment",
+        "message": "Possibly using variable 'orig_key' before assignment",
+        "messageId": "E0606",
+        "confidence": "INFERENCE",
+        "absolutePath": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/wcs.py"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/similar_symbols_not_paired/expected.txt
+++ b/tests/testutils/_primer/cases/similar_symbols_not_paired/expected.txt
@@ -1,0 +1,24 @@
+🤖 **Effect of this PR on checked open source code:** 🤖
+
+
+**Effect on [astroid](https://github.com/pylint-dev/astroid):**
+
+The following messages are now emitted:
+
+<details>
+
+1) unused-import:
+*Unused import os*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/helpers.py#L12
+</details>
+
+The following messages are no longer emitted:
+
+<details>
+
+1) unused-variable:
+*Unused variable 'result'*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/helpers.py#L12
+</details>
+
+*This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/similar_symbols_not_paired/expected_comparator.json
+++ b/tests/testutils/_primer/cases/similar_symbols_not_paired/expected_comparator.json
@@ -1,0 +1,1 @@
+[{ "package": "astroid", "missing": 1, "new": 1 }]

--- a/tests/testutils/_primer/cases/similar_symbols_not_paired/main.json
+++ b/tests/testutils/_primer/cases/similar_symbols_not_paired/main.json
@@ -1,0 +1,22 @@
+{
+  "astroid": {
+    "commit": "1234567890abcdef",
+    "messages": [
+      {
+        "type": "warning",
+        "module": "astroid.helpers",
+        "obj": "",
+        "line": 12,
+        "column": 0,
+        "endLine": 12,
+        "endColumn": 18,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/helpers.py",
+        "symbol": "unused-variable",
+        "message": "Unused variable 'result'",
+        "messageId": "W0612",
+        "confidence": "UNDEFINED",
+        "absolutePath": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/helpers.py"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/similar_symbols_not_paired/pr.json
+++ b/tests/testutils/_primer/cases/similar_symbols_not_paired/pr.json
@@ -1,0 +1,22 @@
+{
+  "astroid": {
+    "commit": "123456789abcdef",
+    "messages": [
+      {
+        "type": "warning",
+        "module": "astroid.helpers",
+        "obj": "",
+        "line": 12,
+        "column": 0,
+        "endLine": 12,
+        "endColumn": 18,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/helpers.py",
+        "symbol": "unused-import",
+        "message": "Unused import os",
+        "messageId": "W0611",
+        "confidence": "UNDEFINED",
+        "absolutePath": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/helpers.py"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :white_check_mark: Test |

## Description

Baseline expectations (current removed+added reporting) for four tricky pairing scenarios:

- a symbol rename at a location that also gains an unrelated message
- similar-looking but unrelated symbols at the same location
- two identical warnings that both moved lines
- a multi-line message (`duplicate-code`) whose content changed

Merging this first makes the behavior change reviewable in #10914: after a rebase, its diff will show these `expected.txt` files *changing* from removed+added to compact diffs instead of appearing as new files.