### PR TITLE
Add SARIF 2.1.0 output format reporter

### DIFF
--- a/doc/user_guide/usage/output.rst
+++ b/doc/user_guide/usage/output.rst
@@ -15,6 +15,7 @@ pylint the ``--output-format=<value>`` option. Possible values are:
 * ``colorized``
 * ``json2``: improved json format
 * ``json``: old json format
+* ``sarif``: `SARIF 2.1.0 <https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html>`_
 * ``msvs``: visual studio
 * ``github``: `GitHub action messages <https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions>`_
 

--- a/doc/whatsnew/fragments/5493.feature
+++ b/doc/whatsnew/fragments/5493.feature
@@ -1,0 +1,4 @@
+Add a ``sarif`` output format that emits a SARIF 2.1.0 report suitable for
+GitHub Code Scanning and other SARIF consumers.
+
+Closes #5493

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -104,7 +104,8 @@ def _make_linter_options(linter: PyLinter) -> Options:
                 "group": "Reports",
                 "help": "Set the output format. Available formats are: 'text', "
                 "'parseable', 'colorized', 'json2' (improved json format), 'json' "
-                "(old json format), msvs (visual studio) and 'github' (GitHub actions). "
+                "(old json format), 'sarif' (SARIF 2.1.0), msvs (visual studio) and "
+                "'github' (GitHub actions). "
                 "You can also give a reporter class, e.g. mypackage.mymodule."
                 "MyReporterClass.",
                 "kwargs": {"linter": linter},

--- a/pylint/reporters/__init__.py
+++ b/pylint/reporters/__init__.py
@@ -13,8 +13,8 @@ from pylint.reporters.base_reporter import BaseReporter
 from pylint.reporters.collecting_reporter import CollectingReporter
 from pylint.reporters.json_reporter import JSON2Reporter, JSONReporter
 from pylint.reporters.multi_reporter import MultiReporter
-from pylint.reporters.sarif_reporter import SARIFReporter
 from pylint.reporters.reports_handler_mix_in import ReportsHandlerMixIn
+from pylint.reporters.sarif_reporter import SARIFReporter
 
 if TYPE_CHECKING:
     from pylint.lint.pylinter import PyLinter

--- a/pylint/reporters/__init__.py
+++ b/pylint/reporters/__init__.py
@@ -13,6 +13,7 @@ from pylint.reporters.base_reporter import BaseReporter
 from pylint.reporters.collecting_reporter import CollectingReporter
 from pylint.reporters.json_reporter import JSON2Reporter, JSONReporter
 from pylint.reporters.multi_reporter import MultiReporter
+from pylint.reporters.sarif_reporter import SARIFReporter
 from pylint.reporters.reports_handler_mix_in import ReportsHandlerMixIn
 
 if TYPE_CHECKING:
@@ -31,4 +32,5 @@ __all__ = [
     "JSONReporter",
     "MultiReporter",
     "ReportsHandlerMixIn",
+    "SARIFReporter",
 ]

--- a/pylint/reporters/sarif_reporter.py
+++ b/pylint/reporters/sarif_reporter.py
@@ -28,9 +28,7 @@ _CATEGORY_TO_LEVEL = {
     "info": "note",
 }
 
-_MESSAGE_DOC_BASE = (
-    "https://pylint.readthedocs.io/en/latest/user_guide/messages"
-)
+_MESSAGE_DOC_BASE = "https://pylint.readthedocs.io/en/latest/user_guide/messages"
 
 
 def _path_to_uri(path: str) -> str:
@@ -102,9 +100,7 @@ class SARIFReporter(BaseReporter):
     def _rule_from_message(self, message: Message) -> dict[str, Any]:
         description = message.symbol
         try:
-            definitions = self.linter.msgs_store.get_message_definitions(
-                message.msg_id
-            )
+            definitions = self.linter.msgs_store.get_message_definitions(message.msg_id)
             if definitions and definitions[0].description:
                 description = definitions[0].description
         except Exception:  # pylint: disable=broad-except

--- a/pylint/reporters/sarif_reporter.py
+++ b/pylint/reporters/sarif_reporter.py
@@ -1,0 +1,150 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+
+"""SARIF reporter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pylint.__pkginfo__ import __version__
+from pylint.reporters.base_reporter import BaseReporter
+
+if TYPE_CHECKING:
+    from pylint.lint.pylinter import PyLinter
+    from pylint.message import Message
+    from pylint.reporters.ureports.nodes import Section
+
+# SARIF 2.1.0 result levels
+_CATEGORY_TO_LEVEL = {
+    "fatal": "error",
+    "error": "error",
+    "warning": "warning",
+    "refactor": "note",
+    "convention": "note",
+    "info": "note",
+}
+
+_MESSAGE_DOC_BASE = (
+    "https://pylint.readthedocs.io/en/latest/user_guide/messages"
+)
+
+
+def _path_to_uri(path: str) -> str:
+    """Return a SARIF-compatible URI for *path*."""
+    pathlib_path = Path(path)
+    if pathlib_path.is_absolute():
+        return pathlib_path.as_uri()
+    return path.replace("\\", "/")
+
+
+def _region_from_message(message: Message) -> dict[str, int]:
+    """Build a SARIF region (1-based line/column) from a pylint message."""
+    region: dict[str, int] = {
+        "startLine": max(message.line, 1),
+        # pylint columns are 0-based; SARIF columns are 1-based
+        "startColumn": message.column + 1,
+    }
+    if message.end_line is not None:
+        region["endLine"] = max(message.end_line, 1)
+    if message.end_column is not None:
+        region["endColumn"] = message.end_column + 1
+    return region
+
+
+class SARIFReporter(BaseReporter):
+    """Report messages in SARIF 2.1.0 format."""
+
+    name = "sarif"
+    extension = "sarif"
+
+    def display_reports(self, layout: Section) -> None:
+        """Don't do anything in this reporter."""
+
+    def _display(self, layout: Section) -> None:
+        """Do nothing."""
+
+    def display_messages(self, layout: Section | None) -> None:
+        """Emit a SARIF log containing all collected messages."""
+        print(json.dumps(self.serialize(), indent=2), file=self.out)
+
+    def serialize(self) -> dict[str, Any]:
+        """Serialize collected messages to a SARIF 2.1.0 object."""
+        rules_by_id: dict[str, dict[str, Any]] = {}
+        results: list[dict[str, Any]] = []
+
+        for message in self.messages:
+            if message.msg_id not in rules_by_id:
+                rules_by_id[message.msg_id] = self._rule_from_message(message)
+            results.append(self._result_from_message(message))
+
+        return {
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "pylint",
+                            "version": __version__,
+                            "informationUri": "https://github.com/pylint-dev/pylint",
+                            "rules": list(rules_by_id.values()),
+                        }
+                    },
+                    "results": results,
+                }
+            ],
+        }
+
+    def _rule_from_message(self, message: Message) -> dict[str, Any]:
+        description = message.symbol
+        try:
+            definitions = self.linter.msgs_store.get_message_definitions(
+                message.msg_id
+            )
+            if definitions and definitions[0].description:
+                description = definitions[0].description
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+        return {
+            "id": message.msg_id,
+            "name": message.symbol,
+            "shortDescription": {"text": message.symbol},
+            "fullDescription": {"text": description},
+            "helpUri": (
+                f"{_MESSAGE_DOC_BASE}/{message.category}/{message.symbol}.html"
+            ),
+            "properties": {"category": message.category},
+        }
+
+    @staticmethod
+    def _result_from_message(message: Message) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "ruleId": message.msg_id,
+            "level": _CATEGORY_TO_LEVEL.get(message.category, "warning"),
+            "message": {"text": message.msg or ""},
+            "locations": [
+                {
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": _path_to_uri(message.path)},
+                        "region": _region_from_message(message),
+                    }
+                }
+            ],
+            "properties": {
+                "category": message.category,
+                "symbol": message.symbol,
+                "confidence": message.confidence.name,
+                "module": message.module,
+                "obj": message.obj,
+            },
+        }
+        return result
+
+
+def register(linter: PyLinter) -> None:
+    linter.register_reporter(SARIFReporter)

--- a/tests/reporters/unittest_sarif_reporter.py
+++ b/tests/reporters/unittest_sarif_reporter.py
@@ -1,0 +1,118 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Test for the SARIF reporter."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from typing import Any
+
+from pylint import checkers
+from pylint.__pkginfo__ import __version__
+from pylint.interfaces import HIGH
+from pylint.lint import PyLinter
+from pylint.reporters.sarif_reporter import SARIFReporter
+
+
+def get_linter_result(message: dict[str, Any]) -> dict[str, Any]:
+    output = StringIO()
+    reporter = SARIFReporter(output)
+    linter = PyLinter(reporter=reporter)
+    checkers.initialize(linter)
+    linter.config.persistent = 0
+    linter.open()
+    linter.set_current_module("0123")
+    linter.add_message(
+        message["msg"],
+        line=message["line"],
+        args=message["args"],
+        end_lineno=message["end_line"],
+        end_col_offset=message["end_column"],
+        confidence=HIGH,
+    )
+    reporter.display_messages(None)
+    return json.loads(output.getvalue())  # type: ignore[no-any-return]
+
+
+def test_simple_sarif_output() -> None:
+    """Test SARIF reporter basic structure and message mapping."""
+    message = {
+        "msg": "line-too-long",
+        "line": 1,
+        "args": (1, 2),
+        "end_line": 1,
+        "end_column": 4,
+    }
+    report = get_linter_result(message)
+
+    assert report["version"] == "2.1.0"
+    assert report["$schema"] == "https://json.schemastore.org/sarif-2.1.0.json"
+    assert len(report["runs"]) == 1
+
+    run = report["runs"][0]
+    driver = run["tool"]["driver"]
+    assert driver["name"] == "pylint"
+    assert driver["version"] == __version__
+    assert driver["informationUri"] == "https://github.com/pylint-dev/pylint"
+
+    assert len(driver["rules"]) == 1
+    rule = driver["rules"][0]
+    assert rule["id"] == "C0301"
+    assert rule["name"] == "line-too-long"
+    assert rule["shortDescription"]["text"] == "line-too-long"
+    assert rule["properties"]["category"] == "convention"
+    assert rule["helpUri"].endswith("/convention/line-too-long.html")
+
+    assert len(run["results"]) == 1
+    result = run["results"][0]
+    assert result["ruleId"] == "C0301"
+    assert result["level"] == "note"
+    assert result["message"]["text"] == "Line too long (1/2)"
+    assert result["properties"]["symbol"] == "line-too-long"
+    assert result["properties"]["confidence"] == "HIGH"
+
+    location = result["locations"][0]["physicalLocation"]
+    assert location["artifactLocation"]["uri"] == "0123"
+    assert location["region"] == {
+        "startLine": 1,
+        "startColumn": 1,  # pylint column 0 -> SARIF 1
+        "endLine": 1,
+        "endColumn": 5,  # pylint end_column 4 -> SARIF 5
+    }
+
+
+def test_sarif_error_level_for_error_category() -> None:
+    """Errors map to SARIF level 'error'."""
+    output = StringIO()
+    reporter = SARIFReporter(output)
+    linter = PyLinter(reporter=reporter)
+    checkers.initialize(linter)
+    linter.config.persistent = 0
+    linter.open()
+    linter.set_current_module("mod")
+    linter.add_message("return-outside-function", line=2, confidence=HIGH)
+    reporter.display_messages(None)
+    report = json.loads(output.getvalue())
+    result = report["runs"][0]["results"][0]
+    assert result["ruleId"].startswith("E")
+    assert result["level"] == "error"
+    assert result["locations"][0]["physicalLocation"]["region"] == {
+        "startLine": 2,
+        "startColumn": 1,
+    }
+
+
+def test_sarif_empty_messages() -> None:
+    """Empty run still produces valid SARIF."""
+    output = StringIO()
+    reporter = SARIFReporter(output)
+    linter = PyLinter(reporter=reporter)
+    checkers.initialize(linter)
+    linter.config.persistent = 0
+    reporter.display_messages(None)
+    report = json.loads(output.getvalue())
+    assert report["runs"][0]["results"] == []
+    assert report["runs"][0]["tool"]["driver"]["rules"] == []


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

- [x] Document your change, if it is a non-trivial one.
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :scroll: Docs          |

## Description

Add a ``sarif`` output format that emits SARIF 2.1.0 reports for GitHub Code Scanning and other SARIF consumers.

Example:

```bash
pylint mymodule --output-format=sarif
pylint mymodule --output-format=sarif:results.sarif