### PR TITLE
[DO NOT MERGE] Test primer venv cache poisoning fix (#11154)

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,3 +6,4 @@ pytest-cov>=6.2,<8.0
 pytest-xdist~=3.8
 six
 tox>=3
+# Do not merge: byte change to invalidate the venv-primer cache key (test for #11154)


### PR DESCRIPTION
End-to-end reproduction of the cache poisoning that broke the primer on #11153, to validate #11154.

**Step 1 (this push)**: `requirements_test.txt` byte change (fresh `venv-primer` cache key) + the exact syntax error from #11153's first push (`return node.infer(context)]` in `pylint/checkers/variables.py`). The primer run will fail (code genuinely broken) but will save a venv cache with the broken pylint baked in.

**Step 2 (force-push)**: remove the syntax error, keep the requirements change → cache hit on the poisoned venv. Before #11154 this crashed at *Get commit string* with `SyntaxError: unmatched ']'`; with #11154 the *Install pylint from the current checkout* step must heal it and the run must go green.

Will be closed (never merged) and its caches deleted once the experiment is done.