### PR TITLE
Derive the primer projects cache key from the pinned commits

### DIFF
--- a/doc/whatsnew/fragments/11192.internal
+++ b/doc/whatsnew/fragments/11192.internal
@@ -1,0 +1,7 @@
+The primer's project cache key is now derived from the commits pinned in
+``packages_to_prime.json`` instead of the remote branch tips. ``main`` and PR primer
+runs now share the same project cache and lint files in the same on-disk order,
+removing spurious diffs from primer comments (message positions and astroid inference
+results depend on the order in which modules are linted).
+
+Closes #11192

--- a/pylint/testutils/_primer/primer_prepare_command.py
+++ b/pylint/testutils/_primer/primer_prepare_command.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import sys
 
-from git.cmd import Git
 from git.repo import Repo
 
 from pylint.testutils._primer.primer_command import PrimerCommand
@@ -27,12 +26,12 @@ class PrepareCommand(PrimerCommand):
                 print(f"Found '{package}' at commit '{local_commit}'.")
                 commit_string += local_commit[:8] + "_"
         elif self.config.make_commit_string:
+            # Use the pinned commits so that runs which only differ by upstream
+            # branch tips share the same cache (and thus the same on-disk file
+            # order, which message positions and inference depend on).
             for package, data in self.packages.items():
-                remote_sha1_commit = (
-                    Git().ls_remote(data.url, data.branch).split("\t")[0][:8]
-                )
-                print(f"'{package}' remote is at commit '{remote_sha1_commit}'.")
-                commit_string += remote_sha1_commit + "_"
+                print(f"'{package}' is pinned to commit '{data.commit[:8]}'.")
+                commit_string += data.commit[:8] + "_"
         elif self.config.read_commit_string:
             with open(
                 self.primer_directory / f"commit_string_{version_string}.txt",


### PR DESCRIPTION
## What

`prepare --make-commit-string` used `git ls-remote` on the branch tips, ignoring the commits pinned in `packages_to_prime.json`. The tips move daily, so `main` primer runs always missed the projects cache and re-cloned, while PR runs (which reuse the commit string from main's artifact, i.e. the pinned commits) restored the cache tar.

A fresh clone and a cache-restored tree walk files in different order, and some results depend on that order — message positions (see #11191) and astroid inference (`too-many-ancestors` counts can differ by 1-2). This produced spurious diffs in primer comments, e.g. https://github.com/pylint-dev/pylint/pull/11176#issuecomment-5084749143 where ~40 astropy messages "moved" on a PR touching only the comparison checker.

## Fix

Build the commit string from the pinned commits, so `main` and PR runs share the same projects cache — same tree, same file order — and the cache is only invalidated when the pins are bumped. `script/update_primer_commits.py` intentionally keeps `ls-remote`: it is the tool that bumps the pins.