### PR TITLE
[False Positive] Fix C0103 invalid-name for module-level all-caps names assigned from function calls

### DIFF
--- a/doc/whatsnew/fragments/11012.false_positive
+++ b/doc/whatsnew/fragments/11012.false_positive
@@ -1,0 +1,1 @@
+Fixed false positive ``invalid-name`` (C0103) for module-level all-caps names assigned from function calls (e.g. ``VERSION = os.path.basename``).

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -516,6 +516,12 @@ class NameChecker(_BasicChecker):
                         self._check_name("const", node.name, node)
                 else:
                     node_type = "variable"
+                    # If the name matches the constant naming style (ALL_CAPS),
+                    # treat it as a constant regardless of the inferred type.
+                    # This handles cases like VERSION = os.path.basename at
+                    # module level. (Issue #11012)
+                    if self._name_regexps["const"].match(node.name) is not None:
+                        node_type = "const"
                     iattrs = tuple(node.frame().igetattr(node.name))
                     if (
                         util.Uninferable in iattrs

--- a/tests/functional/i/invalid/invalid_name/invalid_name_issue_11012.py
+++ b/tests/functional/i/invalid/invalid_name/invalid_name_issue_11012.py
@@ -1,0 +1,22 @@
+"""Tests for issue #11012: C0103 false positive for all-caps names at module level"""
+# pylint: disable=missing-class-docstring,missing-function-docstring,too-few-public-methods
+
+import os
+import sys
+
+# All-caps names at module level assigned from function calls should be
+# recognized as constants, not flagged as variables. (Issue #11012)
+
+VERSION = os.path.basename
+PYTHON = sys.version
+MAINTAINER: str = os.path.basename
+
+# Other test cases that should not be impacted
+from collections import namedtuple
+Class = namedtuple("a", ("b", "c"))
+
+def A():
+    return 1, 2, 3
+
+CONSTD = A()
+CONST = "12 34 ".rstrip().split()


### PR DESCRIPTION
When a module-level all-caps name (e.g., `VERSION = os.path.basename`) is assigned from a value that infers to a FunctionDef, pylint incorrectly classifies it as a `variable` instead of a `const`, triggering a false positive C0103 (invalid-name).

### Root Cause
In `visit_assignname`, the `elif` chain explicitly excludes FunctionDef and Lambda inferred types from being treated as constants (line 504-505). When the name is ALL_CAPS at module level, it should still be checked as a constant regardless.

### Fix
Added a check in the `else` branch: if the name matches the constant naming pattern (ALL_CAPS), it is treated as a constant before any further analysis.

### Checklist
- [x] Added regression test
- [x] Added news fragment
- [x] Existing tests pass
- [x] `#type: papercut`

Closes #11012