### PR TITLE
Fix too-many-lines being reported at another module's pragma line

### DIFF
--- a/doc/whatsnew/fragments/11191.bugfix
+++ b/doc/whatsnew/fragments/11191.bugfix
@@ -1,0 +1,6 @@
+``too-many-lines`` could be reported at the line of a ``# pylint: disable=too-many-lines``
+pragma found in a previously linted module. Pragma positions are now reset between
+modules, so the message is reported at line 1 (or at the current module's own pragma)
+regardless of which files were linted before.
+
+Closes #11191

--- a/doc/whatsnew/fragments/11191.bugfix
+++ b/doc/whatsnew/fragments/11191.bugfix
@@ -3,4 +3,4 @@ pragma found in a previously linted module. Pragma positions are now reset betwe
 modules, so the message is reported at line 1 (or at the current module's own pragma)
 regardless of which files were linted before.
 
-Closes #11191
+Refs #11191

--- a/pylint/lint/message_state_handler.py
+++ b/pylint/lint/message_state_handler.py
@@ -28,6 +28,9 @@ if TYPE_CHECKING:
     from pylint.lint.pylinter import PyLinter
 
 
+CONTROL_PRAGMAS = frozenset({"disable", "disable-next", "enable"})
+
+
 class _MessageStateHandler:
     """Class that handles message disabling & enabling and processing of inline
     pragma's.
@@ -346,7 +349,10 @@ class _MessageStateHandler:
 
         See func_block_disable_msg.py test case for expected behaviour.
         """
-        control_pragmas = {"disable", "disable-next", "enable"}
+        # Pragma positions are only valid for the current module: without this
+        # reset, a pragma from a previously linted module would give its line
+        # number to module-scoped messages (e.g. too-many-lines) of this one.
+        self._pragma_lineno = {}
         prev_line = None
         saw_newline = True
         seen_newline = True
@@ -391,7 +397,7 @@ class _MessageStateHandler:
                         )
                     for msgid in pragma_repr.messages:
                         # Add the line where a control pragma was encountered.
-                        if pragma_repr.action in control_pragmas:
+                        if pragma_repr.action in CONTROL_PRAGMAS:
                             self._pragma_lineno[msgid] = start[0]
 
                         if (pragma_repr.action, msgid) == ("disable", "all"):

--- a/pylint/lint/message_state_handler.py
+++ b/pylint/lint/message_state_handler.py
@@ -349,9 +349,6 @@ class _MessageStateHandler:
 
         See func_block_disable_msg.py test case for expected behaviour.
         """
-        # Pragma positions are only valid for the current module: without this
-        # reset, a pragma from a previously linted module would give its line
-        # number to module-scoped messages (e.g. too-many-lines) of this one.
         self._pragma_lineno = {}
         prev_line = None
         saw_newline = True

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -1304,9 +1304,7 @@ def test_lint_namespace_package_under_dir_on_path(initialized_linter: PyLinter) 
 def test_pragma_line_number_is_reset_between_modules(tmp_path: Path) -> None:
     """A pragma in one module must not change message locations in the next.
 
-    ``too-many-lines`` is reported at the line of the pragma controlling it,
-    defaulting to line 1 when the module has none. The recorded pragma
-    position used to leak between modules of the same run.
+    Regression test for https://github.com/pylint-dev/pylint/pull/11176#issuecomment-5084749143
     """
     pragma_module = tmp_path / "with_pragma.py"
     pragma_module.write_text(

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -1299,3 +1299,35 @@ def test_lint_namespace_package_under_dir_on_path(initialized_linter: PyLinter) 
         with lint.augmented_sys_path(extra_sys_paths):
             linter.check(["namespace_on_path"])
     assert linter.file_state.base_name == "namespace_on_path"
+
+
+def test_pragma_line_number_is_reset_between_modules(tmp_path: Path) -> None:
+    """A pragma in one module must not change message locations in the next.
+
+    ``too-many-lines`` is reported at the line of the pragma controlling it,
+    defaulting to line 1 when the module has none. The recorded pragma
+    position used to leak between modules of the same run.
+    """
+    pragma_module = tmp_path / "with_pragma.py"
+    pragma_module.write_text(
+        '"""Short module with an unneeded pragma."""\n'
+        "# pylint: disable=too-many-lines\n",
+        encoding="utf-8",
+    )
+    long_module = tmp_path / "long_module.py"
+    long_module.write_text(
+        '"""Long module without any pragma."""\n' + "A = 1\n" * 10, encoding="utf-8"
+    )
+    reporter = testutils.GenericTestReporter()
+    linter = PyLinter()
+    linter.set_reporter(reporter)
+    checkers.initialize(linter)
+    linter.config.max_module_lines = 5
+    linter.config.persistent = 0
+    linter.disable("all")
+    linter.enable("too-many-lines")
+    linter.open()
+    linter.check([str(pragma_module), str(long_module)])
+    assert [(m.symbol, m.module, m.line) for m in reporter.messages] == [
+        ("too-many-lines", "long_module", 1)
+    ]


### PR DESCRIPTION
## What

`_MessageStateHandler._pragma_lineno` was never reset between modules, so a `# pylint: disable=too-many-lines` pragma in one file changed the line at which `too-many-lines` was reported in every file linted afterwards (the message is reported at the pragma line, defaulting to 1). Message positions therefore depended on the file iteration order.

Diagnosed through spurious diffs in a primer run (https://github.com/pylint-dev/pylint/pull/11176#issuecomment-5084749143): the `main` and PR runs linted the identical pinned astropy checkout with the same pylint and astroid, yet astropy's `too-many-lines` messages sat at line 1 (92×), line 4 (19×) and line 5 (4×) on one side and at 45×/1×/69× on the other, purely because the two runs walked the files in a different order.

## Fix

Reset `_pragma_lineno` at the start of `process_tokens()`, scoping pragma positions to the current module. Same-module behavior is unchanged (the reset happens before the current module's pragmas are collected). `control_pragmas` is hoisted to a module constant to stay under `too-many-statements`.

The regression test lints two modules in one run and asserts the second module's `too-many-lines` is reported at line 1, not at the first module's pragma line.