### PR TITLE
Don't emit useless-parent-delegation for uninspectable C-level parents

### DIFF
--- a/doc/whatsnew/fragments/9994.false_positive
+++ b/doc/whatsnew/fragments/9994.false_positive
@@ -1,0 +1,7 @@
+Fix a false positive for ``useless-parent-delegation`` when a method overrides a
+method of a C-level parent whose signature cannot be inspected, such as
+``Exception.__init__``. Because ``Exception.__init__`` accepts ``*args``, an
+override taking only ``self`` narrows the accepted arguments and is not useless.
+Overrides of ``object.__init__`` are still reported.
+
+Closes #9994

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -142,12 +142,6 @@ def _definition_equivalent_to_call(
     return all(kw in call.args or kw in definition.kwonlyargs for kw in call.kws)
 
 
-def _is_object_method(method: nodes.FunctionDef) -> bool:
-    """Check whether the given method is defined on the builtin object class."""
-    parent = method.parent
-    return isinstance(parent, nodes.ClassDef) and parent.qname() == "builtins.object"
-
-
 def _is_trivial_super_delegation(function: nodes.FunctionDef) -> bool:
     """Check whether a function definition is a method consisting only of a
     call to the same function on the superclass.
@@ -1409,15 +1403,15 @@ a metaclass class method.",
                 or _has_different_parameters_default_value(
                     meth_node.args, function.args
                 )
-                # arguments to builtins such as Exception.__init__() cannot be
-                # inspected: narrowing them down to 'self' still changes the
-                # accepted signature, unless the parent is object() which
-                # accepts nothing else
+                # Arguments to builtins such as Exception.__init__() cannot be
+                # inspected. If astroid cannot infer the bound super method,
+                # narrowing it down to 'self' can still change the accepted
+                # signature.
                 or (
                     meth_node.args.args is None
                     and (
                         function.argnames() != ["self"]
-                        or not _is_object_method(meth_node)
+                        or util.safe_infer(call.func) is None
                     )
                 )
             ):

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -142,6 +142,12 @@ def _definition_equivalent_to_call(
     return all(kw in call.args or kw in definition.kwonlyargs for kw in call.kws)
 
 
+def _is_object_method(method: nodes.FunctionDef) -> bool:
+    """Check whether the given method is defined on the builtin object class."""
+    parent = method.parent
+    return isinstance(parent, nodes.ClassDef) and parent.qname() == "builtins.object"
+
+
 def _is_trivial_super_delegation(function: nodes.FunctionDef) -> bool:
     """Check whether a function definition is a method consisting only of a
     call to the same function on the superclass.
@@ -1403,8 +1409,17 @@ a metaclass class method.",
                 or _has_different_parameters_default_value(
                     meth_node.args, function.args
                 )
-                # arguments to builtins such as Exception.__init__() cannot be inspected
-                or (meth_node.args.args is None and function.argnames() != ["self"])
+                # arguments to builtins such as Exception.__init__() cannot be
+                # inspected: narrowing them down to 'self' still changes the
+                # accepted signature, unless the parent is object() which
+                # accepts nothing else
+                or (
+                    meth_node.args.args is None
+                    and (
+                        function.argnames() != ["self"]
+                        or not _is_object_method(meth_node)
+                    )
+                )
             ):
                 return
             break

--- a/tests/functional/u/useless/useless_parent_delegation.py
+++ b/tests/functional/u/useless/useless_parent_delegation.py
@@ -430,3 +430,23 @@ class Lemon(Fruit):
 class CustomError(Exception):
     def __init__(self, message="default"):
         super().__init__(message)
+
+
+# https://github.com/pylint-dev/pylint/issues/9994
+# The signature of a C-level parent such as Exception.__init__ cannot be
+# inspected, so an override taking only ``self`` still narrows the accepted
+# arguments (Exception accepts *args) and is therefore not useless.
+class MyException(Exception):
+    def __init__(self):
+        super().__init__()
+
+
+class MyDict(dict):
+    def __init__(self):
+        super().__init__()
+
+
+# object() accepts nothing besides self, so this override really is useless.
+class PlainObject:
+    def __init__(self):  # [useless-parent-delegation]
+        super().__init__()

--- a/tests/functional/u/useless/useless_parent_delegation.txt
+++ b/tests/functional/u/useless/useless_parent_delegation.txt
@@ -23,3 +23,4 @@ useless-parent-delegation:360:4:360:15:UselessSuperPy3.useless:Useless parent or
 useless-parent-delegation:375:4:375:16:Ham.__init__:Useless parent or super() delegation in method '__init__':INFERENCE
 useless-parent-delegation:408:4:408:12:ReturnTypeSpecified.draw:Useless parent or super() delegation in method 'draw':INFERENCE
 useless-parent-delegation:415:4:415:12:ReturnTypeSame.draw:Useless parent or super() delegation in method 'draw':INFERENCE
+useless-parent-delegation:451:4:451:16:PlainObject.__init__:Useless parent or super() delegation in method '__init__':INFERENCE


### PR DESCRIPTION
## Type of Changes

| | Type |
|---|---|
| ☑ | 🐛 Bug fix |

## Description

`useless-parent-delegation` was emitted for

```python
class MyException(Exception):
    def __init__(self):
        super().__init__()
```

astroid cannot inspect the signature of C-level methods, so
`Exception.__init__` gives `meth_node.args.args is None`. The existing guard

```python
or (meth_node.args.args is None and function.argnames() != ["self"])
```

only bailed out when the override took extra parameters. For an override of
exactly `(self)` it fell through and emitted. Removing that override changes
the arguments the class accepts (`MyException("boom")` works without the
override and raises `TypeError` with it), so the override is not useless.

The fix now bases that decision on inference. When astroid cannot inspect the
parent signature, it also tries to infer the bound method behind the
`super()` call. `object.__init__` resolves to one bound method, so the existing
`UselessSuper.__init__` and `PlainObject.__init__` cases still emit. For
`Exception.__init__` and `dict.__init__`, inference stays ambiguous across the
MRO and `astroid.util.safe_infer()` returns `None`, so Pylint does not claim the
override is useless.

## Verification

Before the change, the issue's reproducer emitted:

```
a.py:12:4: W0246: Useless parent or super() delegation in method '__init__' (useless-parent-delegation)
```

After the change the same file is clean, while the equivalent pure-Python
`Base(*args, **kwargs)` / `Derived(self)` pattern keeps behaving as before.

Functional coverage in
`tests/functional/u/useless/useless_parent_delegation.py` now includes:

- `MyException(Exception)` and `MyDict(dict)` with a `self`-only `__init__` — no message
- `PlainObject` with a `self`-only `__init__` — still `[useless-parent-delegation]`

Current checks:

- `pytest -q tests/test_functional.py -k useless_parent_delegation` — 2 passed
- `ruff check pylint/checkers/classes/class_checker.py` — passed

## Refs

Closes #9994
