### PR TITLE
fix: no-member false positive on TypedDict __required_keys__ and __optional_keys__

### DIFF
--- a/doc/whatsnew/fragments/10158.false_positive
+++ b/doc/whatsnew/fragments/10158.false_positive
@@ -1,3 +1,3 @@
-Fix ``no-member`` false positive for ``__required_keys__`` and ``__optional_keys__`` on ``TypedDict`` classes.
+Fix ``no-member`` false positive for ``__required_keys__``, ``__optional_keys__`` and ``__total__`` on ``TypedDict`` classes.
 
 Closes #10158

--- a/doc/whatsnew/fragments/10158.false_positive
+++ b/doc/whatsnew/fragments/10158.false_positive
@@ -1,0 +1,3 @@
+Fix ``no-member`` false positive for ``__required_keys__`` and ``__optional_keys__`` on ``TypedDict`` classes.
+
+Closes #10158

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -449,6 +449,19 @@ def _is_enum_owner(owner: astroid.Instance | nodes.ClassDef) -> bool:
     }
 
 
+TYPING_TYPEDDICT = frozenset({"typing.TypedDict", "typing_extensions.TypedDict"})
+
+
+def _is_typeddict_owner(owner: astroid.Instance | nodes.ClassDef) -> bool:
+    """Return whether ``owner`` is a class that inherits from ``TypedDict``."""
+    if not isinstance(owner, nodes.ClassDef):
+        return False
+    for ancestor in owner.ancestors():
+        if ancestor.qname() in TYPING_TYPEDDICT:
+            return True
+    return False
+
+
 def _emit_no_member(
     node: nodes.Attribute | nodes.AssignAttr | nodes.DelAttr,
     owner: InferenceResult,
@@ -495,6 +508,14 @@ def _emit_no_member(
         # Exclude typed annotations, since these might actually exist
         # at some point during the runtime of the program.
         if utils.is_attribute_typed_annotation(owner, node.attrname):
+            return False
+
+        # TypedDict classes expose __required_keys__ and __optional_keys__.
+        if (
+            isinstance(owner, nodes.ClassDef)
+            and node.attrname in {"__required_keys__", "__optional_keys__"}
+            and _is_typeddict_owner(owner)
+        ):
             return False
     if isinstance(owner, objects.Super):
         # Verify if we are dealing with an invalid Super object.

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -510,10 +510,11 @@ def _emit_no_member(
         if utils.is_attribute_typed_annotation(owner, node.attrname):
             return False
 
-        # TypedDict classes expose __required_keys__ and __optional_keys__.
+        # TypedDict classes expose __required_keys__, __optional_keys__
+        # and __total__.
         if (
             isinstance(owner, nodes.ClassDef)
-            and node.attrname in {"__required_keys__", "__optional_keys__"}
+            and node.attrname in {"__required_keys__", "__optional_keys__", "__total__"}
             and _is_typeddict_owner(owner)
         ):
             return False

--- a/tests/functional/t/type/typedDict_required_optional_keys.py
+++ b/tests/functional/t/type/typedDict_required_optional_keys.py
@@ -1,4 +1,4 @@
-"""Test TypedDict __required_keys__ and __optional_keys__ access."""
+"""Test TypedDict __required_keys__, __optional_keys__ and __total__ access."""
 # pylint: disable=invalid-name,missing-class-docstring,pointless-statement,too-few-public-methods
 from typing import TypedDict
 from typing_extensions import TypedDict as TypedDictExt
@@ -17,18 +17,24 @@ class Child(CustomTD):
     extra: str
 
 
-# Accessing __required_keys__ / __optional_keys__ on a TypedDict class is valid.
+# Accessing __required_keys__ / __optional_keys__ / __total__ on a TypedDict
+# class is valid.
 print(CustomTD.__required_keys__)
 print(CustomTD.__optional_keys__)
+print(CustomTD.__total__)
 print(CustomTDExt.__required_keys__)
+print(CustomTDExt.__total__)
 print(Child.__required_keys__)
+print(Child.__total__)
 
 # Instances are regular dicts and do not have these attributes.
 print(CustomTD().__required_keys__)  # [no-member]
 print(CustomTD().__optional_keys__)  # [no-member]
+print(CustomTD().__total__)  # [no-member]
 
 # Regular classes do not have these attributes.
 class Regular:
     pass
 
 print(Regular.__required_keys__)  # [no-member]
+print(Regular.__total__)  # [no-member]

--- a/tests/functional/t/type/typedDict_required_optional_keys.py
+++ b/tests/functional/t/type/typedDict_required_optional_keys.py
@@ -1,0 +1,34 @@
+"""Test TypedDict __required_keys__ and __optional_keys__ access."""
+# pylint: disable=invalid-name,missing-class-docstring,pointless-statement,too-few-public-methods
+from typing import TypedDict
+from typing_extensions import TypedDict as TypedDictExt
+
+
+class CustomTD(TypedDict):
+    required: str
+    optional: str
+
+
+class CustomTDExt(TypedDictExt):
+    required: str
+
+
+class Child(CustomTD):
+    extra: str
+
+
+# Accessing __required_keys__ / __optional_keys__ on a TypedDict class is valid.
+print(CustomTD.__required_keys__)
+print(CustomTD.__optional_keys__)
+print(CustomTDExt.__required_keys__)
+print(Child.__required_keys__)
+
+# Instances are regular dicts and do not have these attributes.
+print(CustomTD().__required_keys__)  # [no-member]
+print(CustomTD().__optional_keys__)  # [no-member]
+
+# Regular classes do not have these attributes.
+class Regular:
+    pass
+
+print(Regular.__required_keys__)  # [no-member]

--- a/tests/functional/t/type/typedDict_required_optional_keys.txt
+++ b/tests/functional/t/type/typedDict_required_optional_keys.txt
@@ -1,0 +1,3 @@
+no-member:27:6:27:34::Instance of 'CustomTD' has no '__required_keys__' member:INFERENCE
+no-member:28:6:28:34::Instance of 'CustomTD' has no '__optional_keys__' member:INFERENCE
+no-member:34:6:34:31::Class 'Regular' has no '__required_keys__' member:INFERENCE

--- a/tests/functional/t/type/typedDict_required_optional_keys.txt
+++ b/tests/functional/t/type/typedDict_required_optional_keys.txt
@@ -1,3 +1,5 @@
-no-member:27:6:27:34::Instance of 'CustomTD' has no '__required_keys__' member:INFERENCE
-no-member:28:6:28:34::Instance of 'CustomTD' has no '__optional_keys__' member:INFERENCE
-no-member:34:6:34:31::Class 'Regular' has no '__required_keys__' member:INFERENCE
+no-member:31:6:31:34::Instance of 'CustomTD' has no '__required_keys__' member:INFERENCE
+no-member:32:6:32:34::Instance of 'CustomTD' has no '__optional_keys__' member:INFERENCE
+no-member:33:6:33:26::Instance of 'CustomTD' has no '__total__' member:INFERENCE
+no-member:39:6:39:31::Class 'Regular' has no '__required_keys__' member:INFERENCE
+no-member:40:6:40:23::Class 'Regular' has no '__total__' member:INFERENCE


### PR DESCRIPTION
Fixes #10158

TypedDict classes expose the class attributes __required_keys__ and __optional_keys__ at runtime, but pylint was reporting no-member when they were accessed on a TypedDict class. This change suppresses the false positive for these two attributes on TypedDict classes while still reporting the error for instances and non-TypedDict classes.