### PR TITLE
Switch back to tox-dev's pyproject-fmt from the pytest-dev fork

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -164,8 +164,8 @@ repos:
         args: ["--toml=pyproject.toml"]
         additional_dependencies:
           - tomli
-  - repo: https://github.com/pytest-dev/pyproject-fmt
-    rev: "v2.12.1"
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: "v2.26.0"
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/abravalheri/validate-pyproject

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -1,221 +1,4 @@
 [tool.pylint]
-# Only show warnings with the listed confidence levels. Leave empty to show all.
-# Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
-"messages control".confidence = [ "HIGH", "CONTROL_FLOW", "INFERENCE", "INFERENCE_FAILURE", "UNDEFINED" ]
-# Disable the message, report, category or checker with the given id(s). You can
-# either give multiple identifiers separated by comma (,) or put this option
-# multiple times (only on the command line, not in the configuration file where
-# it should appear only once). You can also use "--disable=all" to disable
-# everything first and then re-enable specific checks. For example, if you want
-# to run only the similarities checker, you can use "--disable=all
-# --enable=similarities". If you want to run only the classes checker, but have
-# no Warning level messages displayed, use "--disable=all --enable=classes
-# --disable=W".
-"messages control".disable = [
-  "raw-checker-failed",
-  "bad-inline-option",
-  "locally-disabled",
-  "file-ignored",
-  "suppressed-message",
-  "useless-suppression",
-  "deprecated-pragma",
-  "use-implicit-booleaness-not-comparison-to-string",
-  "use-implicit-booleaness-not-comparison-to-zero",
-  "use-symbolic-message-instead",
-]
-# Enable the message, report, category or checker with the given id(s). You can
-# either give multiple identifier separated by comma (,) or put this option
-# multiple time (only on the command line, not in the configuration file where it
-# should appear only once). See also the "--disable" option for examples.
-# enable =
-# Naming style matching correct argument names.
-basic.argument-naming-style = "snake_case"
-# Regular expression matching correct argument names. Overrides argument-naming-
-# style. If left empty, argument names will be checked with the set naming style.
-# argument-rgx =
-# Naming style matching correct attribute names.
-basic.attr-naming-style = "snake_case"
-# Regular expression matching correct attribute names. Overrides attr-naming-
-# style. If left empty, attribute names will be checked with the set naming
-# style.
-# attr-rgx =
-# Bad variable names which should always be refused, separated by a comma.
-basic.bad-names = [ "foo", "bar", "baz", "toto", "tutu", "tata" ]
-# Bad variable names regexes, separated by a comma. If names match any regex,
-# they will always be refused
-# bad-names-rgxs =
-# Naming style matching correct class attribute names.
-basic.class-attribute-naming-style = "any"
-# Regular expression matching correct class attribute names. Overrides class-
-# attribute-naming-style. If left empty, class attribute names will be checked
-# with the set naming style.
-# class-attribute-rgx =
-# Naming style matching correct class constant names.
-basic.class-const-naming-style = "UPPER_CASE"
-# Regular expression matching correct class constant names. Overrides class-
-# const-naming-style. If left empty, class constant names will be checked with
-# the set naming style.
-# class-const-rgx =
-# Naming style matching correct class names.
-basic.class-naming-style = "PascalCase"
-# Regular expression matching correct class names. Overrides class-naming-style.
-# If left empty, class names will be checked with the set naming style.
-# class-rgx =
-# Naming style matching correct constant names.
-basic.const-naming-style = "UPPER_CASE"
-# Regular expression matching correct constant names. Overrides const-naming-
-# style. If left empty, constant names will be checked with the set naming style.
-# const-rgx =
-# Minimum line length for functions/classes that require docstrings, shorter ones
-# are exempt.
-basic.docstring-min-length = -1
-# Naming style matching correct function names.
-basic.function-naming-style = "snake_case"
-# Regular expression matching correct function names. Overrides function-naming-
-# style. If left empty, function names will be checked with the set naming style.
-# function-rgx =
-# Good variable names which should always be accepted, separated by a comma.
-basic.good-names = [ "i", "j", "k", "ex", "Run", "_" ]
-# Good variable names regexes, separated by a comma. If names match any regex,
-# they will always be accepted
-# good-names-rgxs =
-# Include a hint for the correct naming format with invalid-name.
-# include-naming-hint =
-# Naming style matching correct inline iteration names.
-basic.inlinevar-naming-style = "any"
-# Regular expression matching correct inline iteration names. Overrides
-# inlinevar-naming-style. If left empty, inline iteration names will be checked
-# with the set naming style.
-# inlinevar-rgx =
-# Naming style matching correct method names.
-basic.method-naming-style = "snake_case"
-# Regular expression matching correct method names. Overrides method-naming-
-# style. If left empty, method names will be checked with the set naming style.
-# method-rgx =
-# Naming style matching correct module names.
-basic.module-naming-style = "snake_case"
-# Regular expression matching correct module names. Overrides module-naming-
-# style. If left empty, module names will be checked with the set naming style.
-# module-rgx =
-# Colon-delimited sets of names that determine each other's naming style when the
-# name regexes allow several styles.
-# name-group =
-# Regular expression which should only match function or class names that do not
-# require a docstring.
-basic.no-docstring-rgx = "^_"
-# Regular expression matching correct parameter specification variable names. If
-# left empty, parameter specification variable names will be checked with the set
-# naming style.
-# paramspec-rgx =
-# List of decorators that produce properties, such as abc.abstractproperty. Add
-# to this list to register other decorators that produce valid properties. These
-# decorators are taken in consideration only for invalid-name.
-basic.property-classes = [ "abc.abstractproperty" ]
-# Regular expression matching correct type alias names. If left empty, type alias
-# names will be checked with the set naming style.
-# typealias-rgx =
-# Regular expression matching correct type variable names. If left empty, type
-# variable names will be checked with the set naming style.
-# typevar-rgx =
-# Regular expression matching correct type variable tuple names. If left empty,
-# type variable tuple names will be checked with the set naming style.
-# typevartuple-rgx =
-# Naming style matching correct variable names.
-basic.variable-naming-style = "snake_case"
-# Regular expression matching correct variable names. Overrides variable-naming-
-# style. If left empty, variable names will be checked with the set naming style.
-# variable-rgx =
-# Warn about protected attribute access inside special methods
-# check-protected-access-in-special-methods =
-# List of method names used to declare (i.e. assign) instance attributes.
-classes.defining-attr-methods = [ "__init__", "__new__", "setUp", "asyncSetUp", "__post_init__" ]
-# List of member names, which should be excluded from the protected access
-# warning.
-classes.exclude-protected = [ "_asdict", "_fields", "_replace", "_source", "_make", "os._exit" ]
-# List of valid names for the first argument in a class method.
-classes.valid-classmethod-first-arg = [ "cls" ]
-# List of valid names for the first argument in a metaclass class method.
-classes.valid-metaclass-classmethod-first-arg = [ "mcs" ]
-# List of regular expressions of class ancestor names to ignore when counting
-# public methods (see R0903)
-# exclude-too-few-public-methods =
-# List of qualified class names to ignore when counting class parents (see R0901)
-# ignored-parents =
-# Maximum number of arguments for function / method.
-design.max-args = 5
-# Maximum number of attributes for a class (see R0902).
-design.max-attributes = 7
-# Maximum number of boolean expressions in an if statement (see R0916).
-design.max-bool-expr = 5
-# Maximum number of branch for function / method body.
-design.max-branches = 12
-# Maximum number of locals for function / method body.
-design.max-locals = 15
-# Maximum number of parents for a class (see R0901).
-design.max-parents = 7
-# Maximum number of positional arguments for function / method.
-design.max-positional-arguments = 5
-# Maximum number of public methods for a class (see R0904).
-design.max-public-methods = 20
-# Maximum number of return / yield for function / method body.
-design.max-returns = 6
-# Maximum number of statements in function / method body.
-design.max-statements = 50
-# Minimum number of public methods for a class (see R0903).
-design.min-public-methods = 2
-# Exceptions that will emit a warning when caught.
-exceptions.overgeneral-exceptions = [ "builtins.BaseException", "builtins.Exception" ]
-# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
-# expected-line-ending-format =
-# Regexp for a line that is allowed to be longer than the limit.
-format.ignore-long-lines = "^\\s*(# )?<?https?://\\S+>?$"
-# Number of spaces of indent required inside a hanging or continued line.
-format.indent-after-paren = 4
-# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
-# tab).
-format.indent-string = "    "
-# Maximum number of characters on a single line. Pylint's default of 100 is based
-# on PEP 8's guidance that teams may choose line lengths up to 99 characters.
-format.max-line-length = 100
-# Maximum number of lines in a module.
-format.max-module-lines = 1000
-# Allow the body of a class to be on the same line as the declaration if body
-# contains single statement.
-# single-line-class-stmt =
-# Allow the body of an if to be on the same line as the test if there is no else.
-# single-line-if-stmt =
-# List of modules that can be imported at any level, not just the top level one.
-# allow-any-import-level =
-# Allow explicit reexports by alias from a package __init__.
-# allow-reexport-from-package =
-# Allow wildcard imports from modules that define __all__.
-# allow-wildcard-with-all =
-# Deprecated modules which should not be used, separated by a comma.
-# deprecated-modules =
-# Output a graph (.gv or any supported image format) of external dependencies to
-# the given file (report RP0402 must not be disabled).
-# ext-import-graph =
-# Output a graph (.gv or any supported image format) of all (i.e. internal and
-# external) dependencies to the given file (report RP0402 must not be disabled).
-# import-graph =
-# Output a graph (.gv or any supported image format) of internal dependencies to
-# the given file (report RP0402 must not be disabled).
-# int-import-graph =
-# Force import order to recognize a module as part of the standard compatibility
-# libraries.
-# known-standard-library =
-# Force import order to recognize a module as part of a third party library.
-# known-first-party =
-# Force import order to recognize a module as part of a third party library.
-imports.known-third-party = [ "enchant" ]
-# Couples of modules and preferred modules, separated by a comma.
-# preferred-modules =
-# The type of string formatting that logging methods do. `old` means using %
-# formatting, `new` is for `{}` formatting.
-logging.logging-format-style = "old"
-# Logging modules to check that the string format arguments are in logging
-# function parameter format.
-logging.logging-modules = [ "logging" ]
 # Analyse import fallback blocks. This can be used to support both Python 2 and 3
 # compatible code, which means that the block might have code that exists only in
 # one or another interpreter, leading to false positives when analysed.
@@ -283,6 +66,217 @@ main.persistent = true
 # Minimum Python version to use for version dependent checks. Will default to the
 # version used to run pylint.
 main.py-version = "3.12"
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each category,
+# as well as 'statement' which is the total number of statements analyzed. This
+# score is used by the global evaluation report (RP0004).
+reports.evaluation = "max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))"
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+# msg-template =
+# Set the output format. Available formats are: 'text', 'parseable', 'colorized',
+# 'json2' (improved json format), 'json' (old json format), msvs (visual studio)
+# and 'github' (GitHub actions). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+# output-format =
+# Tells whether to display a full report or only the messages.
+# reports =
+# Activate the evaluation score.
+reports.score = true
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where it
+# should appear only once). See also the "--disable" option for examples.
+# enable =
+# Naming style matching correct argument names.
+basic.argument-naming-style = "snake_case"
+# Regular expression matching correct argument names. Overrides argument-naming-
+# style. If left empty, argument names will be checked with the set naming style.
+# argument-rgx =
+# Naming style matching correct attribute names.
+basic.attr-naming-style = "snake_case"
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+# attr-rgx =
+# Bad variable names which should always be refused, separated by a comma.
+basic.bad-names = [ "bar", "baz", "foo", "tata", "toto", "tutu" ]
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+# bad-names-rgxs =
+# Naming style matching correct class attribute names.
+basic.class-attribute-naming-style = "any"
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+# class-attribute-rgx =
+# Naming style matching correct class constant names.
+basic.class-const-naming-style = "UPPER_CASE"
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+# class-const-rgx =
+# Naming style matching correct class names.
+basic.class-naming-style = "PascalCase"
+# Regular expression matching correct class names. Overrides class-naming-style.
+# If left empty, class names will be checked with the set naming style.
+# class-rgx =
+# Naming style matching correct constant names.
+basic.const-naming-style = "UPPER_CASE"
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming style.
+# const-rgx =
+# Minimum line length for functions/classes that require docstrings, shorter ones
+# are exempt.
+basic.docstring-min-length = -1
+# Naming style matching correct function names.
+basic.function-naming-style = "snake_case"
+# Regular expression matching correct function names. Overrides function-naming-
+# style. If left empty, function names will be checked with the set naming style.
+# function-rgx =
+# Good variable names which should always be accepted, separated by a comma.
+basic.good-names = [ "_", "ex", "i", "j", "k", "Run" ]
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+# good-names-rgxs =
+# Include a hint for the correct naming format with invalid-name.
+# include-naming-hint =
+# Naming style matching correct inline iteration names.
+basic.inlinevar-naming-style = "any"
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+# inlinevar-rgx =
+# Naming style matching correct method names.
+basic.method-naming-style = "snake_case"
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+# method-rgx =
+# Naming style matching correct module names.
+basic.module-naming-style = "snake_case"
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+# module-rgx =
+# Colon-delimited sets of names that determine each other's naming style when the
+# name regexes allow several styles.
+# name-group =
+# Regular expression which should only match function or class names that do not
+# require a docstring.
+basic.no-docstring-rgx = "^_"
+# Regular expression matching correct parameter specification variable names. If
+# left empty, parameter specification variable names will be checked with the set
+# naming style.
+# paramspec-rgx =
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties. These
+# decorators are taken in consideration only for invalid-name.
+basic.property-classes = [ "abc.abstractproperty" ]
+# Regular expression matching correct type alias names. If left empty, type alias
+# names will be checked with the set naming style.
+# typealias-rgx =
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+# typevar-rgx =
+# Regular expression matching correct type variable tuple names. If left empty,
+# type variable tuple names will be checked with the set naming style.
+# typevartuple-rgx =
+# Naming style matching correct variable names.
+basic.variable-naming-style = "snake_case"
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+# expected-line-ending-format =
+# Regexp for a line that is allowed to be longer than the limit.
+format.ignore-long-lines = "^\\s*(# )?<?https?://\\S+>?$"
+# Number of spaces of indent required inside a hanging or continued line.
+format.indent-after-paren = 4
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+format.indent-string = "    "
+# Maximum number of characters on a single line. Pylint's default of 100 is based
+# on PEP 8's guidance that teams may choose line lengths up to 99 characters.
+format.max-line-length = 100
+# Maximum number of lines in a module.
+format.max-module-lines = 1000
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+# exclude-too-few-public-methods =
+# List of qualified class names to ignore when counting class parents (see R0901)
+# ignored-parents =
+# Maximum number of arguments for function / method.
+design.max-args = 5
+# Maximum number of attributes for a class (see R0902).
+design.max-attributes = 7
+# Maximum number of boolean expressions in an if statement (see R0916).
+design.max-bool-expr = 5
+# Maximum number of branch for function / method body.
+design.max-branches = 12
+# Maximum number of locals for function / method body.
+design.max-locals = 15
+# Maximum number of parents for a class (see R0901).
+design.max-parents = 7
+# Maximum number of positional arguments for function / method.
+design.max-positional-arguments = 5
+# Maximum number of public methods for a class (see R0904).
+design.max-public-methods = 20
+# Maximum number of return / yield for function / method body.
+design.max-returns = 6
+# Maximum number of statements in function / method body.
+design.max-statements = 50
+# Minimum number of public methods for a class (see R0903).
+design.min-public-methods = 2
+# Regular expression matching correct variable names. Overrides variable-naming-
+# style. If left empty, variable names will be checked with the set naming style.
+# variable-rgx =
+# Warn about protected attribute access inside special methods
+# check-protected-access-in-special-methods =
+# List of method names used to declare (i.e. assign) instance attributes.
+classes.defining-attr-methods = [ "__init__", "__new__", "__post_init__", "asyncSetUp", "setUp" ]
+# List of member names, which should be excluded from the protected access
+# warning.
+classes.exclude-protected = [ "_asdict", "_fields", "_make", "_replace", "_source", "os._exit" ]
+# List of valid names for the first argument in a class method.
+classes.valid-classmethod-first-arg = [ "cls" ]
+# List of valid names for the first argument in a metaclass class method.
+classes.valid-metaclass-classmethod-first-arg = [ "mcs" ]
+# Exceptions that will emit a warning when caught.
+exceptions.overgeneral-exceptions = [ "builtins.BaseException", "builtins.Exception" ]
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+# single-line-class-stmt =
+# Allow the body of an if to be on the same line as the test if there is no else.
+# single-line-if-stmt =
+# List of modules that can be imported at any level, not just the top level one.
+# allow-any-import-level =
+# Allow explicit reexports by alias from a package __init__.
+# allow-reexport-from-package =
+# Allow wildcard imports from modules that define __all__.
+# allow-wildcard-with-all =
+# Deprecated modules which should not be used, separated by a comma.
+# deprecated-modules =
+# Output a graph (.gv or any supported image format) of external dependencies to
+# the given file (report RP0402 must not be disabled).
+# ext-import-graph =
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be disabled).
+# import-graph =
+# Output a graph (.gv or any supported image format) of internal dependencies to
+# the given file (report RP0402 must not be disabled).
+# int-import-graph =
+# Force import order to recognize a module as part of the standard compatibility
+# libraries.
+# known-standard-library =
+# Force import order to recognize a module as part of a third party library.
+# known-first-party =
+# Force import order to recognize a module as part of a third party library.
+imports.known-third-party = [ "enchant" ]
+# Couples of modules and preferred modules, separated by a comma.
+# preferred-modules =
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging.logging-format-style = "old"
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging.logging-modules = [ "logging" ]
 # Discover python modules and packages in the file system subtree.
 # recursive =
 # Add paths to the list of the source roots. Supports globbing patterns. The
@@ -305,10 +299,6 @@ method_args.timeout-methods = [
   "requests.api.put",
   "requests.api.request",
 ]
-# Whether or not to search for fixme's in docstrings.
-# check-fixme-in-docstring =
-# List of note tags to take in consideration, separated by a comma.
-miscellaneous.notes = [ "FIXME", "XXX", "TODO" ]
 # Regular expression of note tags to take in consideration.
 # notes-rgx =
 # Maximum number of nested blocks for function / method body
@@ -320,24 +310,6 @@ refactoring.never-returning-functions = [ "sys.exit", "argparse.parse_error" ]
 # Let 'consider-using-join' be raised when the separator to join on would be non-
 # empty (resulting in expected fixes of the type: ``"- " + " - ".join(items)``)
 refactoring.suggest-join-with-non-empty-separator = true
-# Python expression which should return a score less than or equal to 10. You
-# have access to the variables 'fatal', 'error', 'warning', 'refactor',
-# 'convention', and 'info' which contain the number of messages in each category,
-# as well as 'statement' which is the total number of statements analyzed. This
-# score is used by the global evaluation report (RP0004).
-reports.evaluation = "max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))"
-# Template used to display messages. This is a python new-style format string
-# used to format the message information. See doc for all details.
-# msg-template =
-# Set the output format. Available formats are: 'text', 'parseable', 'colorized',
-# 'json2' (improved json format), 'json' (old json format), msvs (visual studio)
-# and 'github' (GitHub actions). You can also give a reporter class, e.g.
-# mypackage.mymodule.MyReporterClass.
-# output-format =
-# Tells whether to display a full report or only the messages.
-# reports =
-# Activate the evaluation score.
-reports.score = true
 # Comments are removed from the similarity computation
 similarities.ignore-comments = true
 # Docstrings are removed from the similarity computation
@@ -393,7 +365,7 @@ typecheck.ignored-checks-for-mixins = [
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of
 # qualified names.
-typecheck.ignored-classes = [ "optparse.Values", "thread._local", "_thread._local", "argparse.Namespace" ]
+typecheck.ignored-classes = [ "_thread._local", "argparse.Namespace", "optparse.Values", "thread._local" ]
 # Show a hint with possible names when a member name was not found. The aspect of
 # finding the hint is based on edit distance.
 typecheck.missing-member-hint = true
@@ -416,7 +388,7 @@ variables.allow-global-unused-variables = true
 # allowed-redefined-builtins =
 # List of strings which can identify a callback function by name. A callback name
 # must start or end with one of those strings.
-variables.callbacks = [ "cb_", "_cb" ]
+variables.callbacks = [ "_cb", "cb_" ]
 # A regular expression matching the name of dummy variables (i.e. expected to not
 # be used).
 variables.dummy-variables-rgx = "_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_"
@@ -427,3 +399,31 @@ variables.ignored-argument-names = "_.*|^ignored_|^unused_"
 # List of qualified module names which can have objects that can redefine
 # builtins.
 variables.redefining-builtins-modules = [ "six.moves", "past.builtins", "future.builtins", "builtins", "io" ]
+# Whether or not to search for fixme's in docstrings.
+# check-fixme-in-docstring =
+# List of note tags to take in consideration, separated by a comma.
+miscellaneous.notes = [ "FIXME", "XXX", "TODO" ]
+# Only show warnings with the listed confidence levels. Leave empty to show all.
+# Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+"messages control".confidence = [ "HIGH", "CONTROL_FLOW", "INFERENCE", "INFERENCE_FAILURE", "UNDEFINED" ]
+# Disable the message, report, category or checker with the given id(s). You can
+# either give multiple identifiers separated by comma (,) or put this option
+# multiple times (only on the command line, not in the configuration file where
+# it should appear only once). You can also use "--disable=all" to disable
+# everything first and then re-enable specific checks. For example, if you want
+# to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+"messages control".disable = [
+  "bad-inline-option",
+  "deprecated-pragma",
+  "file-ignored",
+  "locally-disabled",
+  "raw-checker-failed",
+  "suppressed-message",
+  "use-implicit-booleaness-not-comparison-to-string",
+  "use-implicit-booleaness-not-comparison-to-zero",
+  "use-symbolic-message-instead",
+  "useless-suppression",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,9 @@ urls."Bug Tracker" = "https://github.com/pylint-dev/pylint/issues"
 urls."Discord Server" = "https://discord.com/invite/Egy6P8AMB5"
 urls."Docs: Contributor Guide" = "https://pylint.readthedocs.io/en/latest/development_guide/contributor_guide/index.html"
 urls."Docs: User Guide" = "https://pylint.readthedocs.io/en/latest/"
-urls.homepage = "https://github.com/pylint-dev/pylint"
 urls."Source Code" = "https://github.com/pylint-dev/pylint"
 urls."What's New" = "https://pylint.readthedocs.io/en/latest/whatsnew/4/"
+urls.homepage = "https://github.com/pylint-dev/pylint"
 scripts.pylint = "pylint:run_pylint"
 scripts.pylint-config = "pylint:_run_pylint_config"
 scripts.pyreverse = "pylint:run_pyreverse"
@@ -100,14 +100,14 @@ test-min = [
 ]
 
 [tool.setuptools]
-dynamic.version = { attr = "pylint.__pkginfo__.__version__" }
-package-data.pylint = [ "testutils/testing_pylintrc", "py.typed" ]
+packages.find.include = [ "pylint*" ]
 # Simulate editable_mode=compat, described at:
 # https://github.com/pypa/setuptools/issues/3767
 # TODO: remove after solving root cause described at:
 # https://github.com/pylint-dev/astroid/pull/2267#issuecomment-1666642781
 package-dir."" = "."
-packages.find.include = [ "pylint*" ]
+package-data.pylint = [ "py.typed", "testutils/testing_pylintrc" ]
+dynamic.version = { attr = "pylint.__pkginfo__.__version__" }
 
 [tool.ruff]
 # ruff is less lenient than pylint and does not make any exceptions
@@ -168,18 +168,18 @@ lint.pydocstyle.convention = "pep257"
 
 [tool.isort]
 profile = "black"
-known_third_party = [ "platformdirs", "astroid", "sphinx", "isort", "pytest", "mccabe", "six", "toml" ]
 extra_standard_library = [ "_string" ]
+known_third_party = [ "astroid", "isort", "mccabe", "platformdirs", "pytest", "six", "sphinx", "toml" ]
+src_paths = [ "pylint" ]
 skip_glob = [
+  "astroid/**",
+  "tests/data/**",
+  "tests/extensions/data/**",
   "tests/functional/**",
   "tests/input/**",
-  "tests/extensions/data/**",
   "tests/regrtest_data/**",
-  "tests/data/**",
-  "astroid/**",
   "venv/**",
 ]
-src_paths = [ "pylint" ]
 
 [tool.codespell]
 ignore-words = [ "custom_dict.txt" ]
@@ -204,35 +204,16 @@ skip = """\
 [tool.pyproject-fmt]
 max_supported_python = "3.14"
 
-[tool.pytest]
-ini_options.testpaths = [ "tests" ]
-ini_options.python_files = [ "*test_*.py" ]
-ini_options.addopts = "--strict-markers"
-ini_options.filterwarnings = [
-  "error",
-  # Added in Python 3.14
-  "ignore:'break' in a 'finally' block:SyntaxWarning",
-  "ignore:'return' in a 'finally' block:SyntaxWarning",
-  "ignore:'continue' in a 'finally' block:SyntaxWarning",
-]
-ini_options.markers = [
-  "primer_stdlib: Checks for crashes and errors when running pylint on stdlib",
-  "benchmark: Baseline of pylint performance, if this regress something serious happened",
-  "timeout: Marks from pytest-timeout.",
-  "needs_two_cores: Checks that need 2 or more cores to be meaningful",
-]
-
 [tool.mypy]
-scripts_are_modules = true
-warn_unused_ignores = true
-show_error_codes = true
-enable_error_code = "ignore-without-code"
-strict = true
 # TODO: Remove this once pytest has annotations
 disallow_untyped_decorators = false
+warn_unused_ignores = true
+enable_error_code = "ignore-without-code"
+strict = true
+scripts_are_modules = true
+show_error_codes = true
 
 [[tool.mypy.overrides]]
-ignore_missing_imports = true
 module = [
   "_pytest.*",
   "_string",
@@ -245,31 +226,50 @@ module = [
   "enchant.*",
   "git.*",
   "mccabe",
-  "pytest_benchmark.*",
   "pytest",
+  "pytest_benchmark.*",
   "sphinx.*",
 ]
+ignore_missing_imports = true
 
 # For local tests: Enable follow_untyped_imports overwrite for astroid
 # [[tool.mypy.overrides]]
 # module = ["astroid.*"]
 # follow_untyped_imports = true
 [tool.pyright]
+pythonVersion = "3.10"
+typeCheckingMode = "basic"
 include = [
   "pylint",
   # not checking the tests yet, but we could
 ]
-pythonVersion = "3.10"
-typeCheckingMode = "basic"
-reportMissingImports = "none" # pytest / astroid are not detected
-reportOptionalMemberAccess = "none" # 150 issues
-reportArgumentType = "none" # 12 issues
-reportAttributeAccessIssue = "none" # 11 issues
-reportInvalidTypeForm = "none" # 6 issues
-reportOptionalCall = "none" # 2 issues
-reportGeneralTypeIssues = "none" # 1 issue
-reportCallIssue = "none" # 1 issue
-reportInvalidTypeVarUse = "none" # 2 warnings
+reportArgumentType = "none"  # 12 issues
+reportAttributeAccessIssue = "none"  # 11 issues
+reportCallIssue = "none"  # 1 issue
+reportGeneralTypeIssues = "none"  # 1 issue
+reportInvalidTypeForm = "none"  # 6 issues
+reportInvalidTypeVarUse = "none"  # 2 warnings
+reportMissingImports = "none"  # pytest / astroid are not detected
+reportOptionalCall = "none"  # 2 issues
+reportOptionalMemberAccess = "none"  # 150 issues
+
+[tool.pytest]
+ini_options.testpaths = [ "tests" ]
+ini_options.python_files = [ "*test_*.py" ]
+ini_options.addopts = "--strict-markers"
+ini_options.markers = [
+  "benchmark: Baseline of pylint performance, if this regress something serious happened",
+  "needs_two_cores: Checks that need 2 or more cores to be meaningful",
+  "primer_stdlib: Checks for crashes and errors when running pylint on stdlib",
+  "timeout: Marks from pytest-timeout.",
+]
+ini_options.filterwarnings = [
+  "error",
+  # Added in Python 3.14
+  "ignore:'break' in a 'finally' block:SyntaxWarning",
+  "ignore:'continue' in a 'finally' block:SyntaxWarning",
+  "ignore:'return' in a 'finally' block:SyntaxWarning",
+]
 
 [tool.aliases]
 test = "pytest"


### PR DESCRIPTION
Follow-up to the discussion in https://github.com/pylint-dev/pylint/pull/11188#discussion_r3664381876, extracted to its own PR so the 3.15 diff stays clean.

The pinned fork (v2.12.1) reformats PEP 508 direct-URL requirements by removing the whitespace before the environment marker separator (`url ; marker` → `url;marker`). PEP 508 requires that whitespace — `;` is a valid URL character, so without it the marker is parsed as part of the URL and the requirement becomes uninstallable (`packaging` rejects it with `Expected semicolon (after URL and whitespace) or end`). This is fixed upstream in tox-dev (tox-dev/toml-fmt#407), and #11188 needs it because it pins `dill` to a git commit for Python 3.15.

The `pyproject.toml`/`examples/pyproject.toml` churn is the new version sorting arrays alphabetically; no value actually changes (checked by parsing both versions and diffing the resulting dicts — the only order-sensitive option touched is pytest's `filterwarnings`, where `error` stays first and the reordered ignores are mutually independent). The resulting `examples/pyproject.toml` is byte-identical to the one in #11188, so that PR should rebase cleanly.

We can still remove the formatter entirely if the churn becomes annoying again. Side note for later: the git-pinned `dill` can't ship in a release anyway (PyPI rejects direct-URL deps in `Requires-Dist`), so it needs to move out of `[project.dependencies]` before the next release.