### PR TITLE
Add nonsensical-float-arg for infinity and NaN arguments

### DIFF
--- a/doc/data/messages/n/nonsensical-float-arg/bad.py
+++ b/doc/data/messages/n/nonsensical-float-arg/bad.py
@@ -1,0 +1,7 @@
+import math
+
+BASKET = 3.0
+CRATE = 12.0
+
+if math.isclose(BASKET, CRATE, rel_tol=math.inf):  # [nonsensical-float-arg]
+    print("The basket holds about as many apples as the crate.")

--- a/doc/data/messages/n/nonsensical-float-arg/good.py
+++ b/doc/data/messages/n/nonsensical-float-arg/good.py
@@ -1,0 +1,7 @@
+import math
+
+BASKET = 3.0
+CRATE = 12.0
+
+if math.isclose(BASKET, CRATE, rel_tol=0.1):
+    print("The basket holds about as many apples as the crate.")

--- a/doc/whatsnew/fragments/11220.feature
+++ b/doc/whatsnew/fragments/11220.feature
@@ -1,0 +1,6 @@
+Add ``nonsensical-float-arg``, emitted when infinity or NaN is passed to a parameter
+that has no sensible behaviour for it, such as a comparison tolerance, a timeout or a
+conversion to an integer. The check is built as a mixin so a plugin can register the
+arguments of its own library.
+
+Closes #11220

--- a/pylint/checkers/__init__.py
+++ b/pylint/checkers/__init__.py
@@ -50,6 +50,10 @@ from pylint.checkers.base_checker import (
     BaseTokenChecker,
 )
 from pylint.checkers.deprecated import DeprecatedMixin
+from pylint.checkers.nonsensical_args import (
+    NonsensicalArgument,
+    NonsensicalArgumentsMixin,
+)
 from pylint.utils import LinterStats, diff_string, register_plugins
 
 if TYPE_CHECKING:
@@ -135,6 +139,8 @@ __all__ = [
     "BaseRawFileChecker",
     "BaseTokenChecker",
     "DeprecatedMixin",
+    "NonsensicalArgument",
+    "NonsensicalArgumentsMixin",
     "initialize",
     "register_plugins",
 ]

--- a/pylint/checkers/nonsensical_args.py
+++ b/pylint/checkers/nonsensical_args.py
@@ -1,0 +1,262 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Checker for arguments that are never meaningful as infinity or NaN."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, NamedTuple
+
+import astroid
+from astroid import nodes
+
+from pylint.checkers import utils
+from pylint.checkers.base_checker import BaseChecker
+from pylint.checkers.utils import safe_infer
+from pylint.interfaces import INFERENCE
+from pylint.typing import MessageDefinitionTuple
+
+if TYPE_CHECKING:
+    from pylint.lint import PyLinter
+
+ACCEPTABLE_NODES = (
+    astroid.BoundMethod,
+    astroid.UnboundMethod,
+    nodes.FunctionDef,
+    nodes.ClassDef,
+)
+
+
+class NonsensicalArgument(NamedTuple):
+    """An argument that should never be given infinity or NaN.
+
+    ``position`` is the index of the argument when it is passed positionally,
+    counting from zero and ignoring ``self``, or None when the argument is
+    keyword-only. ``name`` is the keyword it is passed under.
+
+    ``on_inf`` and ``on_nan`` describe what goes wrong for each value, and are
+    used as the tail of the emitted message. A value of None means that value
+    is legitimate for this argument, so leaving both as None disables the
+    entry.
+    """
+
+    position: int | None
+    name: str
+    on_inf: str | None = None
+    on_nan: str | None = None
+
+
+def _non_finite_value(node: nodes.NodeNG) -> float | None:
+    """Return the infinity or NaN that `node` evaluates to, else None.
+
+    ``float("inf")`` infers to an instance of float rather than to a constant,
+    so the call has to be read directly. Every other spelling, ``math.inf``,
+    ``math.nan``, a ``1e999`` literal or a name bound to one of those, is
+    handled by inference.
+    """
+    match node:
+        case nodes.Call(args=[nodes.Const(value=str() as text)]) if (
+            isinstance(inferred := safe_infer(node.func), nodes.ClassDef)
+            and inferred.qname() == "builtins.float"
+        ):
+            try:
+                literal = float(text)
+            except ValueError:
+                return None
+            return None if math.isfinite(literal) else literal
+
+    inferred_value = safe_infer(node)
+    if (
+        isinstance(inferred_value, nodes.Const)
+        and isinstance(inferred_value.value, float)
+        and not math.isfinite(inferred_value.value)
+    ):
+        return inferred_value.value
+    return None
+
+
+class NonsensicalArgumentsMixin(BaseChecker):
+    """A mixin implementing logic for arguments that must be finite.
+
+    A class implementing this mixin must define the "nonsensical-float-arg"
+    message, which it can do by unpacking ``NONSENSICAL_ARGUMENT_MESSAGE`` into
+    its own ``msgs``, and should override :meth:`nonsensical_arguments`.
+
+    A checker that defines its own ``visit_call`` must call
+    :meth:`check_nonsensical_arguments` from it, as its own definition shadows
+    the one provided here.
+    """
+
+    NONSENSICAL_ARGUMENT_MESSAGE: dict[str, MessageDefinitionTuple] = {
+        "W3801": (
+            "%s passed as %r to %s(), %s",
+            "nonsensical-float-arg",
+            "Some arguments have no meaningful behaviour for infinity or NaN. "
+            "An infinite tolerance makes a comparison succeed whatever it is "
+            "given, and an infinite timeout is rejected rather than waiting "
+            "forever, so passing one is a mistake even when no exception is "
+            "raised.",
+            {"shared": True},
+        ),
+    }
+
+    def nonsensical_arguments(self, qname: str) -> Iterable[NonsensicalArgument]:
+        """Callback returning the arguments of `qname` that must be finite.
+
+        Args:
+            qname (str): qualified name of the called function, method or class
+
+        Returns:
+            collections.abc.Iterable of NonsensicalArgument, at most one per
+            argument of `qname`.
+        """
+        # pylint: disable=unused-argument
+        return ()
+
+    @utils.only_required_for_messages("nonsensical-float-arg")
+    def visit_call(self, node: nodes.Call) -> None:
+        """Called when a :class:`nodes.Call` node is visited."""
+        self.check_nonsensical_arguments(node)
+
+    def check_nonsensical_arguments(self, node: nodes.Call) -> None:
+        """Check the call for arguments that should not be infinity or NaN.
+
+        This method should be called from the checker implementing this mixin.
+        """
+        inferred = safe_infer(node.func)
+        if not isinstance(inferred, ACCEPTABLE_NODES):
+            return
+
+        keywords = {
+            keyword.arg: keyword.value
+            for keyword in node.keywords or ()
+            if keyword.arg is not None
+        }
+        for argument in self.nonsensical_arguments(inferred.qname()):
+            passed = keywords.get(argument.name)
+            if passed is None:
+                if argument.position is None or argument.position >= len(node.args):
+                    continue
+                passed = node.args[argument.position]
+
+            value = _non_finite_value(passed)
+            if value is None:
+                continue
+            consequence = argument.on_nan if math.isnan(value) else argument.on_inf
+            if consequence is None:
+                continue
+            self.add_message(
+                "nonsensical-float-arg",
+                node=passed,
+                args=(
+                    passed.as_string(),
+                    argument.name,
+                    node.func.as_string(),
+                    consequence,
+                ),
+                confidence=INFERENCE,
+            )
+
+
+# An infinite tolerance widens an approximate comparison until everything
+# matches it, and a NaN tolerance makes every comparison but an exact one fail.
+# A negative infinity is rejected outright rather than matching nothing, hence
+# the deliberately unspecific wording for infinity.
+_TOLERANCE = (
+    "an infinite tolerance makes the comparison meaningless",
+    "a NaN tolerance makes the comparison fail unless the values are equal",
+)
+# assertNotAlmostEqual inverts the test, so the same tolerance breaks it the
+# other way around.
+_INVERTED_TOLERANCE = (
+    "an infinite tolerance makes the assertion meaningless",
+    "a NaN tolerance makes the assertion fail whatever it is given",
+)
+# Timeouts are converted to a deadline in C, which infinity and NaN overflow.
+# The conversion only happens once the call actually has to wait, so the same
+# argument can raise on an empty queue and pass on a full one.
+_TIMEOUT = (
+    "an infinite timeout is not supported, omit the argument to wait forever",
+    "a NaN timeout is not supported, omit the argument to wait forever",
+)
+# Anything converting a float to an integer, directly or through a ratio.
+_INTEGER = (
+    "infinity cannot be converted to an integer",
+    "NaN cannot be converted to an integer",
+)
+
+NONSENSICAL_ARGUMENTS: dict[str, tuple[NonsensicalArgument, ...]] = {
+    "math.isclose": (
+        NonsensicalArgument(None, "rel_tol", *_TOLERANCE),
+        NonsensicalArgument(None, "abs_tol", *_TOLERANCE),
+    ),
+    "cmath.isclose": (
+        NonsensicalArgument(None, "rel_tol", *_TOLERANCE),
+        NonsensicalArgument(None, "abs_tol", *_TOLERANCE),
+    ),
+    "unittest.case.TestCase.assertAlmostEqual": (
+        NonsensicalArgument(4, "delta", *_TOLERANCE),
+    ),
+    "unittest.case.TestCase.assertNotAlmostEqual": (
+        NonsensicalArgument(4, "delta", *_INVERTED_TOLERANCE),
+    ),
+    "time.sleep": (NonsensicalArgument(0, "secs", *_TIMEOUT),),
+    "_socket.socket.settimeout": (NonsensicalArgument(0, "value", *_TIMEOUT),),
+    "threading.lock.acquire": (NonsensicalArgument(1, "timeout", *_TIMEOUT),),
+    "threading.Event.wait": (NonsensicalArgument(0, "timeout", *_TIMEOUT),),
+    "threading.Condition.wait": (NonsensicalArgument(0, "timeout", *_TIMEOUT),),
+    "queue.Queue.get": (NonsensicalArgument(1, "timeout", *_TIMEOUT),),
+    "queue.Queue.put": (NonsensicalArgument(2, "timeout", *_TIMEOUT),),
+    "builtins.int": (NonsensicalArgument(0, "x", *_INTEGER),),
+    "math.floor": (NonsensicalArgument(0, "x", *_INTEGER),),
+    "math.ceil": (NonsensicalArgument(0, "x", *_INTEGER),),
+    "math.trunc": (NonsensicalArgument(0, "x", *_INTEGER),),
+    "fractions.Fraction": (NonsensicalArgument(0, "numerator", *_INTEGER),),
+}
+# datetime is implemented twice, and the pure Python one is what astroid reads.
+for _timedelta in ("datetime.timedelta", "_pydatetime.timedelta"):
+    NONSENSICAL_ARGUMENTS[_timedelta] = tuple(
+        NonsensicalArgument(_position, _unit, *_INTEGER)
+        for _position, _unit in enumerate(
+            (
+                "days",
+                "seconds",
+                "microseconds",
+                "milliseconds",
+                "minutes",
+                "hours",
+                "weeks",
+            )
+        )
+    )
+for _fromtimestamp in (
+    "datetime.datetime.fromtimestamp",
+    "_pydatetime.datetime.fromtimestamp",
+):
+    NONSENSICAL_ARGUMENTS[_fromtimestamp] = (
+        NonsensicalArgument(
+            0,
+            "timestamp",
+            "infinity is outside the range of representable dates",
+            "NaN is not a date",
+        ),
+    )
+
+
+class NonsensicalArgumentsChecker(NonsensicalArgumentsMixin, BaseChecker):
+    """Checks the standard library for arguments given infinity or NaN."""
+
+    name = "nonsensical_arguments"
+    msgs: dict[str, MessageDefinitionTuple] = {
+        **NonsensicalArgumentsMixin.NONSENSICAL_ARGUMENT_MESSAGE,
+    }
+
+    def nonsensical_arguments(self, qname: str) -> Iterable[NonsensicalArgument]:
+        return NONSENSICAL_ARGUMENTS.get(qname, ())
+
+
+def register(linter: PyLinter) -> None:
+    linter.register_checker(NonsensicalArgumentsChecker(linter))

--- a/tests/checkers/unittest_nonsensical_args.py
+++ b/tests/checkers/unittest_nonsensical_args.py
@@ -1,0 +1,121 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Tests for the mixin that third party checkers extend."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import astroid
+
+from pylint.checkers import BaseChecker, NonsensicalArgument, NonsensicalArgumentsMixin
+from pylint.interfaces import INFERENCE
+from pylint.testutils import CheckerTestCase, MessageTest
+
+# What a plugin for a library of our own would register. "juice" is
+# keyword-only and rejects both values, "slices" is positional and only
+# rejects infinity.
+SQUEEZE = (
+    NonsensicalArgument(
+        None,
+        "juice",
+        on_inf="an endless glass of juice is never filled",
+        on_nan="a glass of NaN juice is not a glass of juice",
+    ),
+    NonsensicalArgument(
+        1, "slices", on_inf="an orange has a countable number of slices"
+    ),
+)
+
+
+class _FruitChecker(NonsensicalArgumentsMixin, BaseChecker):
+    name = "fruit"
+    msgs = {**NonsensicalArgumentsMixin.NONSENSICAL_ARGUMENT_MESSAGE}
+
+    def nonsensical_arguments(self, qname: str) -> Iterable[NonsensicalArgument]:
+        return SQUEEZE if qname == "fruit.squeeze" else ()
+
+
+class TestNonsensicalArgumentsMixin(CheckerTestCase):
+    CHECKER_CLASS = _FruitChecker
+
+    @staticmethod
+    def _call(source: str) -> astroid.nodes.Call:
+        node = astroid.extract_node(f"""
+        import math
+
+        def squeeze(orange, slices=8, *, juice=1.0):
+            return orange, slices, juice
+
+        {source}  #@
+        """)
+        node.root().name = "fruit"
+        assert isinstance(node, astroid.nodes.Call)
+        return node
+
+    def test_keyword_only_argument_is_checked(self) -> None:
+        node = self._call("squeeze('orange', juice=math.inf)")
+        with self.assertAddsMessages(
+            MessageTest(
+                msg_id="nonsensical-float-arg",
+                args=(
+                    "math.inf",
+                    "juice",
+                    "squeeze",
+                    "an endless glass of juice is never filled",
+                ),
+                node=node.keywords[0].value,
+                confidence=INFERENCE,
+                line=7,
+                col_offset=24,
+                end_line=7,
+                end_col_offset=32,
+            )
+        ):
+            self.checker.visit_call(node)
+
+    def test_positional_argument_is_checked(self) -> None:
+        node = self._call("squeeze('orange', math.inf)")
+        with self.assertAddsMessages(
+            MessageTest(
+                msg_id="nonsensical-float-arg",
+                args=(
+                    "math.inf",
+                    "slices",
+                    "squeeze",
+                    "an orange has a countable number of slices",
+                ),
+                node=node.args[1],
+                confidence=INFERENCE,
+                line=7,
+                col_offset=18,
+                end_line=7,
+                end_col_offset=26,
+            )
+        ):
+            self.checker.visit_call(node)
+
+    def test_value_the_entry_allows_is_ignored(self) -> None:
+        # "slices" leaves on_nan unset, so NaN is not reported for it.
+        node = self._call("squeeze('orange', math.nan)")
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
+
+    def test_finite_arguments_are_ignored(self) -> None:
+        node = self._call("squeeze('orange', 4, juice=0.5)")
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
+
+    def test_unregistered_call_is_ignored(self) -> None:
+        node = astroid.extract_node("""
+        import math
+
+        def peel(fruit, juice=1.0):
+            return fruit, juice
+
+        peel('banana', juice=math.inf)  #@
+        """)
+        with self.assertNoMessages():
+            self.checker.visit_call(node)

--- a/tests/functional/n/non/nonsensical_float_arg.py
+++ b/tests/functional/n/non/nonsensical_float_arg.py
@@ -1,0 +1,70 @@
+"""Check arguments that are never meaningful as infinity or NaN."""
+# pylint: disable=missing-function-docstring,missing-class-docstring
+# pylint: disable=consider-using-with,expression-not-assigned
+
+import cmath
+import fractions
+import math
+import queue
+import threading
+import time
+import unittest
+from datetime import datetime, timedelta
+
+# Tolerances: an infinite one matches everything, a NaN one matches nothing.
+math.isclose(1, 2, rel_tol=math.inf)  # [nonsensical-float-arg]
+math.isclose(1, 2, abs_tol=math.nan)  # [nonsensical-float-arg]
+math.isclose(1, 2, rel_tol=float("inf"))  # [nonsensical-float-arg]
+math.isclose(1, 2, rel_tol=float("nan"))  # [nonsensical-float-arg]
+math.isclose(1, 2, rel_tol=-math.inf)  # [nonsensical-float-arg]
+math.isclose(1, 2, rel_tol=1e999)  # [nonsensical-float-arg]
+cmath.isclose(1, 2, abs_tol=math.inf)  # [nonsensical-float-arg]
+
+# Timeouts are turned into a deadline, which infinity overflows.
+time.sleep(math.inf)  # [nonsensical-float-arg]
+threading.Event().wait(math.inf)  # [nonsensical-float-arg]
+threading.Condition().wait(timeout=math.nan)  # [nonsensical-float-arg]
+threading.Lock().acquire(True, math.inf)  # [nonsensical-float-arg]
+queue.Queue().get(True, math.inf)  # [nonsensical-float-arg]
+queue.Queue().put("apple", True, math.inf)  # [nonsensical-float-arg]
+
+# Conversions to an integer, directly or through a date or a ratio.
+int(math.inf)  # [nonsensical-float-arg]
+math.floor(math.nan)  # [nonsensical-float-arg]
+math.ceil(math.inf)  # [nonsensical-float-arg]
+math.trunc(math.inf)  # [nonsensical-float-arg]
+fractions.Fraction(math.inf)  # [nonsensical-float-arg]
+timedelta(seconds=math.inf)  # [nonsensical-float-arg]
+timedelta(0, math.nan)  # [nonsensical-float-arg]
+datetime.fromtimestamp(math.inf)  # [nonsensical-float-arg]
+
+# A name bound to infinity is followed too.
+FOREVER = math.inf
+time.sleep(FOREVER)  # [nonsensical-float-arg]
+
+
+class BananaTest(unittest.TestCase):
+    def test_almost(self):
+        self.assertAlmostEqual(1, 2, delta=math.inf)  # [nonsensical-float-arg]
+        self.assertNotAlmostEqual(1, 2, None, None, math.inf)  # [nonsensical-float-arg]
+
+
+# Finite arguments are fine.
+math.isclose(1, 2, rel_tol=0.1)
+math.isclose(1, 2, abs_tol=0.0)
+time.sleep(60)
+threading.Event().wait(0.5)
+queue.Queue().get(True, 1.5)
+int(1.5)
+timedelta(seconds=1)
+datetime.fromtimestamp(0)
+
+# Infinity is only a problem for the arguments that cannot use it.
+math.isclose(math.inf, math.inf)
+math.isnan(math.nan)
+print(math.inf, float("nan"))
+timedelta(seconds=1) * 2
+
+# Omitting the timeout is how you wait forever.
+threading.Event().wait()
+queue.Queue().get()

--- a/tests/functional/n/non/nonsensical_float_arg.txt
+++ b/tests/functional/n/non/nonsensical_float_arg.txt
@@ -1,0 +1,24 @@
+nonsensical-float-arg:15:27:15:35::math.inf passed as 'rel_tol' to math.isclose(), an infinite tolerance makes the comparison meaningless:INFERENCE
+nonsensical-float-arg:16:27:16:35::math.nan passed as 'abs_tol' to math.isclose(), a NaN tolerance makes the comparison fail unless the values are equal:INFERENCE
+nonsensical-float-arg:17:27:17:39::float('inf') passed as 'rel_tol' to math.isclose(), an infinite tolerance makes the comparison meaningless:INFERENCE
+nonsensical-float-arg:18:27:18:39::float('nan') passed as 'rel_tol' to math.isclose(), a NaN tolerance makes the comparison fail unless the values are equal:INFERENCE
+nonsensical-float-arg:19:27:19:36::-math.inf passed as 'rel_tol' to math.isclose(), an infinite tolerance makes the comparison meaningless:INFERENCE
+nonsensical-float-arg:20:27:20:32::inf passed as 'rel_tol' to math.isclose(), an infinite tolerance makes the comparison meaningless:INFERENCE
+nonsensical-float-arg:21:28:21:36::math.inf passed as 'abs_tol' to cmath.isclose(), an infinite tolerance makes the comparison meaningless:INFERENCE
+nonsensical-float-arg:24:11:24:19::math.inf passed as 'secs' to time.sleep(), an infinite timeout is not supported, omit the argument to wait forever:INFERENCE
+nonsensical-float-arg:25:23:25:31::math.inf passed as 'timeout' to threading.Event().wait(), an infinite timeout is not supported, omit the argument to wait forever:INFERENCE
+nonsensical-float-arg:26:35:26:43::math.nan passed as 'timeout' to threading.Condition().wait(), a NaN timeout is not supported, omit the argument to wait forever:INFERENCE
+nonsensical-float-arg:27:31:27:39::math.inf passed as 'timeout' to threading.Lock().acquire(), an infinite timeout is not supported, omit the argument to wait forever:INFERENCE
+nonsensical-float-arg:28:24:28:32::math.inf passed as 'timeout' to queue.Queue().get(), an infinite timeout is not supported, omit the argument to wait forever:INFERENCE
+nonsensical-float-arg:29:33:29:41::math.inf passed as 'timeout' to queue.Queue().put(), an infinite timeout is not supported, omit the argument to wait forever:INFERENCE
+nonsensical-float-arg:32:4:32:12::math.inf passed as 'x' to int(), infinity cannot be converted to an integer:INFERENCE
+nonsensical-float-arg:33:11:33:19::math.nan passed as 'x' to math.floor(), NaN cannot be converted to an integer:INFERENCE
+nonsensical-float-arg:34:10:34:18::math.inf passed as 'x' to math.ceil(), infinity cannot be converted to an integer:INFERENCE
+nonsensical-float-arg:35:11:35:19::math.inf passed as 'x' to math.trunc(), infinity cannot be converted to an integer:INFERENCE
+nonsensical-float-arg:36:19:36:27::math.inf passed as 'numerator' to fractions.Fraction(), infinity cannot be converted to an integer:INFERENCE
+nonsensical-float-arg:37:18:37:26::math.inf passed as 'seconds' to timedelta(), infinity cannot be converted to an integer:INFERENCE
+nonsensical-float-arg:38:13:38:21::math.nan passed as 'seconds' to timedelta(), NaN cannot be converted to an integer:INFERENCE
+nonsensical-float-arg:39:23:39:31::math.inf passed as 'timestamp' to datetime.fromtimestamp(), infinity is outside the range of representable dates:INFERENCE
+nonsensical-float-arg:43:11:43:18::FOREVER passed as 'secs' to time.sleep(), an infinite timeout is not supported, omit the argument to wait forever:INFERENCE
+nonsensical-float-arg:48:43:48:51:BananaTest.test_almost:math.inf passed as 'delta' to self.assertAlmostEqual(), an infinite tolerance makes the comparison meaningless:INFERENCE
+nonsensical-float-arg:49:52:49:60:BananaTest.test_almost:math.inf passed as 'delta' to self.assertNotAlmostEqual(), an infinite tolerance makes the assertion meaningless:INFERENCE


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Description

Flags inf/NaN passed to parameters that can't use them (tolerances, timeouts, integer conversions). An infinite tolerance makes a comparison succeed, whatever it's given; an infinite timeout is rejected rather than waiting forever.

Prompted by pytest-dev/pytest#14754: that PR fixes pytest's own OverflowError, but approx(1.0, rel=inf) stays legal and silently unfailable. Built as a mixin (like DeprecatedMixin) so pylint-pytest can register pytest.approx itself.
