### PR TITLE
Fix crash in consider-using-dict-items on a non-name loop target

### DIFF
--- a/doc/whatsnew/fragments/11173.bugfix
+++ b/doc/whatsnew/fragments/11173.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in ``consider-using-dict-items`` when the ``for`` loop or comprehension target is an attribute or a subscript (e.g. ``for self.key in d``) rather than a simple variable name.
+
+Closes #11173

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -278,6 +278,13 @@ class RecommendationChecker(checkers.BaseChecker):
         if iterating_object_name is None:
             return
 
+        # ``consider-using-dict-items`` only applies to a simple loop variable.
+        # An attribute or subscript target (e.g. ``for self.key in d``) cannot be
+        # rewritten with ``.items()``, and accessing ``node.target.name`` on such
+        # a target raises AttributeError (#10099).
+        if not isinstance(node.target, nodes.AssignName):
+            return
+
         # Verify that the body of the for loop uses a subscript
         # with the object that was iterated. This uses some heuristics
         # in order to make sure that the same object is used in the
@@ -333,6 +340,11 @@ class RecommendationChecker(checkers.BaseChecker):
         """Add message when accessing dict values by index lookup."""
         iterating_object_name = utils.get_iterating_dictionary_name(node)
         if iterating_object_name is None:
+            return
+
+        # See ``_check_consider_using_dict_items``: a non-name target has no
+        # ``.name`` and cannot be rewritten with ``.items()`` (#10099).
+        if not isinstance(node.target, nodes.AssignName):
             return
 
         for child in node.parent.get_children():

--- a/tests/functional/c/consider/consider_using_dict_items.py
+++ b/tests/functional/c/consider/consider_using_dict_items.py
@@ -119,3 +119,29 @@ for k in D:  # [consider-using-dict-items]
 for var in os.environ.keys():  # [consider-iterating-dictionary]
     if var.startswith("foo_"):
         del os.environ[var]  # index lookup necessary here, do not emit error
+
+
+# Crash regression: a non-name loop target (an attribute or a subscript) must not
+# crash the checker. https://github.com/pylint-dev/pylint/issues/10099
+# The ``other[index]`` subscript in the body is required to reach the code path
+# that crashed (``node.target.name`` is only read once the slice is a plain name);
+# do not remove it or this stops covering the bug.
+class Walker:
+    def __init__(self):
+        self.current = None
+
+    def loop_into_attribute(self, other, index):
+        for self.current in D:  # no crash, no message
+            print(other[index])
+
+    def loop_into_attribute_keys(self, other, index):
+        for self.current in D.keys():  # [consider-iterating-dictionary]
+            print(other[index])
+
+    def comprehension_into_attribute(self, other, index):
+        return [other[index] for self.current in D]  # no crash, no message
+
+
+def loop_into_subscript(out, other, index):
+    for out["k"] in D:  # no crash, no message
+        print(other[index])

--- a/tests/functional/c/consider/consider_using_dict_items.txt
+++ b/tests/functional/c/consider/consider_using_dict_items.txt
@@ -15,3 +15,4 @@ consider-iterating-dictionary:95:25:95:42::Consider iterating the dictionary dir
 consider-using-dict-items:95:0:None:None::Consider iterating with .items():UNDEFINED
 consider-using-dict-items:112:0:114:24::Consider iterating with .items():UNDEFINED
 consider-iterating-dictionary:119:11:119:28::Consider iterating the dictionary directly instead of calling .keys():INFERENCE
+consider-iterating-dictionary:138:28:138:36:Walker.loop_into_attribute_keys:Consider iterating the dictionary directly instead of calling .keys():INFERENCE


### PR DESCRIPTION
## Type of Changes

| | Type |
|---|---|
| ✓ | 🐛 Bug fix |

## Description

Closes #11173

`consider-using-dict-items` reads `node.target.name` without checking the target is a plain name, so a `for` loop or comprehension whose target is an attribute or a subscript crashes the checker on legal, runnable Python:

```python
SETTINGS = {"debug": True, "verbose": False}


class Walker:
    def __init__(self):
        self.current = None

    def run(self, key):
        for self.current in SETTINGS:
            print(SETTINGS[key])
```

```
AttributeError: 'AssignAttr' object has no attribute 'name'
a.py:1:0: F0002: Fatal error while checking 'a.py'... (astroid-error)
Your code has been rated at 0.00/10
```

This is the same bug class as #10099, which was fixed for the sibling `consider-using-enumerate` — `recommendation_checker.py:237` already carries exactly this guard, with a comment naming the attribute-target case. `consider-using-dict-items` was never updated to match, so this brings the two into line.

The fix is loss-free: a non-name target can't be rewritten with `.items()`, so there's no message to lose by returning early.

The subscript in the loop body isn't incidental — `node.target.name` is only read once the slice is a plain `Name`, so `and` short-circuits away from the crash otherwise. That's why the added test cases keep `print(other[index])`.

Four forms crash on `main`; I reproduced each and confirmed each is fixed:

| form | site |
|---|---|
| `for self.current in D:` | `_check_consider_using_dict_items` (:293) |
| `for self.current in D.keys():` | same |
| `for out["k"] in D:` | same |
| `[other[index] for self.current in D]` | `_check_consider_using_dict_items_comprehension` (:346) |

The blast radius is a bit wider than the `F0002` line suggests: `ast_walker.walk` re-raises, so the module walk aborts and end-of-module checks are silently lost.

## Testing

Added the four cases to `tests/functional/c/consider/consider_using_dict_items.py`, following the regression test #10099 added to `consider_using_enumerate.py`.

Verified they fail first — on `main` the new file gives `1: astroid-error (times 1)` / `AttributeError: 'AssignAttr' object has no attribute 'name'` — and pass with the fix.

Full suite (excluding `tests/benchmark` and `tests/testutils/_primer`, which need `pytest-benchmark`/`GitPython` that I don't have installed): 2047 passed, 14 failed. Those 14 are identical before and after my change — I diffed the failure lists item by item — and are pre-existing astroid-drift failures unrelated to this.

<!-- AI disclosure -->
This change was AI-assisted (Claude). I reproduced all four crashing forms myself with the real CLI before writing anything, confirmed the example code actually runs, traced the mechanism to the exact lines, checked the sibling guard and #10099 by reading them, and ran the tests and the before/after baseline comparison above myself.
