### PR TITLE
Fix classmethod getattr inference crash

### DIFF
--- a/doc/whatsnew/fragments/11198.bugfix
+++ b/doc/whatsnew/fragments/11198.bugfix
@@ -1,0 +1,3 @@
+Fix a crash when inferring ``getattr()`` on a classmethod.
+
+Closes #11198

--- a/pylint/checkers/classes/special_methods_checker.py
+++ b/pylint/checkers/classes/special_methods_checker.py
@@ -40,14 +40,14 @@ def _safe_infer_call_result(
     try:
         inferit = node.infer_call_result(caller, context=context)
         value = next(inferit)
-    except astroid.InferenceError:
+    except (astroid.InferenceError, AttributeError):
         return None  # inference failed
     except StopIteration:
         return None  # no values inferred
     try:
         next(inferit)
         return None  # there is ambiguity on the inferred node
-    except astroid.InferenceError:
+    except (astroid.InferenceError, AttributeError):
         return None  # there is some kind of ambiguity
     except StopIteration:
         return value

--- a/tests/functional/n/non/non_iterator_returned.py
+++ b/tests/functional/n/non/non_iterator_returned.py
@@ -105,3 +105,15 @@ class SixthGoodIterator:
 
     def __iter__(self):
         return UNINFERABLE
+
+
+class ClassmethodGetattr:
+    """Regression fixture for inference through a classmethod."""
+
+    @classmethod
+    def f(cls):
+        return 2
+
+    @classmethod
+    def h(cls):
+        return getattr(cls.f, "__func__")


### PR DESCRIPTION
## Summary

- Avoid a Pylint crash when inference of `getattr(..., __func__)` on a classmethod raises `AttributeError`.
- Add a functional regression case for the classmethod inference path.
- Add the required news fragment.

## Root cause

`_safe_infer_call_result()` already treats `InferenceError` as an unsuccessful inference. The classmethod `getattr()` path can instead raise `AttributeError` from astroid's object model, allowing it to escape the safety boundary and abort linting.

## Validation

- `python -m pytest tests/test_functional.py -k non_iterator_returned -q` — `1 passed, 901 deselected`
- `python -m towncrier check --compare-with origin/main`
- `git diff origin/main...HEAD --check`
- `python -m pytest tests/test_functional.py -n 4 --benchmark-disable -q` — `886 passed, 15 skipped, 1 failed`; the failure is the pre-existing Windows `symlink_module0` case reporting an unexpected `syntax-error`, unrelated to this classmethod inference path.