### PR TITLE
Fix a crash on calls unpacking dicts with non-string keys

### DIFF
--- a/doc/whatsnew/fragments/11222.bugfix
+++ b/doc/whatsnew/fragments/11222.bugfix
@@ -1,0 +1,4 @@
+Fix a crash when a call unpacks a dictionary whose keys are not string
+constants, e.g. ``copy.copy(**{-1: 1})``.
+
+Closes #11222

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -756,9 +756,11 @@ def infer_kwarg_from_call(call_node: nodes.Call, keyword: str) -> nodes.Name | N
     for arg in call_node.kwargs:
         inferred = safe_infer(arg.value)
         if isinstance(inferred, nodes.Dict):
-            for item in inferred.items:
-                if item[0].value == keyword:
-                    return item[1]
+            for key, value in inferred.items:
+                # Keys can be any expression (or None for '**' unpacking),
+                # only string constants can name a keyword argument.
+                if isinstance(key, nodes.Const) and key.value == keyword:
+                    return value
 
     return None
 

--- a/tests/functional/s/shallow_copy_environ.py
+++ b/tests/functional/s/shallow_copy_environ.py
@@ -35,3 +35,7 @@ copy.copy(x=os.environ)  # [shallow-copy-environ]
 copy.copy(**{"x": os.environ})  # [shallow-copy-environ]
 copy.copy(**{"y": os.environ})  # [unexpected-keyword-arg]
 copy.copy(y=os.environ)  # [no-value-for-parameter, unexpected-keyword-arg]
+
+# Keys that are not string constants must not crash the checker
+copy.copy(**{-1: 1})
+copy.copy(**{None: 1})


### PR DESCRIPTION


<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

``infer_kwarg_from_call`` assumed every key of an inferred dict was a ``Const``, so a call like ``copy.copy(**{-1: 1})`` raised an ``AttributeError`` and aborted checking of the whole file.

Closes #11222
