### PR TITLE
Fix `bad-string-format-type` false positives for `%i`, `%u` and `%a`

### DIFF
--- a/doc/whatsnew/fragments/11147.bugfix
+++ b/doc/whatsnew/fragments/11147.bugfix
@@ -1,0 +1,5 @@
+Fix false positives in `bad-string-format-type` (`E1307`) for valid ``%`` formatting:
+``%i``/``%u`` applied to a float (both truncate like ``%d``) and ``%a`` applied to any
+non-int type (``%a`` is type-agnostic like ``%s``/``%r``).
+
+Closes #11147

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -223,15 +223,16 @@ def get_access_path(key: str | Literal[0], parts: list[tuple[bool, str]]) -> str
 def arg_matches_format_type(
     arg_type: SuccessfulInferenceResult, format_type: str
 ) -> bool:
-    if format_type in "sr":
-        # All types can be printed with %s and %r
+    if format_type in "sra":
+        # All types can be printed with %s, %r and %a
         return True
     if isinstance(arg_type, astroid.Instance):
         match arg_type.pytype():
             case "builtins.str":
                 return format_type == "c"
             case "builtins.float":
-                return format_type in "deEfFgGn%"
+                # ``i`` and ``u`` accept a float at runtime (truncated like ``d``)
+                return format_type in "diueEfFgGn%"
             case "builtins.int":
                 # Integers allow all types
                 return True

--- a/tests/functional/b/bad_string_format_type.py
+++ b/tests/functional/b/bad_string_format_type.py
@@ -21,6 +21,14 @@ b"test".format(1, 2) # [no-member]
 "%s" % None
 "%(key)s" % {"key": None}
 
+# ``%i`` and ``%u`` accept a float (truncated like ``%d``); ``%a`` accepts any
+# type just like ``%s``/``%r``. None of the following are errors.
+"%i" % 1.1
+"%u" % 1.1
+"%a" % 1.1
+"%a" % "abc"
+"%(key)i" % {"key": 1.1}
+
 # Test incorrect format types
 "%d" % "1"  # [bad-string-format-type]
 "%(key)d" % {"key": "1"}  # [bad-string-format-type]

--- a/tests/functional/b/bad_string_format_type.txt
+++ b/tests/functional/b/bad_string_format_type.txt
@@ -1,10 +1,10 @@
 no-member:5:0:5:14::Instance of 'bytes' has no 'format' member:INFERENCE
-bad-string-format-type:25:0:25:10::Argument 'builtins.str' does not match format type 'd':UNDEFINED
-bad-string-format-type:26:0:26:24::Argument 'builtins.str' does not match format type 'd':UNDEFINED
-bad-string-format-type:27:0:27:10::Argument 'builtins.float' does not match format type 'x':UNDEFINED
-bad-string-format-type:28:0:28:24::Argument 'builtins.float' does not match format type 'x':UNDEFINED
-bad-string-format-type:29:0:29:9::Argument 'builtins.list' does not match format type 'd':UNDEFINED
-bad-string-format-type:30:0:30:23::Argument 'builtins.list' does not match format type 'd':UNDEFINED
-bad-string-format-type:33:0:33:11::Argument 'builtins.str' does not match format type 'd':UNDEFINED
-bad-string-format-type:34:0:34:22::Argument 'builtins.str' does not match format type 'd':UNDEFINED
-bad-string-format-type:38:0:38:29::Argument 'builtins.str' does not match format type 'd':UNDEFINED
+bad-string-format-type:33:0:33:10::Argument 'builtins.str' does not match format type 'd':UNDEFINED
+bad-string-format-type:34:0:34:24::Argument 'builtins.str' does not match format type 'd':UNDEFINED
+bad-string-format-type:35:0:35:10::Argument 'builtins.float' does not match format type 'x':UNDEFINED
+bad-string-format-type:36:0:36:24::Argument 'builtins.float' does not match format type 'x':UNDEFINED
+bad-string-format-type:37:0:37:9::Argument 'builtins.list' does not match format type 'd':UNDEFINED
+bad-string-format-type:38:0:38:23::Argument 'builtins.list' does not match format type 'd':UNDEFINED
+bad-string-format-type:41:0:41:11::Argument 'builtins.str' does not match format type 'd':UNDEFINED
+bad-string-format-type:42:0:42:22::Argument 'builtins.str' does not match format type 'd':UNDEFINED
+bad-string-format-type:46:0:46:29::Argument 'builtins.str' does not match format type 'd':UNDEFINED


### PR DESCRIPTION
## Type of Changes

| Type | |
|------|-|
| ✓ | 🐛 Bug fix |

## Description

`bad-string-format-type` (E1307) rejected valid old-style `%` formatting:
- `%i` / `%u` applied to a float (both truncate like `%d`);
- `%a` applied to any non-int type (`%a` is type-agnostic like `%s` / `%r`).

Added `a` to the always-printable early return and `i` / `u` to the float conversion table. The genuine error case (`%x` on a float) is unaffected.

Regression cases added in `tests/functional/b/bad_string_format_type.py`.

Closes #11147
