### PR TITLE
[mccabe] Add functional tests documenting current complexity scores

### DIFF
--- a/tests/functional/ext/mccabe/mccabe.py
+++ b/tests/functional/ext/mccabe/mccabe.py
@@ -350,3 +350,89 @@ def yield_in_for_loop(a=None, b=None, c=None):  # [too-complex]
             yield elt
     if c is not None:
         yield c
+
+
+try:  # [too-complex]
+    # McCabe rating: 5
+    if True:
+        pass
+    else:
+        pass
+except TypeA:
+    pass
+except TypeB:
+    pass
+
+
+match avg:  # [too-complex]
+    # McCabe rating: 4
+    # pylint: disable=bare-name-capture-pattern
+    case avg if avg < 0.3:
+        avg_grade = "F"
+    case avg if avg < 0.7:
+        avg_grade = "E+"
+    case _:
+        avg_grade = "A"
+
+
+def non_exhaustive_match(value):  # [too-complex]
+    """McCabe rating: 3
+
+    No case may apply: the fall-through path counts, as an if/elif would."""
+    match value:
+        case 1:
+            result = "one"
+        case 2:
+            result = "two"
+    return result
+
+
+def match_capture_name(value):  # [too-complex]
+    """McCabe rating: 3
+
+    An unguarded capture name always matches, no other case is tried."""
+    # pylint: disable=bare-name-capture-pattern
+    match value:
+        case 1:
+            result = "one"
+        case something_else:
+            result = str(something_else)
+    return result
+
+
+def match_guarded_wildcard(value):  # [too-complex]
+    """McCabe rating: 3
+
+    A guarded wildcard can fail to match: the fall-through path counts."""
+    match value:
+        case 1:
+            result = "one"
+        case _ if value > 0:
+            result = "positive"
+    return result
+
+
+class PropertyAccessors:  # pylint: disable=too-few-public-methods
+    """Only the last definition of a given name is rated: the deleter
+    hides the more complex getter and setter."""
+
+    @property
+    def attribute(self):
+        """McCabe rating: 2 (not reported: hidden by the deleter)"""
+        if self._attribute is None:
+            raise ValueError("not set")
+        return self._attribute
+
+    @attribute.setter
+    def attribute(self, value):
+        """McCabe rating: 3 (not reported: hidden by the deleter)"""
+        if value is None:
+            raise ValueError("cannot unset")
+        if not isinstance(value, int):
+            value = int(value)
+        self._attribute = value
+
+    @attribute.deleter
+    def attribute(self):  # [too-complex]
+        """McCabe rating: 1"""
+        self._attribute = None

--- a/tests/functional/ext/mccabe/mccabe.txt
+++ b/tests/functional/ext/mccabe/mccabe.txt
@@ -27,3 +27,9 @@ too-complex:296:0:296:31:try_finally_with_nested_ifs:'try_finally_with_nested_if
 too-complex:308:0:308:14:match_case:'match_case' is too complex. The McCabe rating is 4:HIGH
 too-complex:323:0:323:21:nested_match_case:'nested_match_case' is too complex. The McCabe rating is 8:HIGH
 too-complex:345:0:345:21:yield_in_for_loop:'yield_in_for_loop' is too complex. The McCabe rating is 4:HIGH
+too-complex:355:0:364:8::This 'try' is too complex. The McCabe rating is 5:HIGH
+too-complex:367:0:375:23::This 'match' is too complex. The McCabe rating is 4:HIGH
+too-complex:378:0:378:24:non_exhaustive_match:'non_exhaustive_match' is too complex. The McCabe rating is 3:HIGH
+too-complex:390:0:390:22:match_capture_name:'match_capture_name' is too complex. The McCabe rating is 3:HIGH
+too-complex:403:0:403:26:match_guarded_wildcard:'match_guarded_wildcard' is too complex. The McCabe rating is 3:HIGH
+too-complex:436:4:436:17:PropertyAccessors.attribute:'attribute' is too complex. The McCabe rating is 1:HIGH

--- a/tests/functional/ext/mccabe/mccabe_py311.py
+++ b/tests/functional/ext/mccabe/mccabe_py311.py
@@ -1,0 +1,17 @@
+"""Checks for too-complex with syntax requiring Python 3.11 or newer."""
+
+# pylint: disable=missing-docstring
+
+
+def exception_groups(shielded):  # [too-complex]
+    """McCabe rating: 1
+
+    The mccabe library predates ``except*`` and does not count it."""
+    result = "none"
+    try:
+        shielded()
+    except* TypeError:
+        result = "type"
+    except* ValueError:
+        result = "value"
+    return result

--- a/tests/functional/ext/mccabe/mccabe_py311.rc
+++ b/tests/functional/ext/mccabe/mccabe_py311.rc
@@ -1,0 +1,7 @@
+[MAIN]
+load-plugins=pylint.extensions.mccabe,
+
+max-complexity=0
+
+[testoptions]
+min_pyver=3.11

--- a/tests/functional/ext/mccabe/mccabe_py311.txt
+++ b/tests/functional/ext/mccabe/mccabe_py311.txt
@@ -1,0 +1,1 @@
+too-complex:6:0:6:20:exception_groups:'exception_groups' is too complex. The McCabe rating is 1:HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :white_check_mark: Test |

## Description

Baseline functional tests ahead of the mccabe re-implementation in #10551: module-level `try` and `match` statements, exhaustiveness variants of `match`, same-named property accessors, and `except*` (Python 3.11, gated with `min_pyver`).

The expected output encodes the current `mccabe`-library behavior, including its quirks:

- only the last definition of a given name is rated: the trivial `@x.deleter` hides a complex getter and setter (the graphs dict is keyed by name, so same-named siblings overwrite each other),
- an exhaustive `match` (unguarded wildcard or capture name last) still counts a nonexistent fall-through path (see https://github.com/astral-sh/ruff/issues/11421 for the same discussion in ruff),
- `except*` is not counted at all: mccabe 0.7.0 (last release, January 2022) predates Python 3.11 and has no `visitTryStar`, so a `try`/`except*` rates like straight-line code.

Merging this first lets the #10551 diffs show exactly how each of these scores changes.

Refs #10551