### PR TITLE
Fix assignment-from-no-return false positive on trailing raise

### DIFF
--- a/doc/whatsnew/fragments/11114.false_positive
+++ b/doc/whatsnew/fragments/11114.false_positive
@@ -1,0 +1,5 @@
+Fix a false positive for ``assignment-from-no-return`` when the called function's
+body ends in an unconditional ``raise``, such as ``pathlib.Path.readlink()`` on
+platforms without symlink support.
+
+Closes #11114

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1343,6 +1343,11 @@ accessed. Python regular expressions are accepted.",
         return (
             isinstance(function_node, nodes.AsyncFunctionDef)
             or utils.is_error(function_node)
+            # a body ending in an unconditional raise never returns normally
+            or (
+                bool(function_node.body)
+                and isinstance(function_node.body[-1], nodes.Raise)
+            )
             or function_node.is_generator()
             or function_node.is_abstract(pass_is_abstract=False)
         )

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1343,10 +1343,17 @@ accessed. Python regular expressions are accepted.",
         return (
             isinstance(function_node, nodes.AsyncFunctionDef)
             or utils.is_error(function_node)
-            # a body ending in an unconditional raise never returns normally
+            # a body ending in an unconditional raise, with no return statement
+            # anywhere, never returns normally
             or (
                 bool(function_node.body)
                 and isinstance(function_node.body[-1], nodes.Raise)
+                and not any(
+                    function_node.nodes_of_class(
+                        nodes.Return,
+                        skip_klass=(nodes.FunctionDef, nodes.Lambda),
+                    )
+                )
             )
             or function_node.is_generator()
             or function_node.is_abstract(pass_is_abstract=False)

--- a/tests/functional/a/assignment/assignment_from_no_return.py
+++ b/tests/functional/a/assignment/assignment_from_no_return.py
@@ -91,3 +91,15 @@ class Unsupported:
 
 
 link = Unsupported().readlink()  # no error here
+
+
+# The same holds when an earlier branch returns without a value: the function
+# body still ends in an unconditional raise.
+def early_return_then_raise(value):
+    """Returns on one branch, otherwise always raises"""
+    if value:
+        return
+    raise ValueError(value)
+
+
+maybe = early_return_then_raise(None)  # no error here

--- a/tests/functional/a/assignment/assignment_from_no_return.py
+++ b/tests/functional/a/assignment/assignment_from_no_return.py
@@ -93,13 +93,13 @@ class Unsupported:
 link = Unsupported().readlink()  # no error here
 
 
-# The same holds when an earlier branch returns without a value: the function
-# body still ends in an unconditional raise.
+# A trailing raise does not make the function no-return if an earlier branch
+# can still return: here the bare return yields None, which is still reported.
 def early_return_then_raise(value):
-    """Returns on one branch, otherwise always raises"""
+    """Returns on one branch, otherwise raises"""
     if value:
         return
     raise ValueError(value)
 
 
-maybe = early_return_then_raise(None)  # no error here
+maybe = early_return_then_raise(None)  # [assignment-from-none]

--- a/tests/functional/a/assignment/assignment_from_no_return.py
+++ b/tests/functional/a/assignment/assignment_from_no_return.py
@@ -75,3 +75,19 @@ class B(A):
 
 
 res = B().a.f()  # no error here
+
+
+# Regression test for https://github.com/pylint-dev/pylint/issues/11114
+# A function whose body ends in an unconditional raise never returns normally,
+# even when other statements precede the raise (e.g. pathlib.Path.readlink()
+# on platforms without symlink support).
+class Unsupported:
+    """Class with a method that always raises"""
+
+    def readlink(self):
+        """Always raises, so assigning its result is not an error"""
+        message = f"{type(self).__name__}.readlink() is unsupported"
+        raise OSError(message)
+
+
+link = Unsupported().readlink()  # no error here

--- a/tests/functional/a/assignment/assignment_from_no_return.txt
+++ b/tests/functional/a/assignment/assignment_from_no_return.txt
@@ -1,2 +1,3 @@
 assignment-from-no-return:26:8:26:34:Class.some_other_method:Assigning result of a function call, where the function has no return:UNDEFINED
 assignment-from-no-return:31:0:31:19::Assigning result of a function call, where the function has no return:UNDEFINED
+assignment-from-none:105:0:105:37::Assigning result of a function call, where the function returns None:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`_is_ignored_function` relies on `utils.is_error()`, which only matches a function whose body is *exactly* one `raise`. A function that raises unconditionally after other statements also never returns normally, but was not ignored — so `pathlib.Path.readlink()` (which builds a message, then raises, on platforms without symlink support) made `result = path.readlink()` emit `assignment-from-no-return`.

Now any function whose body ends in a `raise` is ignored. The empty-body guard keeps builtin descriptors such as `list.sort()` / `dict.update()` still reported (covered by the existing `assignment_from_no_return_2` functional test).

Closes #11114
