### PR TITLE
Fix `too-many-locals` counting PEP 695 type parameters as local variables

### DIFF
--- a/doc/whatsnew/fragments/11136.bugfix
+++ b/doc/whatsnew/fragments/11136.bugfix
@@ -1,0 +1,3 @@
+Fix a false positive for ``too-many-locals`` (``R0914``): PEP 695 type parameters (e.g. ``def f[T1, T2](...)``) were counted as local variables. They are type-system constructs, not runtime locals, and are now excluded from the local-variable count.
+
+Closes #11136

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -577,7 +577,10 @@ class MisdesignChecker(BaseChecker):
                 )
 
         # check number of local variables
-        locnum = len(node.locals) - ignored_args_num
+        # PEP 695 type parameters live in the function's ``locals`` but are
+        # type-system constructs, not runtime local variables, so exclude them.
+        type_param_names = {param.name.name for param in node.type_params}
+        locnum = len(set(node.locals) - type_param_names) - ignored_args_num
 
         # decrement number of local variables if '_' is one of them
         if "_" in node.locals:

--- a/tests/functional/t/too/too_many_locals_py312.py
+++ b/tests/functional/t/too/too_many_locals_py312.py
@@ -1,0 +1,31 @@
+# pylint: disable=missing-docstring,unused-variable,line-too-long
+
+
+# PEP 695 type parameters live in the function's locals but are type-system
+# constructs, not runtime local variables, so they must not be counted towards
+# ``too-many-locals``. This function has 16 type parameters but only one real
+# local variable, so it must NOT emit ``too-many-locals``.
+def build[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](arg):
+    result = arg
+    return result
+
+
+# Mixed case: 16 type parameters plus 16 genuine local variables. Only the real
+# locals are counted, so this emits ``too-many-locals`` at 16/15 (not 32/15).
+def mixed[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](start):  # [too-many-locals]
+    loc0 = start
+    loc1 = loc0 * 1
+    loc2 = loc1 * 2
+    loc3 = loc2 * 3
+    loc4 = loc3 * 4
+    loc5 = loc4 * 5
+    loc6 = loc5 * 6
+    loc7 = loc6 * 7
+    loc8 = loc7 * 8
+    loc9 = loc8 * 9
+    loc10 = loc9 * 10
+    loc11 = loc10 * 11
+    loc12 = loc11 * 12
+    loc13 = loc12 * 13
+    loc14 = loc13 * 14
+    return loc14

--- a/tests/functional/t/too/too_many_locals_py312.rc
+++ b/tests/functional/t/too/too_many_locals_py312.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.12

--- a/tests/functional/t/too/too_many_locals_py312.txt
+++ b/tests/functional/t/too/too_many_locals_py312.txt
@@ -1,0 +1,1 @@
+too-many-locals:15:0:15:9:mixed:Too many local variables (16/15):UNDEFINED


### PR DESCRIPTION
## Type of Changes

| Type | |
|------|-|
| ✓ | 🐛 Bug fix |

## Description

`too-many-locals` (R0914) counted PEP 695 type parameters as local variables:

```python
def build[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](x: T1) -> T1:
    return x   # 1 real local, but reported "Too many local variables (17/15)"
```

astroid places PEP 695 type-param names into `node.locals`, so `len(node.locals)` over-counts. This excludes them (via `node.type_params` / `param.name.name`, the same accessor already used in `variables.py`, covering `TypeVar` / `TypeVarTuple` / `ParamSpec`), matching how pylint already excludes type parameters from other checkers.

Real locals are still counted (a mixed function with 16 real locals + 16 type params reports `16/15`, not `32/15`).

Added a `min_pyver=3.12`-gated functional fixture (`too_many_locals_py312`) rather than editing the un-gated base fixture (which would be a `SyntaxError` on older Pythons).

Closes #11136
