### PR TITLE
Fix protected-access false positive for self.__class__

### DIFF
--- a/doc/whatsnew/fragments/11160.false_positive
+++ b/doc/whatsnew/fragments/11160.false_positive
@@ -1,0 +1,4 @@
+Fix a false positive for ``protected-access`` when a protected member is
+accessed through ``self.__class__``, which is now treated like ``type(self)``.
+
+Closes #11160

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1926,6 +1926,11 @@ a metaclass class method.",
         if self._is_type_self_call(node.expr):
             return
 
+        # If the expression is self.__class__ (or the class of any other
+        # mandatory first method parameter), that's equivalent to type(self).
+        if self._is_self_class_access(node.expr):
+            return
+
         # Check if we are inside the scope of a class or nested inner class
         inside_klass = True
         outer_klass = klass
@@ -1980,6 +1985,12 @@ a metaclass class method.",
     def _is_type_self_call(self, expr: nodes.NodeNG) -> bool:
         match expr:
             case nodes.Call(func=nodes.Name(name="type"), args=[arg]):
+                return self._is_mandatory_method_param(arg)
+        return False
+
+    def _is_self_class_access(self, expr: nodes.NodeNG) -> bool:
+        match expr:
+            case nodes.Attribute(attrname="__class__", expr=arg):
                 return self._is_mandatory_method_param(arg)
         return False
 

--- a/tests/functional/a/access/access_to_protected_members.py
+++ b/tests/functional/a/access/access_to_protected_members.py
@@ -274,3 +274,19 @@ class Issue3066:
             @staticmethod
             def _bar(i):
                 """Docstring."""
+
+
+class Issue11160:
+    """https://github.com/pylint-dev/pylint/issues/11160"""
+
+    _attr = None
+
+    def access_via_self_class(self):
+        """self.__class__ is equivalent to type(self) and should be accepted."""
+        if self.__class__._attr is None:
+            return self.__class__._attr
+        return None
+
+    def access_via_other_object_class(self, other):
+        """Accessing a protected member through another object's class warns."""
+        return other.__class__._attr  # [protected-access]

--- a/tests/functional/a/access/access_to_protected_members.txt
+++ b/tests/functional/a/access/access_to_protected_members.txt
@@ -26,3 +26,4 @@ protected-access:266:16:266:31:Issue3066.Aclass.Bclass.foobar:Access to a protec
 protected-access:267:16:267:38:Issue3066.Aclass.Bclass.foobar:Access to a protected member _attr of a client class:UNDEFINED
 protected-access:270:16:270:30:Issue3066.Aclass.Bclass.foobar:Access to a protected member _bar of a client class:UNDEFINED
 protected-access:271:16:271:37:Issue3066.Aclass.Bclass.foobar:Access to a protected member _bar of a client class:UNDEFINED
+protected-access:292:15:292:36:Issue11160.access_via_other_object_class:Access to a protected member _attr of a client class:UNDEFINED


### PR DESCRIPTION
- [x] Document your change: changelog fragment ``doc/whatsnew/fragments/11160.false_positive``
- [x] Relate your change to an issue in the tracker: Closes #11160
- [x] Write comprehensive commit messages and/or a good description of what the PR does
- [x] Keep the change small

## Description

``protected-access`` raised a false positive when a protected member was accessed through ``self.__class__`` inside the class that defines it:

```python
class C:
    _X = None

    def f(self):
        if self.__class__._X is None:  # W0212 false positive
            pass
```

The checker already accepts the equivalent ``type(self)._X`` form (via ``_is_type_self_call``). ``self.__class__`` is the same object as ``type(self)`` for any instance without a custom metaclass override, so it is now treated the same way: attribute access through ``<mandatory first parameter>.__class__`` is accepted.

Access through another object's class (``other.__class__._X``) still warns, as before — the allowance only applies to the method's mandatory first parameter (``self``/``cls``/``mcs``), mirroring ``type(self)``.

Added functional tests for both the accepted and the still-warning form.

Closes #11160