### PR TITLE
Support PEP 695 type parameter scopes from astroid's TypeParamScope

### DIFF
--- a/doc/whatsnew/fragments/11058.bugfix
+++ b/doc/whatsnew/fragments/11058.bugfix
@@ -1,0 +1,9 @@
+Fix a crash (``AttributeError: 'TypeVar' object has no attribute 'qname'``)
+in the refactoring checker when a PEP 695 type parameter was used outside its
+type alias (e.g. ``type T[U] = None`` followed by ``U()``). Such a use is now
+correctly reported as ``undefined-variable`` instead: the type parameter is
+scoped to the alias and using it afterwards raises ``NameError`` at runtime.
+
+Requires astroid >= 4.2 (pylint-dev/astroid#3119).
+
+Closes #11058

--- a/doc/whatsnew/fragments/11115.false_positive
+++ b/doc/whatsnew/fragments/11115.false_positive
@@ -1,0 +1,6 @@
+Fix a false positive for ``used-before-assignment`` (E0601) when a PEP 695
+type-parameter bound or default forward-references a name defined later in the
+module (e.g. ``class Container[T: Item]`` with ``Item`` defined afterwards).
+Such bounds are lazily evaluated, so the reference is valid at runtime.
+
+Closes #11115

--- a/doc/whatsnew/fragments/9884.false_positive
+++ b/doc/whatsnew/fragments/9884.false_positive
@@ -1,0 +1,8 @@
+Fix a false positive for ``redefined-outer-name`` when a PEP 695 type
+parameter shadows a module-level name (e.g. ``def func[T: Y](x: T)`` with a
+module-level ``T``). Type parameters now live in their own scope in astroid,
+so they no longer count as a redefinition of the outer name.
+
+Requires astroid >= 4.2 (pylint-dev/astroid#3119).
+
+Closes #9884

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -577,10 +577,7 @@ class MisdesignChecker(BaseChecker):
                 )
 
         # check number of local variables
-        # PEP 695 type parameters live in the function's ``locals`` but are
-        # type-system constructs, not runtime local variables, so exclude them.
-        type_param_names = {param.name.name for param in node.type_params}
-        locnum = len(set(node.locals) - type_param_names) - ignored_args_num
+        locnum = len(node.locals) - ignored_args_num
 
         # decrement number of local variables if '_' is one of them
         if "_" in node.locals:

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1818,11 +1818,6 @@ class VariablesChecker(BaseChecker):
             if utils.is_ancestor_name(consumer.node, node) or (
                 not is_start_index and self._ignore_class_scope(node)
             ):
-                if any(
-                    node.name == param.name.name for param in consumer.node.type_params
-                ):
-                    return False
-
                 return True
 
             match node.parent:
@@ -1833,9 +1828,6 @@ class VariablesChecker(BaseChecker):
         elif consumer.scope_type == "function" and self._defined_in_function_definition(
             node, consumer.node
         ):
-            if any(node.name == param.name.name for param in consumer.node.type_params):
-                return False
-
             # If the name node is used as a function default argument's value or as
             # a decorator, then start from the parent frame of the function instead
             # of the function frame - and thus open an inner class scope

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1783,7 +1783,21 @@ class VariablesChecker(BaseChecker):
                 )
             )
         ) and not utils.node_ignores_exception(node, NameError):
+            if self._is_pep695_type_parameter(node):
+                return
             self.add_message("undefined-variable", args=node.name, node=node)
+
+    @staticmethod
+    def _is_pep695_type_parameter(node: nodes.Name) -> bool:
+        """Check if the name resolves to a PEP 695 type parameter.
+
+        Type parameters live in an implicit ``TypeParamScope`` (astroid >= 4.2)
+        that the consumer stack does not track; delegate to astroid's lookup.
+        """
+        return any(
+            isinstance(definition.scope(), nodes.TypeParamScope)
+            for definition in node.lookup(node.name)[1]
+        )
 
     def _should_node_be_skipped(
         self,
@@ -1983,6 +1997,7 @@ class VariablesChecker(BaseChecker):
                     or isinstance(stmt, nodes.AnnAssign)  # noqa: RUF021
                     and utils.get_node_first_ancestor_of_type(stmt, nodes.FunctionDef)
                     or isinstance(stmt, nodes.TypeAlias)
+                    or utils.is_node_in_pep695_type_context(node)
                 ):
                     self.add_message(
                         "used-before-assignment",

--- a/tests/functional/u/undefined/undefined_variable_py312.py
+++ b/tests/functional/u/undefined/undefined_variable_py312.py
@@ -15,3 +15,10 @@ class Parent[T]:
 
 class Child[T](Parent[T, S]):  # [undefined-variable]
     ...
+
+
+# Regression test for https://github.com/pylint-dev/pylint/issues/11058
+# The type parameter is scoped to the alias; using it afterwards is a
+# NameError at runtime (and used to crash the refactoring checker).
+type AliasWithParam[U] = U | None
+_ = U()  # [undefined-variable]

--- a/tests/functional/u/undefined/undefined_variable_py312.txt
+++ b/tests/functional/u/undefined/undefined_variable_py312.txt
@@ -1,2 +1,3 @@
 undefined-variable:13:32:13:33:Parent.__init__:Undefined variable 'S':UNDEFINED
 undefined-variable:16:25:16:26:Child:Undefined variable 'S':UNDEFINED
+undefined-variable:24:4:24:5::Undefined variable 'U':UNDEFINED

--- a/tests/functional/u/used/used_before_assignment_py312.py
+++ b/tests/functional/u/used/used_before_assignment_py312.py
@@ -19,5 +19,5 @@ class Good[T: Y]: ...
 type OtherAlias[T: Y] = T | None
 
 # https://github.com/pylint-dev/pylint/issues/9884
-def func[T: Y](x: T) -> None:  # [redefined-outer-name]  FALSE POSITIVE
+def func[T: Y](x: T) -> None:
     ...

--- a/tests/functional/u/used/used_before_assignment_py312.txt
+++ b/tests/functional/u/used/used_before_assignment_py312.txt
@@ -1,1 +1,0 @@
-redefined-outer-name:22:9:22:13:func:Redefining name 'T' from outer scope (line 6):UNDEFINED

--- a/tests/functional/u/used/used_before_assignment_py313.py
+++ b/tests/functional/u/used/used_before_assignment_py313.py
@@ -12,5 +12,5 @@ class Good3[**P = [int, Y]]: ...
 type Alias[T = Y] = T | None
 
 # https://github.com/pylint-dev/pylint/issues/9884
-def func[T = Y](x: T) -> None:  # [redefined-outer-name]  FALSE POSITIVE
+def func[T = Y](x: T) -> None:
     ...

--- a/tests/functional/u/used/used_before_assignment_py313.txt
+++ b/tests/functional/u/used/used_before_assignment_py313.txt
@@ -1,1 +1,0 @@
-redefined-outer-name:15:9:15:14:func:Redefining name 'T' from outer scope (line 12):UNDEFINED

--- a/tests/functional/u/used_02/used_before_assignment_py313.py
+++ b/tests/functional/u/used_02/used_before_assignment_py313.py
@@ -12,5 +12,5 @@ class Good3[**P = [int, Y]]: ...
 type Alias[T = Y] = T | None
 
 # https://github.com/pylint-dev/pylint/issues/9884
-def func[T = Y](x: T) -> None:  # [redefined-outer-name]  FALSE POSITIVE
+def func[T = Y](x: T) -> None:
     ...

--- a/tests/functional/u/used_02/used_before_assignment_py313.txt
+++ b/tests/functional/u/used_02/used_before_assignment_py313.txt
@@ -1,1 +1,0 @@
-redefined-outer-name:15:9:15:14:func:Redefining name 'T' from outer scope (line 12):UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Companion to pylint-dev/astroid#3119, which moves PEP 695 type parameters into a dedicated implicit scope (nodes.TypeParamScope) instead of leaking them into the owner's locals.

Two changes in the variables checker:

- Exempt names used inside a type parameter bound/default (or a type alias value) from used-before-assignment: these are lazily evaluated, so forward references are valid at runtime. Fixes the E0601 false positive on 'class Container[T: Item]' with 'Item' defined later. This part works with any astroid version.

- Before emitting undefined-variable for a name the consumer stack cannot resolve, delegate to astroid's lookup and accept names bound in a TypeParamScope. The consumer stack does not track that implicit scope, and type parameter names no longer appear in the owner's locals with astroid >= 4.2.

The redefined-outer-name false positive on type parameters shadowing module-level names (#9884) disappears with the new astroid structure; functional test expectations updated accordingly. Those expectation changes require astroid >= 4.2 (pylint-dev/astroid#3119) to pass.

Closes #11115
Closes #9884
