### PR TITLE
Fix crash in consider-using-with on PEP 695 TypeVar call

### DIFF
--- a/doc/whatsnew/fragments/11058.bugfix
+++ b/doc/whatsnew/fragments/11058.bugfix
@@ -1,0 +1,5 @@
+Fix a crash in ``consider-using-with`` when assigning the result of calling a
+PEP 695 type parameter (inferred as ``astroid.nodes.TypeVar``, which has no
+``qname``).
+
+Closes #11058

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1645,8 +1645,14 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             if not isinstance(value, nodes.Call):
                 continue
             inferred = utils.safe_infer(value.func)
+            # Only callables with a ``qname`` can be context-manager factories.
+            # Inferring a PEP 695 type parameter yields ``nodes.TypeVar``, which
+            # has no ``qname`` and previously crashed here (#11058).
             if not (
                 inferred
+                and isinstance(
+                    inferred, (nodes.FunctionDef, nodes.ClassDef, bases.BoundMethod)
+                )
                 and inferred.qname() in CALLS_RETURNING_CONTEXT_MANAGERS
                 and isinstance(assignee, (nodes.AssignName, nodes.AssignAttr))
             ):

--- a/tests/functional/c/consider/consider_using_with_typevar_crash_py312.py
+++ b/tests/functional/c/consider/consider_using_with_typevar_crash_py312.py
@@ -1,0 +1,12 @@
+"""Crash regression for ``consider-using-with`` with PEP 695 type parameters.
+
+Calling a type parameter inferred as ``nodes.TypeVar`` must not crash when
+checking whether the callee is a known context-manager factory.
+
+https://github.com/pylint-dev/pylint/issues/11058
+"""
+
+# pylint: disable=invalid-name
+
+type T[U] = None
+_ = U()  # [not-callable]

--- a/tests/functional/c/consider/consider_using_with_typevar_crash_py312.rc
+++ b/tests/functional/c/consider/consider_using_with_typevar_crash_py312.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.12

--- a/tests/functional/c/consider/consider_using_with_typevar_crash_py312.txt
+++ b/tests/functional/c/consider/consider_using_with_typevar_crash_py312.txt
@@ -1,0 +1,1 @@
+not-callable:12:4:12:7::U is not callable:UNDEFINED


### PR DESCRIPTION
Guard `_append_context_managers_to_stack` so only FunctionDef/ClassDef/ BoundMethod inferences call ``qname()``. Calling a PEP 695 type parameter infers ``nodes.TypeVar``, which has no ``qname`` and previously crashed.

Closes #11058

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Description

Calling a PEP 695 type parameter in an assignment (e.g. `type T[U] = None` then `_ = U()`) made the `consider-using-with` path crash:

```text
AttributeError: 'TypeVar' object has no attribute 'qname'

