### PR TITLE
Diff the primer on Python 3.15 instead of 3.14

### DIFF
--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -18,7 +18,7 @@ env:
   KEY_PREFIX: venv-primer
   # If you change this, also change PRIMER_CURRENT_INTERPRETER in
   # tests/testutils/_primer/test_primer.py
-  DEFAULT_PYTHON: "3.14"
+  DEFAULT_PYTHON: "3.15"
 
 permissions:
   contents: read
@@ -38,6 +38,7 @@ jobs:
         uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
+          allow-prereleases: true
           check-latest: true
 
       # Restore cached Python environment

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -29,11 +29,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        # 3.15 is here so that main publishes the 'primer_output_main_3.15_*'
-        # artifacts a PR run needs. 3.14 stays until 'primer_comment.yaml'
-        # switches its DEFAULT_PYTHON over, since that job diffs those
-        # artifacts, and dropping them would break the primer comment.
-        python-version: ["3.10", "3.14", "3.15"]
+        python-version: ["3.10", "3.15"]
         batches: [4]
         batchIdx: [0, 1, 2, 3]
     steps:

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -38,13 +38,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        # TODO: Replace 3.14 with 3.15 once main has published a
-        # 'primer_output_main_3.15_*' artifact, which the step below downloads;
-        # asking for one that does not exist yet fails the job. Move
-        # DEFAULT_PYTHON in 'primer_comment.yaml' and
-        # PRIMER_CURRENT_INTERPRETER in 'tests/testutils/_primer/test_primer.py'
-        # in the same commit, and drop 3.14 from 'primer_run_main.yaml'.
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.10", "3.15"]
         batches: [4]
         batchIdx: [0, 1, 2, 3]
     steps:
@@ -57,6 +51,7 @@ jobs:
         uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           check-latest: true
 
       # Restore cached Python environment

--- a/tests/testutils/_primer/test_primer.py
+++ b/tests/testutils/_primer/test_primer.py
@@ -26,7 +26,7 @@ CASES_PATH = HERE / "cases"
 
 # If you change this, also change DEFAULT_PYTHON in
 # ``.github/workflows/primer_comment.yaml``
-PRIMER_CURRENT_INTERPRETER = (3, 14)
+PRIMER_CURRENT_INTERPRETER = (3, 15)
 
 DEFAULT_ARGS = ["python tests/primer/__main__.py", "compare", "--commit=v2.14.2"]
 


### PR DESCRIPTION
## Type of Changes

|     | Type             |
| --- | ---------------- |
| ✓   | :broom: Internal |

## Description

Second half of the primer move to Python 3.15, stacked on #11206.

Refs #10982

