### PR TITLE
tests: add optional pytest-random-order for isolation hunting

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -189,6 +189,29 @@ jobs:
           include-hidden-files: true
           path: .benchmarks/
 
+  tests-random-order:
+    name: run random-order / ${{ matrix.python-version }} / Linux
+    runs-on: ubuntu-latest
+    if: inputs.astroid_sha == ''
+    timeout-minutes: 25
+    needs: [tests]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.14"]
+    steps:
+      - *checkout
+      - *setup-python
+      - *cache-restore-python
+      - name: Run pytest in random order
+        run: |
+          . venv/bin/activate
+          pip install . --no-deps
+          pip list | grep 'astroid\|pylint\|random-order'
+          # Keep the default matrix deterministic; this job surfaces isolation
+          # issues. pytest-random-order prints the seed used for reproduction.
+          python -m pytest --durations=10 --benchmark-disable --random-order tests/
+
   tests-windows:
     name: run / ${{ matrix.python-version }} / Windows
     runs-on: windows-latest

--- a/doc/development_guide/contributor_guide/tests/launching_test.rst
+++ b/doc/development_guide/contributor_guide/tests/launching_test.rst
@@ -24,6 +24,28 @@ Only the functional test "missing_kwoa_py3"::
 
     python3 -m pytest "tests/test_functional.py::test_functional[missing_kwoa_py3]"
 
+Shuffling tests
+---------------
+
+To help catch test isolation problems, run the suite in random order with
+``pytest-random-order`` (installed via the ``test`` dependency group /
+``requirements_test.txt``)::
+
+    python3 -m pytest --random-order
+
+Pin a seed when you need a reproducible shuffle::
+
+    python3 -m pytest --random-order-seed=1234
+
+There is also a dedicated tox environment that is **not** part of the default
+``envlist`` (so normal ``tox`` / CI stays deterministic)::
+
+    python -m tox -e random
+    python -m tox -e random -- -k test_functional
+
+See the `pytest-random-order`_ documentation for bucket / module / class
+shuffling options.
+
 tox
 ---
 
@@ -86,3 +108,5 @@ directory.
 
 .. _pytest-cov: https://pypi.org/project/pytest-cov/
 .. _astroid: https://github.com/pylint-dev/astroid
+
+.. _pytest-random-order: https://pypi.org/project/pytest-random-order/

--- a/doc/development_guide/contributor_guide/tests/launching_test.rst
+++ b/doc/development_guide/contributor_guide/tests/launching_test.rst
@@ -38,10 +38,14 @@ Pin a seed when you need a reproducible shuffle::
     python3 -m pytest --random-order-seed=1234
 
 There is also a dedicated tox environment that is **not** part of the default
-``envlist`` (so normal ``tox`` / CI stays deterministic)::
+``envlist`` (so a normal ``tox`` run stays deterministic)::
 
     python -m tox -e random
     python -m tox -e random -- -k test_functional
+
+On CI, the default matrix stays in fixed order; a separate Linux job runs the
+suite once with ``--random-order`` (the plugin prints the seed on failure so
+you can reproduce with ``--random-order-seed=...``).
 
 See the `pytest-random-order`_ documentation for bucket / module / class
 shuffling options.

--- a/doc/whatsnew/fragments/9063.internal
+++ b/doc/whatsnew/fragments/9063.internal
@@ -1,0 +1,6 @@
+Add ``pytest-random-order`` to the test dependencies and run the suite once
+on CI with ``--random-order`` (dedicated job) so test isolation issues can be
+caught without making the default matrix non-deterministic. Local contributors
+can also use ``tox -e random`` or ``pytest --random-order``.
+
+Closes #9063

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
 test = [
   "coverage~=7.10",
   "pytest-cov>=6.2,<8",
+  "pytest-random-order~=1.1",
   "pytest-xdist~=3.8",
   "six",
   "tox>=3",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,7 @@ coverage~=7.10
 tbump~=6.11.0
 contributors-txt>=1.0.0
 pytest-cov>=6.2,<8.0
+pytest-random-order~=1.1
 pytest-xdist~=3.8
 six
 tox>=3

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,13 @@ commands =
     ; Run tests, ensuring all benchmark tests do not run
     pytest --benchmark-disable {toxinidir}/tests/ {posargs:}
 
+[testenv:random]
+deps =
+    -r {toxinidir}/requirements_test.txt
+commands =
+    ; Shuffle tests to surface isolation issues (opt-in; not in default envlist)
+    pytest --benchmark-disable --random-order {toxinidir}/tests/ {posargs:}
+
 [testenv:spelling]
 deps =
     -r {toxinidir}/requirements_test.txt

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,8 @@ commands =
 deps =
     -r {toxinidir}/requirements_test.txt
 commands =
-    ; Shuffle tests to surface isolation issues (opt-in; not in default envlist)
+    ; Shuffle tests to surface isolation issues (opt-in; not in default envlist).
+    ; CI also runs a dedicated random-order job; see .github/workflows/tests.yaml.
     pytest --benchmark-disable --random-order {toxinidir}/tests/ {posargs:}
 
 [testenv:spelling]


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |
| ✓   | :hammer: Refactoring   |

## Description

Install ``pytest-random-order`` with the test dependencies, document ``--random-order`` / seed usage, and add an opt-in ``tox -e random`` environment so contributors can shuffle the suite when hunting isolation issues.

Default CI / ``tox`` ``envlist`` is unchanged and stays deterministic.

Closes #9063