### PR TITLE
Fix `literal-comparison` suggestion corrupting identifiers containing "is"

### DIFF
--- a/doc/whatsnew/fragments/11146.bugfix
+++ b/doc/whatsnew/fragments/11146.bugfix
@@ -1,0 +1,5 @@
+Fix `literal-comparison` (`R0123`) emitting a corrupted suggestion for identifiers
+that contain ``is`` (e.g. ``axis is 5`` was rendered ``ax== == 5``). The suggestion
+is now rebuilt from the operands and operator.
+
+Closes #11146

--- a/pylint/checkers/base/comparison_checker.py
+++ b/pylint/checkers/base/comparison_checker.py
@@ -203,7 +203,14 @@ class ComparisonChecker(_BasicChecker):
         else:
             equal_or_not_equal = "=="
             is_or_is_not = "is"
-        fixed_node_str = incorrect_node_str.replace(is_or_is_not, equal_or_not_equal)
+        # Rebuild the suggestion from the operands and operator instead of a
+        # blind ``str.replace``, which corrupts identifiers that contain ``is``
+        # (e.g. ``axis is 5`` produced ``ax== == 5``). ``visit_compare`` only
+        # reaches this method for single-operator comparisons.
+        fixed_node_str = (
+            f"{node.left.as_string()} {equal_or_not_equal} "
+            f"{node.ops[0][1].as_string()}"
+        )
         self.add_message(
             "literal-comparison",
             args=(

--- a/tests/functional/l/literal_comparison.py
+++ b/tests/functional/l/literal_comparison.py
@@ -55,3 +55,10 @@ def github_issue_3031(arg=()):
 
     if arg is not ():
         pass
+
+
+def variable_name_containing_is():
+    # Regression test: the suggested replacement must not corrupt an identifier
+    # that contains the substring "is" (e.g. ``axis`` was rendered ``ax==``).
+    axis = 5
+    return axis is 5  # [literal-comparison]

--- a/tests/functional/l/literal_comparison.txt
+++ b/tests/functional/l/literal_comparison.txt
@@ -13,3 +13,4 @@ literal-comparison:31:3:31:22::In '() is not {1, 2, 3}', use '!=' when comparing
 literal-comparison:38:3:38:13::In 'CONST is 0', use '==' when comparing constant literals not 'is' ('CONST == 0'):HIGH
 literal-comparison:41:3:41:13::In 'CONST is 1', use '==' when comparing constant literals not 'is' ('CONST == 1'):HIGH
 literal-comparison:44:3:44:14::In 'CONST is 42', use '==' when comparing constant literals not 'is' ('CONST == 42'):HIGH
+literal-comparison:64:11:64:20:variable_name_containing_is:In 'axis is 5', use '==' when comparing constant literals not 'is' ('axis == 5'):HIGH


### PR DESCRIPTION
## Type of Changes

| Type | |
|------|-|
| ✓ | 🐛 Bug fix |

## Description

`literal-comparison` (R0123) built its suggested `==` replacement with a blind `str.replace` of the first `is` occurrence in the rendered comparison, corrupting any identifier that contains the substring `is` (e.g. `axis is 5` → `ax== == 5`, `prefix_is_set is 5` → `prefix_==_set == 5`).

The suggestion is now rebuilt from the operands and operator. `visit_compare` only reaches this path for single-operator comparisons (`len(node.ops) != 1` returns early), so `left op right` is faithful and the parse tree is unchanged.

Regression test added in `tests/functional/l/literal_comparison.py`.

Closes #11146
