### PR TITLE
Run CI on the released Python 3.15 beta

### DIFF
--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -30,8 +30,8 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        # TODO: Bump upper bound to 3.15 after final release of 3.15
-        python-version: &matrix-python-version ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version:
+          &matrix-python-version ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -29,8 +29,11 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        # TODO: Bump upper bound to 3.15 after final release of 3.15
-        python-version: ["3.10", "3.14"]
+        # 3.15 is here so that main publishes the 'primer_output_main_3.15_*'
+        # artifacts a PR run needs. 3.14 stays until 'primer_comment.yaml'
+        # switches its DEFAULT_PYTHON over, since that job diffs those
+        # artifacts, and dropping them would break the primer comment.
+        python-version: ["3.10", "3.14", "3.15"]
         batches: [4]
         batchIdx: [0, 1, 2, 3]
     steps:
@@ -41,6 +44,7 @@ jobs:
         uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           check-latest: true
 
       # Create a re-usable virtual environment

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -38,7 +38,12 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        # TODO: Bump upper bound to 3.15 after final release of 3.15
+        # TODO: Replace 3.14 with 3.15 once main has published a
+        # 'primer_output_main_3.15_*' artifact, which the step below downloads;
+        # asking for one that does not exist yet fails the job. Move
+        # DEFAULT_PYTHON in 'primer_comment.yaml' and
+        # PRIMER_CURRENT_INTERPRETER in 'tests/testutils/_primer/test_primer.py'
+        # in the same commit, and drop 3.14 from 'primer_run_main.yaml'.
         python-version: ["3.10", "3.14"]
         batches: [4]
         batchIdx: [0, 1, 2, 3]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version:
-          &matrix-python-version ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15-dev"]
+          &matrix-python-version ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
         include:
           - os: macos-latest
             python-version: "3.10"

--- a/tests/testutils/_primer/test_primer.py
+++ b/tests/testutils/_primer/test_primer.py
@@ -26,7 +26,7 @@ CASES_PATH = HERE / "cases"
 
 # If you change this, also change DEFAULT_PYTHON in
 # ``.github/workflows/primer_comment.yaml``
-PRIMER_CURRENT_INTERPRETER = (3, 13)
+PRIMER_CURRENT_INTERPRETER = (3, 14)
 
 DEFAULT_ARGS = ["python tests/primer/__main__.py", "compare", "--commit=v2.14.2"]
 


### PR DESCRIPTION
## Type of Changes

|     | Type             |
| --- | ---------------- |
| ✓   | :broom: Internal |

## Description

Splits the CI part out of #10983 so the Python 3.15 work can land
independently, and does the `TODO` left by #11188.

That follow-up is #11207, opened as a draft and stacked on this branch. It stays
a draft until this PR is merged and `main` has run its primer once, because its
own primer jobs cannot pass before the 3.15 artifacts exist.

Refs #10982
