### PR TITLE
Fix `useless-parent-delegation` false positive on positional-only default

### DIFF
--- a/doc/whatsnew/fragments/11148.bugfix
+++ b/doc/whatsnew/fragments/11148.bugfix
@@ -1,0 +1,5 @@
+Fix a false positive for `useless-parent-delegation` (`W0246`) when an override changes
+the default value of a positional-only parameter. ``_has_different_parameters_default_value``
+now also considers ``posonlyargs``.
+
+Closes #11148

--- a/doc/whatsnew/fragments/11148.bugfix
+++ b/doc/whatsnew/fragments/11148.bugfix
@@ -1,4 +1,4 @@
-Fix a false positive for `useless-parent-delegation` (`W0246`) when an override changes
+Fix a false positive for  ':ref:`useless-super-delegation`' when an override changes
 the default value of a positional-only parameter.
 
 Closes #11148

--- a/doc/whatsnew/fragments/11148.bugfix
+++ b/doc/whatsnew/fragments/11148.bugfix
@@ -1,4 +1,4 @@
-Fix a false positive for  ':ref:`useless-super-delegation`' when an override changes
+Fix a false positive for :ref:`useless-parent-delegation` when an override changes
 the default value of a positional-only parameter.
 
 Closes #11148

--- a/doc/whatsnew/fragments/11148.bugfix
+++ b/doc/whatsnew/fragments/11148.bugfix
@@ -1,5 +1,4 @@
 Fix a false positive for `useless-parent-delegation` (`W0246`) when an override changes
-the default value of a positional-only parameter. ``_has_different_parameters_default_value``
-now also considers ``posonlyargs``.
+the default value of a positional-only parameter.
 
 Closes #11148

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -225,7 +225,7 @@ def _has_different_parameters_default_value(
     if original.args is None or overridden.args is None:
         return False
 
-    for param in chain(original.args, original.kwonlyargs):
+    for param in chain(original.posonlyargs, original.args, original.kwonlyargs):
         try:
             original_default = original.default_value(param.name)
         except astroid.exceptions.NoDefault:

--- a/tests/functional/u/useless/useless_parent_delegation_py38.py
+++ b/tests/functional/u/useless/useless_parent_delegation_py38.py
@@ -15,3 +15,20 @@ class Spam(Egg):
 class Ham(Egg):
     def __init__(self, first: Any, /, second: Any) -> None:  # [useless-parent-delegation]
         super().__init__(first, second)
+
+
+class EggWithDefaults:
+    def __init__(self, first: Any = 1, /, second: Any = 2) -> None:
+        pass
+
+
+class HamChangedPosonlyDefault(EggWithDefaults):
+    # Not useless: the positional-only ``first`` has a different default from the
+    # base, so the override changes behaviour (regression test for posonlyargs).
+    def __init__(self, first: Any = 9, /, second: Any = 2) -> None:
+        super().__init__(first, second)
+
+
+class SpamSamePosonlyDefault(EggWithDefaults):
+    def __init__(self, first: Any = 1, /, second: Any = 2) -> None:  # [useless-parent-delegation]
+        super().__init__(first, second)

--- a/tests/functional/u/useless/useless_parent_delegation_py38.txt
+++ b/tests/functional/u/useless/useless_parent_delegation_py38.txt
@@ -1,1 +1,2 @@
 useless-parent-delegation:16:4:16:16:Ham.__init__:Useless parent or super() delegation in method '__init__':INFERENCE
+useless-parent-delegation:33:4:33:16:SpamSamePosonlyDefault.__init__:Useless parent or super() delegation in method '__init__':INFERENCE


### PR DESCRIPTION
## Type of Changes

| Type | |
|------|-|
| ✓ | 🐛 Bug fix |

## Description

`useless-parent-delegation` (W0246) falsely flagged an override that changes the default value of a **positional-only** parameter. `_has_different_parameters_default_value` iterated `original.args` and `original.kwonlyargs` but omitted `original.posonlyargs`, so the changed default was not detected and the override was treated as useless.

Included `posonlyargs` in the chain. A regular positional argument with a differing default was already (correctly) excused; positional-only now matches.

Regression tests added in `tests/functional/u/useless/useless_parent_delegation_py38.py` (changed positional-only default → not flagged; identical default → still flagged).

Closes #11148
