### PR TITLE
Guarantee deterministic recursive file discovery

### DIFF
--- a/doc/whatsnew/fragments/9943.bugfix
+++ b/doc/whatsnew/fragments/9943.bugfix
@@ -1,0 +1,3 @@
+Directory arguments are now discovered in deterministic order.
+
+Refs #9943

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -670,7 +670,8 @@ class PyLinter(
                 os.path.join(something, "__init__.py")
             ):
                 skip_subtrees: list[str] = []
-                for root, _, files in os.walk(something):
+                for root, directories, files in os.walk(something):
+                    directories.sort()
                     if any(root.startswith(s) for s in skip_subtrees):
                         # Skip subtree of already discovered package.
                         continue
@@ -688,6 +689,7 @@ class PyLinter(
                         skip_subtrees.append(root + os.sep)
                         yield root
                     else:
+                        files.sort()
                         yield from (
                             os.path.join(root, file)
                             for file in files

--- a/tests/lint/unittest_discover_files.py
+++ b/tests/lint/unittest_discover_files.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
 
 import os
+from collections.abc import Iterator
 from unittest import mock
 
 import pytest
@@ -70,6 +71,34 @@ def _mock_tree() -> list[tuple[str, list[str], list[str]]]:
             ["test1.py", "test2.py", "__init__.py"],
         ),
     ]
+
+
+def test_discover_files_in_deterministic_order(initialized_linter: PyLinter) -> None:
+    def unordered_walk(
+        _path: str,
+    ) -> Iterator[tuple[str, list[str], list[str]]]:
+        directories = ["z_package", "a_directory"]
+        yield ".", directories, ["z.py", "README.rst", "a.py"]
+        for directory in directories:
+            if directory == "z_package":
+                yield directory, [], ["__init__.py"]
+            else:
+                yield directory, [], ["z.py", "a.py"]
+
+    with (
+        mock.patch("os.path.isdir", return_value=True),
+        mock.patch("os.path.isfile", return_value=False),
+        mock.patch("os.walk", side_effect=unordered_walk),
+    ):
+        results = tuple(initialized_linter._discover_files(["."]))
+
+    assert results == (
+        f".{os.sep}a.py",
+        f".{os.sep}z.py",
+        f"a_directory{os.sep}a.py",
+        f"a_directory{os.sep}z.py",
+        "z_package",
+    )
 
 
 def test_does_not_ignore_similarly_named_package(


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Sort directory names in place before recursive traversal and sort file names before yielding Python files, making directory discovery independent of filesystem enumeration order. Add a regression test covering both directory and file ordering.

Closes #9943