### PR TITLE
Remove a dead Python 3.5 interpreter check in yield-inside-async-function

### DIFF
--- a/pylint/checkers/async_checker.py
+++ b/pylint/checkers/async_checker.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING
 
 import astroid
@@ -48,9 +47,7 @@ class AsyncChecker(checkers.BaseChecker):
     @checker_utils.only_required_for_messages("yield-inside-async-function")
     def visit_asyncfunctiondef(self, node: nodes.AsyncFunctionDef) -> None:
         for child in node.nodes_of_class(nodes.Yield):
-            if child.scope() is node and (
-                sys.version_info[:2] == (3, 5) or isinstance(child, nodes.YieldFrom)
-            ):
+            if child.scope() is node and isinstance(child, nodes.YieldFrom):
                 self.add_message("yield-inside-async-function", node=child)
 
     @checker_utils.only_required_for_messages("not-async-context-manager")


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :broom: Internal |

## Description

`yield-inside-async-function` guarded its check with
`sys.version_info[:2] == (3, 5) or isinstance(child, nodes.YieldFrom)`. `pylint`
requires Python 3.10, so the first operand is always false and the condition
reduces to the `isinstance` check. Removing it also drops the last `sys` usage
in `async_checker.py`.

No behavior change: `tests/functional/y/yield_inside_async_function.py` passes
unchanged.
