### PR TITLE
Fix consider-using-dict-items crash for non-name for-loop targets

### DIFF
--- a/doc/whatsnew/fragments/11173.bugfix
+++ b/doc/whatsnew/fragments/11173.bugfix
@@ -1,0 +1,4 @@
+Fix a crash in ``consider-using-dict-items`` when a ``for`` loop target is
+an attribute, subscript, or another non-name target.
+
+Refs #11173

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -274,6 +274,13 @@ class RecommendationChecker(checkers.BaseChecker):
         # that the object which is iterated is used as a subscript in the
         # body of the for.
 
+        # ``consider-using-dict-items`` only applies to a simple loop variable.
+        # A tuple or attribute target (e.g. ``for self.idx in my_dict``) cannot
+        # be rewritten with ``.items()``, and accessing
+        # ``node.target.name`` on such a target raises AttributeError (#11173).
+        if not isinstance(node.target, nodes.AssignName):
+            return
+
         iterating_object_name = utils.get_iterating_dictionary_name(node)
         if iterating_object_name is None:
             return

--- a/tests/functional/c/consider/consider_using_dict_items.py
+++ b/tests/functional/c/consider/consider_using_dict_items.py
@@ -119,3 +119,16 @@ for k in D:  # [consider-using-dict-items]
 for var in os.environ.keys():  # [consider-iterating-dictionary]
     if var.startswith("foo_"):
         del os.environ[var]  # index lookup necessary here, do not emit error
+
+
+# Regression test for issue #11173
+SETTINGS = {"debug": True, "verbose": False}
+
+
+class Walker:
+    def __init__(self):
+        self.current = None
+
+    def run(self, key):
+        for self.current in SETTINGS:
+            print(SETTINGS[key])


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Refs #11173

`consider-using-dict-items` assumes every `for` target has a `.name`
attribute. Legal attribute, subscript, and unpacking targets use different
astroid node types, so the checker raises `AttributeError` when it reaches
that lookup.

Return early unless the loop target is an `AssignName`. A non-name target
cannot be rewritten with `.items()`, so the recommendation does not apply.
This also follows the concrete-node-type approach used by the neighboring
`consider-using-enumerate` check.

### Validation

- Reproduced the attribute-target crash on upstream `main`.
- Verified the same ordinary `for` loop no longer crashes with this branch.
- `git diff --check` passes.

### Remaining work

The analogous comprehension path still reads `node.target.name` and can
crash for a non-name target. This draft therefore references, rather than
closes, #11173. Regression tests and the comprehension guard still need to
be added before marking the PR ready for review.
