### PR TITLE
fix: avoid crash for lambda-backed bound methods

### DIFF
--- a/doc/whatsnew/fragments/11175.bugfix
+++ b/doc/whatsnew/fragments/11175.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in :ref:`comparison-with-callable` when comparing a lambda assigned as a class attribute.
+
+Closes #11175

--- a/pylint/checkers/base/comparison_checker.py
+++ b/pylint/checkers/base/comparison_checker.py
@@ -273,17 +273,18 @@ class ComparisonChecker(_BasicChecker):
         if operator not in COMPARISON_OPERATORS:
             return
 
-        bare_callables = (nodes.FunctionDef, astroid.BoundMethod)
         left_operand, right_operand = node.left, node.ops[0][1]
         # this message should be emitted only when there is comparison of bare callable
         # with non bare callable.
         number_of_bare_callables = 0
         for operand in left_operand, right_operand:
             inferred = utils.safe_infer(operand)
+            if isinstance(inferred, astroid.BoundMethod):
+                inferred = inferred._proxied
             # Ignore callables that raise, as well as typing constants
             # implemented as functions (that raise via their decorator)
             if (
-                isinstance(inferred, bare_callables)
+                isinstance(inferred, nodes.FunctionDef)
                 and "typing._SpecialForm" not in inferred.decoratornames()
                 and not any(isinstance(x, nodes.Raise) for x in inferred.body)
             ):

--- a/pylint/checkers/base/comparison_checker.py
+++ b/pylint/checkers/base/comparison_checker.py
@@ -279,7 +279,7 @@ class ComparisonChecker(_BasicChecker):
         number_of_bare_callables = 0
         for operand in left_operand, right_operand:
             inferred = utils.safe_infer(operand)
-            if isinstance(inferred, astroid.BoundMethod):
+            while isinstance(inferred, (astroid.BoundMethod, astroid.UnboundMethod)):
                 inferred = inferred._proxied
             # Ignore callables that raise, as well as typing constants
             # implemented as functions (that raise via their decorator)

--- a/tests/functional/c/comparison_with_callable.py
+++ b/tests/functional/c/comparison_with_callable.py
@@ -69,3 +69,11 @@ if a == eventually_raise:
     # Does not emit comparison-with-callable because the
     # function (eventually) raises
     pass
+
+
+class LambdaAttribute:
+    lambda_attribute = lambda self: 1
+
+
+if LambdaAttribute().lambda_attribute == 1:
+    pass

--- a/tests/functional/c/comparison_with_callable.py
+++ b/tests/functional/c/comparison_with_callable.py
@@ -71,7 +71,9 @@ if a == eventually_raise:
     pass
 
 
-class LambdaAttribute:
+class LambdaAttribute:  # pylint: disable=too-few-public-methods
+    # Regression case: class attributes backed by lambdas infer as bound methods.
+    # pylint: disable-next=unnecessary-lambda-assignment
     lambda_attribute = lambda self: 1
 
 


### PR DESCRIPTION
## Summary
- unwrap bound methods before inspecting the underlying callable node
- skip lambda-backed bound methods, which do not expose function decorators or a statement body
- add a functional regression and changelog fragment

## Root cause
A class attribute lambda accessed through an instance is inferred as a `BoundMethod` proxying a `Lambda`. The checker treated every bound method as a `FunctionDef` and called `decoratornames()` on the proxied lambda, causing an `astroid-error`.

Fixes #11175

## Validation
- Baseline minimal reproduction raises the reported `AttributeError` through `astroid-error`.
- Patched minimal reproduction exits cleanly with `--enable=comparison-with-callable`.
- A regular function comparison still emits `comparison-with-callable`.
- `python -m py_compile pylint/checkers/base/comparison_checker.py`