### PR TITLE
Fix deprecated-class for version-guarded imports

### DIFF
--- a/doc/whatsnew/fragments/9533.false_positive
+++ b/doc/whatsnew/fragments/9533.false_positive
@@ -1,0 +1,4 @@
+Avoid emitting ``deprecated-class`` for imports inside a recognized
+``sys.version_info`` guard.
+
+Closes #9533

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -159,6 +159,8 @@ class DeprecatedMixin(BaseChecker):
         basename = get_import_name(node, node.modname)
         assert basename is not None, "Module name should not be None"
         self.check_deprecated_module(node, basename)
+        if isinstance(node.parent, nodes.If) and utils.is_sys_guard(node.parent):
+            return
         class_names = (name for name, _ in node.names)
         self.check_deprecated_class(node, basename, class_names)
 

--- a/tests/checkers/unittest_deprecated.py
+++ b/tests/checkers/unittest_deprecated.py
@@ -556,50 +556,6 @@ class TestDeprecatedChecker(CheckerTestCase):
         ):
             self.checker.visit_importfrom(node)
 
-    def test_deprecated_class_import_from_sys_guard(self) -> None:
-        import_nodes = astroid.extract_node("""
-        import sys
-        if sys.version_info > (3,):
-            from deprecated import DeprecatedClass #@
-        else:
-            from deprecated import DeprecatedClass #@
-        """)
-        assert isinstance(import_nodes, list)
-        for node in import_nodes:
-            with self.assertNoMessages():
-                self.checker.visit_importfrom(node)
-
-    def test_deprecated_class_import_from_other_guard(self) -> None:
-        node = astroid.extract_node("""
-        if condition:
-            from deprecated import DeprecatedClass #@
-        """)
-        with self.assertAddsMessages(
-            MessageTest(
-                msg_id="deprecated-class",
-                args=("DeprecatedClass", "deprecated"),
-                node=node,
-            ),
-            ignore_position=True,
-        ):
-            self.checker.visit_importfrom(node)
-
-    def test_deprecated_module_import_from_sys_guard(self) -> None:
-        node = astroid.extract_node("""
-        import sys
-        if sys.version_info > (3,):
-            from deprecated_module import myfunction #@
-        """)
-        with self.assertAddsMessages(
-            MessageTest(
-                msg_id="deprecated-module",
-                args="deprecated_module",
-                node=node,
-            ),
-            ignore_position=True,
-        ):
-            self.checker.visit_importfrom(node)
-
     def test_deprecated_class_import(self) -> None:
         # Tests detecting deprecated class via import
         node = astroid.extract_node("""

--- a/tests/checkers/unittest_deprecated.py
+++ b/tests/checkers/unittest_deprecated.py
@@ -556,6 +556,50 @@ class TestDeprecatedChecker(CheckerTestCase):
         ):
             self.checker.visit_importfrom(node)
 
+    def test_deprecated_class_import_from_sys_guard(self) -> None:
+        import_nodes = astroid.extract_node("""
+        import sys
+        if sys.version_info > (3,):
+            from deprecated import DeprecatedClass #@
+        else:
+            from deprecated import DeprecatedClass #@
+        """)
+        assert isinstance(import_nodes, list)
+        for node in import_nodes:
+            with self.assertNoMessages():
+                self.checker.visit_importfrom(node)
+
+    def test_deprecated_class_import_from_other_guard(self) -> None:
+        node = astroid.extract_node("""
+        if condition:
+            from deprecated import DeprecatedClass #@
+        """)
+        with self.assertAddsMessages(
+            MessageTest(
+                msg_id="deprecated-class",
+                args=("DeprecatedClass", "deprecated"),
+                node=node,
+            ),
+            ignore_position=True,
+        ):
+            self.checker.visit_importfrom(node)
+
+    def test_deprecated_module_import_from_sys_guard(self) -> None:
+        node = astroid.extract_node("""
+        import sys
+        if sys.version_info > (3,):
+            from deprecated_module import myfunction #@
+        """)
+        with self.assertAddsMessages(
+            MessageTest(
+                msg_id="deprecated-module",
+                args="deprecated_module",
+                node=node,
+            ),
+            ignore_position=True,
+        ):
+            self.checker.visit_importfrom(node)
+
     def test_deprecated_class_import(self) -> None:
         # Tests detecting deprecated class via import
         node = astroid.extract_node("""

--- a/tests/functional/d/deprecated/deprecated_class_sys_guard.py
+++ b/tests/functional/d/deprecated/deprecated_class_sys_guard.py
@@ -1,0 +1,9 @@
+"""Do not emit deprecated-class for imports protected by a version guard."""
+# pylint: disable=unused-import
+
+import sys
+
+if sys.version_info >= (3, 9):
+    from collections.abc import Set
+else:
+    from collections import Set

--- a/tests/functional/d/deprecated/deprecated_class_sys_guard.py
+++ b/tests/functional/d/deprecated/deprecated_class_sys_guard.py
@@ -1,5 +1,5 @@
-"""Do not emit deprecated-class for imports protected by a version guard."""
-# pylint: disable=unused-import
+"""Test deprecated imports inside version and non-version guards."""
+# pylint: disable=no-name-in-module,unused-import
 
 import sys
 
@@ -7,3 +7,9 @@ if sys.version_info >= (3, 9):
     from collections.abc import Set
 else:
     from collections import Set
+
+if sys.platform == "win32":
+    from collections import Iterable  # [deprecated-class]
+
+if sys.version_info >= (3, 3):
+    from xml.etree.cElementTree import Element  # [deprecated-module]

--- a/tests/functional/d/deprecated/deprecated_class_sys_guard.rc
+++ b/tests/functional/d/deprecated/deprecated_class_sys_guard.rc
@@ -1,0 +1,2 @@
+[main]
+py-version=3.3

--- a/tests/functional/d/deprecated/deprecated_class_sys_guard.txt
+++ b/tests/functional/d/deprecated/deprecated_class_sys_guard.txt
@@ -1,0 +1,2 @@
+deprecated-class:12:4:12:36::Using deprecated class Iterable of module collections:UNDEFINED
+deprecated-module:15:4:15:46::Deprecated module 'xml.etree.cElementTree':UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Avoid emitting `deprecated-class` for `from ... import ...` statements directly
inside recognized system-version guards.

The checker reuses the existing `utils.is_sys_guard` helper, as requested in the
issue discussion. It performs the existing `deprecated-module` check before
skipping only the guarded `deprecated-class` check, so other deprecation warnings
remain unchanged.

Regression coverage includes both branches of a version guard, an unrelated
conditional that must still warn, preservation of `deprecated-module`, and an
end-to-end `collections.Set` compatibility fallback.

Closes #9533

## Tests

- `pytest tests/test_functional.py -k deprecated_class_sys_guard -q`
- `pytest tests/test_functional.py -k deprecated_class -q`
- `pytest tests/checkers -q`
- `towncrier build --draft`
