### PR TITLE
[primer] Always install pylint from the current checkout

### DIFF
--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -51,6 +51,13 @@ jobs:
             env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ hashFiles('pyproject.toml',
             'requirements_test.txt', 'requirements_test_min.txt',
             'requirements_test_pre_commit.txt') }}
+      # The cached venv contains the pylint that was installed when the cache was
+      # created, which can be stale. Reinstall from the current checkout so the
+      # comparison and comment rendering use the right code (see #11153).
+      - name: Install pylint from the current checkout
+        run: |
+          . venv/bin/activate
+          pip install . --no-deps
 
       - name: Download outputs
         uses: actions/github-script@v9.0.0

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -71,6 +71,13 @@ jobs:
             env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ hashFiles('pyproject.toml',
             'requirements_test.txt', 'requirements_test_min.txt',
             'requirements_test_pre_commit.txt') }}
+      # The cached venv contains the pylint that was installed when the cache was
+      # created, which can be stale. Reinstall from the current checkout so every
+      # following step uses the right code (see #11153).
+      - name: Install pylint from the current checkout
+        run: |
+          . venv/bin/activate
+          pip install . --no-deps
 
       # Cache primer packages
       - name: Get commit string
@@ -113,7 +120,6 @@ jobs:
       - name: Run pylint primer
         run: |
           . venv/bin/activate
-          pip install . --no-deps
           python tests/primer/__main__.py run --type=main --batches=${{ matrix.batches }} --batchIdx=${{ matrix.batchIdx }} 2>warnings.txt
       - name: Echo warnings
         if: success() || failure()

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -83,6 +83,14 @@ jobs:
             env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ hashFiles('pyproject.toml',
             'requirements_test.txt', 'requirements_test_min.txt',
             'requirements_test_pre_commit.txt') }}
+      # The cached venv contains the pylint that was installed when the cache was
+      # created, which can be stale or even broken if it was created on an earlier
+      # (force-pushed away) commit of this PR. Reinstall from the current checkout
+      # so every following step uses the right code (see #11153).
+      - name: Install pylint from the current checkout
+        run: |
+          . venv/bin/activate
+          pip install . --no-deps
 
       # Cache primer packages
       - name: Download last 'main' run info


### PR DESCRIPTION
## Type of Changes

|   | Type                   |
| - | ---------------------- |
| ✓ | 🔨 Refactoring         |

## Description

Fixes the primer pipeline failure seen on #11153, and the stale primer *comment* format seen there too.

The primer venv cache bakes in a full copy of pylint (`requirements_test.txt` installs `.[testutils,spelling]`), so every step that does `. venv/bin/activate; python tests/primer/__main__.py ...` runs whatever pylint was checked out **when the cache was created**, not the commit being tested. Two concrete symptoms on #11153:

1. **Pipeline crash**: the first pushed commit both changed the requirements (astroid `4.2.0b3` → `4.2.0b4`, brand new cache key) and contained a syntax error in `pylint/checkers/variables.py` (`return node.infer(context)]`). That broken copy got baked into the `venv-primer` cache. The follow-up force-pushes fixed the code but didn't touch the requirements, so every rerun restored the poisoned venv and crashed at *Get commit string* — before the existing `pip install . --no-deps` in the run step could repair it. (Unblocked already by deleting the two poisoned caches scoped to `refs/pull/11153/merge` and re-running.)
2. **Stale comment format**: the [primer comment](https://github.com/pylint-dev/pylint/pull/11153#issuecomment-4883576420) still used the pre-#10914 removed+added format even though #10914 was merged two hours earlier — `primer_comment.yaml`'s *Compare outputs* step rendered it with the pylint snapshot from the `main` venv cache created on 2026-06-14.

This adds an explicit "Install pylint from the current checkout" step right after the venv cache restore in all three primer workflows, so no step ever imports a stale (or broken) cached copy. In `primer_run_main.yaml` the now-redundant install inside *Run pylint primer* is removed; in `primer_run_pr.yaml` it is kept because the *Pull 'main'* merge changes the working tree in between.